### PR TITLE
Add probability sampler details

### DIFF
--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -130,9 +130,8 @@ According to the [W3C Trace Context
 spec](https://www.w3.org/TR/trace-context/#trace-id), vendor-supplied trace IDs
 may include both random and non-random components. To avoid sampling based on
 the non-random component, the sampler should consider only the leftmost portion
-(i.e. some number of high-order bits) of the trace ID. Implementations MAY
-allow the user to configure the number of bits of the trace ID that the sampler
-considers.
+of the trace ID. Implementations MAY allow the user to configure the number of
+bits of the trace ID that the sampler considers.
 
 The `ProbabilitySampler` should generally only sample traces with trace IDs
 less than a certain value. This value can be computed from the sampling rate,
@@ -151,19 +150,20 @@ Where:
   big-endian byte order
 - `round(float f)`: is a function that rounds `f` to the nearest integer
 
-Note that the effective sampling rate is the number closest to `rate` than can
+Note that the effective sampling rate is the number closest to `rate` that can
 be expressed as a multiple of `2^-precision`. As a consequence, it's not
 possible to set arbitrarily low sampling rates, even on platforms that support
 arbitrary-precision arithmetic.
 
 A `ProbabilitySampler` with rate `0.0` MUST NOT choose to sample any traces,
-even if the leftmost precision-many bits of trace ID are all `0`. Similarly, a
-`ProbabilitySampler` with rate `1.0` MUST choose to sample all traces, even if
-the leftmost precision-many bits of trace ID trace ID are all `1`.
+even if the leftmost precision-many bits of the trace ID are all `0`.
+Similarly, a `ProbabilitySampler` with rate `1.0` MUST choose to sample all
+traces, even if the leftmost precision-many bits of the trace ID trace ID are
+all `1`.
 
 **Example:**
 
-Consider a ProbabilitySampler with rate `.25` and 16 bit precision.
+Consider a `ProbabilitySampler` with rate `.25` and 16 bit precision.
 
 First, find the lowest truncated trace ID that will not be sampled. This number
 represents the 25th percentile of the range of possible values:

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -140,7 +140,7 @@ and implementations may choose to cache it. The sampling decision should follow
 the formula:
 
 ```
-to_sample = traceID >> (128 - precision) < round(rate * 2^precision)
+to_sample = traceID >> (128 - precision) < round(rate * pow(2, precision))
 ```
 
 Where:

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -157,9 +157,9 @@ possible to set arbitrarily low sampling rates, even on platforms that support
 arbitrary-precision arithmetic.
 
 A `ProbabilitySampler` with rate `0.0` MUST NOT choose to sample any traces,
-even those with trace ID `0x0`. Similarly, a `ProbabilitySampler` with rate
-`1.0` MUST choose to sample all traces, even those with trace ID `2^precision -
-1`.
+even if the leftmost precision-many bits of trace ID are all `0`. Similarly, a
+`ProbabilitySampler` with rate `1.0` MUST choose to sample all traces, even if
+the leftmost precision-many bits of trace ID trace ID are all `1`.
 
 **Example:**
 


### PR DESCRIPTION
This PR adds details on the `ProbabilitySampler` sampling algorithm, following the implementation in https://github.com/open-telemetry/opentelemetry-python/pull/225.

One big change in this PR is that it recommends making the sampling decision based on the *left*most bytes of the trace ID, which should be random according to https://www.w3.org/TR/trace-context/#trace-id. All OT and OC clients use the rightmost bytes now, see e.g. the [java implementation](https://github.com/c24t/opentelemetry-java/blob/39a0664dbf8bda82c3fe05176b3a87526df2786b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java#L136-L142).

It also doesn't specify the number of bytes the sampler should consider, even though leaving this up to the implementation would mean getting different sampling decisions for the same trace ID in different clients. After chatting with @bogdandrutu, it sounds like the spec should prescribe this number. This is difficult since the java client currently uses **63** bits so it can [store an internal upper bound as a `Long`](https://github.com/c24t/opentelemetry-java/blob/39a0664dbf8bda82c3fe05176b3a87526df2786b/sdk/src/main/java/io/opentelemetry/sdk/trace/Samplers.java#L159-L163), which seems like an insane thing to require other languages to do.

This PR only affects the description of the sampling algorithm, but there's more work to do elsewhere in the doc to fully describe the `ProbabilitySampler`.