### PR TITLE
Add flush interface to span processor

### DIFF
--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -218,10 +218,18 @@ Shuts down the processor. Called when SDK is shut down. This is an opportunity
 for processor to do any cleanup required.
 
 Shutdown should be called only once for each `Processor` instance. After the
-call to shutdown subsequent calls to `onStart` or `onEnd` are not allowed.
+call to shutdown subsequent calls to `onStart`, `onEnd`, or `flush` are not allowed.
 
 Shutdown should not block indefinitely. Language library authors can decide if
-they want to make the shutdown timeout to be configurable.
+they want to make the shutdown timeout configurable.
+
+##### Flush()
+
+Export all ended spans to the configured `Exporter` that have not yet been exported.
+
+`Flush` should only be called in cases where it is absolutely necessary, such as when using some FaaS providers that may suspend the process after an invocation, but before the `Processor` exports the completed spans.
+
+`Flush` should not block indefinitely. Language library authors can decide if they want to make the flush timeout configurable.
 
 #### Built-in span processors
 
@@ -328,7 +336,7 @@ return FailedNotRetryable error.
 
 `Shutdown` should not block indefinitely (e.g. if it attempts to flush the data
 and the destination is unavailable). Language library authors can decide if they
-want to make the shutdown timeout to be configurable.
+want to make the shutdown timeout configurable.
 
 #### Further Language Specialization
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -218,18 +218,18 @@ Shuts down the processor. Called when SDK is shut down. This is an opportunity
 for processor to do any cleanup required.
 
 Shutdown should be called only once for each `Processor` instance. After the
-call to shutdown subsequent calls to `onStart`, `onEnd`, or `flush` are not allowed.
+call to shutdown subsequent calls to `onStart`, `onEnd`, or `forceFlush` are not allowed.
 
 Shutdown should not block indefinitely. Language library authors can decide if
 they want to make the shutdown timeout configurable.
 
-##### Flush()
+##### ForceFlush()
 
 Export all ended spans to the configured `Exporter` that have not yet been exported.
 
-`Flush` should only be called in cases where it is absolutely necessary, such as when using some FaaS providers that may suspend the process after an invocation, but before the `Processor` exports the completed spans.
+`ForceFlush` should only be called in cases where it is absolutely necessary, such as when using some FaaS providers that may suspend the process after an invocation, but before the `Processor` exports the completed spans.
 
-`Flush` should not block indefinitely. Language library authors can decide if they want to make the flush timeout configurable.
+`ForceFlush` should not block indefinitely. Language library authors can decide if they want to make the flush timeout configurable.
 
 #### Built-in span processors
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/351

Some cases like AWS lambda can suspend a process before span processors export the completed spans. In these cases, it is desirable to flush the span processor to the exporter before the process suspends so that no spans are lost.

### Alternatives considered

#### call shutdown

- Shutdown is not required by the specification to flush spans
- In many FaaS services, the same process will be used for multiple requests. In these cases it is desirable to only initialize span processors and exporters a single time per process, not per request.

#### use simple span processor

The simple span processor does not batch, so will export spans as soon as they are completed. While this solves the flushing problem, it can be inefficient in many cases. It is a common use case for a lambda function to make many async calls and return as soon as they are all complete. With a simple span processor, the function may call the export function many times just as the function completes. Since it is specified that `Export` may not be called concurrently, these exports will happen serially. In these cases it is preferable to batch spans and export them in a single call.