### PR TITLE
Remove `component` attribute from semantic conventions

### DIFF
--- a/specification/data-database.md
+++ b/specification/data-database.md
@@ -13,7 +13,6 @@ attribute names.
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |
-| `component`    | Database driver name or database name (when known) `"JDBI"`, `"jdbc"`, `"odbc"`, `"postgreSQL"`. | Yes       |
 | `db.type`      | Database type. For any SQL database, `"sql"`. For others, the lower-case database category, e.g. `"cassandra"`, `"hbase"`, or `"redis"`. | Yes       |
 | `db.instance`  | Database instance name. E.g., In java, if the jdbc.url=`"jdbc:mysql://db.example.com:3306/customers"`, the instance name is `"customers"`. | Yes       |
 | `db.statement` | A database statement for the given database type. Note, that the value may be sanitized to exclude sensitive information. E.g., for `db.type="sql"`, `"SELECT * FROM wuser_table"`; for `db.type="redis"`, `"SET mykey 'WuValue'"`. | Yes       |

--- a/specification/data-http.md
+++ b/specification/data-http.md
@@ -70,7 +70,6 @@ Note that the items marked with [1] are different from the mapping defined in th
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |
-| `component`    | Denotes the type of the span and needs to be `"http"`. | Yes |
 | `http.method` | HTTP request method. E.g. `"GET"`. | Yes |
 | `http.url` | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. | Defined later. |
 | `http.target` | The full request target as passed in a [HTTP request line][] or equivalent, e.g. `"/path/12314/?q=ddds#123"`. | Defined later. |
@@ -216,7 +215,6 @@ Span name: `/webshop/articles/4` (NOTE: This is subject to change, see [open-tel
 
 |   Attribute name   |                                       Value             |
 | :----------------- | :-------------------------------------------------------|
-| `component`        | `"http"`                                                |
 | `http.method`      | `"GET"`                                                 |
 | `http.flavor`      | `"1.1"`                                                 |
 | `http.url`         | `"https://example.com:8080/webshop/articles/4?s=1"`     |
@@ -230,7 +228,6 @@ Span name: `/webshop/articles/:article_id`.
 
 |   Attribute name   |                      Value                      |
 | :----------------- | :---------------------------------------------- |
-| `component`        | `"http"`                                        |
 | `http.method`      | `"GET"`                                         |
 | `http.flavor`      | `"1.1"`                                         |
 | `http.target`      | `"/webshop/articles/4?s=1"`                     |

--- a/specification/data-rpc.md
+++ b/specification/data-rpc.md
@@ -32,7 +32,6 @@ Examples of span name: `grpc.test.EchoService/Echo`.
 
 | Attribute name | Notes and examples                                           | Required? |
 | -------------- | ------------------------------------------------------------ | --------- |
-| `component`    | Declares that this is a grpc component. Value MUST be `"grpc"`. | Yes       |
 | `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
 | `net.peer.ip`  | See [network attributes][]. | See below |
 | `net.peer.name`  | See [network attributes][]. | See below |


### PR DESCRIPTION
In #271 it was decided to drop the span attribute `component` from the semantic conventions.