### PR TITLE
Combined Metrics API updates for v0.3 (Add Observer instrument, remove Gauge instrument, etc.)

### DIFF
--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -23,13 +23,15 @@
   * [Counters and Measures compared](#counters-and-measures-compared)
   * [Observer instruments](#observer-instruments)
 - [Examples](#examples)
-  * [Reporting bytes read and written](#reporting-bytes-read-and-written)
-  * [Reporting per-request CPU usage](#reporting-per-request-cpu-usage)
+  * [Reporting total bytes read](#reporting-total-bytes-read)
+  * [Reporting total bytes read and bytes per request](#reporting-total-bytes-read-and-bytes-per-request)
   * [Reporting system call duration](#reporting-system-call-duration)
   * [Reporting request size](#reporting-request-size)
   * [Reporting a per-request finishing account balance](#reporting-a-per-request-finishing-account-balance)
   * [Reporting process-wide CPU usage](#reporting-process-wide-cpu-usage)
   * [Reporting per-shard memory holdings](#reporting-per-shard-memory-holdings)
+  * [Reporting number of active requests](#reporting-number-of-active-requests)
+  * [Reporting bytes read and written correlated by end user](#reporting-bytes-read-and-written-correlated-by-end-user)
 
 <!-- tocstop -->
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -554,3 +554,16 @@ rises and falls as new requests begin and end processing.
 Observer the number of active requests periodically with an Observer
 instrument.  Labels can be used to indicate which application-specific
 properties are associated with these events.
+
+### Reporting bytes read and written correlated by end user
+
+An application uses storage servers to read and write from some
+underlying media.  These requests are made in the context of the end
+user that made the request into the frontend system, with Correlation
+Context passed from the frontend to the storage servers carrying these
+properties.
+
+Use Counter instruments to report the number of bytes read and written
+by the storage server.  Configure the SDK to use a Correltion Context
+label key (e.g., named "app.user") to aggregate events by all metric
+instruments.

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -238,9 +238,7 @@ by definition.
 
 Labels associated with Counter instrument events can be used to
 compute rates and totals from the instrument, over selected
-dimensions.  When aggregating Counter events, we naturally combine
-values using arithmetic addition.  Counter `Add(0)` events are no-ops,
-by definition.
+dimensions.  Counter `Add(0)` events are no-ops, by definition.
 
 ### Measure
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -271,6 +271,13 @@ semantically equivalent to one `Add(2)` event--`Add(m)` and `Add(n)`
 is equivalent to `Add(m+n)`.  This property means that Counter events
 can be combined inexpensively, by definition.
 
+Counter instruments can be seen as special cases of Measure
+instruments with the additive property described above and a
+more-specific verb to improve readability (i.e., "Add" instead of
+"Record").  Counter instruments are special cases of Measure
+instruments in that they only preserve a Sum, by default, and no other
+summary statistics.
+
 Labels associated with Counter instrument events can be used to
 compute rates and totals from the instrument, over selected
 dimensions.  Counter `Add(0)` events are no-ops, by definition.

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -431,7 +431,7 @@ rate or as a total sum.
 ### Observer instruments
 
 Observer instruments are recommended for reporting measurements about
-the state of the program at a moment in time.  These expose current
+the state of the program periodically.  These expose current
 information about the program itself, not related to individual events
 taking place in the program.  Observer instruments are reported
 outside of a context, thus do not have an effective span context or

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -36,11 +36,22 @@
 ## Overview
 
 The OpenTelemetry Metrics API supports capturing measurements about
-the execution of a computer program as it runs.  The Metrics API is
+the execution of a computer program at run time.  The Metrics API is
 designed explicitly for processing raw measurements, generally with
 the intent to produce continuous summaries of those measurements
 simultaneously.  Hereafter, "the API" refers to the OpenTelemetry
 Metrics API.
+
+The API provides functions for entering raw measurements, through
+several [calling
+conventions](api-metrics-user.md#metric-calling-conventions) that
+offer different levels of performance.  Regardless of calling
+convention, we define a _metric event_ as the logical thing that
+happens when a new measurement is entered.  The word "enter" as used
+here refers to the logical creation of an event through one of the
+calling conventions.  This moment of entry defines an implicit
+timestamp, which is the wall time an SDK would read from a clock at
+that moment.
 
 The word "semantic" or "semantics" as used here refers to _how we give
 meaning_ to metric events, as they take place under the API.  The term
@@ -52,15 +63,6 @@ understand their meaning.  The standard implementation performs
 aggregation corresponding to the default interpretation for each kind
 of metric event.
 
-The API provides functions for entering raw measurements, through
-several [calling
-conventions](api-metrics-user.md#metric-calling-conventions) that
-offer different levels of performance.  Regardless of calling
-convention, we define a _metric event_ as the logical thing that
-happens when a new measurement is entered.  The word "enter" as used
-here refers to the logical creation of an event through one of the
-calling conventions.
-
 Monitoring and alerting systems commonly use the data provided through
 metric events, after applying various [aggregations](#aggregations)
 and converting into various [exposition formats](#exposition-formats).
@@ -68,7 +70,7 @@ However, we find that there are many other uses for metric events,
 such as to record aggregated or raw measurements in tracing and
 logging systems.  For this reason, [OpenTelemetry requires a
 separation of the API from the SDK](library-guidelines.md#requirements),
-so that different SDKs can be configured at runtime.
+so that different SDKs can be configured at run time.
 
 ### Metric Instruments
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -80,8 +80,8 @@ properties.  Instruments are created and defined through calls to a
 Each kinds of metric instrument has its own semantics, briefly
 described as:
 
-- Counter: metric events of this kind _Add_ to a value that you would sum over time
-- Measure: metric events of this kind _Record_ a value that you would average over time
+- Counter: metric events of this kind _Add_ to a value that is summed over time
+- Measure: metric events of this kind _Record_ a value that is aggregated over time
 - Observer: metric events of this kind _Observe_ a coherent set of values at an instant in time.
 
 An _instrument definition_ describes several properties of the
@@ -305,15 +305,15 @@ Depending on the exposition format, sums are exported either as pairs
 of label set and cumulative _difference_ or as pairs of label set and
 cumulative _total.
 
-2. Measure.  Use the `Record()` function to report summary statistics
-about the distribution of values, for each distinct label set.  The
-summary statistics to use are determined by the aggregation, but
-they usually include at least the sum of values, the count of
-measurements, and the minimum and maximum values.  When aggregating
-distinct Measure events, report summary statistics of the combined
-value distribution.  Exposition formats for summary statistics vary
-widely, but typically include pairs of label set and (sum, count,
-minimum and maximum value).
+2. Measure.  Use the `Record()` function to report events that for
+which the SDK will compute summary statistics about the distribution
+of values, for each distinct label set.  The summary statistics to use
+are determined by the aggregation, but they usually include at least
+the sum of values, the count of measurements, and the minimum and
+maximum values.  When aggregating distinct Measure events, report
+summary statistics of the combined value distribution.  Exposition
+formats for summary statistics vary widely, but typically include
+pairs of label set and (sum, count, minimum and maximum value).
 
 3. Observer.  Current values are provided by the Observer callback at
 the end of each Metric collection period.  When aggregating values
@@ -392,10 +392,10 @@ user-provided LabelSet values.
 
 Start with an application for metrics data in mind.  It is useful to
 consider whether you are more likely to be interested in the sum of
-values or the average value, as processed by the instrument.  Counters
-are useful when only the sum is interesting.  Measures are useful when
-the sum and any other kind of summary information about the individual
-values are of interest.
+values or any other aggregate value (e.g., average, histogram), as
+processed by the instrument.  Counters are useful when only the sum is
+interesting.  Measures are useful when the sum and any other kind of
+summary information about the individual values are of interest.
 
 If only the sum is of interest, use a Counter instrument.
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -113,30 +113,74 @@ Observer or the Measure instrument in this API.
 
 ### Brief: Three kinds of instrument
 
-Two of the three kinds of instrument have been introduced through
-examples above:
+Two of the three kinds of instrument have been used in the examples
+above.  The three instruments are:
 
-1. Counter.  Events contribute to a sum (i.e., a running total).  The
-key property of Counter events is that they can be semantically
-combined without affecting their meaning.  For example, two `Add(1)`
-events are semantically equivalent to one `Add(2)` event.
-2. Measure. Events are individual measurements.  The key property of
-Measure events is that they correspond to real events, they cannot be
-semantically combined.
+#### Counter
 
-The third kind of instrument is the Observer instrument, used for
-recording the current value from a measurement source.  Each
-collection interval, Observer instruments contribute the current value
-for each distinct set of labels.  When aggregating Observer instrument
-values across distinct label sets, the default implementation is to
-compute a sum of current values.
+Counter instruments are used to report sums.  These are sometimes used
+to monitor _rates_, and they are sometimes used to report _totals_.
+One key property of Counter instruments is that two `Add(1)` events
+are semantically equivalent to one `Add(2)` event, meaning that
+Counter events can be combined using addition by definition.
 
-Whereas Counter and Measure are both synchronous instruments, called
-by the program to report on itself, the Observer instrument is
-activated by the SDK through a callback, synchronized with collection.
-Two key properties of an Observer instrument are (1) that it allows
-the programmer to report a coherent set of values, (2) that it can
-lower collection cost by computing values on demand.
+Labels associated with Counter instrument events can be used to
+compute rates and totals over selected dimensions.  When aggregating
+Counter events we naturally combine values using addition.  Counter
+`Add(0)` events are no-ops by definition.
+
+Counters are monotonic by default, meaning `Add()` logically accepts
+only non-negative values.  Monotonicity is useful for defining rates,
+especially; non-monotonic Counter instruments are an option to support
+sums that rise and fall.
+
+Examples: requests processed, bytes read or written, memory allocated.
+
+#### Measure
+
+Measure instruments are used to report individual measurements.
+Measure events are semantically independent and cannot be naturally
+combined like with Counters.  Measure instruments are used to report
+many kinds of information, recommended for reporting measurements
+associated with real events in a computer program.
+
+As a synchronous API, Measure `Record()` events can be used to record
+information with associated labels and context.  This is the more
+general of the two synchronous metric instruments.
+
+Measure instruments support non-negative values by default, also known
+as "absolute" in the sense that, mathematically, absolute values are
+never negative.  As an option, Measure instruments can be defined as
+not absolute, supporting both postive and negative values.
+
+Examples: request latency, number of terms in a query, temperature.
+
+#### Observer
+
+Observer instruments are used to report a current set of values at the
+time of collection.  Observer instruments report not only current
+values, but also which label sets are current at the moment of
+collection as a coherent set of values.  These instruments reduce
+collection cost because they are computed and reported only once per
+collection interval, by definition.
+
+Unlike Counter and Measure instruments, Observer instruments are
+synchronized with collection, used to report values not based in
+events but periodically, on demand, by the program itself.  There is
+no aggregation across time for Observer instruments by definition,
+only the current value is defined.
+
+Observer instruments support being declared as monotonic.  A monotonic
+measure instrument supports reporting values that are not less than
+the value reported in the previous collection interval.
+
+When aggregating Observer instrument values across dimensions other
+than time, Observer instruments may be treated like Counters (to
+combine a rate or sum) or like Measures (to combine a distribution).
+Unless otherwise configured, Observers are aggregated as Counters
+would be.
+
+Examples: memory held per shard, queue size by name.
 
 ### Interpretation
 
@@ -149,40 +193,51 @@ the same form (i.e., a timestamp, an instrument, a number, and a label
 set)?
 
 Establishing different kinds of instrument is important because in
-most cases it allows the SDK to provide default functionality without
-requiring alternative beahviors to be configured.  The choice of
-instrument determines not only the meaning of the events but also the
-name of the function used to report data.  The function names--`Add()`
-for Counter instruments, `Record()` for Measure instruments, and
-`Observe()` for Observer instruments--help convey and reinforce the
-semantics of the event.
+most cases it allows the SDK to provide good default functionality
+without requiring alternative behaviors to be configured.  The choice
+of instrument determines not only the meaning of the events but also
+the name of the function used to report data.  The function
+names--`Add()` for Counter instruments, `Record()` for Measure
+instruments, and `Observe()` for Observer instruments--help convey and
+reinforce the semantics of the event.
 
 The standard implementation for the three instruments is defined as
 follows:
 
-1. Counter.  Accumulate a total for each distinct label set.  When
-aggregating distinct label sets for a Counter, combine using addition.
-Export as the computed sum.
-2. Measure.  Compute summary statistics of the value distribution for
-each distinct label set.  Which statistics are used is determined by
-the implementation, but they usually include at least the sum of
-values, the count of measurements, and the minimum and maximum values.
-When aggregating distinct label sets for a Measure, report summary
-statistics of the combined value distribution.  Exposition formats for
-Measure data vary widely by backend service.
-
+1. Counter.  The `Add()` function accumulates a total for each
+distinct label set.  When aggregating over distinct label sets for a
+Counter, combine using addition.  Export as the computed sum.
+2. Measure.  Use the `Record()` function to report summary statistics
+about the distribution of values, for each distinct label set.  Which
+statistics are used is determined by the implementation, but they
+usually include at least the sum of values, the count of measurements,
+and the minimum and maximum values.  When aggregating distinct label
+sets for a Measure, report summary statistics of the combined value
+distribution.  Exposition formats for Measure data vary widely by
+backend service.
 3. Observer.  Current values are provided by the Observer callback at
 the end of each Metric collection period.  When aggregating values
-_for the same label set_, combine using the more-recent value.  When
+_for the same label set_, combine using the most-recent value.  When
 aggregating values _for different label sets_, combine using the sum.
-Export as label set, calculated value pairs.
+Export as pairs of label set and calculated value.
 
-### Optional restrictions
+We recognize that the standard behavior of the three instruments does
+not cover all use-cases perfectly.  There is a natural tension between
+offering dedicated metric instruments for every distinct metric
+application and combining use-cases, generalizing semantics to reduce
+the API surface area.  We could have define more than or fewer than
+three kinds of instrument; we have three because we these seem like
+enough.  Where a uncommon use-cases call for non-standard
+implementation (e.g., a Measure instrument configured to with
+last-value aggregation), we accept that users will be required to
+provide additional configuration for how to view certain metric data.
+
+### Optional semantic restrictions
 
 It is common to apply restrictions on the input range of metric
-values passed to inputs `Add()`, `Record()`, and `Observe()`.  
+values passed to inputs `Add()`, `Record()`, and `Observe()`.  As 
 
-@@@ HERE
+@@@ HERE note that it's semantics, not required enforcement.
 
 Generally, there is a question of whether the instrument can be used
 to compute a rate, because that is usually a desirable analysis.  Each
@@ -193,7 +248,11 @@ and durations; a Measure option is provided to record positive or
 negative values, but it does not change the kind of instrument or the
 method name used, as the semantics are unchanged.
 
+@@@ Optional special case for timer instrument: SHOULD
+
 ## Metric instrument selection
+
+@@@ HERE add many more examples.
 
 To guide the user in selecting the right kind of metric for an
 application, we'll consider the following questions about the primary

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -259,9 +259,10 @@ dimensions.  Counter `Add(0)` events are no-ops, by definition.
 
 Semantically, metric events from Measure instruments are independent,
 meaning they cannot be combined naturally, as with Counters.  Measure
-instruments are used to capture many kinds of information, and are
-recommended for all cases where the additive property of Counter
-instruments does not apply.
+instruments are used to capture many kinds of information,
+synchronously, and are recommended for all cases that reflect an event
+in the application where the additive property of Counter instruments
+does not apply.
 
 Labels associated with Measure instrument events can be used to
 compute information about the distribution of values from the

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -266,10 +266,10 @@ individual semantics.
 Counter instruments are used to capture changes in running sums,
 synchronously.  These are commonly used to monitor rates, and they are
 sometimes used to capture totals that rise and fall.  An essential
-property of Counter instruments is that two `Add(1)` events are
-semantically equivalent to one `Add(2)` event--`Add(m)` and `Add(n)`
-is equivalent to `Add(m+n)`.  This property means that Counter events
-can be combined inexpensively, by definition.
+property of Counter instruments is that two events `Add(m)` and
+`Add(n)` are semantically equivalent to one event `Add(m+n)`.  This
+property means that Counter events can be combined inexpensively, by
+definition.  Counter `Add(0)` events are no-ops, by definition.
 
 Counter instruments can be seen as special cases of Measure
 instruments with the additive property described above and a
@@ -280,7 +280,7 @@ summary statistics.
 
 Labels associated with Counter instrument events can be used to
 compute rates and totals from the instrument, over selected
-dimensions.  Counter `Add(0)` events are no-ops, by definition.
+dimensions.  
 
 ### Measure
 
@@ -350,9 +350,9 @@ Depending on the exposition format, sums are exported either as pairs
 of label set and cumulative _delta_ or as pairs of label set and
 cumulative _total_.
 
-2. Measure.  Use the `Record()` function to report events that for
-which the SDK will compute summary statistics about the distribution
-of values, for each distinct label set.  The summary statistics to use
+2. Measure.  Use the `Record()` function to report events for which
+the SDK will compute summary statistics about the distribution of
+values, for each distinct label set.  The summary statistics to use
 are determined by the aggregation, but they usually include at least
 the sum of values, the count of measurements, and the minimum and
 maximum values.  When aggregating distinct Measure events, report

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -271,7 +271,12 @@ sometimes used to capture totals that rise and fall.  An essential
 property of Counter instruments is that two events `Add(m)` and
 `Add(n)` are semantically equivalent to one event `Add(m+n)`.  This
 property means that Counter events can be combined inexpensively, by
-definition.  Counter `Add(0)` events are no-ops, by definition.
+definition.
+
+Note that `Add(0)` events are not considered a special case, despite
+contributing nothing to a sum.  `Add(0)` events MUST be observed by
+the SDK in case non-default aggregations are configured for the
+instrument.
 
 Counter instruments can be seen as special cases of Measure
 instruments with the additive property described above and a
@@ -357,33 +362,13 @@ We believe that the standard behavior of one of these three
 instruments covers nearly all use-cases for users of OpenTelemetry in
 terms of the intended semantics.
 
-### Option: Dedicated Measure instrument for timing measurements
-
-As a language-optional feature, the API MAY support a dedicated
-instrument for reporting timing measurements.  This kind of
-instrument, with recommended name `Timer` (and `BoundTimer`), is
-semantically equivalent to a Measure instrument.  Like the Measure
-instrument, Timers support a `Record()` function.  The input value to
-this instrument is in the language's conventional data type for timing
-measurements.
-
-Timer instruments MUST capture only the magnitude of the input value
-(i.e., an absolute value).  When the user provides a negative value to
-the Timer `Record()` function, the captured measurement is the number
-stripped of its sign.
-
-For example, in Go the API will accept a `time.Duration`, and in C++
-the API will accept a `std::chrono::duration`.  These instruments
-apply the correct units automatically, reducing the potential for
-confusion over timing metric events.
-
 ### Future Work: Option Support
 
 We are aware of a number of reasons to iterate on these
 instrumentation kinds, in order to offer:
 
 1. Range restrictions on input data.  Instruments accepting negative values is rare in most applications, for example, and it is useful to offer both a semantic declaration (e.g., "negative values are meaningless") and a data validation step (e.g., "negative values should be dropped").
-2. Monotonicity support.  When a series of values is known to be monotonic, it is useful to declare this; this allows us to detect process resets.
+2. Monotonicity support.  When a series of values is known to be monotonic, it is useful to declare this..
 
 For the most part, these behaviors are not necessary for correctness
 within the local process or the SDK, but they are valuable in
@@ -402,6 +387,8 @@ supports configuring aggregations, including which operator is applied
 
 1. Should the API user be provided with options to configure specific views, statically, in the source?
 2. Should the View API be a stand-alone facility, able to install configurable aggregations, at runtime?
+
+See the [current issue on this topic](https://github.com/open-telemetry/opentelemetry-specification/issues/466).
 
 ## Metric instrument selection
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -7,11 +7,18 @@
   * [Meter API](#meter-api)
   * [Purpose of this document](#purpose-of-this-document)
 - [Metric API / SDK separation](#metric-api--sdk-separation)
-  * [Justification for three kinds of instrument](#justification-for-three-kinds-of-instrument)
-  * [Metric instrument selection](#metric-instrument-selection)
-  * [Counter](#counter)
-  * [Gauge](#gauge)
-  * [Measure](#measure)
+  * [Three kinds of instrument](#three-kinds-of-instrument)
+    + [Counter](#counter)
+    + [Measure](#measure)
+    + [Observer](#observer)
+  * [Standard Interpretation](#standard-interpretation)
+  * [Optional semantic restrictions](#optional-semantic-restrictions)
+    + [Absolute vs. Non-Absolute](#absolute-vs-non-absolute)
+    + [Monotonic vs. Non-Monotonic](#monotonic-vs-non-monotonic)
+- [Metric instrument selection](#metric-instrument-selection)
+  * [Counters and Measures compared](#counters-and-measures-compared)
+  * [Observer instruments](#observer-instruments)
+- [Examples](#examples)
 
 <!-- tocstop -->
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -470,22 +470,39 @@ change of state in the program.
 
 ## Examples
 
-### Reporting bytes read and written
+### Reporting total bytes read
 
-You wish to monitor the number of bytes read and written from a
-messaging server that supports several protocols.  The number of bytes
-read and written should be labeled with the protocol name and
-aggregated in the process.
+You wish to monitor the total number of bytes read from a messaging
+server that supports several protocols.  The number of bytes read
+should be labeled with the protocol name and aggregated in the
+process.
 
 This is a typical application for the Counter instrument.  Use one
-Counter for bytes read and one Counter for bytes written.  When
-handling a request, compute a LabelSet containing the name of the
-protocol and potentially other useful labels, then call `Add()` twice
-with the same label set and the number of bytes read and written.
+Counter for capturing the number bytes read.  When handling a request,
+compute a LabelSet containing the name of the protocol and potentially
+other useful labels, then call `Add()` with the same label set and the
+number of bytes read.
 
 To lower the cost of this reporting, you can `Bind()` the
 instrument with each of the supported protocols ahead of time and
 avoid computing the label set for each request.
+
+### Reporting total bytes read and bytes per request
+
+You wish to monitor the total number of bytes read as well as the
+number of bytes read per request, to have observability into total
+traffic as well as typical request size.  As with the example above,
+these metric events should be labeled with a protocol name.
+
+This is a typical application for the Measure instrument.  Use one
+Measure for capturing the number of bytes per request.  A sum
+aggregation applied to this data yields the total bytes read; other
+aggregations allow you to export the minimum and maximum number of
+bytes read, as well as the average value, and quantile estimates.
+
+In this case, the guidance is to create a single instrument.  Do not
+create a Counter instrument to export a sum when you want to export
+other summary statistics using a Measure instrument.
 
 ### Reporting per-request CPU usage
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -36,10 +36,10 @@
 ## Overview
 
 The OpenTelemetry Metrics API supports capturing measurements about
-the execution of a computer program in real time.  The Metrics API is
+the execution of a computer program as it runs.  The Metrics API is
 designed explicitly for processing raw measurements, generally with
-the intent to produce continuous summaries of those measurements, also
-in real time.  Hereafter, "the API" refers to the OpenTelemetry
+the intent to produce continuous summaries of those measurements
+simultaneously.  Hereafter, "the API" refers to the OpenTelemetry
 Metrics API.
 
 The word "semantic" or "semantics" as used here refers to _how we give

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -578,7 +578,7 @@ distinct label sets.
 Suppose your server maintains the count of active requests, which
 rises and falls as new requests begin and end processing.
 
-Observer the number of active requests periodically with an Observer
+Observe the number of active requests periodically with an Observer
 instrument.  Labels can be used to indicate which application-specific
 properties are associated with these events.
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -68,15 +68,15 @@ accomplishes its goals and the export capabilities it supports are
 specified for the default SDK in the (Metric SDK specification
 WIP)[#WIP-spec-issue-347].
 
-The standard interpretation for `Meter` implementations to follow is
-given so that users understand the intended use for each kind of
-metric.  For example, a Counter instrument supports `Add()` events,
-and the default implementation is to compute a sum.  The sum may be
-exported as an absolute value or as the change in value, but
-regardless of the exporter and the implementation, the purpose of
-using a Counter with `Add()` is to monitor a sum.  A detailed
-explanation for how to select metric instruments for common use-cases
-is given below, according to the semantics defined next.
+The standard implementation for `Meter` implementations to follow is
+given, to aid with understanding the different instrument use-cases.
+For example, a Counter instrument supports `Add()` events, and the
+standard implementation is to compute a sum.  The sum may be exported
+as a grand total or as the change in the grand total, but regardless
+of the exporter and specific techniques, the purpose of using a
+Counter with `Add()` is to monitor a sum.  A detailed explanation for
+how to select metric instruments for common use-cases is given below,
+according to the semantics defined next.
 
 ### Purpose of this document
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -162,8 +162,8 @@ collection interval.  The default SDK takes this approach.
 
 Counter and Measure instruments offer synchronous APIs for entering
 measurements.  Metric events from Counter and Measure instruments are
-captured when they happen, the moment the SDK receives the function
-call.
+captured at the moment they happen, when the SDK receives the
+corresponding function call.
 
 The Observer instrument supports an asynchronous API, allowing the SDK
 to collect metric data on demand, once per collection interval.  A
@@ -184,15 +184,15 @@ Metric events have the same logical representation, regardless of
 kind.  Whether a Counter, a Measure, or an Observer instrument, metric
 events produced through an instrument consist of:
 
-- an implicit timestamp at the moment the API function is called
-- the instrument definition (name, kind, and options)
-- a value (numeric)
-- a [Context](api-context.md) (span context, correlation context)
-- a label set
+- [Context](context.md) (Span context, Correlation context)
+- timestamp (implicit to the SDK)
+- instrument definition (name, kind, and semantic options)
+- label set (associated key-values)
+- value (a number)
 
-This is the outcome of separating the API from the SDK--a common
+This format is the result of separating the API from the SDK--a common
 representation for metric events, where the only semantic distinction
-is the kind of instrument that was used.
+is the kind of instrument that was specified by the user.
 
 ## Three kinds of instrument
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -58,7 +58,7 @@ To produce measurements using an instrument, you need an SDK that
 supports the `Meter` API, which consists of a set of constructors, the
 `Labels` function for building label sets, and the `RecordBatch`
 function for batch reporting.  Refer to the [sdk-facing OpenTelemetry
-API specification](api-metrics-user.md) for more implementation notes.
+API specification](api-metrics-meter.md) for more implementation notes.
 
 Because of API-SDK separation, the `Meter` implementation ultimately
 determines how metrics events are handled.  The specification's task
@@ -95,8 +95,8 @@ convention, compared with a number of common metric libraries, and
 stems from the separation of the API and the SDK.  The SDK ultimately
 determines how to handle metric events and could potentially implement
 non-standard behavior.  All metric events can be represented as
-consisting of a timestamp, an instrument, a number (the value), and a
-label set.  The semantics defined here are meant to assist both
+consisting of a timestamp, an instrument, a number (the _value_), and
+a label set.  The semantics defined here are meant to assist both
 application and SDK implementors, and examples will be given below.
 
 The separation of API and SDK explains why the metric API does not
@@ -117,6 +117,21 @@ nature.  Using the word "gauge" suggests a behavior, that the
 instrument will be used to expose the last value, not a semantic
 definition.  Uses of traditional gauge instruments translate into an
 Observer or the Measure instrument in this API.
+
+### Label sets
+
+_Label_ is the term used to refer to a key:value attribute associated
+with a metric event.  Although they are fundamentally similar to [Span
+attributes](api-tracing.md#span) in the tracing API, a set of labels
+is given its own type in the Metric API, `LabelSet`.  Label sets are a
+feature of the API to facilitate re-use across the metric API.  Users
+are encouraged to re-use label sets whenever possible, as they may
+contain a previously encoded representation of the data.
+
+Users obtain label sets by calling the `Meter` API function (e.g.,
+`Meter.GetLabels({ key, value }, ...)`).  Each of the instrument
+calling conventions detailed in the [user-facing API
+specification](api-metrics-user.md) accepts a `LabelSet`.
 
 ### Three kinds of instrument
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -42,21 +42,6 @@ the intent to produce continuous summaries of those measurements, also
 in real time.  Hereafter, "the API" refers to the OpenTelemetry
 Metrics API.
 
-The API provides functions for entering raw measurements, through
-several [calling conventions](TODO: link to user doc) that offer
-different levels of performance.  Regardless of calling convention, we
-define a _metric event_ as the logical thing that happens when a new
-measurement is entered.
-
-Monitoring and alerting systems commonly use the data provided through
-metric events, after applying various [aggregations](#aggregations)
-and converting into various [exposition formats](#exposition-formats).
-However, we find that there are many other uses for metric events,
-such as to record aggregated or raw measurements in tracing and
-logging systems.  For this reason, [OpenTelemetry requires a
-separation of the API from the SDK](library-guidelines.md#requirements),
-so that different SDKs can be configured at runtime.
-
 The word "semantic" or "semantics" as used here refers to _how we give
 meaning_ to metric events, as they take place under the API.  The term
 is used extensively in this document to define and explain these API
@@ -66,6 +51,24 @@ _standard implementation_ will be described below to help us
 understand their meaning.  The standard implementation performs
 aggregation corresponding to the default interpretation for each kind
 of metric event.
+
+The API provides functions for entering raw measurements, through
+several [calling
+conventions](api-metrics-user.md#metric-calling-conventions) that
+offer different levels of performance.  Regardless of calling
+convention, we define a _metric event_ as the logical thing that
+happens when a new measurement is entered.  The word "enter" as used
+here refers to the logical creation of an event through one of the
+calling conventions.
+
+Monitoring and alerting systems commonly use the data provided through
+metric events, after applying various [aggregations](#aggregations)
+and converting into various [exposition formats](#exposition-formats).
+However, we find that there are many other uses for metric events,
+such as to record aggregated or raw measurements in tracing and
+logging systems.  For this reason, [OpenTelemetry requires a
+separation of the API from the SDK](library-guidelines.md#requirements),
+so that different SDKs can be configured at runtime.
 
 ### Metric Instruments
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -103,12 +103,12 @@ covered in the [user-level API specification](api-metrics-user.md).
 
 _Label_ is the term used to refer to a key-value attribute associated
 with a metric event.  Although they are fundamentally similar to [Span
-attributes](api-tracing.md#span) in the tracing API, a [label
-set](TODO: link to user doc) is given its own type in the Metrics API
-(generally: `LabelSet`).  Label sets are a feature of the API meant to
-facilitate re-use and thereby to lower the cost of processing metric events.
-Users are encouraged to re-use label sets whenever possible, as they
-may contain a previously encoded representation of the labels.
+attributes](api-tracing.md#span) in the tracing API, a label set is
+given its own type in the Metrics API (generally: `LabelSet`).  Label
+sets are a feature of the API meant to facilitate re-use and thereby
+to lower the cost of processing metric events.  Users are encouraged
+to re-use label sets whenever possible, as they may contain a
+previously encoded representation of the labels.
 
 Users obtain label sets by calling a `Meter` API function.  Each of
 the instrument calling conventions detailed in the [user-level API
@@ -117,9 +117,14 @@ specification](api-metrics-user.md) accepts a label set.
 ### Meter Interface
 
 To produce measurements using an instrument, you need an SDK that
-implements the `Meter` API.  This interface consists of a set of instrument
-constructors, functionality related to label sets, and a facility for
-entering batches of measurements in a semantically atomic way.
+implements the `Meter` API.  This interface consists of a set of
+instrument constructors, functionality related to label sets, and a
+facility for entering batches of measurements in a semantically atomic
+way.  As an obligatory step, the API requires the caller to provide
+the name of the instrumenting library (optionally, the version), that
+is meant to be used for identifying instrumentation produced from that
+library for such purposes as disabling instrumentation, configuring
+aggregation, and applying sampling policies.
 
 There is a global `Meter` instance available for use that facilitates
 automatic instrumentation for third-party code.  Use of this instance

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -112,7 +112,7 @@ specification](api-metrics-user.md) accepts a label set.
 ### Meter Interface
 
 To produce measurements using an instrument, you need an SDK that
-supports the `Meter` API, which consists of a set of instrument
+implements the `Meter` API, which consists of a set of instrument
 constructors, functionality related to label sets, and a facility for
 entering batches of measurements in a semantically atomic way.
 
@@ -309,7 +309,7 @@ cumulative _total.
 
 2. Measure.  Use the `Record()` function to report summary statistics
 about the distribution of values, for each distinct label set.  The
-summary statistics to use are determined by the implementation, but
+summary statistics to use are determined by the aggregation, but
 they usually include at least the sum of values, the count of
 measurements, and the minimum and maximum values.  When aggregating
 distinct Measure events, report summary statistics of the combined

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -133,7 +133,7 @@ a `Meter` implementation, that is meant to be used for identifying
 instrumentation produced from that library for such purposes as
 disabling instrumentation, configuring aggregation, and applying
 sampling policies.  (TODO: refer to the semantic convention on the
-Named Tracer/Meter).
+reporting library name).
 
 Details about installing an SDK and obtaining a named `Meter` are
 covered in the [SDK-level API specification](api-metrics-meter.md).
@@ -284,12 +284,14 @@ and ratios, because values are part of a set.
 Unlike Counter and Measure instruments, Observer instruments are
 synchronized with collection.  There is no aggregation across time for
 Observer instruments by definition, only the current set of values is
-semantically defined.
+semantically defined.  Because Observer instruments are activated by
+the SDK, they can be effectively disabled at low cost.
 
 These values are considered coherent, because measurements from an
 Observer instrument in a single collection interval are captured at
 the same logical time.  A single callback invocation generates (zero
 or more) simultaneous metric events, all sharing an implicit timestamp.
+
 
 ## Interpretation
 
@@ -542,3 +544,12 @@ with a shard label.  These can be aggregated across hosts to compute
 cluster-wide memory holdings by shard, for example, using the standard
 aggregation for Observers, which sums the current value across
 distinct label sets.
+
+### Reporting number of active requests
+
+Suppose your server maintains the count of active requests, which
+rises and falls as new requests begin and end processing.
+
+Observer the number of active requests periodically with an Observer
+instrument.  Labels can be used to indicate which application-specific
+properties are associated with these events.

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -301,10 +301,12 @@ data set.
 
 ### Observer
 
-Observer instruments are used to capture a _current set of values_ at a
-point in time.  Observer instruments are asynchronous, with the use of
-callbacks allowing the user to capture multiple values per collection
-interval.  
+Observer instruments are used to capture a _current set of values_ at
+a point in time.  Observer instruments are asynchronous, with the use
+of callbacks allowing the user to capture multiple values per
+collection interval.  Observer instruments are not associated with a
+Context, meaning it is impossible to associate Observer instruments
+with Correlation Context.
 
 Observer instruments capture not only current values, but also
 effectively _which label sets are current_ at the moment of

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -282,7 +282,7 @@ summary statistics.
 
 Labels associated with Counter instrument events can be used to
 compute rates and totals from the instrument, over selected
-dimensions.  
+dimensions.
 
 ### Measure
 
@@ -325,7 +325,6 @@ Observer instrument in a single collection interval are captured at
 the same logical time.  A single callback invocation generates (zero
 or more) simultaneous metric events, all sharing an implicit timestamp.
 
-
 ## Interpretation
 
 We believe the three instrument kinds Counter, Measure, and Observer
@@ -348,29 +347,11 @@ meaning of these actions.
 The standard implementation for the three instruments is defined as
 follows:
 
-1. Counter.  The `Add()` function accumulates a total for each
-distinct label set.  When aggregating over distinct label sets for a
-Counter, combine using arithmetic addition and export as a sum.
-Depending on the exposition format, sums are exported either as pairs
-of label set and cumulative _delta_ or as pairs of label set and
-cumulative _total_.
+1. Counter.  The `Add()` function accumulates a total for each distinct label set.  When aggregating over distinct label sets for a Counter, combine using arithmetic addition and export as a sum. Depending on the exposition format, sums are exported either as pairs of label set and cumulative _delta_ or as pairs of label set and cumulative _total_.
 
-2. Measure.  Use the `Record()` function to report events for which
-the SDK will compute summary statistics about the distribution of
-values, for each distinct label set.  The summary statistics to use
-are determined by the aggregation, but they usually include at least
-the sum of values, the count of measurements, and the minimum and
-maximum values.  When aggregating distinct Measure events, report
-summary statistics of the combined value distribution.  Exposition
-formats for summary statistics vary widely, but typically include
-pairs of label set and (sum, count, minimum and maximum value).
+2. Measure.  Use the `Record()` function to report events for which the SDK will compute summary statistics about the distribution of values, for each distinct label set.  The summary statistics to use are determined by the aggregation, but they usually include at least the sum of values, the count of measurements, and the minimum and maximum values.  When aggregating distinct Measure events, report summary statistics of the combined value distribution.  Exposition formats for summary statistics vary widely, but typically include pairs of label set and (sum, count, minimum and maximum value).
 
-3. Observer.  Current values are provided by the Observer callback at
-the end of each Metric collection period.  When aggregating values
-_for the same label set_, combine using the most-recent value.  When
-aggregating values _for different label sets_, combine the value
-distribution as for Measure instruments.  Export as pairs of label set
-and (sum, count, minimum and maximum value).
+3. Observer.  Current values are provided by the Observer callback at the end of each Metric collection period.  When aggregating values _for the same label set_, combine using the most-recent value.  When aggregating values _for different label sets_, combine the value distribution as for Measure instruments.  Export as pairs of label set and (sum, count, minimum and maximum value).
 
 We believe that the standard behavior of one of these three
 instruments covers nearly all use-cases for users of OpenTelemetry in
@@ -401,14 +382,8 @@ confusion over timing metric events.
 We are aware of a number of reasons to iterate on these
 instrumentation kinds, in order to offer:
 
-1. Range restrictions on input data.  Instruments accepting negative
-values is rare in most applications, for example, and it is useful to
-offer both a semantic declaration (e.g., "negative values are
-meaningless") and a data validation step (e.g., "negative values
-should be dropped").
-2. Monotonicity support.  When a series of values is known to be
-monotonic, it is useful to declare this; this allows us to detect
-process resets.
+1. Range restrictions on input data.  Instruments accepting negative values is rare in most applications, for example, and it is useful to offer both a semantic declaration (e.g., "negative values are meaningless") and a data validation step (e.g., "negative values should be dropped").
+2. Monotonicity support.  When a series of values is known to be monotonic, it is useful to declare this; this allows us to detect process resets.
 
 For the most part, these behaviors are not necessary for correctness
 within the local process or the SDK, but they are valuable in
@@ -425,10 +400,8 @@ A _View API_ is defined as an interface to an SDK mechanism that
 supports configuring aggregations, including which operator is applied
 (sum, p99, last-value, etc.) and which dimensions are used.
 
-1. Should the API user be provided with options to configure specific
-views, statically, in the source?
-2. Should the View API be a stand-alone facility, able to install
-configurable aggregations, at runtime?
+1. Should the API user be provided with options to configure specific views, statically, in the source?
+2. Should the View API be a stand-alone facility, able to install configurable aggregations, at runtime?
 
 ## Metric instrument selection
 
@@ -557,19 +530,8 @@ cost of collecting this information.
 CPU usage is something that we naturally sum, which raises several
 questions.
 
-- Why not use a Counter instrument?  In order to use a Counter
-instrument, we would need to convert total usage figures into
-deltas.  Calculating deltas from the previous measurement is
-easy to do, but Counter instruments are not meant to be used from
-callbacks.
-- Why not report deltass in the Observer callback?  Observer
-instruments are meant to be used to observe current values. Nothing
-prevents reporting deltas with an Observer, but the standard
-aggregation for Observer instruments is to sum the current value
-across distinct label sets.  The standard behavior is useful for
-determining the current rate of CPU usage, but special configuration
-would be required for an Observer instrument to use Counter
-aggregation.
+- Why not use a Counter instrument?  In order to use a Counter instrument, we would need to convert total usage figures into deltas.  Calculating deltas from the previous measurement is easy to do, but Counter instruments are not meant to be used from callbacks.
+- Why not report deltass in the Observer callback?  Observer instruments are meant to be used to observe current values. Nothing prevents reporting deltas with an Observer, but the standard aggregation for Observer instruments is to sum the current value across distinct label sets.  The standard behavior is useful for determining the current rate of CPU usage, but special configuration would be required for an Observer instrument to use Counter aggregation.
 
 ### Reporting per-shard memory holdings
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -8,7 +8,7 @@
   * [Meter Interface](#meter-interface)
   * [Aggregations](#aggregations)
   * [Time](#time)
-  * [WithKeys declaration on metric instruments](#withkeys-declaration-on-metric-instruments)
+  * [WithRecommendedKeys declaration on metric instruments](#withrecommendedkeys-declaration-on-metric-instruments)
   * [Metric Event Format](#metric-event-format)
 - [Three kinds of instrument](#three-kinds-of-instrument)
   * [Counter](#counter)
@@ -206,7 +206,7 @@ use of this term for the SDK specification, to refer to parts of a
 data format that express explicitly timestamped values, in a sequence,
 resulting from an aggregation of raw measurements over time.
 
-### WithKeys declaration on metric instruments
+### WithRecommendedKeys declaration on metric instruments
 
 A standard feature of metric SDKs is to pre-aggregate metric events
 according to a specified set of label keys (i.e., dimensions).  To
@@ -229,12 +229,12 @@ ik2]` are the ignored keys, then a metric event having labels
 event having labels `{ak1=A, ak2=B, ik1=Y, ik1=Z}` because they
 have identical label values for all of the aggregation keys.
 
-The API provides a `WithKeys` option for the user to declare the
+The API provides a `WithRecommendedKeys` option for the user to declare the
 recommended aggregation keys when declaring new metric instruments,
 intended as the default way to configure an exporter for
 pre-aggregation, if it is expected.  Since this is only expected in
 some exporters, it is regarded as an option relevant to the exporter,
-whether keys configured through `WithKeys` are applied for aggregation
+whether keys configured through `WithRecommendedKeys` are applied for aggregation
 purposes or not.  This allows the user influence the standard
 implementation behavior, especially for exporters that require
 pre-specified aggregation keys.

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -77,11 +77,11 @@ API are associated with an instrument, which gives the measurement its
 properties.  Instruments are created and defined through calls to a
 `Meter` API, which is the user-facing entry point to the SDK.
 
-Each kinds of metric instrument has its own semantics, briefly
+Each kind of metric instrument has its own semantics, briefly
 described as:
 
-- Counter: metric events of this kind _Add_ to a value that is summed over time
-- Measure: metric events of this kind _Record_ a value that is aggregated over time
+- Counter: metric events of this kind _Add_ to a value that is summed over time.
+- Measure: metric events of this kind _Record_ a value that is aggregated over time.
 - Observer: metric events of this kind _Observe_ a coherent set of values at an instant in time.
 
 An _instrument definition_ describes several properties of the
@@ -101,7 +101,7 @@ with a metric event.  Although they are fundamentally similar to [Span
 attributes](api-tracing.md#span) in the tracing API, a [label
 set](TODO: link to user doc) is given its own type in the Metrics API
 (generally: `LabelSet`).  Label sets are a feature of the API meant to
-facilitate re-use, to lower the cost of processing metric events.
+facilitate re-use and thereby to lower the cost of processing metric events.
 Users are encouraged to re-use label sets whenever possible, as they
 may contain a previously encoded representation of the labels.
 
@@ -112,12 +112,12 @@ specification](api-metrics-user.md) accepts a label set.
 ### Meter Interface
 
 To produce measurements using an instrument, you need an SDK that
-implements the `Meter` API, which consists of a set of instrument
+implements the `Meter` API.  This interface consists of a set of instrument
 constructors, functionality related to label sets, and a facility for
 entering batches of measurements in a semantically atomic way.
 
 There is a global `Meter` instance available for use.  Use of the this
-instance allows library code that uses it to be automatically enabled
+instance allows library code to operate in a no-op fashion until
 whenever the main application configures an SDK at the global level.
 
 Details about installing an SDK and obtaining a `Meter` are covered in
@@ -167,7 +167,7 @@ insignificant when aggregating data across minutes or hours of data.
 
 Aggregations are commonly computed over a series of events that fall
 into a contiguous region of time, known as the collection interval.
-Since the SDK controls decision to start collection, it is possible to
+Since the SDK controls the decision to start collection, it is possible to
 collect aggregated metric data while only reading the clock once per
 collection interval.  The default SDK takes this approach.
 
@@ -303,7 +303,7 @@ distinct label set.  When aggregating over distinct label sets for a
 Counter, combine using arithmetic addition and export as a sum.
 Depending on the exposition format, sums are exported either as pairs
 of label set and cumulative _difference_ or as pairs of label set and
-cumulative _total.
+cumulative _total_.
 
 2. Measure.  Use the `Record()` function to report events that for
 which the SDK will compute summary statistics about the distribution
@@ -328,7 +328,7 @@ terms of the intended semantics.
 
 ### Option: Dedicated Measure instrument for timing measurements
 
-As a language-optional feature, the API may support a dedicated
+As a language-optional feature, the API MAY support a dedicated
 instrument for reporting timing measurements.  This kind of
 instrument, with recommended name `Timer` (and
 `BoundTimer`), is semantically equivalent to a Measure

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -52,9 +52,9 @@ is used extensively in this document to define and explain these API
 functions and how we should interpret them.  As far as possible, the
 terminology used here tries to convey the intended semantics, and a
 _standard implementation_ will be described below to help us
-understand their meaning.  The standard implementation defined here
-corresponds to the behavior of the default [OpenTelemetry Metrics
-Default SDK](TODO: after PR #347 merges).
+understand their meaning.  The standard implementation performs
+aggregation corresponding to the default interpretation for each kind
+of metric event.
 
 ### Metric Instruments
 
@@ -185,8 +185,8 @@ events produced through an instrument consist of:
 - an implicit timestamp at the moment the API function is called
 - the instrument definition (name, kind, and options)
 - a value (numeric)
+- a [Context](api-context.md) (span context, correlation context)
 - a label set
-- a [Context](api-context.md)
 
 This is the outcome of separating the API from the SDK--a common
 representation for metric events, where the only semantic distinction
@@ -194,10 +194,10 @@ is the kind of instrument that was used.
 
 ## Three kinds of instrument
 
-Because of API-SDK separation, the `Meter` implementation ultimately
-determines how metrics events are handled.  Therefore, the choice of
-instrument should be guided by semantics and the intended
-interpretation.  Here we detail the three instruments.
+Because the API is separated from the SDK, the implementation
+ultimately determines how metric events are handled.  Therefore, the
+choice of instrument should be guided by semantics and the intended
+interpretation.  Here we detail the three instruments and their semantics.
 
 ### Counter
 
@@ -206,7 +206,8 @@ to monitor rates, and they are sometimes used to report totals.  One
 key property of Counter instruments is that two `Add(1)` events are
 semantically equivalent to one `Add(2)` event--`Add(m)` and `Add(n)`
 is equivalent to `Add(m+n)`.  This means that Counter events can be
-combined using addition, by definition.
+combined using addition, by definition, which makes them relatively
+inexpensive
 
 Labels associated with Counter instrument events can be used to
 compute rates and totals over selected dimensions.  When aggregating

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -105,7 +105,7 @@ values, for example "Histogram" and "Summary" values, which are
 different ways to expose a distribution of measurements.  This API
 specifies the use of a Measure kind of instrument with `Record()` for
 recording individual measurements.  The instruments are defined so
-that users and implementors understand what they mean, beacuse
+that users and implementors understand what they mean, because
 different SDKs will handle events differently.
 
 There is a common metric instrument known as a "Gauge" that is not
@@ -369,7 +369,7 @@ Observer instruments are meant to be used when measured values report
 on the current state of the program, as opposed to a change of state
 in the program.  When Observer instruments are used to report physical
 quantities, use a (default) absolute Observer.  When Observer
-instruments are used to report measurements can be negative for any
+instruments are used to report measurements that can be negative for any
 reason, use a non-absolute Observer.
 
 If the Observer reports a current total sum, declare it as a monotonic
@@ -391,7 +391,7 @@ handling a request, compute a LabelSet containing the name of the
 protocol and potentially other useful labels, then call `Add()` twice
 with the same label set and the number of bytes read and written.
 
-To make lower the cost of this reporting, you can `Bind()` the
+To lower the cost of this reporting, you can `Bind()` the
 instrument with each of the supported protocols ahead of time and
 avoid computing the label set for each request.
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -518,7 +518,7 @@ CPU usage is something that we naturally sum, which raises several
 questions.
 
 - Why not use a Counter instrument?  In order to use a Counter instrument, we would need to convert total usage figures into deltas.  Calculating deltas from the previous measurement is easy to do, but Counter instruments are not meant to be used from callbacks.
-- Why not report deltass in the Observer callback?  Observer instruments are meant to be used to observe current values. Nothing prevents reporting deltas with an Observer, but the standard aggregation for Observer instruments is to sum the current value across distinct label sets.  The standard behavior is useful for determining the current rate of CPU usage, but special configuration would be required for an Observer instrument to use Counter aggregation.
+- Why not report deltas in the Observer callback?  Observer instruments are meant to be used to observe current values. Nothing prevents reporting deltas with an Observer, but the standard aggregation for Observer instruments is to sum the current value across distinct label sets.  The standard behavior is useful for determining the current rate of CPU usage, but special configuration would be required for an Observer instrument to use Counter aggregation.
 
 ### Reporting per-shard memory holdings
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -235,7 +235,7 @@ intended as the default way to configure an exporter for
 pre-aggregation, if it is expected.  Since this is only expected in
 some exporters, it is regarded as an option relevant to the exporter,
 whether keys configured through `WithRecommendedKeys` are applied for aggregation
-purposes or not.  This allows the user influence the standard
+purposes or not.  This allows the user to influence the standard
 implementation behavior, especially for exporters that require
 pre-specified aggregation keys.
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -120,11 +120,7 @@ To produce measurements using an instrument, you need an SDK that
 implements the `Meter` API.  This interface consists of a set of
 instrument constructors, functionality related to label sets, and a
 facility for entering batches of measurements in a semantically atomic
-way.  As an obligatory step, the API requires the caller to provide
-the name of the instrumenting library (optionally, the version), that
-is meant to be used for identifying instrumentation produced from that
-library for such purposes as disabling instrumentation, configuring
-aggregation, and applying sampling policies.
+way.
 
 There is a global `Meter` instance available for use that facilitates
 automatic instrumentation for third-party code.  Use of this instance
@@ -133,8 +129,16 @@ explicit dependency injection.  The global `Meter` instance acts as a
 no-op implementation until the application explicitly initializes a
 global `Meter` by installing an SDK.
 
-Details about installing an SDK and obtaining a `Meter` are covered in
-the [SDK-level API specification](api-metrics-meter.md).
+As an obligatory step, the API requires the caller to provide the name
+of the instrumenting library (optionally, the version) when obtaining
+a `Meter` implementation, that is meant to be used for identifying
+instrumentation produced from that library for such purposes as
+disabling instrumentation, configuring aggregation, and applying
+sampling policies.  (TODO: refer to the semantic convention on the
+Named Tracer/Meter).
+
+Details about installing an SDK and obtaining a named `Meter` are
+covered in the [SDK-level API specification](api-metrics-meter.md).
 
 ### Aggregations
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -118,7 +118,8 @@ _Aggregation_ refers to the process of combining a large number of
 measurements into exact or estimated statistics about the metric
 events that took place during a window of real time, during program
 execution.  Computing aggregations is mainly a subject of the SDK
-specification.
+specification, with the goal of reducing the amount of data that must
+be sent to the telemetry collection backend.
 
 Users do not have a facility in the API to select the aggregation they
 want for particular instruments.  The choice of instrument dictates
@@ -142,9 +143,10 @@ of statistics, such as histogram and quantile summaries.
 ### Time
 
 Time is a fundamental property of metric events, but not an explicit
-one.  Users do not provide explicit timestamps for metric events.  The
-SDK is welcome to, but not required to capture the current timestamp
-for each event by reading from a clock.
+one.  Users do not provide explicit timestamps for metric events.
+SDKs are discouraged from capturing the current timestamp for each
+event (by reading from a clock) unless there is a definite need for
+high-precision timestamps.
 
 This non-requirement stems from a common optimization in metrics
 reporting, which is to configure metric data collection with a
@@ -156,11 +158,11 @@ Aggregations are commonly computed over a series of events that fall
 into a contiguous region of time, known as the collection interval.
 Since the SDK controls decision to start collection, it is possible to
 collect aggregated metric data while only reading the clock once per
-collection interval.
+collection interval.  The default SDK takes this approach.
 
 Counter and Measure instruments offer synchronous APIs for entering
-measurements.  Metric events from Counter and Measure instruments
-happen when they happen, the moment the SDK receives the function
+measurements.  Metric events from Counter and Measure instruments are
+captured when they happen, the moment the SDK receives the function
 call.
 
 The Observer instrument supports an asynchronous API, allowing the SDK

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -504,18 +504,6 @@ In this case, the guidance is to create a single instrument.  Do not
 create a Counter instrument to export a sum when you want to export
 other summary statistics using a Measure instrument.
 
-### Reporting per-request CPU usage
-
-Suppose you have a way to measure the CPU usage of processing an
-individual request.  This is given to you in terms of cpu-seconds
-consumed.  You may wish to monitor total CPU usage, or you could be
-interested in the peak rate of CPU usage.
-
-Use a Counter instrument to `Add()` this quantity to an instrument
-named `cpu.seconds.used` after sending the response.  A Counter is
-called for, in this case, because a sum is requested, meaning a sum of
-all `Add()` events for the instrument in the specified time range.
-
 ### Reporting system call duration
 
 You wish to monitor the duration of a specific system call being made

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -207,15 +207,35 @@ resulting from an aggregation of raw measurements over time.
 ### WithKeys declaration on metric instruments
 
 A standard feature of metric SDKs is to pre-aggregate metric events
-according to a specified set of label keys (i.e., dimensions).  The
-API provides a `WithKeys` option for the user to declare the
-recommended aggregation keys.
+according to a specified set of label keys (i.e., dimensions).  To
+perform this task, the SDK must aggregate metric events over the
+collection interval: (1) across time, (2) across key dimensions in
+_label space_.
 
-This feature is useful for configuring _pre-aggegation_ within the
-SDK, prior to export, and generally helps lower the cost of exporting
-metric data.  This feature is included in the API to ensure that this
-optimization is easily configured at the point where instruments are
-declared.
+When aggregating across spatial dimensions, metric events for
+different label sets are combined into an aggregated value for each
+distinct "group" of values for the key dimensions.  It means that
+measurements are combined for all metric events having the same values
+for selected keys, explicitly disregarding any additional labels with
+keys not in the set of aggregation keys.  Some exporters are known to
+require pre-specifying the label keys used for aggregation (e.g.,
+Prometheus).
+
+For example, if `[ak1, ak2]` are the aggregation keys and `[ik1,
+ik2]` are the ignored keys, then a metric event having labels
+`{ak1=A, ak2=B, ik1=C, ik1=D}` will be combined with a metric
+event having labels `{ak1=A, ak2=B, ik1=Y, ik1=Z}` because they
+have identical label values for all of the aggregation keys.
+
+The API provides a `WithKeys` option for the user to declare the
+recommended aggregation keys when declaring new metric instruments,
+intended as the default way to configure an exporter for
+pre-aggregation, if it is expected.  Since this is only expected in
+some exporters, it is regarded as an option relevant to the exporter,
+whether keys configured through `WithKeys` are applied for aggregation
+purposes or not.  This allows the user influence the standard
+implementation behavior, especially for exporters that require
+pre-specified aggregation keys.
 
 ### Metric Event Format
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -345,7 +345,7 @@ function, but the input value to this instrument is in the language's
 conventional data type for timing measurements.
 
 For example, in Go the API will accept a `time.Duration`, and in C++
-the API will accept a `std::chrono::duration`.  These advantage of
+the API will accept a `std::chrono::duration`.  The advantage of
 using these instruments is that they use the correct units
 automatically, avoiding the potential for confusion over timing metrics.
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -330,8 +330,8 @@ terms of the intended semantics.
 
 As a language-optional feature, the API may support a dedicated
 instrument for reporting timing measurements.  This kind of
-instrument, with recommended name `TimingMeasure` (and
-`BoundTimingMeasure`), is semantically equivalent to a Measure
+instrument, with recommended name `Timer` (and
+`BoundTimer`), is semantically equivalent to a Measure
 instrument, and like the Measure instrument supports a `Record()`
 function, but the input value to this instrument is in the language's
 conventional data type for timing measurements.

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -287,10 +287,9 @@ Observer instruments by definition, only the current set of values is
 semantically defined.
 
 These values are considered coherent, because measurements from an
-Observer instrument in a single collection interval are considered
-simultaneous.  The set of measurements captured through one callback
-invocation are considered independent metric events; explicitly, these
-events share a single timestamp.
+Observer instrument in a single collection interval are captured at
+the same logical time.  A single callback invocation generates (zero
+or more) simultaneous metric events, all sharing an implicit timestamp.
 
 ## Interpretation
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -49,9 +49,9 @@ offer different levels of performance.  Regardless of calling
 convention, we define a _metric event_ as the logical thing that
 happens when a new measurement is entered.  The word "enter" as used
 here refers to the logical creation of an event through one of the
-calling conventions.  This moment of entry defines an implicit
-timestamp, which is the wall time an SDK would read from a clock at
-that moment.
+calling conventions.  This moment of entry (at "run time") defines an
+implicit timestamp, which is the wall time an SDK would read from a
+clock at that moment.
 
 The word "semantic" or "semantics" as used here refers to _how we give
 meaning_ to metric events, as they take place under the API.  The term

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -289,7 +289,8 @@ semantically defined.
 These values are considered coherent, because measurements from an
 Observer instrument in a single collection interval are considered
 simultaneous.  The set of measurements captured through one callback
-invocation implicitly share a single timestamp.
+invocation are considered independent metric events; explicitly, these
+events share a single timestamp.
 
 ## Interpretation
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -351,8 +351,8 @@ automatically, avoiding the potential for confusion over timing metrics.
 
 ### Future Work: Option Support
 
-We are aware of a number of reasons to refine on these types, in order
-to offer:
+We are aware of a number of reasons to iterate on these
+instrumentation kinds, in order to offer:
 
 1. Range restrictions on input data.  Instruments accepting negative
 values is rare in most applications, for example, and it is useful to

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -305,8 +305,9 @@ Observer instruments are used to capture a _current set of values_ at
 a point in time.  Observer instruments are asynchronous, with the use
 of callbacks allowing the user to capture multiple values per
 collection interval.  Observer instruments are not associated with a
-Context, meaning it is impossible to associate Observer instruments
-with Correlation Context.
+Context, by definition.  This means, for example, it is not possible
+to associate Observer instrument events with Correlation or Span
+context.
 
 Observer instruments capture not only current values, but also
 effectively _which label sets are current_ at the moment of

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -345,16 +345,21 @@ terms of the intended semantics.
 
 As a language-optional feature, the API MAY support a dedicated
 instrument for reporting timing measurements.  This kind of
-instrument, with recommended name `Timer` (and
-`BoundTimer`), is semantically equivalent to a Measure
-instrument, and like the Measure instrument supports a `Record()`
-function, but the input value to this instrument is in the language's
-conventional data type for timing measurements.
+instrument, with recommended name `Timer` (and `BoundTimer`), is
+semantically equivalent to a Measure instrument.  Like the Measure
+instrument, Timers support a `Record()` function.  The input value to
+this instrument is in the language's conventional data type for timing
+measurements.
+
+Timer instruments MUST capture only the magnitude of the input value
+(i.e., an absolute value).  When the user provides a negative value to
+the Timer `Record()` function, the captured measurement is the number
+stripped of its sign.
 
 For example, in Go the API will accept a `time.Duration`, and in C++
-the API will accept a `std::chrono::duration`.  The advantage of
-using these instruments is that they use the correct units
-automatically, avoiding the potential for confusion over timing metrics.
+the API will accept a `std::chrono::duration`.  These instruments
+apply the correct units automatically, reducing the potential for
+confusion over timing metric events.
 
 ### Future Work: Option Support
 

--- a/specification/api-metrics.md
+++ b/specification/api-metrics.md
@@ -116,9 +116,12 @@ implements the `Meter` API.  This interface consists of a set of instrument
 constructors, functionality related to label sets, and a facility for
 entering batches of measurements in a semantically atomic way.
 
-There is a global `Meter` instance available for use.  Use of the this
-instance allows library code to operate in a no-op fashion until
-whenever the main application configures an SDK at the global level.
+There is a global `Meter` instance available for use that facilitates
+automatic instrumentation for third-party code.  Use of this instance
+allows code to statically initialize its metric instruments, without
+explicit dependency injection.  The global `Meter` instance acts as a
+no-op implementation until the application explicitly initializes a
+global `Meter` by installing an SDK.
 
 Details about installing an SDK and obtaining a `Meter` are covered in
 the [SDK-level API specification](api-metrics-meter.md).


### PR DESCRIPTION
This specifies the changes described in these OTEPs:
https://github.com/open-telemetry/oteps/pull/80
https://github.com/open-telemetry/oteps/pull/72