### PR TITLE
Define HTTP User-Agent attribute

### DIFF
--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -40,7 +40,7 @@ various ways.  Review the [SDK-facing OpenTelemetry API
 specification](api-metrics-meter.md) known as `Meter`.
 
 Because of API-SDK separation, the `Meter` implementation ultimately
-determines how metrics events are handled, .  The specification's task
+determines how metrics events are handled.  The specification's task
 is to define the semantics of the event and describe standard
 interpretation in high-level terms.  How the `Meter` accomplishes its
 goals and the export capabilities it supports are not specified.

--- a/specification/data-http.md
+++ b/specification/data-http.md
@@ -176,7 +176,7 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.server_name` | The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead). | [1] |
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
-| `http.user_agent` | Value of the HTTP [User-Agent] header sent by the client or else a calculated user agent device identifier compatible with the backend system in use. | No |
+| `http.user_agent` | Value of the HTTP [User-Agent] header sent by the client. | No |
 
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4

--- a/specification/data-http.md
+++ b/specification/data-http.md
@@ -176,10 +176,12 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.server_name` | The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead). | [1] |
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
+| `http.user_agent` | Value of the HTTP [User-Agent] header sent by the client or else a calculated user agent device identifier compatible with the backend system in use. | No |
 
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
 [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+[User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
 
 **[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/148>).
 It is thus preferred to supply the raw data that *is* available.

--- a/specification/data-http.md
+++ b/specification/data-http.md
@@ -176,7 +176,7 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.server_name` | The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead). | [1] |
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
-| `http.user_agent` | Value of the HTTP [User-Agent] header sent by the client. | No |
+| `http.user_agent` | Value of the HTTP [User-Agent][] header sent by the client. | No |
 
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4


### PR DESCRIPTION
Having user agent data is often useful in troubleshooting. There are also extreme use cases like my current project where only certain browsers are contractually supported. Storing with traces eliminates the need to jump back and forth between tracing backend and log aggregation backend.
