### PR TITLE
Add general semantic conventions for networking.

### DIFF
--- a/specification/data-database.md
+++ b/specification/data-database.md
@@ -18,15 +18,8 @@ attribute names.
 | `db.instance`  | Database instance name. E.g., In java, if the jdbc.url=`"jdbc:mysql://db.example.com:3306/customers"`, the instance name is `"customers"`. | Yes       |
 | `db.statement` | A database statement for the given database type. Note, that the value may be sanitized to exclude sensitive information. E.g., for `db.type="sql"`, `"SELECT * FROM wuser_table"`; for `db.type="redis"`, `"SET mykey 'WuValue'"`. | Yes       |
 | `db.user`      | Username for accessing database. E.g., `"readonly_user"` or `"reporting_user"` | No        |
+| `db.url`       | JDBC substring like `"mysql://db.example.com:3306"`          | Yes      |
 
-For database client calls, peer information can be populated and interpreted as
-follows:
+Additionally at least one of `net.peer.name` or `net.peer.ip` from the [network attributes][] is required and `net.peer.port` is recommended.
 
-| Attribute name  | Notes and examples                                           | Required |
-| :-------------- | :----------------------------------------------------------- | -------- |
-| `peer.address`  | JDBC substring like `"mysql://db.example.com:3306"`          | Yes      |
-| `peer.hostname` | Remote hostname. `"db.example.com"`                          | Yes      |
-| `peer.ipv4`     | Remote IPv4 address as a `.`-separated tuple. E.g., `"127.0.0.1"` | No       |
-| `peer.ipv6`     | Remote IPv6 address as a string of colon-separated 4-char hex tuples. E.g., `"2001:0db8:85a3:0000:0000:8a2e:0370:7334"` | No       |
-| `peer.port`     | Remote port. E.g., `80` (integer)                            | No       |
-| `peer.service`  | Remote service name. Can be database friendly name or `"db.instance"` | No       |
+[network attributes]: data-span-general.md#general-network-connection-attributes

--- a/specification/data-http.md
+++ b/specification/data-http.md
@@ -71,8 +71,9 @@ Note that the items marked with [1] are different from the mapping defined in th
 | `http.status_text` | [HTTP reason phrase][]. E.g. `"OK"` | No |
 | `http.flavor` | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |  No |
 
-It is recommended to also use the `peer.*` attributes, especially `peer.ip*`.
+It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
+[network attributes]: data-span-general.md#general-network-connection-attributes
 [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
 [HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
 
@@ -172,11 +173,9 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |
-| `http.server_name` | The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `host.name` should be used instead). | [1] |
-| `host.name` | Analogous to `peer.hostname` but for the host instead of the peer. | [1] |
-| `host.port` | Local port. E.g., `80` (integer). Analogous to `peer.port`. | [1] |
+| `http.server_name` | The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead). | [1] |
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
-| `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `peer.ip*`, which would identify the network-level peer, which may be a proxy. | No |
+| `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
 
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
@@ -187,8 +186,8 @@ It is thus preferred to supply the raw data that *is* available.
 Namely, one of the following sets is required (in order of usual preference unless for a particular web server/framework it is known that some other set is preferable for some reason; all strings must be non-empty):
 
 * `http.scheme`, `http.host`, `http.target`
-* `http.scheme`, `http.server_name`, `host.port`, `http.target`
-* `http.scheme`, `host.name`, `host.port`, `http.target`
+* `http.scheme`, `http.server_name`, `net.host.port`, `http.target`
+* `http.scheme`, `net.host.name`, `net.host.port`, `http.target`
 * `http.url`
 
 Of course, more than the required attributes can be supplied, but this is recommended only if they cannot be inferred from the sent ones.
@@ -232,7 +231,7 @@ Span name: `/webshop/articles/:article_id`.
 | `http.status_code` | `200`                                           |
 | `http.status_text` | `"OK"`                                          |
 | `http.client_ip`   | `"192.0.2.4"`                                   |
-| `peer.ip4`         | `"192.0.2.5"` (the client goes through a proxy) |
+| `net.peer.ip`      | `"192.0.2.5"` (the client goes through a proxy) |
 
 Note that following the recommendations above, `http.url` is not set in the above example.
 If set, it would be

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -33,9 +33,12 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 | Attribute name | Notes and examples                                           | Required? |
 | -------------- | ------------------------------------------------------------ | --------- |
 | `component`    | Declares that this is a grpc component. Value MUST be `"grpc"` | Yes       |
