### PR TITLE
Use uniform terminology for Span and Resource attributes

### DIFF
--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -1,6 +1,6 @@
 # Resource Conventions
 
-This document defines standard labels for resources. These labels are typically used in the [Resource](sdk-resource.md) and are also recommended to be used anywhere else where there is a need to describe a resource in a consistent manner. The majority of these labels are inherited from
+This document defines standard attributes for resources. These attributes are typically used in the [Resource](sdk-resource.md) and are also recommended to be used anywhere else where there is a need to describe a resource in a consistent manner. The majority of these attributes are inherited from
 [OpenCensus Resource standard](https://github.com/census-instrumentation/opencensus-specs/blob/master/resource/StandardResources.md).
 
 * [Service](#service)
@@ -19,14 +19,14 @@ This document defines standard labels for resources. These labels are typically 
 * Add more compute units: Process, Lambda Function, AppEngine unit, etc.
 * Add Device (mobile) and Web Browser.
 * Decide if lower case strings only.
-* Consider to add optional/required for each label and combination of labels
+* Consider to add optional/required for each attribute and combination of attributes
   (e.g when supplying a k8s resource all k8s may be required).
 
 ### Document Conventions
 
-Labels are grouped logically by the type of the concept that they described. Labels in the same group have a common prefix that ends with a dot. For example all labels that describe Kubernetes properties start with "k8s."
+Attributes are grouped logically by the type of the concept that they described. Attributes in the same group have a common prefix that ends with a dot. For example all attributes that describe Kubernetes properties start with "k8s."
 
-Certain label groups in this document have a **Required** column. For these groups if any label from the particular group is present in the Resource then all labels that are marked as Required MUST be also present in the Resource. However it is also valid if the entire label group is omitted (i.e. none of the labels from the particular group are present even though some of them are marked as Required in this document).
+Certain attribute groups in this document have a **Required** column. For these groups if any attribute from the particular group is present in the Resource then all attributes that are marked as Required MUST be also present in the Resource. However it is also valid if the entire attribute group is omitted (i.e. none of the attributes from the particular group are present even though some of them are marked as Required in this document).
 
 ## Service
 
@@ -34,29 +34,29 @@ Certain label groups in this document have a **Required** column. For these grou
 
 **Description:** A service instance.
 
-| Label  | Description  | Example  | Required? |
+| Attribute  | Description  | Example  | Required? |
 |---|---|---|---|
 | service.name | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. | `shoppingcart` | Yes |
 | service.namespace | A namespace for `service.name`.<br/>A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. The field is optional. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace. | `Shop` | No |
-| service.instance.id | The string ID of the service instance. <br/>MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this label it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations). | `627cc493-f310-47de-96bd-71410b7dec09` | Yes |
+| service.instance.id | The string ID of the service instance. <br/>MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations). | `627cc493-f310-47de-96bd-71410b7dec09` | Yes |
 
-Note: `service.namespace` and `service.name` are not intended to be concatenated for the purpose of forming a single globally unique name for the service. For example the following 2 sets of labels actually describe 2 different services (despite the fact that the concatenation would result in the same string):
+Note: `service.namespace` and `service.name` are not intended to be concatenated for the purpose of forming a single globally unique name for the service. For example the following 2 sets of attributes actually describe 2 different services (despite the fact that the concatenation would result in the same string):
 
 ```
-# Resource labels that describes a service.
+# Resource attributes that describes a service.
 namespace = Company.Shop
 service.name = shoppingcart
 ```
 
 ```
-# Another set of resource labels that describe a different service.
+# Another set of resource attributes that describe a different service.
 namespace = Company
 service.name = Shop.shoppingcart
 ```
 
 ## Compute Unit
 
-Labels defining a compute unit (e.g. Container, Process, Lambda Function).
+Attributes defining a compute unit (e.g. Container, Process, Lambda Function).
 
 ### Container
 
@@ -64,7 +64,7 @@ Labels defining a compute unit (e.g. Container, Process, Lambda Function).
 
 **Description:** A container instance.
 
