### PR TITLE
List SpanKind as a span property in api-tracing.md

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -197,6 +197,7 @@ sub-operations.
   `Span`
 - A parent span in the form of a [`Span`](#span), [`SpanContext`](#spancontext),
   or null
+- A [`SpanKind`](#spankind)
 - A start timestamp
 - An end timestamp
 - An ordered mapping of [`Attribute`s](#set-attributes)


### PR DESCRIPTION
Seems like SpanKind was forgotten to be mentioned in the list of span properties.