### PR TITLE
specification/api-distributedcontext: fix typo

### DIFF
--- a/specification/api-distributedcontext.md
+++ b/specification/api-distributedcontext.md
@@ -6,7 +6,7 @@ with a specific operation, such as an HTTP request.
 Each key of `DistributedContext` is associated with exactly one value. `DistributedContext` is serializable,
 to facilitate propagating it not only inside the process but also across process boundaries.
 `DistributedContext` is used to annotate telemetry with the name:value pair `Entry`.
-Those values can be used to add dimension to the metric or additional contest properties to logs and traces.
+Those values can be used to add dimension to the metric or additional context properties to logs and traces.
 
 `DistributedContext` is a recommended name but languages can have more language-specific names like `dctx`.
 


### PR DESCRIPTION
Simple typo in distributed context API: contest -> context