### PR TITLE
Add the Context notion.

### DIFF
--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -26,7 +26,7 @@ Cross-cutting concerns send their state to the next process using
 context data to and from messages exchanged by the applications.
 Each concern creates a set of `Propagator`s for every supported `Format`.
 
-Propagators leverage `Context` to inject and extract data for each
+Propagators leverage the `Context` to inject and extract data for each
 cross-cutting concern, such as traces and correlation context.
 
 The Propagators API is expected to be leveraged by users writing

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -92,8 +92,9 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
-If a cross-cutting concern value could not be parsed, the implementation MUST set a value
-it deems appropiate, and it MUST NOT throw any exception.
+If a cross-cutting concern value could not be parsed from the carrier,
+the implementation MUST NOT throw an exception. It MUST store a value in `Context`
+that the implementation can recognize as a null or empty value.
 
 Required arguments:
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -97,7 +97,7 @@ an empty value, and MUST NOT throw any exception.
 
 Required arguments:
 
-- a `Context` used as parent of a new `Context` containing the extracted value. The Propagator MUST store the extracted value in the new `Context`, which can be a `SpanContext`, `DistributedContext` or another cross-cutting concern context. This argument can default to the current `Context` if such facility exists.
+- a `Context` used as parent of a new `Context` containing the extracted value, which can be a `SpanContext`, `DistributedContext` or another cross-cutting concern context. This argument can default to the current `Context` if such facility exists.
 - the carrier holds propagation fields. For example, an outgoing message or http request.
 - the instance of `Getter` invoked for each propagation key to get.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -90,7 +90,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 
 ### Extract
 
-Extracts the value from an incoming request. For example, as http headers.
+Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
 If the value could not be parsed, the implementation MUST set a null value or
 an empty value, and MUST NOT throw any exception.

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -24,7 +24,7 @@ data for each cross-cutting concern, such as traces and metrics.
 
 The Propagators API consists of the following formats:
 
