### PR TITLE
allow end timestamp be an option to span creation

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -242,12 +242,13 @@ The API SHOULD require the caller to provide:
 - The parent span, and whether the new `Span` should be a root `Span`
 
 The API MUST allow users to provide the following properties, which SHOULD be
-empty by default:
+empty by default, except for `Start timestamp` which defaults to the current time:
 
 - [`SpanKind`](#spankind)
 - `Attribute`s - similar API with [Span::SetAttributes](#set-attributes)
 - `Link`s - see API definition [here](#add-links)
 - `Start timestamp`
+- `End timestamp`
 
 Each span has zero or one parent span and zero or more child spans, which
 represent causally related operations. A tree of related spans comprises a


### PR DESCRIPTION
My understanding was that the intention with removal of SpanData was that when creating a span you must be able to include an end timestamp.

This patch adds that to the api and mentions that unlike the other properties the start timestamp will not be empty by default.