### PR TITLE
make maxExportBatchSize an optional part of an implementation

### DIFF
--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -222,11 +222,16 @@ high contention in a very high traffic service.
 
 **Configurable parameters:**
 
+Configurable parameters that MUST be supported:
+
 * `exporter` - the exporter where the spans are pushed.
 * `maxQueueSize` - the maximum queue size. After the size is reached spans are
   dropped. The default value is `2048`.
 * `scheduledDelayMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
+  
+Configurable parameters that MAY be supported:
+
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.
 


### PR DESCRIPTION
Implementations where the batches to be exported are best left where they are after finishing, instead of copying, can not reasonably support a batch size smaller than the `maxQueueSize`, so this change makes it an optional configuration to support..

With the Erlang implementation the exporters are passed a reference to a table that is the queue, up to `maxQueueSize`, to support a `maxExportBatchSize` would require copying from the table to the process heap, doubling the memory usage.