### PR TITLE
Initial composite/global Propagators update for OTEP 66.

### DIFF
--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -26,8 +26,8 @@ Table of Contents
 
 Cross-cutting concerns send their state to the next process using
 `Propagator`s, which are defined as objects used to read and write
-context data into RPC requests. Each concern creates a set of `Propagator`s
-for every supported format.
+context data to and from RPC requests. Each concern creates a set
+of `Propagator`s for every supported format.
 
 The Propagators API is expected to be leveraged by users writing
 instrumentation libraries.
@@ -208,13 +208,13 @@ containing W3C TraceContext and CorrelationContext `Propagator`s,
 in order to provide propagation even in the presence of no-op
 OpenTelemetry implementations.
 
-### Get Propagator
+### Get Global Propagator
 
 This method MUST exist for each supported format.
 
 Returns a global `Propagator`. This usually will be composite instance.
 
-### Set Propagator
+### Set Global Propagator
 
 This method MUST exist for each supported format.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -177,7 +177,7 @@ Required arguments:
 
 ## Global Propagators
 
-Implementations can optionally provide global `Propagator`s for
+Implementations MAY provide global `Propagator`s for
 each supported format.
 
 If offered, the global `Propagator`s should default to a composite `Propagator`

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -24,19 +24,19 @@ Table of Contents
 Cross-cutting concerns send their state to the next process using
 `Propagator`s, which are defined as objects used to read and write
 context data to and from messages exchanged by the applications.
-Each concern creates a set of `Propagator`s for every supported format.
+Each concern creates a set of `Propagator`s for every supported `Format`.
 
 The Propagators API is expected to be leveraged by users writing
 instrumentation libraries.
 
