### PR TITLE
Add details for determining the parent Span from a Context

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -20,7 +20,7 @@ Table of Contents
 * [SpanContext](#spancontext)
 * [Span](#span)
   * [Span creation](#span-creation)
-    * [Parenting from a Context](#parenting-from-a-context)
+    * [Determining the Parent Span from a Context](#determining-the-parent-span-from-a-context)
     * [Add Links](#add-links)
   * [Span operations](#span-operations)
     * [Get Context](#get-context)
@@ -293,7 +293,7 @@ created in another process. Each propagators' deserialization must set
 `IsRemote` to true on a parent `SpanContext` so `Span` creation knows if the
 parent is remote.
 
-#### Parenting from a Context
+#### Determining the Parent Span from a Context
 
 When a new `Span` is created from a `Context`, the `Context` may contain:
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -304,7 +304,7 @@ When a new `Span` is created from a `Context` the `Context` may contain:
 
 The parent should be selected in the following order of precedence:
 
-- Use the current `Span`.
+- Use the current `Span`, if available.
 - Use the extracted `SpanContext`.
 - There is no parent. Create a root `Span`.
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -305,7 +305,7 @@ When a new `Span` is created from a `Context` the `Context` may contain:
 The parent should be selected in the following order of precedence:
 
 - Use the current `Span`, if available.
-- Use the extracted `SpanContext`.
+- Use the extracted `SpanContext`, if available.
 - There is no parent. Create a root `Span`.
 
 #### Add Links

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -295,7 +295,7 @@ parent is remote.
 
 #### Parenting from a Context
 
-When a new `Span` is created from a `Context` the `Context` may contain:
+When a new `Span` is created from a `Context`, the `Context` may contain:
 
 - A current `Span`
 - An extracted `SpanContext`

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -20,6 +20,7 @@ Table of Contents
 * [SpanContext](#spancontext)
 * [Span](#span)
   * [Span creation](#span-creation)
+    * [Parenting from a Context](#parenting-from-a-context)
     * [Add Links](#add-links)
   * [Span operations](#span-operations)
     * [Get Context](#get-context)
@@ -260,6 +261,11 @@ The API MUST accept the following parameters:
 - The parent Span or parent Span context, and whether the new `Span` should be a
   root `Span`. API MAY also have an option for implicit parent context
   extraction from the current context as a default behavior.
+- The parent `Span` or a `Context` containing a parent `Span` or `SpanContext`,
+  and whether the new `Span` should be a root `Span`. API MAY also have an
+  option for implicit parenting from the current context as a default behavior.
+  See [Parenting from a Context](#parenting-from-a-context) for guidance on
+  `Span` parenting from explicit and implicit `Context`s.
 - [`SpanKind`](#spankind), default to `SpanKind.Internal` if not specified.
 - `Attribute`s - A collection of key-value pairs, with the same semantics as
   the ones settable with [Span::SetAttributes](#set-attributes). Additionally,
@@ -289,6 +295,23 @@ A `Span` is said to have a _remote parent_ if it is the child of a `Span`
 created in another process. Each propagators' deserialization must set
 `IsRemote` to true on a parent `SpanContext` so `Span` creation knows if the
 parent is remote.
+
+#### Parenting from a Context
+
+When a new `Span` is created from a `Context` there are several scenarios to
+consider when selecting a parent. A `Context` can contain:
+
+- A current `Span`
+- An extracted `SpanContext`
+- A current `Span` and an extracted `SpanContext`
+- Neither a current `Span` or an extracted `Span` context
+
+In order handle these scenarios, a convention has been established for assigning
+a parent from a `Context`. The precedence for parent selection is as follows:
+
+- Use the current `Span`.
+- Use the extracted `SpanContext`.
+- There is no parent. Create a root `Span`.
 
 #### Add Links
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -261,8 +261,8 @@ The API MUST accept the following parameters:
 - The parent `Span` or a `Context` containing a parent `Span` or `SpanContext`,
   and whether the new `Span` should be a root `Span`. API MAY also have an
   option for implicit parenting from the current context as a default behavior.
-  See [Parenting from a Context](#parenting-from-a-context) for guidance on
-  `Span` parenting from explicit and implicit `Context`s.
+  See [Determining the Parent Span from a Context](#determining-the-parent-span-from-a-context)
+  for guidance on `Span` parenting from explicit and implicit `Context`s.
 - [`SpanKind`](#spankind), default to `SpanKind.Internal` if not specified.
 - `Attribute`s - A collection of key-value pairs, with the same semantics as
   the ones settable with [Span::SetAttributes](#set-attributes). Additionally,

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -300,7 +300,7 @@ When a new `Span` is created from a `Context` the `Context` may contain:
 - A current `Span`
 - An extracted `SpanContext`
 - A current `Span` and an extracted `SpanContext`
-- Neither a current `Span` or an extracted `Span` context
+- Neither a current `Span` nor an extracted `Span` context
 
 The parent should be selected in the following order of precedence:
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -258,9 +258,6 @@ as a separate operation.
 The API MUST accept the following parameters:
 
 - The span name. This is a required parameter.
-- The parent Span or parent Span context, and whether the new `Span` should be a
-  root `Span`. API MAY also have an option for implicit parent context
-  extraction from the current context as a default behavior.
 - The parent `Span` or a `Context` containing a parent `Span` or `SpanContext`,
   and whether the new `Span` should be a root `Span`. API MAY also have an
   option for implicit parenting from the current context as a default behavior.
@@ -298,16 +295,14 @@ parent is remote.
 
 #### Parenting from a Context
 
-When a new `Span` is created from a `Context` there are several scenarios to
-consider when selecting a parent. A `Context` can contain:
+When a new `Span` is created from a `Context` the `Context` may contain:
 
 - A current `Span`
 - An extracted `SpanContext`
 - A current `Span` and an extracted `SpanContext`
 - Neither a current `Span` or an extracted `Span` context
 
-In order handle these scenarios, a convention has been established for assigning
-a parent from a `Context`. The precedence for parent selection is as follows:
+The parent should be selected in the following order of precedence:
 
 - Use the current `Span`.
 - Use the extracted `SpanContext`.


### PR DESCRIPTION
[OTEP 66](https://github.com/open-telemetry/oteps/blob/master/text/0066-separate-context-propagation.md#default-span-parentage) has a section where it offers guidance on how to parent a `Span` given a `Context`. This PR integrates those details into the api-tracing spec.

The bulk of this PR is the following text:

#### Parenting from a Context

When a new `Span` is created from a `Context` there are several scenarios to
consider when selecting a parent. A `Context` can contain:

- A current `Span`
- An extracted `SpanContext`
- A current `Span` and an extracted `SpanContext`
- Neither a current `Span` or an extracted `Span` context

In order handle these scenarios, a convention has been established for assigning
a parent from a `Context`. The precedence for parent selection is as follows:

- Use the current `Span`.
- Use the extracted `SpanContext`.
- There is no parent. Create a root `Span`.

