### PR TITLE
Fix indentation in Golang example code

### DIFF
--- a/specification/api-metrics-user.md
+++ b/specification/api-metrics-user.md
@@ -509,7 +509,7 @@ import "go.opentelemetry.io/api/distributedcontext"
 func (s *server) doThing(ctx context.Context) {
     var doLabels []core.KeyValue{
      key1.String("..."),
- key2.String("..."),
+     key2.String("..."),
     }
 
     correlations := distributedcontext.FromContext()


### PR DESCRIPTION
Just a minor detail but it hurts my eyes :).