### PR TITLE
Correct a markdown syntax error

### DIFF
--- a/terminology.md
+++ b/terminology.md
@@ -88,7 +88,7 @@ propagated from parent to child **Spans**.
 - **Tracestate** carries tracing-system specific context in a list of key value
   pairs. **Tracestate** allows different vendors propagate additional
   information and inter-operate with their legacy Id formats. For more details
-  see [this][https://w3c.github.io/trace-context/#tracestate-field].
+  see [this](https://w3c.github.io/trace-context/#tracestate-field).
 
 ### Links between spans
 


### PR DESCRIPTION
Just a minor edit.. I guess it meant to be a link in markdown syntax. 