### PR TITLE
SDK tracing: clarify multi-processors scenarios

### DIFF
--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -161,6 +161,20 @@ Manipulation of the span processors collection must only happen on `TracerFactor
 instances. This means methods like `addSpanProcessor` must be implemented on
 `TracerFactory`.
 
+Each processor registered on `TracerFactory` is a start of the processing pipeline 
+that consist of other processors and exporters. Processors (or exporters) may implement 
+tagging, batching, filtering and other advanced scenarios. 
+
+SDK MUST allow to end each pipeline with individual exporter and do filtering
+or batching independently on each pipeline.      
+
+SDK MUST allow implementing helpers as composable components that use the same
+  chainable `SpanProcessor` interface. 
+
+SDK authors are encouraged to implement common functionality such as queuing, 
+batching, tagging, etc. as helpers. This functionality will be applicable 
+regardless of what protocol exporter is used.
+
 The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:
 
@@ -260,10 +274,8 @@ The goals of the interface are:
   The protocol exporter is expected to be primarily a simple telemetry data
   encoder and transmitter.
 * Allow implementing helpers as composable components that use the same
-  chainable `Exporter` interface. SDK authors are encouraged to implement common
-  functionality such as queuing, batching, tagging, etc. as helpers. This
-  functionality will be applicable regardless of what protocol exporter is used.
-
+  chainable `Exporter` interface. 
+  
 #### Interface Definition
 
 The exporter must support two functions: **Export** and **Shutdown**. In

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -167,7 +167,7 @@ of span processor and optional exporter. SDK MUST allow to end each pipeline wit
 individual exporter.
 
 SDK MUST allow users to implement and configure custom processors and decorate
-built-in processors for advanced scenarios such as tagging or filtering.
+built-in processors for advanced scenarios such as tagging or filtering. 
 
 The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:
@@ -224,6 +224,10 @@ Shutdown should not block indefinitely. Language library authors can decide if
 they want to make the shutdown timeout to be configurable.
 
 #### Built-in span processors
+
+SDK MUST implement simple and batch processors described below. Other common
+processing scenarios should be first considered for implementation out-of-process
+in [OpenTelemetry Collector](overview.md#collector)
 
 ##### Simple processor
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -167,7 +167,7 @@ of span processor and optional exporter. SDK MUST allow to end each pipeline wit
 individual exporter.
 
 SDK MUST allow users to implement and configure custom processors and decorate
-built-in processors for advanced scenarios such as tagging or filtering. 
+built-in processors for advanced scenarios such as tagging or filtering.
 
 The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -166,7 +166,7 @@ that consist of other processors and exporters. Processors (or exporters) may im
 tagging, batching, filtering and other advanced scenarios.
 
 SDK MUST allow to end each pipeline with individual exporter and do filtering
-or batching independently on each pipeline.     
+or batching independently on each pipeline.
 
 SDK MUST allow implementing helpers as composable components that use the same
 chainable `SpanProcessor` interface.
@@ -274,8 +274,8 @@ The goals of the interface are:
   The protocol exporter is expected to be primarily a simple telemetry data
   encoder and transmitter.
 * Allow implementing helpers as composable components that use the same
-  chainable `Exporter` interface. 
-  
+  chainable `Exporter` interface.
+
 #### Interface Definition
 
 The exporter must support two functions: **Export** and **Shutdown**. In

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -179,18 +179,18 @@ The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:
 
 ```
-  +-----+------------+   +---------------------+   +-------------------+
-  |     |            |   |                     |   |                   |
-  |     |            |   | BatchProcessor      |   |    SpanExporter   |
-  |     |            +---> SimpleProcessor     +--->  (JaegerExporter) |
-  | SDK | Span.end() |   |                     |   |                   |
-  |     |            |   +---------------------+   +-------------------+
-  |     |            |
-  |     |            |   +---------------------+
-  |     |            |   |                     |
-  |     |            +---> ZPagesProcessor     |
-  |     |            |   |                     |
-  +-----+------------+   +---------------------+
+  +-----+----------------+   +---------------------+   +-------------------+
+  |     |                |   |                     |   |                   |
+  |     |                |   | BatchProcessor      |   |    SpanExporter   |
+  |     | Span.start() leProcessor     +--->  (JaegerExporter) |
+  | SDK | Span.end()   |   |                     |   |                   |
+  |     |              |   +---------------------+   +-------------------+
+  |     |              |
+  |     |              |   +---------------------+
+  |     |              |   |                     |
+  |     |              +---> ZPagesProcessor     |
+  |     |              |   |                     |
+  +-----+--------------+   +---------------------+
 ```
 
 Another example demonstrates more complicated configuration where spans sent
@@ -199,18 +199,18 @@ spans. Since span instances are shared between processors so any tagging done by
 affects all futher processsors/exporters from all pipelines.
 
 ```
