### PR TITLE
Remove BinaryFormat and HttpTextFormat from Tracer

### DIFF
--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -24,6 +24,10 @@ Propagators API consists of two main formats:
 - `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
 in-band across process boundaries.
 
+Each language SHOULD provide a way to differentiate `SpanContext` and `DistributedContext`
+formats. This can be done with providing two sets of APIs (e.g `TracingPropagator` vs.
+`DistributedContextPropagator`), using generics, etc.
+
 ## Binary Format
 
 `BinaryFormat` is a formatter to serialize and deserialize a value into a binary format.
@@ -54,7 +58,7 @@ Returns a value deserialized from bytes.
 
 ## HTTP Text Format
 
-`HTTPTextFormat` is a formatter that injects and extracts a value as text into carriers that 
+`HTTPTextFormat` is a formatter that injects and extracts a value as text into carriers that
 travel in-band across process boundaries.
 
 Encoding is expected to conform to the HTTP Header Field semantics. Values are often encoded as

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -16,8 +16,6 @@ Table of Content
     * [WithSpan](#withspan)
     * [SpanBuilder](#spanbuilder)
     * [RecordSpanData](#recordspandata)
-    * [GetBinaryFormat](#getbinaryformat)
-    * [GetHttpTextFormat](#gethttptextformat)
 * [SpanContext](#spancontext)
 * [Span](#span)
   * [Span creation](#span-creation)
@@ -165,25 +163,6 @@ Note, the `SpanContext` object in the span population with the values that will
 allow correlation of telemetry is also a caller responsibility.
 
 This API should be non-blocking.
-
-#### GetBinaryFormat
-Returns the binary format interface which can serialize/deserialize `Span`s.
-
-There should be no parameter.
-
-Returns the binary format for this implementation. If no implementation is
-provided then no-op implementation will be used.
-
-#### GetHttpTextFormat
-Returns the HTTP text format interface which can inject/extract `Span`s.
-
-There should be no parameter.
-
-Returns the HTTP text format for this implementation. If no implementation is
-provided then no-op implementation will be used.
-
-Usually this will be the W3C Trace Context as the HTTP text format. For more
-details, see [trace-context](https://github.com/w3c/trace-context).
 
 ## SpanContext
 A `SpanContext` represents the portion of a `Span` which must be serialized and


### PR DESCRIPTION
Fixes #112. Those formats are moved into [Propagators](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-propagators.md).