### PR TITLE
Add Resource semantic conventions for telemetry library attributes

### DIFF
--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -4,6 +4,7 @@ This document defines standard attributes for resources. These attributes are ty
 [OpenCensus Resource standard](https://github.com/census-instrumentation/opencensus-specs/blob/master/resource/StandardResources.md).
 
 * [Service](#service)
+* [Library](#library)
 * [Compute Unit](#compute-unit)
   * [Container](#container)
 * [Deployment Service](#deployment-service)
@@ -53,6 +54,27 @@ service.name = shoppingcart
 namespace = Company
 service.name = Shop.shoppingcart
 ```
+
+## Library
+
+**type:** `library`
+
+**Description:** Telemetry library information.
+
+| Attribute  | Description  | Example  | Required? |
+|---|---|---|---|
+| library.name | The name of the telemetry library. | `opentelemetry` | No |
+| library.language | The language of telemetry library and of the code instrumented with it. <br/> The following spelling SHOULD be used for language strings: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
+| library.version | The version string of the library as defined below. | `semver:1.2.3` | No |
+
+`library.version` is a `string`, with naming schemas hinting at the type of a version,
+as follows:
+
+- `semver:1.2.3` (a semantic version)
+- `git:8ae73a` (a git sha hash)
+- `0.0.4.2.20190921` (a untyped version)
+
+The type and version value MUST be separated by a colon character `:`.
 
 ## Compute Unit
 


### PR DESCRIPTION
Some exporting protocols have built-in fields for this information
(e.g. OpenCensus), some other protocols don't (e.g. Jaeger).

Our approach so far has been that this sort of information is best to be
standardized via semantic conventions and conveyed as generic attributes.
This change adds the appropriate semantic conventions.

A companion change in https://github.com/open-telemetry/opentelemetry-proto/
will be made to remove no longer needed messages that describe the Library.

Resolves https://github.com/open-telemetry/opentelemetry-specification/issues/235