### PR TITLE
Resource API: constructors suffice for the Create API

### DIFF
--- a/specification/resources-api.md
+++ b/specification/resources-api.md
@@ -42,7 +42,7 @@ labels"](../semantic-conventions.md) that have prescribed semantic meanings.
 ### Create
 
 Creates a new `Resource` out of the collection of labels. This is a static
-method.
+method. For object-oriented languages, a constructor is also valid.
 
 Required parameter:
 


### PR DESCRIPTION
As many programming languages are object-oriented, a constructor can satisfy
the requirements of a Create function. Calling that out in the spec would
be helpful to clarify.

I spoke to @carlosalberto briefly about this, and he clarified. I figured it would be great to clarify.