### PR TITLE
add timeout for how long the exporter can run

### DIFF
--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -227,6 +227,8 @@ high contention in a very high traffic service.
   dropped. The default value is `2048`.
 * `scheduledDelayMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
+* `exporterTimeout` - how long the export can run before it is cancelled.
+  The default value is `30000`.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -243,7 +243,7 @@ high contention in a very high traffic service.
   dropped. The default value is `2048`.
 * `scheduledDelayMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
-* `exporterTimeout` - how long the export can run before it is cancelled.
+* `exporterTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.


### PR DESCRIPTION
This adds an option for how long an exporter can run before it is cancelled for taking too long, default of 30 seconds.