-- `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
+- `HTTPTextFormat` is used to inject values into and extract values from carriers as text that travel
   in-band across process boundaries.
 
 ## HTTP Text Format

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -106,8 +106,6 @@ Returns a new `Context` as child of the `Context` passed as argument,
 containing the extracted value, which can be a `SpanContext`,
 `DistributedContext` or another cross-cutting concern context.
 
-The `Context` passed as an argument MUST NOT be modified.
-
 If the extracted value is a `SpanContext`, its `IsRemote` property MUST be set to true.
 
 #### Getter argument

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -105,7 +105,7 @@ Returns a new `Context` as child of the `Context` passed as argument,
 containing the extracted value, which can be a `SpanContext`,
 `DistributedContext` or another cross-cutting concern context.
 
-The `Context` passed as argument MUST NOT be modified.
+The `Context` passed as an argument MUST NOT be modified.
 
 If the extracted value is a `SpanContext`, its `IsRemote` property MUST be set to true.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -95,7 +95,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 Extracts the value from an incoming request. For example, as http headers.
 
 If the value could not be parsed, the underlying implementation MUST set a null value or
-an empty value, without throwing any exception.
+an empty value, and MUST NOT throw any exception.
 
 Required arguments:
 
@@ -103,8 +103,8 @@ Required arguments:
 - the carrier holds propagation fields. For example, an outgoing message or http request.
 - the instance of `Getter` invoked for each propagation key to get.
 
-Returns a new `Context` containing the extracted value. The extracted value will not
-be present in the old `Context`.
+Returns a new `Context` containing the extracted value. The `Context` passed as argument
+SHOULD NOT be modified.
 
 #### Getter argument
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -92,7 +92,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 
 Extracts the value from an incoming request. For example, as http headers.
 
-If the value could not be parsed, the underlying implementation MUST set a null value or
+If the value could not be parsed, the implementation MUST set a null value or
 an empty value, and MUST NOT throw any exception.
 
 Required arguments:

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -102,7 +102,7 @@ Required arguments:
 - the carrier holds propagation fields. For example, an outgoing message or http request.
 - the instance of `Getter` invoked for each propagation key to get.
 
-Returns a new `Context` as child of the `Context` passed as argument,
+Returns a new `Context` derived from the `Context` passed as argument,
 containing the extracted value, which can be a `SpanContext`,
 `DistributedContext` or another cross-cutting concern context.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -64,7 +64,7 @@ Injects the value downstream. For example, as http headers.
 
 Required arguments:
 
-- A `Context`. The Propagator MUST retrieve the appropiate value from the `Context` first, which can be `SpanContext`, `DistributedContext` or another cross-cutting concern context. For languages supporting current `Context` state this argument is OPTIONAL, defaulting to the current `Context` instance.
+- A `Context`. The Propagator MUST retrieve the appropriate value from the `Context` first, which can be a `SpanContext`, a `DistributedContext` or another cross-cutting concern context. For languages supporting current `Context` state, this argument is OPTIONAL, defaulting to the current `Context` instance.
 - the carrier that holds propagation fields. For example, an outgoing message or http request.
 - the `Setter` invoked for each propagation key to add or remove.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -107,7 +107,7 @@ containing the extracted value, which can be a `SpanContext`,
 
 The `Context` passed as argument MUST NOT be modified.
 
-`IsRemote` must be set to true if the extracted value is a `SpanContext`.
+If the extracted value is a `SpanContext`, its `IsRemote` property MUST be set to true.
 
 #### Getter argument
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -102,7 +102,7 @@ Required arguments:
 - the instance of `Getter` invoked for each propagation key to get.
 
 Returns a new `Context` containing the extracted value. The `Context` passed as argument
-SHOULD NOT be modified.
+MUST NOT be modified.
 
 `IsRemote` must be set to true if the extracted value is a `SpanContext`.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -64,7 +64,7 @@ Injects the value downstream. For example, as http headers.
 
 Required arguments:
 
-- A `Context`. The Propagator MUST retrieve the appropiate value from the `Context` first, which can be `SpanContext`, `DistributedContext` or another cross-cutting concern context. This argument can default to the current `Context` if such facility exists.
+- A `Context`. The Propagator MUST retrieve the appropiate value from the `Context` first, which can be `SpanContext`, `DistributedContext` or another cross-cutting concern context. For languages supporting current `Context` state this argument is OPTIONAL, defaulting to the current `Context` instance.
 - the carrier that holds propagation fields. For example, an outgoing message or http request.
 - the `Setter` invoked for each propagation key to add or remove.
 
@@ -97,7 +97,7 @@ an empty value, and MUST NOT throw any exception.
 
 Required arguments:
 
-- A `Context`. This argument can default to the current `Context` if such facility exists.
+- A `Context`. For languages supporting current `Context` state this argument is OPTIONAL, defaulting to the current `Context` instance.
 - the carrier holds propagation fields. For example, an outgoing message or http request.
 - the instance of `Getter` invoked for each propagation key to get.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -97,12 +97,15 @@ an empty value, and MUST NOT throw any exception.
 
 Required arguments:
 
-- a `Context` used as parent of a new `Context` containing the extracted value, which can be a `SpanContext`, `DistributedContext` or another cross-cutting concern context. This argument can default to the current `Context` if such facility exists.
+- A `Context`. This argument can default to the current `Context` if such facility exists.
 - the carrier holds propagation fields. For example, an outgoing message or http request.
 - the instance of `Getter` invoked for each propagation key to get.
 
-Returns a new `Context` containing the extracted value. The `Context` passed as argument
-MUST NOT be modified.
+Returns a new `Context` as child of the `Context` passed as argument,
+containing the extracted value, which can be a `SpanContext`,
+`DistributedContext` or another cross-cutting concern context.
+
+The `Context` passed as argument MUST NOT be modified.
 
 `IsRemote` must be set to true if the extracted value is a `SpanContext`.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -20,7 +20,7 @@ Table of Contents
 ## Overview
 
 Propagators leverage the `Context` to inject and extract
-data for each cross-cutting concern, such as traces and metrics.
+data for each cross-cutting concern, such as traces and correlation context.
 
 The Propagators API currently consists of one format:
 
@@ -66,7 +66,7 @@ Injects the value downstream. For example, as http headers.
 
 Required arguments:
 
-- A `Context`. The Propagator MUST retrieve the appropriate value from the `Context` first, which can be a `SpanContext`, a `DistributedContext` or another cross-cutting concern context. For languages supporting current `Context` state, this argument is OPTIONAL, defaulting to the current `Context` instance.
+- A `Context`. The Propagator MUST retrieve the appropriate value from the `Context` first, which can be a `SpanContext`, a `CorrelationContext` or another cross-cutting concern context. For languages supporting current `Context` state, this argument is OPTIONAL, defaulting to the current `Context` instance.
 - the carrier that holds propagation fields. For example, an outgoing message or http request.
 - the `Setter` invoked for each propagation key to add or remove.
 
@@ -106,7 +106,7 @@ Required arguments:
 
 Returns a new `Context` derived from the `Context` passed as argument,
 containing the extracted value, which can be a `SpanContext`,
-`DistributedContext` or another cross-cutting concern context.
+`CorrelationContext` or another cross-cutting concern context.
 
 If the extracted value is a `SpanContext`, its `IsRemote` property MUST be set to true.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -92,7 +92,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
-If a cross-cutting concern value could not be parsed from the carrier,
+If a value can not be parsed from the carrier for a cross-cutting concern,
 the implementation MUST NOT throw an exception. It MUST store a value in `Context`
 that the implementation can recognize as a null or empty value.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -27,8 +27,6 @@ The Propagators API consists of the following formats:
 - `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.
 
