### PR TITLE
Producer SpanKind does not always imply a remote call

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -590,6 +590,6 @@ To summarize the interpretation of these kinds:
 |--|--|--|--|--|
 | `CLIENT` | yes | | | yes |
 | `SERVER` | yes | | yes | |
-| `PRODUCER` | | yes | | yes|
+| `PRODUCER` | | yes | | may be |
 | `CONSUMER` | | yes | yes | |
 | `INTERNAL` | | | | |

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -581,7 +581,7 @@ These are the possible SpanKinds:
   individual messages requires a new `PRODUCER` span per message to
   be created.
 * `CONSUMER` Indicates that the span describes the child of an
-  asynchronous `PRODUCER` request. 
+  asynchronous `PRODUCER` request.
 * `INTERNAL` Default value. Indicates that the span represents an
   internal operation within an application, as opposed to an
   operations with remote parents or children.

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -577,9 +577,13 @@ These are the possible SpanKinds:
 * `PRODUCER` Indicates that the span describes the parent of an
   asynchronous request.  This parent span is expected to end before
   the corresponding child `CONSUMER` span, possibly even before the
-  child span starts.
+  child span starts. In messaging scenarios with batching, tracing
+  individual messages requires a new span per message to be created (with
+  `PRODUCER` kind), while publishing a batch is represented by another span
+  (with `CLIENT` kind).
 * `CONSUMER` Indicates that the span describes the child of an
-  asynchronous remote `PRODUCER` request.
+  asynchronous `PRODUCER` request. Asynchronous scenarios may
+  be remote or local.
 * `INTERNAL` Default value. Indicates that the span represents an
   internal operation within an application, as opposed to an
   operations with remote parents or children.
@@ -591,5 +595,5 @@ To summarize the interpretation of these kinds:
 | `CLIENT` | yes | | | yes |
 | `SERVER` | yes | | yes | |
 | `PRODUCER` | | yes | | may be |
-| `CONSUMER` | | yes | yes | |
+| `CONSUMER` | | yes | may be | |
 | `INTERNAL` | | | | |

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -557,7 +557,7 @@ Span represents a synchronous call.  When a child span is synchronous,
 the parent is expected to wait for it to complete under ordinary
 circumstances.  It can be useful for tracing systems to know this
 property, since synchronous Spans may contribute to the overall trace
-latency.
+latency. Asynchronous scenarios can be remote or local.
 
 In order for `SpanKind` to be meaningful, callers should arrange that
 a single Span does not serve more than one purpose.  For example, a
@@ -578,12 +578,10 @@ These are the possible SpanKinds:
   asynchronous request.  This parent span is expected to end before
   the corresponding child `CONSUMER` span, possibly even before the
   child span starts. In messaging scenarios with batching, tracing
-  individual messages requires a new span per message to be created (with
-  `PRODUCER` kind), while publishing a batch is represented by another span
-  (with `CLIENT` kind).
+  individual messages requires a new `PRODUCER` span per message to
+  be created.
 * `CONSUMER` Indicates that the span describes the child of an
-  asynchronous `PRODUCER` request. Asynchronous scenarios may
-  be remote or local.
+  asynchronous `PRODUCER` request. 
 * `INTERNAL` Default value. Indicates that the span represents an
   internal operation within an application, as opposed to an
   operations with remote parents or children.
@@ -594,6 +592,6 @@ To summarize the interpretation of these kinds:
 |--|--|--|--|--|
 | `CLIENT` | yes | | | yes |
 | `SERVER` | yes | | yes | |
-| `PRODUCER` | | yes | | may be |
-| `CONSUMER` | | yes | may be | |
+| `PRODUCER` | | yes | | maybe |
+| `CONSUMER` | | yes | maybe | |
 | `INTERNAL` | | | | |


### PR DESCRIPTION
It's popular in asynchronous scenarios to send messages in batches.

In this case, each message should carry a unique context to be individually traceable. Arguably it means creating span per message. Such spans do not represent remote calls.

Sending a batch (which is remote outgoing call) is represented by a different span that is linked to all of the messages span contexts.

So async messaging scenarios with batching involve
* *message* spans with PRODUCER kind (each of them is a parent of asynchronous request)
* *send* span that is CLIENT kind (which is remote outgoing call). But it is not a parent of any asynchronous request

In some cases (not involving batching) it is possible that dedicated *message* span is not needed and *send* may represent both: context in the message and remote outgoing call. In this case, such span should have PRODUCER kind