### PR TITLE
Generalize span operations

### DIFF
--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -2,7 +2,7 @@
 
 <details>
 <summary>
-Table of Content
+Table of Contents
 </summary>
 
 - [Meter](#meater)

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -2,7 +2,7 @@
 
 <details>
 <summary>
-Table of Content
+Table of Contents
 </summary>
 
 - [Binary Format](#binary-format)

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -2,7 +2,7 @@
 
 <details>
 <summary>
-Table of Content
+Table of Contents
 </summary>
 
 * [Data types](#data-types)

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -88,9 +88,9 @@ way of the `Tracer`.
 
 The `Tracer` is responsible for tracking the currently active `Span`, and
 exposes methods for creating and activating new `Span`s. The `Tracer` is
-configured with `Propagator`s which support transferring context across process
+configured with `Propagator`s which support transferring span context across process
 boundaries, and `Exporter`s and `SpanProcessor`s which control how spans are
-exported to APMs.
+exported to APMs and Z pages.
 
 `Tracer`s are generally expected to be used as singletons. Implementations
 SHOULD provide a single global default `Tracer`.
@@ -142,7 +142,7 @@ When creating a new `Span`, the `Tracer` MUST allow the caller to specify the
 new `Span`'s parent in the form of a `Span` or `SpanContext`. The `Tracer`
 SHOULD create each new `Span` as a child of its active `Span` unless an
 explicit parent is provided or the option to create a span without a parent is
-selected.
+selected, or the current active `Span` is invalid.
 
 The `Tracer` MUST provide a way to update its active `Span`, and MAY provide
 convenience methods to manage a `Span`'s lifetime and the scope in which a

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -109,20 +109,17 @@ Implementations might require the user to specify configuration properties at
 `Tracer` creation time, or rely on external configuration, e.g. in the case of
 the provider pattern.
 
-Tracer provider is an internal class used by the global registry
-(`OpenTelemetry`) to get a tracer instance. The global registry delegates calls
-to the provider every time a tracer instance is requested. This is necessary
-for use-cases when a single instrumentation code runs for multiple deployments.
+##### Runtimes with multiple deployments/applications
 
-The tracer provider is registered to API usually via language-specific
-mechanism, for instance `ServiceLoader` in Java.
+Runtimes that support multiple deployments or applications might need to
+provide a different `Tracer` instance to each deployment. To support this,
 
-##### Runtime with multiple deployments/applications
+the global `Tracer` registry may delegate calls to create new `Tracer`s to a
+separate `Provider` component, and the runtime may include its own `Provider`
+implementation which returns a different `Tracer` for each deployment.
 
-Application runtimes which support multiple deployments/applications might need
-to provide a different tracer instance to each deployment. In this case the
-runtime provides its own implementation of provider which returns a different
-tracer for each deployment.
+`Provider`s are registered with the API via some language-specific mechanism,
+for instance the `ServiceLoader` class in Java.
 
 ### Tracer operations
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -272,7 +272,7 @@ empty by default:
 The `Tracer` MUST allow the caller to specify the new `Span`'s parent in the
 form of a `Span` or `SpanContext`. The `Tracer` SHOULD create each new `Span` as
 a child of its active `Span` unless an explicit parent is provided or the
-option to create a span without a parent is selected.```
+option to create a span without a parent is selected.
 
 The `Tracer` MUST provide a way to update its active `Span`, and MAY provide
 convenience methods to manage a `Span`'s lifetime of and the scope in which a

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -130,10 +130,10 @@ The `Tracer` MUST provide methods to:
 - Set a given `Span` as active
 
 The `Tracer` SHOULD allow end users to configure other tracing components that
-control how spans are serialized and exported:
+control how `Span`s are serialized and exported:
 
-- the binary and text format `Propagator`s used to serialize `Spans` created by the `Tracer`
-- the `SpanProcessor`s and `Exporter`s used to export `Spans` created by the `Tracer`
+- the binary and text format `Propagator`s used to serialize `Span`s created by the `Tracer`
+- the `SpanProcessor`s and `Exporter`s used to export `Span`s created by the `Tracer`
 
 When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.
@@ -146,12 +146,12 @@ selected.
 
 The `Tracer` MUST provide a way to update its active `Span`, and MAY provide
 convenience methods to manage a `Span`'s lifetime and the scope in which a
-`Span` is active. When an active span is finished, the previously-active span
-SHOULD be made active.
+`Span` is active. When an active `Span` is finished, the previously-active
+`Span` SHOULD be made active.
 
-The `Tracer` MUST support recording spans that were created _out of band_, i.e.
-not by the tracer itself. For this reason, implementations MUST NOT require
-that a `Span`'s start and end timestamps match the wall time when it is
+The `Tracer` MUST support recording `Span`s that were created _out of band_,
+i.e.  not by the tracer itself. For this reason, implementations MUST NOT
+require that a `Span`'s start and end timestamps match the wall time when it is
 created, made active, or finished.
 
 The implementation MUST provide no-op binary and text `Propagator`s, which the

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -128,7 +128,7 @@ The `Tracer` MUST provide methods to:
 
 - Get the currently active `Span`
 - Create a new `Span`
-- Set a given `Span` as active
+- Make a given `Span` as active
 
 The `Tracer` SHOULD allow end users to configure other tracing components that
 control how `Span`s are passed across process boundaries and exported:

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -144,8 +144,10 @@ selected, or the current active `Span` is invalid.
 
 The `Tracer` MUST provide a way to update its active `Span`, and MAY provide
 convenience methods to manage a `Span`'s lifetime and the scope in which a
-`Span` is active. When an active `Span` is finished, the previously-active
-`Span` SHOULD be made active.
+`Span` is active. When an active `Span` is made inactive, the previously-active
+`Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end
+time) but stil active. A `Span` may be active on one thread after it has been
+made inactive on another.
 
 The `Tracer` MUST support recording `Span`s that were created _out of band_,
 i.e.  not by the tracer itself. For this reason, implementations MUST NOT

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -89,9 +89,7 @@ way of the `Tracer`.
 The `Tracer` is responsible for tracking the currently active `Span`, and
 exposes methods for creating and activating new `Span`s. The `Tracer` is
 configured with `Propagator`s which support transferring span context across
-process boundaries, `Exporter`s responsible for exporting span data to APMs and
-Z pages, and `SpanProcessor`s which affect how spans are exported and allow end
-users to extend the export pipeline with custom behavior.
+process boundaries.
 
 `Tracer`s are generally expected to be used as singletons. Implementations
 SHOULD provide a single global default `Tracer`.
@@ -131,10 +129,9 @@ The `Tracer` MUST provide methods to:
 - Make a given `Span` as active
 
 The `Tracer` SHOULD allow end users to configure other tracing components that
-control how `Span`s are passed across process boundaries and exported:
-
-- the binary and text format `Propagator`s used to serialize `Span`s created by the `Tracer`
-- the `SpanProcessor`s and `Exporter`s used to export `Span`s created by the `Tracer`
+control how `Span`s are passed across process boundaries, inclucding the binary
+and text format `Propagator`s used to serialize `Span`s created by the
+`Tracer`.
 
 When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -130,7 +130,7 @@ The `Tracer` MUST provide methods to:
 - Set a given `Span` as active
 
 The `Tracer` SHOULD allow end users to configure other tracing components that
-control how `Span`s are serialized and exported:
+control how `Span`s are passed across process boundaries and exported:
 
 - the binary and text format `Propagator`s used to serialize `Span`s created by the `Tracer`
 - the `SpanProcessor`s and `Exporter`s used to export `Span`s created by the `Tracer`

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -88,9 +88,10 @@ way of the `Tracer`.
 
 The `Tracer` is responsible for tracking the currently active `Span`, and
 exposes methods for creating and activating new `Span`s. The `Tracer` is
-configured with `Propagator`s which support transferring span context across process
-boundaries, and `Exporter`s and `SpanProcessor`s which control how spans are
-exported to APMs and Z pages.
+configured with `Propagator`s which support transferring span context across
+process boundaries, `Exporter`s responsible for exporting span data to APMs and
+Z pages, and `SpanProcessor`s which affect how spans are exported and allow end
+users to extend the export pipeline with custom behavior.
 
 `Tracer`s are generally expected to be used as singletons. Implementations
 SHOULD provide a single global default `Tracer`.

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -106,8 +106,8 @@ registry of `Tracer`s for such applications.
 from linked dependencies using the provider pattern.
 
 Implementations might require the user to specify configuration properties at
-`Tracer` creation time, or rely on external configuration, e.g. in the case of
-the provider pattern.
+`Tracer` creation time, or rely on external configuration, e.g. when using the
+provider pattern.
 
 ##### Runtimes with multiple deployments/applications
 


### PR DESCRIPTION
Like #190, this PR removes references to the java implementation and specific method names in favor of a general description of tracing API.

Updates #165.