-  +-----+------------+   +--------------+   +-----------------+   +----------------+   +-------------------+
-  |     |            |   |              |   |                 |   |                |   |                   |
-  |     |            |   |              |   |                 |   |                |   |    SpanExporter   |
-  |     |            +---> TagProcessor +---> FilterProcessor +---> BatchProcessor +--->  (JaegerExporter) |
-  | SDK | Span.end() |   |              |   |                 |   |                |   |                   |
-  |     |            |   +--------------+   +-----------------+   +----------------+   +-------------------+
-  |     |            |
-  |     |            |   +-----------------+
-  |     |            |   |                 |
-  |     |            +---> ZPagesProcessor |
-  |     |            |   |                 |
-  +-----+------------+   +-----------------+
+  +-----+--------------+   +--------------+   +-----------------+   +----------------+   +-------------------+
+  |     |              |   |              |   |                 |   |                |   |                   |
+  |     |              |   |              |   |                 |   |                |   |    SpanExporter   |
+  |     | Span.start() +---> TagProcessor +---> FilterProcessor +---> BatchProcessor +--->  (JaegerExporter) |
+  | SDK | Span.end()   |   |              |   |                 |   |                |   |                   |
+  |     |              |   +--------------+   +-----------------+   +----------------+   +-------------------+
+  |     |              |
+  |     |              |   +-----------------+
+  |     |              |   |                 |
+  |     |              +---> ZPagesProcessor |
+  |     |              |   |                 |
+  +-----+--------------+   +-----------------+
 ```
 
 #### Interface definition
@@ -223,7 +223,7 @@ exceptions.
 
 **Parameters:**
 
-* `Span` - a readable span object.
+* `Span` - a readable   span object    .       -- 
 
 **Returns:** `Void`
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -161,18 +161,18 @@ Manipulation of the span processors collection must only happen on `TracerFactor
 instances. This means methods like `addSpanProcessor` must be implemented on
 `TracerFactory`.
 
-Each processor registered on `TracerFactory` is a start of the processing pipeline 
-that consist of other processors and exporters. Processors (or exporters) may implement 
-tagging, batching, filtering and other advanced scenarios. 
+Each processor registered on `TracerFactory` is a start of the processing pipeline
+that consist of other processors and exporters. Processors (or exporters) may implement
+tagging, batching, filtering and other advanced scenarios.
 
 SDK MUST allow to end each pipeline with individual exporter and do filtering
-or batching independently on each pipeline.      
+or batching independently on each pipeline.     
 
 SDK MUST allow implementing helpers as composable components that use the same
-  chainable `SpanProcessor` interface. 
+chainable `SpanProcessor` interface.
 
-SDK authors are encouraged to implement common functionality such as queuing, 
-batching, tagging, etc. as helpers. This functionality will be applicable 
+SDK authors are encouraged to implement common functionality such as queuing,
+batching, tagging, etc. as helpers. This functionality will be applicable
 regardless of what protocol exporter is used.
 
 The following diagram shows `SpanProcessor`'s relationship to other components

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -223,7 +223,7 @@ exceptions.
 
 **Parameters:**
 
-* `Span` - a readable span object
+* `Span` - a readable span object.
 
 **Returns:** `Void`
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -211,6 +211,7 @@ affects all futher processsors/exporters from all pipelines.
   |     |            +---> ZPagesProcessor |
   |     |            |   |                 |
   +-----+------------+   +-----------------+
+```
 
 #### Interface definition
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -223,7 +223,7 @@ exceptions.
 
 **Parameters:**
 
-* `Span` - a readable   span object    .       -- 
+* `Span` - a readable span object
 
 **Returns:** `Void`
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -173,12 +173,12 @@ The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:
 
 ```
-  +-----+--------------+   +---------------------+   +-------------------+
-  |     |              |   |                     |   |                   |
-  |     |              |   | BatchProcessor      |   |    SpanExporter   |
-  |     |              +---> SimpleProcessor     +--->  (JaegerExporter) |
-  |     |              |   |                     |   |                   |
-  | SDK | Span.start() |   +---------------------+   +-------------------+
+  +-----+--------------+   +-------------------------+   +-------------------+
+  |     |              |   |                         |   |                   |
+  |     |              |   | BatchExporterProcessor  |   |    SpanExporter   |
+  |     |              +---> SimpleExporterProcessor +--->  (JaegerExporter) |
+  |     |              |   |                         |   |                   |
+  | SDK | Span.start() |   +-------------------------+   +-------------------+
   |     | Span.end()   |
   |     |              |   +---------------------+
   |     |              |   |                     |


### PR DESCRIPTION
Fixes #316

Clarifies that multiple processors registered on TracerFactory allow multiple exporters (i.e. not chainable) but chaining could be done on additionally.

Now spec recommends chaining on exporters, check out #316 for reasons why processors are better suited for it.