### PR TITLE
Resource On SpanData + Specify SpanData format

### DIFF
--- a/specification/resources-api.md
+++ b/specification/resources-api.md
@@ -12,7 +12,8 @@ When used with distributed tracing resource can be associated with the
 [SpanData](tracing-api.md#spandata). When associated with `Tracer`, all `Span`s
 produced by this `Tracer` will automatically be associated with this `Resource`.
 When associated with the `SpanData` explicitly for out-of-band spans -
-`Resource` that is set on `Tracer` MUST be ignored.
+`Resource` that is set on `Tracer` MUST be ignored. Note, that association
+of `Tracer` with the `Resource` will be done in SDK, not as API call.
 
 **TODO**: explain how resource is associated with metrics.
 

--- a/specification/tracing-api.md
+++ b/specification/tracing-api.md
@@ -158,14 +158,15 @@ arguments:
 - Name of this `SpanData`.
 - `Kind` of this `SpanData`.
 - Start and End timestamps
-- Set of attributed with the string key and the value, which must be either a
+- Set of attributes with the string key and the value, which must be either a
   string, a boolean value, or a numeric type.
 - Set of `Events`.
 - Set of `Links`.
 - `Status` of `SpanData` execution.
 
-All collections passes as an argument MUST be copied so the change of the
-collection will not mutate the `SpanData`.
+All collections passes as an argument MUST be either immutable if language
+allows it or copied so the change of the collection will not mutate the
+`SpanData`.
 
 ## GetResource
 

--- a/specification/tracing-api.md
+++ b/specification/tracing-api.md
@@ -142,4 +142,33 @@ record already completed span - [`SpanData`](#spandata) API HAVE TO be used.
 
 ## SpanData
 
-TODO: SpanData operations https://github.com/open-telemetry/opentelemetry-specification/issues/35
+TODO: SpanData operations
+https://github.com/open-telemetry/opentelemetry-specification/issues/35
+
+## Constructing SpanData
+
+`SpanData` is an immutable object that can be constructed using the following
+arguments:
+
+- `SpanContext` identifying this `SpanData`.
+- Parent's `SpanId`.
+- `Resource` this SpanData is recorded for. If not specified - `Tracer`'s
+  `Resource` will be used instead when the `RecordSpanData` called on the
+  `Tracer`.
+- Name of this `SpanData`.
+- `Kind` of this `SpanData`.
+- Start and End timestamps
+- Set of attributed with the string key and the value, which must be either a
+  string, a boolean value, or a numeric type.
+- Set of `Events`.
+- Set of `Links`.
+- `Status` of `SpanData` execution.
+
+All collections passes as an argument MUST be copied so the change of the
+collection will not mutate the `SpanData`.
+
+## GetResource
+
+Returns the `Resource` associated with this `SpanData`. When `null` is returned
+the assumption is that `Resource` will be taken from the `Tracer` that is used
+to record this `SpanData`.


### PR DESCRIPTION
Based on https://github.com/open-telemetry/opentelemetry-java/pull/352 discussion.

This also raise the question - if SpanData is immutable, Tracer will need to create a new `SpanData` with the `Tracer`'s `Resource` set before passing it to the exporter. Which requires a new allocation. Creating issue: https://github.com/open-telemetry/opentelemetry-specification/issues/68