-Deserializing must set `IsRemote` to true on the returned `SpanContext`.
-
 ## HTTP Text Format
 
 `HTTPTextFormat` is a formatter that injects and extracts a value as text into carriers that
@@ -105,6 +103,8 @@ Required arguments:
 
 Returns a new `Context` containing the extracted value. The `Context` passed as argument
 SHOULD NOT be modified.
+
+`IsRemote` must be set to true if the extracted value is a `SpanContext`.
 
 #### Getter argument
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -92,7 +92,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
-If the value could not be parsed, the implementation MUST set a null value or
+If a cross-cutting concern value could not be parsed, the implementation MUST set a null value or
 an empty value, and MUST NOT throw any exception.
 
 Required arguments:

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -64,7 +64,7 @@ Injects the value downstream. For example, as http headers.
 
 Required arguments:
 
-- a `Context`. The Propagator MUST retrieve the appropiate value from the `Context` first, which can be `SpanContext`, `DistributedContext` or another cross-cutting concern context. This argument can default to the current `Context` if such facility exists.
+- A `Context`. The Propagator MUST retrieve the appropiate value from the `Context` first, which can be `SpanContext`, `DistributedContext` or another cross-cutting concern context. This argument can default to the current `Context` if such facility exists.
 - the carrier that holds propagation fields. For example, an outgoing message or http request.
 - the `Setter` invoked for each propagation key to add or remove.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -105,7 +105,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
 If a value can not be parsed from the carrier for a cross-cutting concern,
-the implementation MUST NOT throw an exception. It MUST store a value in `Context`
+the implementation MUST NOT throw an exception. It MUST store a value in the `Context`
 that the implementation can recognize as a null or empty value.
 
 Required arguments:

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -92,8 +92,8 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
-If a cross-cutting concern value could not be parsed, the implementation MUST set a null value or
-an empty value, and MUST NOT throw any exception.
+If a cross-cutting concern value could not be parsed, the implementation MUST set a value
+it deems appropiate, and it MUST NOT throw any exception.
 
 Required arguments:
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -144,7 +144,7 @@ SHOULD create each new `Span` as a child of its active `Span` unless an
 explicit parent is provided or the option to create a span without a parent is
 selected, or the current active `Span` is invalid.
 
