### PR TITLE
Restore missing Link details

### DIFF
--- a/specification/concurrency.md
+++ b/specification/concurrency.md
@@ -18,4 +18,4 @@ SpanBuilder is used by more than one thread/coroutine.
 
 **Span** - All methods of Span are safe to be called concurrently.
 
-**Link** - same as SpanData.
+**Link** - Link is immutable and is safe to be used concurrently.


### PR DESCRIPTION
This info was removed here: https://github.com/open-telemetry/opentelemetry-specification/pull/215/commits/055aedce2b9b94202190090f9cc95d13a5214106#diff-ee16351a427ae7ec4c060edb16018b9fL21