-Propagators API currently consists of one format:
+Propagators API currently consists of one `Format`:
 
 - `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.
 
 Deserializing must set `IsRemote` to true on the returned `SpanContext`.
 
-A binary format will be added in the future.
+A binary `Format` will be added in the future.
 
 ## HTTP Text Format
 
@@ -131,7 +131,7 @@ Required arguments:
 - the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text format implemenations MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
+The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text `Format` implementions MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
 
 ## Composite Propagator
 
@@ -142,8 +142,8 @@ single entity.
 The resulting composite `Propagator` will invoke the `Propagators`
 in the order they were specified.
 
-Each composite `Propagator` will be bound to a specific format, such
-as `HttpTextFormat`, as different formats will likely operate on different
+Each composite `Propagator` will be bound to a specific `Format`, such
+as `HttpTextFormat`, as different `Format`s will likely operate on different
 data types.
 There MUST be functions to accomplish the following operations.
 
@@ -178,7 +178,7 @@ Required arguments:
 ## Global Propagators
 
 Implementations MAY provide global `Propagator`s for
-each supported format.
+each supported `Format`.
 
 If offered, the global `Propagator`s should default to a composite `Propagator`
 containing W3C Trace Context and Correlation Context `Propagator`s,
@@ -187,13 +187,13 @@ OpenTelemetry implementations.
 
 ### Get Global Propagator
 
-This method MUST exist for each supported format.
+This method MUST exist for each supported `Format`.
 
 Returns a global `Propagator`. This usually will be composite instance.
 
 ### Set Global Propagator
 
-This method MUST exist for each supported format.
+This method MUST exist for each supported `Format`.
 
 Sets the global `Propagator` instance.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -23,8 +23,8 @@ Table of Contents
 
 Cross-cutting concerns send their state to the next process using
 `Propagator`s, which are defined as objects used to read and write
-context data to and from RPC requests. Each concern creates a set
-of `Propagator`s for every supported format.
+context data to and from messages exchanged by the applications.
+Each concern creates a set of `Propagator`s for every supported format.
 
 The Propagators API is expected to be leveraged by users writing
 instrumentation libraries.

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -181,7 +181,7 @@ Implementations MAY provide global `Propagator`s for
 each supported format.
 
 If offered, the global `Propagator`s should default to a composite `Propagator`
-containing W3C TraceContext and CorrelationContext `Propagator`s,
+containing W3C Trace Context and Correlation Context `Propagator`s,
 in order to provide propagation even in the presence of no-op
 OpenTelemetry implementations.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -178,7 +178,7 @@ Each composite `Propagator` will be bound to a specific format, such
 as `HttpTextFormat`, as different formats will likely work on a different
 data types.
 
-### Create Composite Propagator
+### Create a Composite Propagator
 
 Required arguments:
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -201,6 +201,8 @@ Required arguments:
 
 ### Inject
 
+Required arguments:
+
 - A `Context`.
 - The carrier that holds propagation fields.
 - The instance of `Getter` invoked for each propagation key to get.

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -5,6 +5,7 @@
 Table of Contents
 </summary>
 
+- [Overview](#overview)
 - [Binary Format](#binary-format)
   - [ToBytes](#tobytes)
   - [FromBytes](#frombytes)
@@ -16,10 +17,22 @@ Table of Contents
   - [Extract](#extract)
     - [Getter argument](#getter)
       - [Get](#get)
+- [Composite Propagator](#composite-propagator)
+- [Global Propagators](#global-propagators)
 
 </details>
 
-Propagators API consists of two main formats:
+## Overview
+
+Cross-cutting concerns send their state to the next process using
+`Propagator`s, which are defined as objects used to read and write
+context data into RPC requests. Each concern creates a set of `Propagator`s
+for every supported format.
+
+The Propagators API is expected to be leveraged by users writing
+instrumentation libraries.
+
+The Propagators API defines two main formats:
 
 - `BinaryFormat` is used to serialize and deserialize a value into a binary representation.
 - `HTTPTextFormat` is used to inject and extract a value as text into carriers that travel
@@ -59,8 +72,8 @@ Returns a value deserialized from bytes.
 
 ## HTTP Text Format
 
-`HTTPTextFormat` is a formatter that injects and extracts a value as text into carriers that
-travel in-band across process boundaries.
+`HTTPTextFormat` is a formatter that injects and extracts a cross-cutting concern
+value as text into carriers that travel in-band across process boundaries.
 
 Encoding is expected to conform to the HTTP Header Field semantics. Values are often encoded as
 RPC/HTTP request headers.
@@ -94,7 +107,7 @@ Injects the value downstream. For example, as http headers.
 
 Required arguments:
 
-- the value to be injected, can be `SpanContext` or `DistributedContext`.
+- the cross-cutting concern value to be injected, such as `SpanContext` or `DistributedContext`.
 - the carrier that holds propagation fields. For example, an outgoing message or http request.
 - the `Setter` invoked for each propagation key to add or remove.
 
@@ -131,7 +144,7 @@ Required arguments:
 - the carrier holds propagation fields. For example, an outgoing message or http request.
 - the instance of `Getter` invoked for each propagation key to get.
 
-Returns the non-null extracted value.
+Returns the non-null cross-cutting concern extracted value.
 
 #### Getter argument
 
@@ -151,3 +164,62 @@ Required arguments:
 - the key of the field.
 
 The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text format implemenations MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
+
+## Composite Propagator
+
+Implementations MUST offer a facility to group multiple `Propagator`s
+from different cross-cutting concerns in order to leverage them as a
+single entity.
+
+The resulting composite `Propagator` will invoke the `Propagators`
+in the order they were specified.
+
+Each composite `Propagator` will be bound to a specific format, such
+as `HttpTextFormat`, as different formats will likely work on a different
+data types.
+
+### Create Composite Propagator
+
+Required arguments:
+
+- A list of `Propagator`s.
+
+Returns a new composite `Propagator` with the specified `Propagator`s.
+
+### Extract
+
+- A `Context`.
+- The carrier that holds propagation fields.
+- the `Setter` invoked for each propagation key to add or remove.
+
+### Inject
+
+- A `Context`.
+- The carrier that holds propagation fields.
+- The instance of `Getter` invoked for each propagation key to get.
+
+## Global Propagators
+
+Implementations can optionally provide global `Propagator`s for
+each supported format.
+
+If offered, the global `Propagator`s should default to a composite `Propagator`
+containing W3C TraceContext and CorrelationContext `Propagator`s,
+in order to provide propagation even in the presence of no-op
+OpenTelemetry implementations.
+
+### Get Propagator
+
+This method MUST exist for each supported format.
+
+Returns a global `Propagator`. This usually will be composite instance.
+
+### Set Propagator
+
+This method MUST exist for each supported format.
+
+Sets the global `Propagator` instance.
+
+Required parameters:
+
+- A `Propagator`. This usually will be a composite instance.

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -193,6 +193,8 @@ Returns a new composite `Propagator` with the specified `Propagator`s.
 
 ### Extract
 
+Required arguments:
+
 - A `Context`.
 - The carrier that holds propagation fields.
 - the `Setter` invoked for each propagation key to add or remove.

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -175,7 +175,7 @@ The resulting composite `Propagator` will invoke the `Propagators`
 in the order they were specified.
 
 Each composite `Propagator` will be bound to a specific format, such
-as `HttpTextFormat`, as different formats will likely work on a different
+as `HttpTextFormat`, as different formats will likely operate on different
 data types.
 There MUST be functions to accomplish the following operations.
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -165,7 +165,7 @@ Required arguments:
 
 - A `Context`.
 - The carrier that holds propagation fields.
-- The `Setter` invoked for each propagation key to add or remove.
+- The instance of `Getter` invoked for each propagation key to get.
 
 ### Inject
 
@@ -173,7 +173,7 @@ Required arguments:
 
 - A `Context`.
 - The carrier that holds propagation fields.
-- The instance of `Getter` invoked for each propagation key to get.
+- The `Setter` invoked for each propagation key to add or remove.
 
 ## Global Propagators
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -177,6 +177,11 @@ in the order they were specified.
 Each composite `Propagator` will be bound to a specific format, such
 as `HttpTextFormat`, as different formats will likely work on a different
 data types.
+There MUST be functions to accomplish the following operations.
+
+- Create a composite propagator
+- Extract from a composite propagator
+- Inject into a composite propagator
 
 ### Create a Composite Propagator
 

--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -165,7 +165,7 @@ Required arguments:
 
 - A `Context`.
 - The carrier that holds propagation fields.
-- the `Setter` invoked for each propagation key to add or remove.
+- The `Setter` invoked for each propagation key to add or remove.
 
 ### Inject
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -238,7 +238,7 @@ for an example.
 ## Propagators
 
 OpenTelemetry uses `Propagators` to serialize and deserialize `SpanContext` and `DistributedContext`
-into text format. Currently there is one type of propagator:
+into text `Format`. Currently there is one type of propagator:
 
 - `HTTPTextFormat` which is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -237,8 +237,9 @@ for an example.
 
 ## Propagators
 
-OpenTelemetry uses `Propagators` to serialize and deserialize `SpanContext` and `DistributedContext`
-into text `Format`. Currently there is one type of propagator:
+OpenTelemetry uses `Propagators` to serialize and deserialize cross-cutting concern values
+such as  `SpanContext` and `DistributedContext` into a `Format`. Currently there is one
+type of propagator:
 
 - `HTTPTextFormat` which is used to inject and extract a value as text into carriers that travel
   in-band across process boundaries.


### PR DESCRIPTION
This is an initial PR focusing on updating the `Propagator`s API, and is meant to be get **initial feedback**, rather than getting merged right away. This is because related PRs are still not merged, which hopefully will change soon ;)

Overall:

1. Composite Propagator concept: Even though in OTEP 66 this part is rather defined as a function taking a **list** of propagators, I think it makes sense to **try** to go with a composite `Propagator` concept.
2. (Optional) Global Propagators. This has TraceContext/CorrelationContext as default global propagators, as some language implementations already do this.