-The `Tracer` SHOULD provide a way to update its active `Span`, and it MAY provide
+The `Tracer` SHOULD provide a way to update its active `Span`, and MAY provide
 convenience methods to manage a `Span`'s lifetime and the scope in which a
 `Span` is active. When an active `Span` is made inactive, the previously-active
 `Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -129,7 +129,7 @@ The `Tracer` SHOULD provide methods to:
 - Get the currently active `Span`
 - Make a given `Span` as active
 
-The `Tracer` MUST internally leverage `Context` in order to get and set the
+The `Tracer` MUST internally leverage the `Context` in order to get and set the
 current `Span` state and how `Span`s are passed across process boundaries.
 
 When getting the current span, the `Tracer` MUST return a placeholder `Span`

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -132,7 +132,7 @@ The `Tracer` SHOULD provide methods to:
 - Get the currently active `Span`
 - Make a given `Span` as active
 
-The `Tracer` MUST internally leverage the context layer in order to handle the
+The `Tracer` MUST internally leverage `Context` in order to get and set the
 current `Span` state and how `Span`s are passed across process boundaries.
 
 When getting the current span, the `Tracer` MUST return a placeholder `Span`

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -144,7 +144,7 @@ SHOULD create each new `Span` as a child of its active `Span` unless an
 explicit parent is provided or the option to create a span without a parent is
 selected, or the current active `Span` is invalid.
 
-The `Tracer` SHOULD provide a way to update its active `Span`, and MAY provide
+The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
 convenience methods to manage a `Span`'s lifetime and the scope in which a
 `Span` is active. When an active `Span` is made inactive, the previously-active
 `Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -142,7 +142,7 @@ explicit parent is provided or the option to create a span without a parent is
 selected, or the current active `Span` is invalid.
 
 The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
