### PR TITLE
Fix RPC semantic conventions

### DIFF
--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -34,9 +34,10 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 | -------------- | ------------------------------------------------------------ | --------- |
 | `component`    | Declares that this is a grpc component. Value MUST be `"grpc"` | Yes       |
 | `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
+| `net.peer.port`  | see [network attributes][] | Yes |
 
-Additionally, at least one of `net.peer.name` or `net.peer.ip` is required as well as `net.peer.port`.
-These are defined in [network attributes][].
+Additionally, at least one of `net.peer.name` or `net.peer.ip` is required.
+These attributes are also defined in [network attributes][].
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -32,12 +32,11 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 
 | Attribute name | Notes and examples                                           | Required? |
 | -------------- | ------------------------------------------------------------ | --------- |
-| `component`    | Declares that this is a grpc component. Value MUST be `"grpc"` | Yes       |
+| `component`    | Declares that this is a grpc component. Value MUST be `"grpc"`. | Yes       |
 | `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
-| `net.peer.port`  | see [network attributes][] | Yes |
+| `net.peer.port`  | See [network attributes][]. | Yes |
 
-Additionally, at least one of `net.peer.name` or `net.peer.ip` is required.
-These attributes are also defined in [network attributes][].
+Additionally, at least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -39,8 +39,8 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 | `net.peer.port`  | See [network attributes][]. | See below |
 
 At least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
-For client-side spans describing the server they are connecting to, `net.peer.port` is required.
-For server-side spans describing the client connecting to them, `net.peer.port` is optional.
+For client-side spans `net.peer.port` is required (it describes the server port they are connecting to).
+For server-side spans `net.peer.port` is optional (it describes the port the client is connecting from).
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -36,9 +36,11 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 | `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
 | `net.peer.ip`  | See [network attributes][]. | See below |
 | `net.peer.name`  | See [network attributes][]. | See below |
-| `net.peer.port`  | See [network attributes][]. | Yes |
+| `net.peer.port`  | See [network attributes][]. | See below |
 
-Additionally, at least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
+At least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
+For client-side spans describing the server they are connecting to, `net.peer.port` is required.
+For server-side spans describing the client connecting to them, `net.peer.port` is optional.
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -35,7 +35,8 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 | `component`    | Declares that this is a grpc component. Value MUST be `"grpc"` | Yes       |
 | `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
 
-Additionally, the `net.peer.name` and `net.peer.port` [network attributes][] are required.
+Additionally, at least one of `net.peer.name` or `net.peer.ip` is required as well as `net.peer.port`.
+These are defined in [network attributes][].
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -34,6 +34,8 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 | -------------- | ------------------------------------------------------------ | --------- |
 | `component`    | Declares that this is a grpc component. Value MUST be `"grpc"`. | Yes       |
 | `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
+| `net.peer.ip`  | See [network attributes][]. | See below |
+| `net.peer.name`  | See [network attributes][]. | See below |
 | `net.peer.port`  | See [network attributes][]. | Yes |
 
 Additionally, at least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.


### PR DESCRIPTION
The previously defined requirement of always providing `net.peer.name` only works for a client connecting to a server.
A server on the other hand is usually not able to provide the host name of a client connecting to it, since it only has access to the IP address of the incoming request.