### PR TITLE
Add semantic conventions for errors

### DIFF
--- a/specification/data-error-semantic-conventions.md
+++ b/specification/data-error-semantic-conventions.md
@@ -14,6 +14,6 @@ their types.
 
 | Attribute name | Type       | Notes and examples                                           | Required? |
 | :------------- | :--------- | :----------------------------------------------------------- | :-------- |
-| error.type     | String     | The type of the error. E.g. "Exception", "OSError"           | Yes       |
+| error.type     | String     | The type of the error (its fully-qualified class name, if applicable). E.g. "java.net.ConnectException", "OSError"           | Yes       |
 | error.message  | String     | The error message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"` | Yes       |
 | error.stack    | Array\<String\> | A stack trace formatted as an array of strings. The stackframe at which the exeception occurred should be the first entry. E.g. `["Exception in thread \"main\" java.lang.RuntimeException: Test exception", "  at com.example.GenerateTrace.methodB(GenerateTrace.java:13)", "  at com.example.GenerateTrace.methodA(GenerateTrace.java:9)", "  at com.example.GenerateTrace.main(GenerateTrace.java:5)" ]` | No        |

--- a/specification/data-error-semantic-conventions.md
+++ b/specification/data-error-semantic-conventions.md
@@ -1,0 +1,19 @@
+# Semantic conventions for errors
+
+This document defines semantic conventions for recording errors.
+
+## Recording an Error
+
+An error SHOULD be recorded as an `Event` on the span during which it occurred.
+The name of the event MUST be `"error"`.
+
+## Attributes
+
+The table below indicates which attributes should be added to the `Event` and
+their types.
+
+| Attribute name | Type       | Notes and examples                                           | Required? |
+| :------------- | :--------- | :----------------------------------------------------------- | :-------- |
+| error.type     | String     | The type of the error. E.g. "Exception", "OSError"           | Yes       |
+| error.message  | String     | The error message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"` | Yes       |
+| error.stack    | Array\<String\> | A stack trace formatted as an array of strings. The stackframe at which the exeception occurred should be the first entry. E.g. `["Exception in thread \"main\" java.lang.RuntimeException: Test exception", "  at com.example.GenerateTrace.methodB(GenerateTrace.java:13)", "  at com.example.GenerateTrace.methodA(GenerateTrace.java:9)", "  at com.example.GenerateTrace.main(GenerateTrace.java:5)" ]` | No        |


### PR DESCRIPTION
Having a way to record errors and annotate spans with that information is essential functionality that is currently missing from OpenTelemetry. 

There is currently [OTEP-69](https://github.com/open-telemetry/oteps/pull/69) that proposes typed events and includes structures for recording errors.

Since it was authored, [array-value attributes](https://github.com/open-telemetry/opentelemetry-specification/pull/368) have been added to the specification. This addition makes it possible to record errors using the existing event type by representing a stack trace as an array of strings, where each entry corresponds to a stackframe.

This PR doesn't intend to compete with OTEP-69, but offers another approach to be considered. Hopefully, between this proposal and OTEP-69 we can begin to drive a discussion on how to record errors forward.