### PR TITLE
Typo languages -> language

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ### Terminology
 
-[terminology.md](./terminology.md) provides a glossary for languages commonly used throughout the OpenTelemetry project.
+[terminology.md](./terminology.md) provides a glossary for language commonly used throughout the OpenTelemetry project.
 
 ### Specification
 


### PR DESCRIPTION
Language can mean both a literal language (like English, or Chinese or C++, or Python) or some way of expressing things (terminology). But in the plural I think it primarily means the former (and in any case, we hopefully do not have multiple terminologies but only one).