### PR TITLE
Specify the user-facing API for metric instruments

### DIFF
--- a/specification/api-metrics-meter.md
+++ b/specification/api-metrics-meter.md
@@ -1,6 +1,5 @@
 # Metric SDK-facing API
 
-This document is a placeholder pending active discussion.  It will
-eventually contain portions that were removed from
-https://github.com/open-telemetry/opentelemetry-specification/blob/3d2b8ecf410f62172a22a9fbff88304724d4cc78/specification/api-metrics.md
-after further discussion.
+This document will be updated as part of the v0.2 milestone with a
+detailed list of `Meter` API methods.  These methods will match the
+user-facing API specified [here](api-metrics-user.md).

--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -197,10 +197,7 @@ To obtain a handle given an instrument and label set, use the
 `GetHandle()` method to return an interface that supports the `Add()`,
 `Set()`, or `Record()` method of the instrument in question.
 
-Instrument handles may consume SDK resources indefinitely.  Handles
-support a `Delete` method that will allow these resources to be
-reclaimed after all the corresponding metric events have been
-collected.
+Instrument handles may consume SDK resources indefinitely.
 
 ```golang
 func (s *server) processStream(ctx context.Context) {
@@ -217,8 +214,6 @@ func (s *server) processStream(ctx context.Context) {
      // High-performance metric calling convention: use of handles.
      counter2Handle.Add(ctx, item.size())
   }
-
-  counter2Handle.Delete()
 }
 ```
 
@@ -439,9 +434,6 @@ handles for the high-performance calling convention.  The
 `Instrument.GetHandle(LabelSet)` method returns an interface which
 implements the `Add()`, `Set()` or `Record()` method, respectively,
 for counter, gauge, and measure instruments.
-
-Instrument handles support a `Delete` method, allowing users to
-discard handles that are no longer used.
 
 ### Instrument direct calling convention
 

--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -47,12 +47,14 @@ Labels are key:value pairs associated with events describing various
 dimensions or categories that describe the event.  A "label key"
 refers to the key component while "label value" refers to the
 correlated value component of a label.  Label refers to the pair of
-label key and value.
+label key and value.  Labels are passed in to the metric event in the
+form of a `LabelSet` argument, using several input methods discussed
+below.
 
-Metric events always have an associated `component` label, by virtue
-of the named `Meter` used in their definition.  Other labels are
-passed in to the metric event in the form of a `LabelSet` argument,
-using several input methods discussed below.
+Metric events always have an associated component name, the name
+passed when constructing the corresponding `Meter`.  Metric events are
+associated with the current (implicit or explicit) OpenTelemetry
+context, including distributed correlation context and span context.
 
 ### New constructors
 
@@ -63,7 +65,7 @@ either floating point or integer inputs, see the detailed design below.
 
 Binding instruments to a single `Meter` instance has two benefits:
 
-1. Instruments can be exported freom the zero state, prior to first use, with no explicit `Register` call
+1. Instruments can be exported from the zero state, prior to first use, with no explicit `Register` call
 1. The component name provided by the named `Meter` satisfies a namespace requirement
 
 The recommended practice is to define structures to contain the
@@ -74,14 +76,16 @@ We recognize that many existing metric systems support allocating
 metric instruments statically and providing the `Meter` interface at
 the time-of-use.  In this example, typical of statsd clients, existing
 code may not be structured with a convenient place to store new metric
-instruments.  Where this becomes a burden, it may be acceptable to use
-the global `Meter` as a workaround.
+instruments.  Where this becomes a burden, it is recommended to use
+the global meter factory to construct a static named `Meter` in order
+to construct metric instruments.
 
 The situation is similar for users of Prometheus clients, where
 instruments are allocated statically and there is an implicit global.
 Such code may not have access to the appropriate `Meter` where
-instruments are defined.  Where this becomes a burden, it may be
-acceptable to use the global `Meter` as a workaround.
+instruments are defined.  Where this becomes a burden, it is
+recommended to use the global meter factory to construct a static
+named `Meter` in order to construct metric instruments.
 
 #### Metric instrument descriptors
 

