### PR TITLE
Add OpenTelemetry API package layout

### DIFF
--- a/specification/package-layout.md
+++ b/specification/package-layout.md
@@ -1,0 +1,56 @@
+# OpenTelemetry Project Package Layout
+This documentation serves to document the "look and feel" of a basic layout for OpenTelemetry projects. This package layout is intentionally generic and it doesn't try to impose a language specific package structure.
+
+## API Package
+Here is a proposed generic package structure for Public API package.
+
+### `/metrics`
+
+This directory describes the Metrics API that can be used to record application Metrics.
+
+### `/resources`
+
+This API for resource information population.
+
+The resource directory primarily defines a type [Resource](../terminology.md#resources) that captures information about the entity for which stats or traces are recorded. For example, metrics exposed by a Kubernetes container can be linked to a resource that specifies the cluster, namespace, pod, and container name.
+
+### `/distributedcontext`
+
+This directory describes the DistributedContext API that can be used to manage metrics-related labeling.
+
+This API consists of a few main classes:
+
+- `Entry` is used to label anything that is associated with a specific operation, such as an HTTP request.
+- An `Entry` consists of `EntryMetadata`, `EntryKey`, and `EntryValue`.
+
+### `/trace`
+
+This API consist of a few main classes:
+
+- `Tracer` is used for all operations. See [Tracer](./tracing-api.md#tracer) section.
+- `Span` is a mutable object storing information about the current operation
+   execution. See [Span](./tracing-api.md#span) section.
+- `SpanData` is an immutable object that is used to report out-of-band completed
+  spans. See [SpanData](./tracing-api.md#spandata) section.
+
+### `/internal` (_Optional_)
+Private application and library code.
+
+### `/log` (_In the future_)
+> TODO: log operations
+
+
+A typical top-level directory layout:
+```
+api
+   ├── metrics
+   ├── resources
+   ├── trace
+   │   ├── propagation # headers that are the public API for trace propagation, using different encodings.
+   │   └── samplers    # is used to make decisions on `Span` sampling.
+   ├── distributedcontext
+   │   └── propagation
+   ├── internal
+   └── log
+```
+> Use lowercase or CamelCase or Snake Case (stylized as snake_case) depends on the language.

--- a/specification/package-layout.md
+++ b/specification/package-layout.md
@@ -4,6 +4,10 @@ This documentation serves to document the "look and feel" of a basic layout for 
 ## API Package
 Here is a proposed generic package structure for OpenTelemetry API package.
 
+### `/context`
+
+This directory describes the API that provides in-process context propagation.
+
 ### `/metrics`
 
 This directory describes the Metrics API that can be used to record application metrics.
@@ -43,6 +47,8 @@ Private application and library code.
 A typical top-level directory layout:
 ```
 api
+   ├── context
+   │   └── propagation
    ├── metrics
    ├── resources
    ├── trace

--- a/specification/package-layout.md
+++ b/specification/package-layout.md
@@ -2,11 +2,11 @@
 This documentation serves to document the "look and feel" of a basic layout for OpenTelemetry projects. This package layout is intentionally generic and it doesn't try to impose a language specific package structure.
 
 ## API Package
-Here is a proposed generic package structure for Public API package.
+Here is a proposed generic package structure for OpenTelemetry API package.
 
 ### `/metrics`
 
-This directory describes the Metrics API that can be used to record application Metrics.
+This directory describes the Metrics API that can be used to record application metrics.
 
 ### `/resources`
 
@@ -16,7 +16,7 @@ The resource directory primarily defines a type [Resource](../terminology.md#res
 
 ### `/distributedcontext`
 
-This directory describes the DistributedContext API that can be used to manage metrics-related labeling.
+This directory describes the DistributedContext API that can be used to manage context propagation and metrics-related labeling.
 
 This API consists of a few main classes:
 
@@ -36,8 +36,8 @@ This API consist of a few main classes:
 ### `/internal` (_Optional_)
 Private application and library code.
 
-### `/log` (_In the future_)
-> TODO: log operations
+### `/logs` (_In the future_)
+> TODO: logs operations
 
 
 A typical top-level directory layout:
@@ -46,11 +46,10 @@ api
    ├── metrics
    ├── resources
    ├── trace
-   │   ├── propagation # headers that are the public API for trace propagation, using different encodings.
    │   └── samplers    # is used to make decisions on `Span` sampling.
    ├── distributedcontext
    │   └── propagation
    ├── internal
-   └── log
+   └── logs
 ```
-> Use lowercase or CamelCase or Snake Case (stylized as snake_case) depends on the language.
+> Use lowercase or CamelCase or Snake Case (stylized as snake_case) names depends on the language.


### PR DESCRIPTION
Fixes #52 

The best way to view this is: https://github.com/open-telemetry/opentelemetry-specification/blob/84c835b1746d14fa18d087d789728bb5e071afad/specification/package-layout.md