### PR TITLE
Add out-of-date notices in api-metrics-user.md and api-metrics-meter.md

### DIFF
--- a/specification/api-metrics-meter.md
+++ b/specification/api-metrics-meter.md
@@ -1,5 +1,9 @@
 # Metric SDK-facing API
 
-This document will be updated as part of the v0.2 milestone with a
-detailed list of `Meter` API methods.  These methods will match the
-user-facing API specified [here](api-metrics-user.md).
+<!-- toc -->
+<!-- tocstop -->
+
+This document will be updated as part of the v0.4 milestone with a
+detailed list of `Meter` API functions.  These functions are given a
+high-level description in the [overview document](api-metrics.md) and
+this document will simply give details on the `Meter` API.

--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -1,11 +1,40 @@
 # Metric User-facing API
 
-Note: This specification for the v0.2 OpenTelemetry milestone does not
-cover the Observer gauge instrument discussed in the
-[overview](api-metrics.md).  Observer instruments will be added in the
-v0.3 milestone.
+<!-- toc -->
 
-TODO: Add a table of contents.
+- [Overview](#overview)
+  * [Obtaining a Meter](#obtaining-a-meter)
+  * [Metric names](#metric-names)
+  * [Format of a metric event](#format-of-a-metric-event)
+  * [New constructors](#new-constructors)
+    + [Metric instrument constructor example code](#metric-instrument-constructor-example-code)
+  * [Metric calling conventions](#metric-calling-conventions)
+    + [Bound instrument calling convention](#bound-instrument-calling-convention)
+    + [Direct instrument calling convention](#direct-instrument-calling-convention)
+    + [RecordBatch calling convention](#recordbatch-calling-convention)
+    + [Label set re-use is encouraged](#label-set-re-use-is-encouraged)
+      - [Missing label keys](#missing-label-keys)
+      - [Option: Convenience method to bypass `meter.Labels(...)`](#option-convenience-method-to-bypass-meterlabels)
+      - [Option: Ordered LabelSet construction](#option-ordered-labelset-construction)
+- [Detailed specification](#detailed-specification)
+  * [Instrument construction](#instrument-construction)
+    + [Recommended label keys](#recommended-label-keys)
+    + [Instrument options](#instrument-options)
+  * [Bound instrument API](#bound-instrument-api)
+  * [Direct instrument API](#direct-instrument-api)
+  * [Interaction with distributed correlation context](#interaction-with-distributed-correlation-context)
+
+<!-- tocstop -->
+
+Note: This specification for the v0.3 OpenTelemetry milestone does not
+include specification related to the Observer instrument, as described
+in the [overview](api-metrics.md).  Observer instruments were detailed
+in [OTEP
+72-metric-observer](https://github.com/open-telemetry/oteps/blob/master/text/0072-metric-observer.md)
+and will be added to this document following the v0.3 milestone.
+Gauge instruments will be removed from this specification folowing the
+v0.3 milestone too, as discussed in [OTEP
+80-remove-metric-gauge](https://github.com/open-telemetry/oteps/blob/master/text/0080-remove-metric-gauge.md).
 
 ## Overview
 


### PR DESCRIPTION
Two documents have not been updated.
(1) api-metrics-user.md with detail on the user-facing API, needs to add Observer and remove Gauge as per OTEP 72 and 80
(2) api-metrics-meter.md was never finished following v0.3 as promised, push back to v0.4
This also adds TOCs in these documents.