### PR TITLE
Return weight value alongside a sampling decision.

### DIFF
--- a/specification/sampling-api.md
+++ b/specification/sampling-api.md
@@ -55,6 +55,14 @@ be displayed on debug pages or in the logs. Example:
 
 Return sampling decision whether span should be sampled or not.
 
+### GetSampleWeight
+
+Return the a floating point `weight` value approximating the number of similar spans that were seen by the Sampler.
+
+Downstream systems can use this value for numerical calculations/aggregations, statistically approximating the distribution of values found in the unsampled trace span set based on the observed weights and spans sent after sampling. With this feature, unsampled metrics can be utilized directly alongside weighted aggregations calculated from spans.
+
+For instance, its value should be `1 / samplingProbability` for a ProbabilitySampler, or `observedQps / targetQps` for a `RateLimitingSampler`.  With a sampling probability of `0.01`, `COUNT(spans) WHERE service=foo` will return `49*100=4900` rather than the unweighted value `49` and `sum(request_count{service=foo})` will return an exact number like `4930`.
+
 ### GetAttributes
 
 Return attributes to be attached to the `Span`. These attributes should be added

--- a/specification/sampling-api.md
+++ b/specification/sampling-api.md
@@ -63,6 +63,8 @@ Downstream systems can use this value for numerical calculations/aggregations, s
 
 For instance, its value should be `1 / samplingProbability` for a ProbabilitySampler, or `observedQps / targetQps` for a `RateLimitingSampler`.  With a sampling probability of `0.01`, `COUNT(spans) WHERE service=foo` will return `49*100=4900` rather than the unweighted value `49` and `sum(request_count{service=foo})` will return an exact number like `4930`.
 
+This value should be passed along on the wire between different OpenTelemetry-using applications as part of the trace header, along with the `recorded` bit that `IsSampled()` might influence.
+
 ### GetAttributes
 
 Return attributes to be attached to the `Span`. These attributes should be added

--- a/specification/tracing-api.md
+++ b/specification/tracing-api.md
@@ -190,7 +190,7 @@ The OpenTelemetry `SpanContext` representation conforms to the [w3c TraceContext
 
 `SpanId` A valid span identifier is an 8-byte array with at least one non-zero byte.
 
-`TraceOptions` contain details about the trace. Unlike Tracestate values, TraceOptions are present in all traces. Currently, the only TraceOption is a boolean `recorded` [flag](https://www.w3.org/TR/trace-context/#recorded-flag-00000001).
+`TraceOptions` contain details about the trace. Unlike Tracestate values, TraceOptions are present in all traces. Currently, TraceOption includes a boolean `recorded` [flag](https://www.w3.org/TR/trace-context/#recorded-flag-00000001) and the `sampleWeight`, which is the approximate number of potentially unsampled events a recorded span represents.
 
 `Tracestate` carries system-specific configuration data, represented as a list of key-value pairs. TraceState allows multiple tracing systems to participate in the same trace. 
 


### PR DESCRIPTION
See https://www.honeycomb.io/blog/dynamic-sampling-by-example/2/ for info on why this is necessary.

RFC in flight: https://github.com/open-telemetry/rfcs/pull/24

cc @maplebed on our end who also will be interested in this.