### PR TITLE
Fixed typo for sdk/trace description

### DIFF
--- a/specification/library-layout.md
+++ b/specification/library-layout.md
@@ -97,7 +97,7 @@ and container name.
 
 ### [/sdk/trace](sdk-tracing.md)
 
-This directory describes the SDK implementation for api/metrics.
+This directory describes the SDK implementation for api/trace.
 
 ### `/sdk/internal` (_Optional_)
 


### PR DESCRIPTION
I think /sdk/trace directory for /api/trace