-| Label  | Description  | Example  |
+| Attribute  | Description  | Example  |
 |---|---|---|
 | container.name | Container name. | `opentelemetry-autoconf` |
 | container.image.name | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` |
@@ -72,7 +72,7 @@ Labels defining a compute unit (e.g. Container, Process, Lambda Function).
 
 ## Deployment Service
 
-Labels defining a deployment service (e.g. Kubernetes).
+Attributes defining a deployment service (e.g. Kubernetes).
 
 ### Kubernetes
 
@@ -80,7 +80,7 @@ Labels defining a deployment service (e.g. Kubernetes).
 
 **Description:** A Kubernetes resource.
 
-| Label  | Description  | Example  |
+| Attribute  | Description  | Example  |
 |---|---|---|
 | k8s.cluster.name | The name of the cluster that the pod is running in. | `opentelemetry-cluster` |
 | k8s.namespace.name | The name of the namespace that the pod is running in. | `default` |
@@ -89,7 +89,7 @@ Labels defining a deployment service (e.g. Kubernetes).
 
 ## Compute Instance
 
-Labels defining a computing instance (e.g. host).
+Attributes defining a computing instance (e.g. host).
 
 ### Host
 
@@ -97,7 +97,7 @@ Labels defining a computing instance (e.g. host).
 
 **Description:** A host is defined as a general computing instance.
 
-| Label  | Description  | Example  |
+| Attribute  | Description  | Example  |
 |---|---|---|
 | host.hostname | Hostname of the host.<br/> It contains what the `hostname` command returns on the host machine. | `opentelemetry-test` |
 | host.id | Unique host id.<br/> For Cloud this must be the instance_id assigned by the cloud provider | `opentelemetry-test` |
@@ -106,7 +106,7 @@ Labels defining a computing instance (e.g. host).
 
 ## Environment
 
-Labels defining a running environment (e.g. Cloud, Data Center).
+Attributes defining a running environment (e.g. Cloud, Data Center).
 
 ### Cloud
 
@@ -114,7 +114,7 @@ Labels defining a running environment (e.g. Cloud, Data Center).
 
 **Description:** A cloud infrastructure (e.g. GCP, Azure, AWS).
 
-| Label  | Description  | Example  |
+| Attribute  | Description  | Example  |
 |---|---|---|
 | cloud.provider | Name of the cloud provider.<br/> Example values are aws, azure, gcp. | `gcp` |
 | cloud.account.id | The cloud account id used to identify different entities. | `opentelemetry` |

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -1,6 +1,6 @@
 # Semantic Conventions
 
-These documents define standard names and values of Resource labels and
+These documents define standard names and values of Resource attributes and
 Span attributes.
 
 * [Resource Conventions](data-resource-semantic-conventions.md)

--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -24,12 +24,12 @@ The API interface must support two ways to instantiate new resources. Those are:
 ### Create
 
 The interface MUST provide a way to create a new resource, from a collection of
-labels. Examples include a factory method or a constructor for a resource
+attributes. Examples include a factory method or a constructor for a resource
 object. A factory method is recommended to enable support for cached objects.
 
 Required parameters:
 
-- a collection of name/value labels, where name is a string and value can be one
+- a collection of name/value attributes, where name is a string and value can be one
   of: string, int64, double, bool.
 
 ### Merge
@@ -38,19 +38,19 @@ The interface MUST provide a way for a primary resource to merge with a
 secondary resource, resulting in the creation of a brand new resource. The
 original resources should be unmodified.
 
-This is utilized for merging of resources whose labels come from different
+This is utilized for merging of resources whose attributes come from different
 sources, such as environment variables, or metadata extracted from the host or
 container.
 
-Already set labels MUST NOT be overwritten unless they are the empty string.
+Already set attributes MUST NOT be overwritten unless they are the empty string.
 
-Label key namespacing SHOULD be used to prevent collisions across different
+Attribute key namespacing SHOULD be used to prevent collisions across different
 resource detection steps.
 
 Required parameters:
 
-- the primary resource whose labels takes precedence.
-- the secondary resource whose labels will be merged.
+- the primary resource whose attributes takes precedence.
+- the secondary resource whose attributes will be merged.
 
 ### The empty resource
 
@@ -58,21 +58,21 @@ It is recommended, but not required, to provide a way to quickly create an empty
 resource.
 
 Note that the OpenTelemetry project documents certain ["standard
-labels"](data-semantic-conventions.md) that have prescribed semantic meanings.
+attributes"](data-semantic-conventions.md) that have prescribed semantic meanings.
 
 ## Resource operations
 
 In addition to resource creation, the following operations should be provided:
 
-### Retrieve labels
+### Retrieve attributes
 
-The API should provide a way to retrieve a read only collection of labels
-associated with a resource. The labels should consist of the name and values,
+The API should provide a way to retrieve a read only collection of attributes
+associated with a resource. The attributes should consist of the name and values,
 both of which should be strings.
 
-There is no need to guarantee the order of the labels.
+There is no need to guarantee the order of the attributes.
 
-The most common operation when retrieving labels is to enumerate over them. As
+The most common operation when retrieving attributes is to enumerate over them. As
 such, it is recommended to optimize the resulting collection for fast
 enumeration over other considerations such as a way to quickly retrieve a value
-for a label with a specific key.
+for a attribute with a specific key.


### PR DESCRIPTION
We use the term "attribute" to describe arbitrary key/value pairs that can be added
to Span, while for a similar concept of key/values pairs on Resource we previously
used the term "label".

This commit makes the terminology uniform and uses the term "attribute" universally.

A separate question is whether we want to also support Resource "attributes" to
support all data types that Span "attributes" allow (currently only string "labels"
are allowed for Resource).

This fixes issue https://github.com/open-telemetry/opentelemetry-specification/issues/342