### PR TITLE
Add Concurrency and Thread-Safety specification

### DIFF
--- a/specification/concurrency.md
+++ b/specification/concurrency.md
@@ -2,25 +2,22 @@
 
 For languages which support concurrent execution the OpenTelemetry APIs provide
 specific guarantees and safeties. Not all of API functions are safe to
-call concurrently. Function and method documentation must explicitly
+be called concurrently. Function and method documentation must explicitly
 specify whether it is safe or no to make concurrent calls and in what 
 situations.
 
 The following are general recommendations of concurrent call safety of
 specific subsets of the API.
 
-**Tracer** - the tracer is a singleton and all of its methods are safe to call
-concurrently.
+**Tracer** - all methods are safe to be called concurrently.
 
 **SpanBuilder** - It is not safe to concurrently call any methods of the 
 same SpanBuilder instance. Different instances of SpanBuilder can be safely 
 used concurrently by different threads/coroutines, provided that no single
 SpanBuilder is used by more than one thread/coroutine.
 
-**Span** - Span methods are not safe to be called concurrently by user code 
-for the same instance of the Span. 
+**Span** - All methods of Span are safe to be called concurrently. 
 
-**SpanData** - same guarantees as **Span**.
+**SpanData** - SpanData is immutable and is safe to be used concurrently.
 
-**Link** - same guarantees as **Span**. In addition a Link should never
-created for a Span that is already finished.
+**Link** - same as SpanData.

--- a/specification/concurrency.md
+++ b/specification/concurrency.md
@@ -1,0 +1,26 @@
+# Concurrency and Thread-Safety of OpenTelemetry API
+
+For languages which support concurrent execution the OpenTelemetry APIs provide
+specific guarantees and safeties. Not all of API functions are safe to
+call concurrently. Function and method documentation must explicitly
+specify whether it is safe or no to make concurrent calls and in what 
+situations.
+
+The following are general recommendations of concurrent call safety of
+specific subsets of the API.
+
+**Tracer** - the tracer is a singleton and all of its methods are safe to call
+concurrently.
+
+**SpanBuilder** - It is not safe to concurrently call any methods of the 
+same SpanBuilder instance. Different instances of SpanBuilder can be safely 
+used concurrently by different threads/coroutines, provided that no single
+SpanBuilder is used by more than one thread/coroutine.
+
+**Span** - Span methods are not safe to be called concurrently by user code 
+for the same instance of the Span. 
+
+**SpanData** - same guarantees as **Span**.
+
+**Link** - same guarantees as **Span**. In addition a Link should never
+created for a Span that is already finished.

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -73,3 +73,9 @@ An example use case for alternate implementations is automated testing. A mock i
 Note that mocking is also possible by using the SDK and a Mock Exporter without needed to swap out the entire SDK. 
 
 The mocking approach chosen will depend on the testing goals and at which point exactly it is desirable to intercept the telemetry data path during the test.
+
+## Concurrency and Thread-Safety
+
+See [Concurrency and Thread-Safety](concurrency.md) specification for
+guidelines on what concurrency safeties should API implementations provide
+and how they should be documented.


### PR DESCRIPTION
Concurrency and Thread-Safety is specified in a separate document and
is linked from Language Library Design principles document.

Implements issue: https://github.com/open-telemetry/opentelemetry-specification/issues/91