### PR TITLE
Remove links from section titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@
 
 ## Layout
 
-### [Terminology](./terminology.md)
+### Terminology
 
 [terminology.md](./terminology.md) provides a glossary for languages commonly used throughout the OpenTelemetry project.
 
-### [Specification](./specification.md)
+### Specification
 
 [specification.md](./specification.md) is the versioned OpenTelemetry standard, explaining the cross-language requirements and expectations for implementations.
 
-### [Semantic Conventions](./semantic-conventions.md)
+### Semantic Conventions
 
 [semantic-conventions.md](./semantic-conventions.md) describes conventional tags, log keys, etc. that should be used for common scenarios to ensure a consistent usage experience.
 


### PR DESCRIPTION
The description text in every section already contains the link, which makes section titles look confusing.