+| `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
 
-`peer.*` attributes MUST define service name as `peer.service`, host as
-`peer.hostname` and port as `peer.port`.
+Additionally, the `net.peer.name` and `net.peer.port` [network attributes][] are required.
+
+[network attributes]: data-span-general.md#general-network-connection-attributes
+
 
 ### Status
 

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -39,7 +39,6 @@ Additionally, the `net.peer.name` and `net.peer.port` [network attributes][] are
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 
-
 ### Status
 
 Implementations MUST set status which MUST be the same as the gRPC client/server

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -24,3 +24,4 @@ The following semantic conventions for spans are defined:
 * [HTTP](data-http.md): Spans for HTTP client and server.
 * [Database](data-database.md): Spans for SQL and NoSQL client calls.
 * [RPC/RMI](data-rpc.md): Spans for remote procedure calls (e.g., gRPC).
+* [General](data-span-general.md): General semantic attributes that may be used in describing different kinds of operations.

--- a/specification/data-span-general.md
+++ b/specification/data-span-general.md
@@ -29,7 +29,7 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | `net.peer.name` | Remote hostname or similar, see note below.                                        |
 | `net.host.ip`   | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.         |
 | `net.host.port` | Like `net.peer.port` but for the host port.                                        |
-| `net.host.name` | Like `net.peer.name` but for the host name. If known, the name that the peer used to refer to the host should be preferred. For IP-based communication, an value otbained via an API like POSIX `gethostname` may be used as fallback. |
+| `net.host.name` | Like `net.peer.name` but for the host name. If known, the name that the peer used to refer to the host should be preferred. For IP-based communication, an value obtained via an API like POSIX `gethostname` may be used as fallback. |
 
 [RFC5952]: https://tools.ietf.org/html/rfc5952
 

--- a/specification/data-span-general.md
+++ b/specification/data-span-general.md
@@ -1,0 +1,47 @@
+# General attributes
+
+The attributes described in this section are not specific to a particular operation but rather generic.
+They may be used in any Span they apply to.
+Particular operations may refer to or require some of these attributes.
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [General network connection attributes](#general-network-connection-attributes)
+
+<!-- tocstop -->
+
+## General network connection attributes
+
+These attributes may be used for any network related operation.
+
+|  Attribute name  |                                 Notes and examples                                |
+| :--------------- | :-------------------------------------------------------------------------------- |
+| `net.transport` | Transport protocol used. See note below.                                           |
+| `net.peer.ip`   | Remote address of the peer (dotted decimal for IPv4 or [RFC5952][] for IPv6)       |
+| `net.peer.port` | Remote port number as an integer. E.g., `80`.                                      |
+| `net.peer.name` | Remote hostname or similar, see note below.                                        |
+| `net.host.ip`   | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.         |
+| `net.host.port` | Like `net.peer.port` but for the host port.                                        |
+| `net.host.name` | Like `net.peer.name` but for the host name. If known, the name that the peer used to connect should be preferred. For IP-based communication, an value otbained via an API like POSIX `gethostname` may be used as fallback. |
+
+[RFC5952]: https://tools.ietf.org/html/rfc5952
+
+**net.transport**: The name of the transport layer protocol (or the relevant protocol below the "application protocol"). Should be one of these strings:
+
+* `IP.TCP`
+* `IP.UDP`
+* `IP`: Another IP-based protocol.
+* `Unix`: Unix Domain socket.
+* `pipe`: Named or anonymous pipe.
+* `inproc`: Signals that there is only in-process communication not using a "real" network protocol in cases where network attributes would normally be expected. Usually all other network attributes can be left out in that case.
+* `other`: Something else (not IP-based).
+
+**net.peer.name**, **net.host.name**:
+For IP-based communication, the name should be the host name that was used to look up the IP adress in `peer.ip`
+(e.g., `"example.com"` if connecting to an URL `https://example.com/foo`).
+If that is not available, reverse-lookup of the IP can be used to obtain it.
+If `net.transport` is `"unix"` or `"pipe"`, the absolute path to the file representing it should be used.
+If there is no such file (e.g., anonymous pipe),
+the name should explicitly be set to the empty string to distinguish it from the case where the name is just unknown or not covered by the instrumentation.

--- a/specification/data-span-general.md
+++ b/specification/data-span-general.md
@@ -23,30 +23,45 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 
 |  Attribute name  |                                 Notes and examples                                |
 | :--------------- | :-------------------------------------------------------------------------------- |
