### PR TITLE
Add semantic conventions for logs and errors

### DIFF
--- a/specification/data-error-semantic-conventions.md
+++ b/specification/data-error-semantic-conventions.md
@@ -14,6 +14,6 @@ their types.
 
 | Attribute name | Type       | Notes and examples                                           | Required? |
 | :------------- | :--------- | :----------------------------------------------------------- | :-------- |
-| error.type     | String     | The type of the error. E.g. "Exception", "OSError"           | Yes       |
+| error.type     | String     | The type of the error (its fully-qualified class name, if applicable). E.g. "java.net.ConnectException", "OSError"           | Yes       |
 | error.message  | String     | The error message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"` | Yes       |
 | error.stack    | Array\<String\> | A stack trace formatted as an array of strings. The stackframe at which the exeception occurred should be the first entry. E.g. `["Exception in thread \"main\" java.lang.RuntimeException: Test exception", "  at com.example.GenerateTrace.methodB(GenerateTrace.java:13)", "  at com.example.GenerateTrace.methodA(GenerateTrace.java:9)", "  at com.example.GenerateTrace.main(GenerateTrace.java:5)" ]` | No        |

--- a/specification/data-error-semantic-conventions.md
+++ b/specification/data-error-semantic-conventions.md
@@ -1,6 +1,26 @@
-# Semantic conventions for errors
+# Semantic conventions for logs and errors
 
-This document defines semantic conventions for recording errors.
+This document defines semantic conventions for recording logs and errors.
+
+## Recording a Log
+
+A log SHOULD be recorded as an `Event` on the span during which it occurred.
+The name of the event MUST be `"log"`.
+
+## Attributes
+
+The table below indicates which attributes should be added to the `Event` and
+their types.
+
+| Attribute name | Type       | Notes and examples                                           | Required? |
+| :------------- | :--------- | :----------------------------------------------------------- | :-------- |
+| log.type | String | The source of the log message such as `syslog`, `log4j`, or `log` if the source is unknown | Yes |
+| log.severity | String | One of `debug`, `info`, `warn`, `error`, `fatal`, and `panic` | Yes |
+| log.message | String | The log message. E.g. `"User not found"` or `"json.Marshal failed"`. | Yes |
+| frame.file | String | Filename where the log occurred, e.g. `main.go` | No |
+| frame.line | uint32 | Line number where the log occurred, e.g. `10` | No |
+| frame.func | String | Function name where the log occurred, e.g. `method1` | No |
+| frame.stack | String | An array of stackframes formatted as JSON. The stackframe at which the log occurred should be the first entry. E.g. `[{"func": "method1", "file": "main.go", "line": 10}, {"func": "main", "file": "main.go", "line": 5}]` | No |
 
 ## Recording an Error
 
@@ -14,6 +34,10 @@ their types.
 
 | Attribute name | Type       | Notes and examples                                           | Required? |
 | :------------- | :--------- | :----------------------------------------------------------- | :-------- |
-| error.type     | String     | The type of the error (its fully-qualified class name, if applicable). E.g. "java.net.ConnectException", "OSError"           | Yes       |
-| error.message  | String     | The error message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"` | Yes       |
-| error.stack    | Array\<String\> | A stack trace formatted as an array of strings. The stackframe at which the exeception occurred should be the first entry. E.g. `["Exception in thread \"main\" java.lang.RuntimeException: Test exception", "  at com.example.GenerateTrace.methodB(GenerateTrace.java:13)", "  at com.example.GenerateTrace.methodA(GenerateTrace.java:9)", "  at com.example.GenerateTrace.main(GenerateTrace.java:5)" ]` | No        |
+| log.type | String | The type of the error (its fully-qualified class name, if applicable). E.g. "java.net.ConnectException", "OSError" | Yes |
+| log.severity | String | One of `error`, `fatal`, and `panic` | Yes |
+| log.message | String | The error message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"` | Yes |
+| frame.file | String | Filename where the error occurred, e.g. `main.go` | No |
+| frame.line | uint32 | Line number where the error occurred, e.g. `10` | No |
+| frame.func | String | Function name where the error occurred, e.g. `method1` | No |
+| frame.stack | String | An array of stackframes formatted as JSON. The stackframe at which error log occurred should be the first entry. E.g. `[{"func": "method1", "file": "main.go", "line": 10}, {"func": "main", "file": "main.go", "line": 5}]` | No |

--- a/specification/data-error-semantic-conventions.md
+++ b/specification/data-error-semantic-conventions.md
@@ -1,0 +1,19 @@
+# Semantic conventions for errors
+
+This document defines semantic conventions for recording errors.
+
+## Recording an Error
+
+An error SHOULD be recorded as an `Event` on the span during which it occurred.
+The name of the event MUST be `"error"`.
+
+## Attributes
+
+The table below indicates which attributes should be added to the `Event` and
+their types.
+
+| Attribute name | Type       | Notes and examples                                           | Required? |
+| :------------- | :--------- | :----------------------------------------------------------- | :-------- |
+| error.type     | String     | The type of the error. E.g. "Exception", "OSError"           | Yes       |
+| error.message  | String     | The error message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"` | Yes       |
+| error.stack    | Array\<String\> | A stack trace formatted as an array of strings. The stackframe at which the exeception occurred should be the first entry. E.g. `["Exception in thread \"main\" java.lang.RuntimeException: Test exception", "  at com.example.GenerateTrace.methodB(GenerateTrace.java:13)", "  at com.example.GenerateTrace.methodA(GenerateTrace.java:9)", "  at com.example.GenerateTrace.main(GenerateTrace.java:5)" ]` | No        |


### PR DESCRIPTION
This PR is based on https://github.com/open-telemetry/opentelemetry-specification/pull/427 . There was some discussion about

>unique hash for the particular exception and another unique hash for the exception type and line it was thrown in the code. This is important for deduplication and aggregation.

I think this is too vendor specific - some vendors don't need this hash and it is not obvious what to hash and how. Also spans may be deduplicated and aggregated too - why this is log/error specific and not span/event specific?

>Also I still think it is important to support more kinds of errors besides application exceptions. For example, core dumps from IoT devices which would get sent after the device reboots.

I could add to this list symbolication (iOS), Linux core dumps, crash reports for system X etc. It is too much work to cover everything and I simply have no clue about core dumps for IoT devices.

### Using single `log.` prefix for logs and errors

I also considered using `msg.` as a prefix/namespace (e.g. `msg.type`, `msg.severity`, `msg.message`), but we already use `messaging` in https://github.com/open-telemetry/opentelemetry-specification/pull/418 so it may be confusing

### Support for exception cause / nested exceptions

I would like to support nested exceptions, but I don't have good ideas how to do it with data types OTEL currently supports. Adding some field like `log.cause` with JSON payload seems to be the only option.