### PR TITLE
Clarify case sensitivity in propagator spec.

### DIFF
--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -141,7 +141,6 @@ Getter is an argument in `Extract` that get value from given field
 
 `Getter` MUST be stateless and allowed to be saved as a constant to avoid runtime allocations. One of the ways to implement it is `Getter` class with `Get` method as described below.
 
-
 ##### Get
 
 The Get function MUST return the first value of the given propagation key or return null if the key doesn't exist.

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -116,6 +116,8 @@ Required arguments:
 - the key of the field.
 - the value of the field.
 
+The implemenation SHOULD preserve casing (e.g. it should not transform `Content-Type` to `content-type`) if the used protocol is case insensitive, otherwise it MUST preserve casing.
+
 ### Extract
 
 Extracts the value from upstream. For example, as http headers.
@@ -139,13 +141,11 @@ Getter is an argument in `Extract` that get value from given field
 
 `Getter` MUST be stateless and allowed to be saved as a constant to avoid runtime allocations. One of the ways to implement it is `Getter` class with `Get` method as described below.
 
-##### Get
-
-Returns the first value of the given propagation key or returns null if the key doesn't exist.
+It MUST return the first value of the given propagation key or return null if the key doesn't exist.
 
 Required arguments:
 
-- the carrier of propagation fields, such as an http request.
+- the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-Returns the first value of the given propagation key or returns null if the key doesn't exist.
+The user of the extract API is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text format implemenations MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -141,11 +141,14 @@ Getter is an argument in `Extract` that get value from given field
 
 `Getter` MUST be stateless and allowed to be saved as a constant to avoid runtime allocations. One of the ways to implement it is `Getter` class with `Get` method as described below.
 
-It MUST return the first value of the given propagation key or return null if the key doesn't exist.
+
+##### Get
+
+The Get function MUST return the first value of the given propagation key or return null if the key doesn't exist.
 
 Required arguments:
 
 - the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-The user of the extract API is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text format implemenations MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
+The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text format implemenations MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).


### PR DESCRIPTION
Raising https://github.com/open-telemetry/opentelemetry-python/issues/214 to the spec: The [specification for extract](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-propagators.md#extract) should mention how to deal with case sensitivity.