-| `net.transport` | Transport protocol used. See note below.                                           |
+| `net.transport` | Transport protocol used. See [note below](#net.transport).                         |
 | `net.peer.ip`   | Remote address of the peer (dotted decimal for IPv4 or [RFC5952][] for IPv6)       |
 | `net.peer.port` | Remote port number as an integer. E.g., `80`.                                      |
-| `net.peer.name` | Remote hostname or similar, see note below.                                        |
+| `net.peer.name` | Remote hostname or similar, see [note below](#net.name).                           |
 | `net.host.ip`   | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.         |
 | `net.host.port` | Like `net.peer.port` but for the host port.                                        |
-| `net.host.name` | Like `net.peer.name` but for the host name. If known, the name that the peer used to refer to the host should be preferred. For IP-based communication, an value obtained via an API like POSIX `gethostname` may be used as fallback. |
+| `net.host.name` | Local hostname or similar, see [note below](#net.name).                            |
 
 [RFC5952]: https://tools.ietf.org/html/rfc5952
 
-**net.transport**: The name of the transport layer protocol (or the relevant protocol below the "application protocol"). Should be one of these strings:
+<a name="net.transport"></a>
+
+### `net.transport` attribute
+
+This attribute should be set to the name of the transport layer protocol (or the relevant protocol below the "application protocol"). One of these strings should be used:
 
 * `IP.TCP`
 * `IP.UDP`
 * `IP`: Another IP-based protocol.
-* `Unix`: Unix Domain socket.
-* `pipe`: Named or anonymous pipe.
+* `Unix`: Unix Domain socket. See note below.
+* `pipe`: Named or anonymous pipe. See note below.
 * `inproc`: Signals that there is only in-process communication not using a "real" network protocol in cases where network attributes would normally be expected. Usually all other network attributes can be left out in that case.
 * `other`: Something else (not IP-based).
 
-**net.peer.name**, **net.host.name**:
-For IP-based communication, the name should be the host name that was used to look up the IP adress in `peer.ip`
-(e.g., `"example.com"` if connecting to an URL `https://example.com/foo`).
-If that is not available, reverse-lookup of the IP can be used to obtain it.
-If `net.transport` is `"unix"` or `"pipe"`, the absolute path to the file representing it should be used.
+For `Unix` and `pipe`, since the connection goes over the file system instead of being directly to a known peer, `net.peer.name` is the only attribute that usually makes sense (see description of `net.peer.name` below).
+
+<a name="net.name"></a>
+
+### `net.*.name` attributes
+
+For IP-based communication, the name should be a DNS host name.
+For `net.peer.name`, this should be the name that was used to look up the IP address that was connected to
+(i.e., matching `net.peer.ip` if that one is set; e.g., `"example.com"` if connecting to an URL `https://example.com/foo`).
+If only the IP address but no host name is available, reverse-lookup of the IP may optionally be used to obtain it.
+`net.host.name` should be the host name of the local host,
+preferably the one that the peer used to connect for the current operation.
+If that is not known, a public hostname should be preferred over a private one. However, in that case it may be redundant with information already contained in resources and may be left out.
+It will usually not make sense to use reverse-lookup to obtain `net.host.name`, as that would result in static information that is better stored as resource information.
+
+If `net.transport` is `"unix"` or `"pipe"`, the absolute path to the file representing it should be used as `net.peer.name` (`net.host.name` doesn't make sense in that context).
 If there is no such file (e.g., anonymous pipe),
 the name should explicitly be set to the empty string to distinguish it from the case where the name is just unknown or not covered by the instrumentation.

--- a/specification/data-span-general.md
+++ b/specification/data-span-general.md
@@ -15,6 +15,11 @@ Particular operations may refer to or require some of these attributes.
 ## General network connection attributes
 
 These attributes may be used for any network related operation.
+The `net.peer.*` attributes describe properties of the remote end of the network connection
+(usually the transport-layer peer, e.g. the node to which a TCP connection was established),
+while the `net.host.*` properties describe the local end.
+In an ideal situation, not accounting for proxies, multiple IP addresses or host names,
+the `net.peer.*` properties of a client are equal to the `net.host.*` properties of the server and vice versa.
 
 |  Attribute name  |                                 Notes and examples                                |
 | :--------------- | :-------------------------------------------------------------------------------- |
@@ -24,7 +29,7 @@ These attributes may be used for any network related operation.
 | `net.peer.name` | Remote hostname or similar, see note below.                                        |
 | `net.host.ip`   | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.         |
 | `net.host.port` | Like `net.peer.port` but for the host port.                                        |
-| `net.host.name` | Like `net.peer.name` but for the host name. If known, the name that the peer used to connect should be preferred. For IP-based communication, an value otbained via an API like POSIX `gethostname` may be used as fallback. |
+| `net.host.name` | Like `net.peer.name` but for the host name. If known, the name that the peer used to refer to the host should be preferred. For IP-based communication, an value otbained via an API like POSIX `gethostname` may be used as fallback. |
 
 [RFC5952]: https://tools.ietf.org/html/rfc5952
 


### PR DESCRIPTION
This splits the "peer" attributes from the database conventions where they don't really belong and reworks it, adding a common `net.` prefix and more.

Related changes (I felt leaving them out of this PR would make the conventions inconsistent):
- `peer.address` was renamed to `db.url` for DB
- `peer.service` was renamed to `rpc.service` for (g)RPC
- `peer.service` was dropped for DB
- Requirement for `peer.hostname`/`net.peer.name` in db was modified so that only one of name or IP is required (since you might connect by IP only to a DB).

Closes #295.