### PR TITLE
Remove binary format propagator

### DIFF
--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -16,12 +16,14 @@ Table of Contents
 
 </details>
 
-Propagators API consists of one main format:
+Propagators API currently consists of one format:
 
 - `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.
 
 Deserializing must set `IsRemote` to true on the returned `SpanContext`.
+
+A binary format will be added in the future.
 
 ## HTTP Text Format
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -5,9 +5,6 @@
 Table of Contents
 </summary>
 
-- [Binary Format](#binary-format)
-  - [ToBytes](#tobytes)
-  - [FromBytes](#frombytes)
 - [HTTP Text Format](#http-text-format)
   - [Fields](#fields)
   - [Inject](#inject)
@@ -19,43 +16,12 @@ Table of Contents
 
 </details>
 
-Propagators API consists of two main formats:
+Propagators API consists of one main format:
 
-- `BinaryFormat` is used to serialize and deserialize a value into a binary representation.
 - `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.
 
 Deserializing must set `IsRemote` to true on the returned `SpanContext`.
-
-## Binary Format
-
-`BinaryFormat` is a formatter to serialize and deserialize a value into a binary format.
-
-`BinaryFormat` MUST expose the APIs that serializes values into bytes,
-and deserializes values from bytes.
-
-### ToBytes
-
-Serializes the given value into the on-the-wire representation.
-
-Required arguments:
-
-- the value to serialize, can be `SpanContext` or `DistributedContext`.
-
-Returns the on-the-wire byte representation of the value.
-
-### FromBytes
-
-Creates a value from the given on-the-wire encoded representation.
-
-If the value could not be parsed, the underlying implementation SHOULD decide to return ether
-an empty value, an invalid value, or a valid value.
-
-Required arguments:
-
-- on-the-wire byte representation of the value.
-
-Returns a value deserialized from bytes.
 
 ## HTTP Text Format
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -15,7 +15,6 @@ Table of Contents
     * [GetCurrentSpan](#getcurrentspan)
     * [WithSpan](#withspan)
     * [SpanBuilder](#spanbuilder)
-    * [GetBinaryFormat](#getbinaryformat)
     * [GetHttpTextFormat](#gethttptextformat)
 * [SpanContext](#spancontext)
 * [Span](#span)
@@ -131,9 +130,8 @@ The `Tracer` MUST provide methods to:
 - Make a given `Span` as active
 
 The `Tracer` SHOULD allow end users to configure other tracing components that
-control how `Span`s are passed across process boundaries, including the binary
-and text format `Propagator`s used to serialize `Span`s created by the
-`Tracer`.
+control how `Span`s are passed across process boundaries, including the text
+format `Propagator` used to serialize `Span`s created by the `Tracer`.
 
 When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.
@@ -151,7 +149,7 @@ convenience methods to manage a `Span`'s lifetime and the scope in which a
 time) but stil active. A `Span` may be active on one thread after it has been
 made inactive on another.
 
-The implementation MUST provide no-op binary and text `Propagator`s, which the
+The implementation MUST provide a text `Propagator`, which the
 `Tracer` SHOULD use by default if other propagators are not configured. SDKs
 SHOULD use the W3C HTTP Trace Context as the default text format. For more
 details, see [trace-context](https://github.com/w3c/trace-context).

--- a/specification/data-http.md
+++ b/specification/data-http.md
@@ -79,12 +79,14 @@ Note that the items marked with [1] are different from the mapping defined in th
 | `http.status_code` | [HTTP response status code][]. E.g. `200` (integer) | If and only if one was received/sent. |
 | `http.status_text` | [HTTP reason phrase][]. E.g. `"OK"` | No |
 | `http.flavor` | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |  No |
+| `http.user_agent` | Value of the HTTP [User-Agent][] header sent by the client. | No |
 
 It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 [network attributes]: data-span-general.md#general-network-connection-attributes
 [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
 [HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
+[User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
 
 ## HTTP client
 
@@ -185,12 +187,10 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.server_name` | The primary server name of the matched virtual host. This should be obtained via configuration. If no such configuration can be obtained, this attribute MUST NOT be set ( `net.host.name` should be used instead). | [1] |
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
-| `http.user_agent` | Value of the HTTP [User-Agent][] header sent by the client. | No |
 
 [HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
 [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
-[User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
 
 **[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/148>).
 It is thus preferred to supply the raw data that *is* available.
@@ -220,7 +220,7 @@ Span name: `/webshop/articles/4` (NOTE: This is subject to change, see [open-tel
 | `http.method`      | `"GET"`                                                 |
 | `http.flavor`      | `"1.1"`                                                 |
 | `http.url`         | `"https://example.com:8080/webshop/articles/4?s=1"`     |
-| `peer.ip4`         | `"192.0.2.5"`                                           |
+| `net.peer.ip`      | `"192.0.2.5"`                                           |
 | `http.status_code` | `200`                                                   |
 | `http.status_text` | `"OK"`                                                  |
 
@@ -243,6 +243,7 @@ Span name: `/webshop/articles/:article_id`.
 | `http.status_text` | `"OK"`                                          |
 | `http.client_ip`   | `"192.0.2.4"`                                   |
 | `net.peer.ip`      | `"192.0.2.5"` (the client goes through a proxy) |
+| `http.user_agent`  | `"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:72.0) Gecko/20100101 Firefox/72.0"`                               |
 
 Note that following the recommendations above, `http.url` is not set in the above example.
 If set, it would be

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -238,9 +238,8 @@ for an example.
 ## Propagators
 
 OpenTelemetry uses `Propagators` to serialize and deserialize `SpanContext` and `DistributedContext`
-into a binary or text format. Currently there are two types of propagators:
+into text format. Currently there is one type of propagator:
 
-- `BinaryFormat` which is used to serialize and deserialize a value into a binary representation.
 - `HTTPTextFormat` which is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.
 


### PR DESCRIPTION
The Propagators API includes both binary and text propagators, however the binary format is not well defined and is without an agreed protocol. This has lead many languages to simply have a Noop implementation.

The W3C has binary protocols for different transports in progress but they have not been formally accept yet. It make senses to remove the binary propagator from the Open Telemetry spec for now and re-add once a protocol has been accepted.

In-progress W3C binary protocol proposals:
Trace Context Binary Spec: https://github.com/w3c/trace-context-binary
Trace Context AMQP: https://github.com/w3c/trace-context-amqp
Trace Context MQTT: https://github.com/w3c/trace-context-mqtt