### PR TITLE
update Resource spec based on the move to the SDK and named tracers

### DIFF
--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -1,25 +1,25 @@
 # Resource SDK
 
 A [Resource](overview.md#resources) represents the entity producing telemetry.
-The primary purpose of resources as a first-class concept in the API is
+The primary purpose of resources as a first-class concept in the SDK is
 decoupling of discovery of resource information from exporters. This allows for
 independent development and easy customization for users that need to integrate
-with closed source environments. API MUST allow for creation of `Resources` and
+with closed source environments. SDK MUST allow for creation of `Resources` and
 for associating them with telemetry.
 
 When used with distributed tracing, a resource can be associated with the
-[TracerSdk](sdk-tracing.md#tracer-sdk). When associated with `TracerSdk`, all
-`Span`s produced by the `Tracer`, that is implemented by this `TracerSdk`, will
+[TracerProvider](sdk-tracing.md#tracer-sdk). When associated with
+`TracerProvider` all `Span`s produced by any `Tracer` from the provider will
 automatically be associated with this `Resource`.
 
 When used with metrics, a resource can be associated with the
-[MeterSdk](sdk-metrics.md#meter-sdk). When associated with `MeterSdk`, all
-`Metrics` produced by this `Meter`, that is implemented by this `MeterSdk`, will
-automatically be associated with this `Resource`.
+[MeterProvider](sdk-metrics.md#meter-sdk). When associated with `MeterProvider`
+all `Metrics` produced by any `Meter` from the provider will automatically be
+associated with this `Resource`.
 
 ## Resource creation
 
-The API interface must support two ways to instantiate new resources. Those are:
+The SDK must support two ways to instantiate new resources. Those are:
 
 ### Create
 
@@ -66,7 +66,7 @@ In addition to resource creation, the following operations should be provided:
 
 ### Retrieve attributes
 
-The API should provide a way to retrieve a read only collection of attributes
+The SDK should provide a way to retrieve a read only collection of attributes
 associated with a resource. The attributes should consist of the name and values,
 both of which should be strings.
 

--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -13,7 +13,7 @@ When used with distributed tracing, a resource can be associated with the
 automatically be associated with this `Resource`.
 
 When used with metrics, a resource can be associated with the
-[MeterProvider](sdk-metrics.md#meter-sdk). When associated with `MeterProvider`
+[MeterProvider](sdk-metrics.md#meter-sdk). When associated with a `MeterProvider`,
 all `Metrics` produced by any `Meter` from the provider will automatically be
 associated with this `Resource`.
 

--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -8,7 +8,7 @@ with closed source environments. SDK MUST allow for creation of `Resources` and
 for associating them with telemetry.
 
 When used with distributed tracing, a resource can be associated with the
-[TracerProvider](sdk-tracing.md#tracer-sdk). When associated with
+[TracerProvider](sdk-tracing.md#tracer-sdk). When associated with a
 `TracerProvider` all `Span`s produced by any `Tracer` from the provider will
 automatically be associated with this `Resource`.
 

--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -9,7 +9,7 @@ for associating them with telemetry.
 
 When used with distributed tracing, a resource can be associated with the
 [TracerProvider](sdk-tracing.md#tracer-sdk). When associated with a
-`TracerProvider` all `Span`s produced by any `Tracer` from the provider will
+`TracerProvider`, all `Span`s produced by any `Tracer` from the provider will
 automatically be associated with this `Resource`.
 
 When used with metrics, a resource can be associated with the

--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -1,6 +1,11 @@
 # Resource SDK
 
-A [Resource](overview.md#resources) represents the entity producing telemetry.
+A [Resource](overview.md#resources) represents the entity producing
+telemetry. For example, a process producing telemetry that is running in a
+container on Kubernetes has a Pod name, it is in a namespace and possibly is
+part of a Deployment which also has a name. All three of these attributes can be
+included in the `Resource`.
+
 The primary purpose of resources as a first-class concept in the SDK is
 decoupling of discovery of resource information from exporters. This allows for
 independent development and easy customization for users that need to integrate

--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -9,7 +9,7 @@ included in the `Resource`.
 The primary purpose of resources as a first-class concept in the SDK is
 decoupling of discovery of resource information from exporters. This allows for
 independent development and easy customization for users that need to integrate
-with closed source environments. SDK MUST allow for creation of `Resources` and
+with closed source environments. The SDK MUST allow for creation of `Resources` and
 for associating them with telemetry.
 
 When used with distributed tracing, a resource can be associated with the


### PR DESCRIPTION
The Resource spec was moved from the API to the SDK but it still referred to the API in the text. This also updates to reference the Providers and all the tracers that may be retrieved from the provider (named tracers and meters).