### PR TITLE
Allow array values for attributes

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -344,8 +344,10 @@ A `Span` MUST have the ability to set attributes associated with it.
 An `Attribute` is defined by the following properties:
 
 - (Required) The attribute key, which must be a string.
-- (Required) The attribute value, which must be either a string, a boolean
-  value, or a numeric type.
+- (Required) The attribute value, which is either:
+  - A primitive type: string, boolean or numeric.
+  - An array of primitive type values. The array MUST be homogeneous,
+    i.e. it MUST NOT contain values of different types.
 
 The Span interface MUST provide:
 

--- a/specification/data-semantic-conventions.md
+++ b/specification/data-semantic-conventions.md
@@ -6,6 +6,11 @@ Span attributes.
 * [Resource Conventions](data-resource-semantic-conventions.md)
 * [Span Conventions](#span-conventions)
 
+The type of the attribute SHOULD be specified in the semantic convention
+for that attribute. Array values are allowed for attributes. For
+protocols that do not natively support array values such values MUST be
+represented as JSON strings.
+
 ## Span Conventions
 
 In OpenTelemetry spans can be created freely and it’s up to the implementor to


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-specification/issues/341

Array values are useful for representing attributes that can have
multiple values (e.g. representing a Memcached `get` that can be
over multiple keys and making the keys a span attribute).

This change allows homogeneous array values for span attributes
and specifies that array values should be JSON encoded string when
exporting using protocols that do not natively support array values.