### PR TITLE
Add a note for language library authors

### DIFF
--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -6,6 +6,8 @@ The language libraries are expected to provide full features out of the box and 
 
 The document does not attempt to describe a language library API. For API specs see [specification](../README.md).
 
+_Note to Language Library Authors:_ OpenTelemetry specification, API and SDK implementation guidelines are work in progress. If you notice incomplete or missing information, contradictions, inconsistent styling and other defects please let specification writers know by creating an issue in this repository or posting in [Gitter](https://gitter.im/open-telemetry/opentelemetry-specification). As implementors of the specification you will often have valuable insights into how the specification can be improved. The Specification SIG and members of Technical Committee highly value you opinion and welcome your feedback.
+
 ## Requirements
 
 1. The OpenTelemetry API must be well-defined and clearly decoupled from the implementation. This allows end users to consume API only without also consuming the implementation (see points 2 and 3 for why it is important).


### PR DESCRIPTION
We want to encourage language library authors to give feedback to
specification writers and help improve the specification.

This notice is one of the ways to express this encouragement.