--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -415,11 +415,10 @@ that it used, and the metric name is the only required field.
 | Unit         | WithUnit(string) | Units specified according to the [UCUM](http://unitsofmeasure.org/ucum.html). |
 | Recommended label keys | WithRecommendedKeys(list) | Recommended grouping keys for this instrument. |
 | Monotonic   | WithMonotonic(boolean) | Configure a counter or gauge that accepts only monotonic/non-monotonic updates. |
-| Signed    | WithSigned(boolean) | Configure a measure that accepts positive and negative updates. |
+| Absolute    | WithAbsolute(boolean) | Configure a measure that does or does not accept negative updates. |
 
 See the Metric API [specification overview](api-metrics.md) for more
-information about the kind-specific monotonic, non-monotonic, and
-signed options.
+information about the kind-specific monotonic and absolute options.
 
 ### Instrument handle calling convention
 

--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -39,8 +39,8 @@ prefix](https://prometheus.io/docs/practices/naming/#metric-names).
 ### Format of a metric event
 
 Regardless of the instrument kind or method of input, metric events
-include the instrument descriptor, a numerical value, and an optional
-set of labels.  The descriptor, discussed in detail below, contains
+include the instrument, a numerical value, and an optional
+set of labels.  The instrument, discussed in detail below, contains
 the metric name and various optional settings.
 
 Labels are key:value pairs associated with events describing various

--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -89,7 +89,7 @@ named `Meter`, to construct metric instruments.
 
 Applications are expected to construct long-lived instruments.
 Instruments are considered permanent for the lifetime of a SDK, there
-is no method to delete them.  SDKs should 
+is no method to delete them.
 
 ####  Metric instrument constructor example code
 
@@ -232,7 +232,7 @@ becomes a problem, one option is to use handles as described above.
 Another performance option, in some cases, is to just re-use the
 labels.  In the example here, `meter.Labels(...)` constructs a
 re-usable label set which may be an important performance
-optimization, as discussed next.
+optimization.
 
 #### Label set calling convention
 
@@ -286,6 +286,27 @@ When the SDK interprets a `LabelSet` in the context of aggregating
 values for an exporter, and where there are grouping keys that are
 missing, the SDK is required to consider these values _explicitly
 unspecified_, a distinct value type of the exported data model.
+
+##### Option: Convenience method to bypass `meter.Labels(...)`
+
+As a language-optional feature, the direct and handle calling
+convention APIs may support alternate convenience methods to pass raw
+labels at the call site.  These may be offered as overloaded methods
+for `Add()`, `Set()`, and `Record()` (direct calling convention) or
+`GetHandle()` (handle calling convention), in both cases bypassing a
+call to `meter.Labels(...)`.  For example:
+
+```java
+  public void method() {
+    // pass raw labels, no explicit `LabelSet` 
+    s.instruments.counter1.add(1, labelA.value(...), labelB.value(...))
+
+    // ... or
+
+    // pass raw labels, no explicit `LabelSet` 
+    handle := s.instruments.gauge1.getHandle(labelA.value(...), labelB.value(...))
+  }
+```
 
 ##### Option: Ordered LabelSet construction
 
@@ -417,7 +438,7 @@ Counter, gauge, and measure instruments support the appropriate
 `Add()`, `Set()`, and `Record()` method for submitting individual
 metric events.
 
-### Interaction with distrubuted correlation context
+### Interaction with distributed correlation context
 
 The `LabelSet` type introduced above applies strictly to "local"
 labels, meaning provided in a call to `meter.Labels(...)`.  The

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -4,7 +4,7 @@ TODO: Table of contents
 
 ## Overview
 
-The user-facing metrics API supports reporting diagnostic measurements
+The user-facing metrics API supports producing diagnostic measurements
 using three basic kinds of instrument.  "Metrics" are the thing being
 produced--mathematical, statistical summaries of certain observable
 behavior in the program.  "Instruments" are the devices used by the

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -4,7 +4,7 @@ TODO: Table of contents
 
 ## Overview
 
-The user-facing metrics API supports producing diagnostic measurements
+The user-facing metrics API supports reporting diagnostic measurements
 using three basic kinds of instrument.  "Metrics" are the thing being
 produced--mathematical, statistical summaries of certain observable
 behavior in the program.  "Instruments" are the devices used by the


### PR DESCRIPTION
This is rewritten content that was removed from PR#250.  There is only only substantial change here, but it is substantial. This specification now says that instruments are allocated by the `Meter`, meaning they are automatically registered and qualified by the named Meter's component namespace.  This resolves questions about what kind of registry support is needed and how to export metrics that have not been updated.

See the new caveats about instrument storage.  These changes will encourage users not to store instruments in static scope, otherwise they will be forced to use the global Meter to allocate metric instruments. 