### PR TITLE
Allow non-string Resource label values

### DIFF
--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -29,7 +29,8 @@ object. A factory method is recommended to enable support for cached objects.
 
 Required parameters:
 
-- a collection of name/value labels, where name and value are both strings.
+- a collection of name/value labels, where name is a string and value can be one
+  of: string, int64, double, bool.
 
 ### Merge
 


### PR DESCRIPTION
Previously Resource label values could be only strings. This change allows
label values to be also bool, int64 or double if needed.

While it is expected that most label values will be strings (see for example
labels defined by semantic conventions [1]) there may be rare cases when
non-string values make more sense, for example a process ID is typically a
numeric value and belongs to the Resource.

This change also makes Resource label value types uniform with Span attribute
value types [2].

[1] - https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/data-resource-semantic-conventions.md
[2] - https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/api-tracing.md#set-attributes