-convenience methods to manage a `Span`'s lifetime and the scope in which a
+convenience functions to manage a `Span`'s lifetime and the scope in which a
 `Span` is active. When an active `Span` is made inactive, the previously-active
 `Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end
 time) but stil active. A `Span` may be active on one thread after it has been

--- a/specification/context.md
+++ b/specification/context.md
@@ -23,7 +23,8 @@ Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 
 `Context` MUST be immutable, and all its operations MUST
-result in the creation of a new `Context` with updated values.
+result in the creation of a new `Context` cointaining the original
+values and the specified values updated.
 
 Languages are expected to use the single, widely used `Context` implementation
 if one exists for them. In the cases where an extremely clear, pre-existing

--- a/specification/context.md
+++ b/specification/context.md
@@ -32,10 +32,9 @@ option is not available, OpenTelemetry MUST provide its own `Context`
 implementation. Depending on the language, its usage may be either explicit
 or implicit.
 
-Users writing instrumentation in languages that
-use `Context` implicitly are discouraged from using the `Context` API directly.
-In those cases, users will manipulate `Context` through the cross-cutting
-concerns APIs instead.
+Users writing instrumentation in languages that use `Context` implicitly are
+discouraged from using the `Context` API directly. In those cases, users will
+manipulate `Context` through the cross-cutting concerns APIs instead.
 
 `Context` is expected to have the following operations, with their
 respective language differences:

--- a/specification/context.md
+++ b/specification/context.md
@@ -71,7 +71,7 @@ The API SHOULD accept the following parameters:
 - (Required) The `Context`.
 - (Required) The concern identifier.
 
-The API SHOULD return a new `Context` with the value cleared.
+The API MUST return a new `Context` with the value cleared.
 The `Context` passed as parameter SHOULD NOT be modified.
 
 ## Optional Global operations

--- a/specification/context.md
+++ b/specification/context.md
@@ -39,10 +39,10 @@ respective language differences:
 Concerns can access their local state in the current execution state
 represented by a `Context`.
 
-The API SHOULD accept the following parameters:
+The API MUST accept the following parameters:
 
-- (Required) The `Context`.
-- (Required) The concern identifier.
+- The `Context`.
+- The concern identifier.
 
 The API MUST return the value in the `Context` for the specified concern
 identifier.
@@ -52,23 +52,23 @@ identifier.
 Concerns can record their local state in the current execution state
 represented by a `Context`.
 
-The API SHOULD accept the following parameters:
+The API MUST accept the following parameters:
 
-- (Required) The `Context`.
-- (Required) The concern identifier.
-- (Required) The value to be set.
+- The `Context`.
+- The concern identifier.
+- The value to be set.
 
-The API SHOULD return a new `Context` containing the new value.
-The `Context` passed as parameter SHOULD NOT be modified.
+The API MUST return a new `Context` containing the new value.
+The `Context` passed as parameter MUST NOT be modified.
 
 ## Remove value
 
 Concerns can clear their local state in a specified `Context`.
 
-The API SHOULD accept the following parameters:
+The API MUST accept the following parameters:
 
-- (Required) The `Context`.
-- (Required) The concern identifier.
+- The `Context`.
+- The concern identifier.
 
 The API MUST return a new `Context` with the value cleared.
 The `Context` passed as parameter MUST NOT be modified.
@@ -86,6 +86,6 @@ The API MUST return the `Context` associated with the caller's current execution
 
 Associates a `Context` with the caller's current execution unit.
 
-The API SHOULD accept the following parameters:
+The API MUST accept the following parameters:
 
 - (Required) The `Context`.

--- a/specification/context.md
+++ b/specification/context.md
@@ -79,7 +79,7 @@ implement automatic scope switching and define higher level APIs.
 
 ### Get current Context
 
-The API SHOULD return the `Context` associated with program execution.
+The API SHOULD return the `Context` associated with the caller's current execution unit.
 
 ### Set current Context
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -98,7 +98,7 @@ The API MUST accept the following parameters:
 
 - The `Context`.
 
-The API MUST return an object that can be used as `Token` to restore the previous
+The API MUST return an object that can be used as a `Token` to restore the previous
 `Context`.
 
 ### Detach Context

--- a/specification/context.md
+++ b/specification/context.md
@@ -74,7 +74,7 @@ The removed value still remains present in the old `Context`.
 
 ## Optional Global operations
 
-These operations are optional, and are protected to specifically
+These operations are optional, and SHOULD ONLY be used to
 implement automatic scope switching and define higher level APIs.
 
 ### Get current Context

--- a/specification/context.md
+++ b/specification/context.md
@@ -22,6 +22,9 @@ across API boundaries and between logically associated execution units.
 Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 
+`Context` MUST be immutable, and all its operations MUST
+result in the creation of a new `Context` with updated values.
+
 Languages are expected to use the single, widely used `Context` implementation
 if one exists for them. In the cases where an extremely clear, pre-existing
 option is not available, OpenTelemetry MUST provide its own `Context`
@@ -63,7 +66,6 @@ The API MUST accept the following parameters:
 - The value to be set.
 
 The API MUST return a new `Context` containing the new value.
-The `Context` passed as parameter MUST NOT be modified.
 
 ## Remove value
 
@@ -75,7 +77,6 @@ The API MUST accept the following parameters:
 - The concern identifier.
 
 The API MUST return a new `Context` with the value cleared.
-The `Context` passed as parameter MUST NOT be modified.
 
 ## Optional Global operations
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -24,7 +24,7 @@ Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 
 A `Context` MUST be immutable, and its write operations MUST
-result in the creation of a new `Context` cointaining the original
+result in the creation of a new `Context` containing the original
 values and the specified values updated.
 
 Languages are expected to use the single, widely used `Context` implementation

--- a/specification/context.md
+++ b/specification/context.md
@@ -22,7 +22,7 @@ across API boundaries and between logically associated execution units.
 Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 
-`Context` MUST be immutable, and all its operations MUST
+`Context` MUST be immutable, and its set and remove operations MUST
 result in the creation of a new `Context` cointaining the original
 values and the specified values updated.
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -75,7 +75,7 @@ The `Context` passed as parameter MUST NOT be modified.
 
 ## Optional Global operations
 
-These operations are optional, and SHOULD ONLY be used to
+These operations are optional, and SHOULD only be used to
 implement automatic scope switching and define higher level APIs.
 
 ### Get current Context

--- a/specification/context.md
+++ b/specification/context.md
@@ -31,12 +31,10 @@ option is not available, OpenTelemetry MUST provide its own `Context`
 implementation. Depending on the language, its usage may be either explicit
 or implicit.
 
-`Context` can be considered as an implementation detail of the SDK.
-Users will manipulate `Context` through the cross-cutting concerns APIs
-rather than directly.
-
 Users writing instrumentation in languages that
 use `Context` implicitly are discouraged from using the `Context` API directly.
+In those cases, users will manipulate `Context` through the cross-cutting
+concerns APIs instead.
 
 `Context` is expected to have the following operations, with their
 respective language differences:

--- a/specification/context.md
+++ b/specification/context.md
@@ -28,9 +28,8 @@ option is not available, OpenTelemetry MUST provide its own `Context`
 implementation. Depending on the language, its usage may be either explicit
 or implicit.
 
-For languages without explicit `Context` usage, this should
-be considered to primarily be a SDK API, and thus be used by SDK and
-cross-cutting concerns authors, rather than users writing instrumentation.
+Users writing instrumentation in languages that implicitly use `Context`
+are discouraged to use the `Context` API directly.
 
 `Context` is expected to have the following operations, with their
 respective language differences:

--- a/specification/context.md
+++ b/specification/context.md
@@ -28,8 +28,12 @@ option is not available, OpenTelemetry MUST provide its own `Context`
 implementation. Depending on the language, its usage may be either explicit
 or implicit.
 
-Users writing instrumentation in languages that implicitly use `Context`
-are discouraged to use the `Context` API directly.
+`Context` can be considered as an implementation detail of the SDK.
+Users will manipulate `Context` through the cross-cutting concerns APIs
+rather than directly.
+
+Users writing instrumentation in languages that
+use `Context` implicitly are discouraged to use the `Context` API directly.
 
 `Context` is expected to have the following operations, with their
 respective language differences:

--- a/specification/context.md
+++ b/specification/context.md
@@ -45,7 +45,7 @@ The API SHOULD accept the following parameters:
 - (Required) The `Context`.
 - (Required) The concern identifier.
 
-The API SHOULD return the value in the `Context` for the specified concern
+The API MUST return the value in the `Context` for the specified concern
 identifier.
 
 ## Set value

--- a/specification/context.md
+++ b/specification/context.md
@@ -11,7 +11,8 @@ Table of Contents
 - [Set value](#set-value)
 - [Optional operations](#optional-operations)
     - [Get current Context](#get-current-context)
-    - [Set current Context](#set-current-context)
+    - [Attach Context](#attach-context)
+    - [Detach Context](#detach-context)
 
 </details>
 
@@ -89,7 +90,7 @@ higher level APIs by SDK components and OpenTelemetry instrumentation libraries.
 
 The API MUST return the `Context` associated with the caller's current execution unit.
 
-### Set current Context
+### Attach Context
 
 Associates a `Context` with the caller's current execution unit.
 
@@ -97,5 +98,14 @@ The API MUST accept the following parameters:
 
 - The `Context`.
 
-The API SHOULD return a handle that can be used to restore the previous
+The API MUST return an object that can be used as `Token` to restore the previous
 `Context`.
+
+### Detach Context
+
+Resets the `Context` associated with the caller's current execution unit
+to the value it had before attaching a specified `Context`.
+
+The API MUST accept the following parameters:
+
+- A `Token` that was returned by a previous call to attach a `Context`.

--- a/specification/context.md
+++ b/specification/context.md
@@ -60,7 +60,7 @@ The API SHOULD accept the following parameters:
 - (Required) The value to be set.
 
 The API SHOULD return a new `Context` containing the new value.
-The new value will not be present in the old `Context`.
+The `Context` passed as parameter SHOULD NOT be modified.
 
 ## Remove value
 
@@ -72,7 +72,7 @@ The API SHOULD accept the following parameters:
 - (Required) The concern identifier.
 
 The API SHOULD return a new `Context` with the value cleared.
-The removed value still remains present in the old `Context`.
+The `Context` passed as parameter SHOULD NOT be modified.
 
 ## Optional Global operations
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -18,7 +18,7 @@ Table of Contents
 ## Overview
 
 `Context` is a propagation mechanism which carries execution-scoped values
-across API boundaries and between execution units.
+across API boundaries and between logically associated execution units.
 
 Languages are expected to use the single, widely used `Context` implementation
 if one exists for them. In the cases where an extremely clear, pre-existing

--- a/specification/context.md
+++ b/specification/context.md
@@ -6,6 +6,7 @@ Table of Contents
 </summary>
 
 - [Overview](#overview)
+- [Create a key](#create-a-key)
 - [Get value](#get-value)
 - [Set value](#set-value)
 - [Optional operations](#optional-operations)
@@ -40,6 +41,18 @@ a specified `Context`.
 `Context` is expected to have the following operations, with their
 respective language differences:
 
+## Create a key
+
+Keys are used to allow cross-cutting concerns to control access to their local state,
+and they cannot be guessed by third parties. It is recommended that concerns mediate
+data access via an API, rather than provide direct public access to their keys.
+
+The API MUST accept the following parameter:
+
+- The key identifier. Different languages may impose different restrictions on the expected types, so this parameter remains an implementation detail.
+
+The API MUST return an opaque object representing the newly created key.
+
 ## Get value
 
 Concerns can access their local state in the current execution state
@@ -48,10 +61,9 @@ represented by a `Context`.
 The API MUST accept the following parameters:
 
 - The `Context`.
-- The concern identifier.
+- The key.
 
-The API MUST return the value in the `Context` for the specified concern
-identifier.
+The API MUST return the value in the `Context` for the specified key.
 
 ## Set value
 
@@ -61,7 +73,7 @@ represented by a `Context`.
 The API MUST accept the following parameters:
 
 - The `Context`.
-- The concern identifier.
+- The key.
 - The value to be set.
 
 The API MUST return a new `Context` containing the new value.

--- a/specification/context.md
+++ b/specification/context.md
@@ -19,6 +19,8 @@ Table of Contents
 
 `Context` is a propagation mechanism which carries execution-scoped values
 across API boundaries and between logically associated execution units.
+Cross-cutting concerns access their data in-process using the same shared
+`Context` object.
 
 Languages are expected to use the single, widely used `Context` implementation
 if one exists for them. In the cases where an extremely clear, pre-existing

--- a/specification/context.md
+++ b/specification/context.md
@@ -78,9 +78,10 @@ The API MUST return a new `Context` with the value cleared.
 
 ## Optional Global operations
 
-These operations are optional, and SHOULD only be used to
-implement automatic scope switching and define higher level APIs
-by SDK components and OpenTelemetry instrumentation libraries.
+These operations are expected to only be implemented by languages
+using `Context` implicitly, and thus are optional. These operations
+SHOULD only be used to implement automatic scope switching and define
+higher level APIs by SDK components and OpenTelemetry instrumentation libraries.
 
 ### Get current Context
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -74,7 +74,7 @@ The removed value still remains present in the old `Context`.
 
 ## Optional Global operations
 
-These operations are optional, and are protected to be specifically
+These operations are optional, and are protected to specifically
 implement automatic scope switching and define higher level APIs.
 
 ### Get current Context

--- a/specification/context.md
+++ b/specification/context.md
@@ -23,7 +23,7 @@ across API boundaries and between logically associated execution units.
 Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 
-`Context` MUST be immutable, and its write operations MUST
+A `Context` MUST be immutable, and its write operations MUST
 result in the creation of a new `Context` cointaining the original
 values and the specified values updated.
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -81,7 +81,7 @@ implement automatic scope switching and define higher level APIs.
 
 ### Get current Context
 
-The API SHOULD return the `Context` associated with the caller's current execution unit.
+The API MUST return the `Context` associated with the caller's current execution unit.
 
 ### Set current Context
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -24,7 +24,7 @@ Cross-cutting concerns access their data in-process using the same shared
 
 Languages are expected to use the single, widely used `Context` implementation
 if one exists for them. In the cases where an extremely clear, pre-existing
-option is not available, OpenTelemetry should provide its own `Context`
+option is not available, OpenTelemetry MUST provide its own `Context`
 implementation. Depending on the language, its usage may be either explicit
 or implicit.
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -93,4 +93,4 @@ Associates a `Context` with the caller's current execution unit.
 
 The API MUST accept the following parameters:
 
-- (Required) The `Context`.
+- The `Context`.

--- a/specification/context.md
+++ b/specification/context.md
@@ -33,7 +33,7 @@ Users will manipulate `Context` through the cross-cutting concerns APIs
 rather than directly.
 
 Users writing instrumentation in languages that
-use `Context` implicitly are discouraged to use the `Context` API directly.
+use `Context` implicitly are discouraged from using the `Context` API directly.
 
 `Context` is expected to have the following operations, with their
 respective language differences:

--- a/specification/context.md
+++ b/specification/context.md
@@ -39,7 +39,7 @@ manipulate `Context` through cross-cutting concerns APIs instead, in order to
 perform operations such as setting trace or correlation context values for
 a specified `Context`.
 
-`Context` is expected to have the following operations, with their
+A `Context` is expected to have the following operations, with their
 respective language differences:
 
 ## Create a key

--- a/specification/context.md
+++ b/specification/context.md
@@ -72,7 +72,7 @@ The API SHOULD accept the following parameters:
 - (Required) The concern identifier.
 
 The API MUST return a new `Context` with the value cleared.
-The `Context` passed as parameter SHOULD NOT be modified.
+The `Context` passed as parameter MUST NOT be modified.
 
 ## Optional Global operations
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -8,7 +8,6 @@ Table of Contents
 - [Overview](#overview)
 - [Get value](#get-value)
 - [Set value](#set-value)
-- [Remove value](#remove-value)
 - [Optional operations](#optional-operations)
     - [Get current Context](#get-current-context)
     - [Set current Context](#set-current-context)
@@ -22,7 +21,7 @@ across API boundaries and between logically associated execution units.
 Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 
-`Context` MUST be immutable, and its set and remove operations MUST
+`Context` MUST be immutable, and its write operations MUST
 result in the creation of a new `Context` cointaining the original
 values and the specified values updated.
 
@@ -64,17 +63,6 @@ The API MUST accept the following parameters:
 - The value to be set.
 
 The API MUST return a new `Context` containing the new value.
-
-## Remove value
-
-Concerns can clear their local state in a specified `Context`.
-
-The API MUST accept the following parameters:
-
-- The `Context`.
-- The concern identifier.
-
-The API MUST return a new `Context` with the value cleared.
 
 ## Optional Global operations
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -98,7 +98,7 @@ The API MUST accept the following parameters:
 
 - The `Context`.
 
-The API MUST return an object that can be used as a `Token` to restore the previous
+The API MUST return a value that can be used as a `Token` to restore the previous
 `Context`.
 
 ### Detach Context

--- a/specification/context.md
+++ b/specification/context.md
@@ -93,3 +93,6 @@ Associates a `Context` with the caller's current execution unit.
 The API MUST accept the following parameters:
 
 - The `Context`.
+
+The API SHOULD return a handle that can be used to restore the previous
+`Context`.

--- a/specification/context.md
+++ b/specification/context.md
@@ -76,7 +76,8 @@ The `Context` passed as parameter MUST NOT be modified.
 ## Optional Global operations
 
 These operations are optional, and SHOULD only be used to
-implement automatic scope switching and define higher level APIs.
+implement automatic scope switching and define higher level APIs
+by SDK components and OpenTelemetry instrumentation libraries.
 
 ### Get current Context
 

--- a/specification/context.md
+++ b/specification/context.md
@@ -18,7 +18,7 @@ Table of Contents
 
 ## Overview
 
-`Context` is a propagation mechanism which carries execution-scoped values
+A `Context` is a propagation mechanism which carries execution-scoped values
 across API boundaries and between logically associated execution units.
 Cross-cutting concerns access their data in-process using the same shared
 `Context` object.

--- a/specification/context.md
+++ b/specification/context.md
@@ -33,7 +33,9 @@ or implicit.
 
 Users writing instrumentation in languages that use `Context` implicitly are
 discouraged from using the `Context` API directly. In those cases, users will
-manipulate `Context` through the cross-cutting concerns APIs instead.
+manipulate `Context` through cross-cutting concerns APIs instead, in order to
+perform operations such as setting trace or correlation context values for
+a specified `Context`.
 
 `Context` is expected to have the following operations, with their
 respective language differences:

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -238,15 +238,8 @@ for an example.
 ## Context Propagation
 
 All of OpenTelemetry cross-cutting concerns, such as traces and metrics,
-share an underlying context propagation layer, for storing state and
+share an underlying `Context` mechanism for storing state and
 accessing data across the lifespan of a distributed transaction.
-
-Concerns access their data in-process using the same, shared context object.
-Each concern has its own slot in this `Context`, containing
-all of its data.
-
-Observe that the context propagation layer is intended to be used primarily
-as a SDK API, rather than by instrumentation logic.
 
 See the [Context](context.md)
 


### PR DESCRIPTION
This PR intends to include some of the changes of OTEP 66, by making the Specification `Context` aware.

Summary of changes:

1. Add a `Context` mechanism section to describe what is expected in all languages overall. This is mostly described as a SDK API, in order to signal that users instrumenting their application shouldn't use it directly.
2. Update `Propagators` to make them directly consume `Context`.
3. Relax the `Tracer`'s current `Span` handling as this now belongs to `Context` (changes this part from MUST to SHOULD).
3. Removed `Binary` support for now. `Binary` needs to be updated to play along well, and it's still a work in progress anyway. The plan is to add it again in the near future, once it has been prototyped/tested.

I'm specially interested in feedback regarding 1), so feel free to provide insights ;)