### PR TITLE
distinguish starting an active span and creating an inactive span

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -139,6 +139,12 @@ currently active `Span` and how `Span`s are passed across process boundaries. A
 `Span` that is started but inactive is not tracked in the `Context` by the
 `Tracer`, but it still MUST have a start timestamp set at the time of creation.
 
+A common case where starting an inactive `Span` is used is with asynchronous
+callbacks. Before the callback is set up, an inactive `Span` is started, with
+the currently active `Span`, if one exists, as the parent. This new `Span` is
+passed to the callback as an argument and to be set as active within the body of
+the callback when it is run.
+
 When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.
 
@@ -252,16 +258,6 @@ directly. All `Span`s MUST be created via a `Tracer`.
 Implementations MUST provide a way to create `Span`s via a `Tracer`. By default,
 the currently active `Span` is set as the new `Span`'s parent. The `Tracer`
 MAY provide other default options for newly created `Span`s.
-
-`Span` creation MUST NOT set the newly created `Span` as the currently
-active `Span` by default. While starting a `Span` through a `Tracer` MUST
-set the `Span` as the currently active `Span`.
-
-A common case where creating a `Span` but not making it active is in the use of
-async callbacks. Before the callback is set up, a `Span` is created, with the
-currently active `Span`, if one exists, as the parent. This new `Span` is passed
-to the callback as an argument and to be set as active within the body of the
-callback when it is run.
 
 The API functions for starting a `Span` MUST accept the following parameters:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -120,7 +120,7 @@ mechanism, for instance the `ServiceLoader` class in Java.
 
 ### Tracer operations
 
-The currently active `Span` for a `Tracer` is one that is tracked in the current
+The currently active `Span` for a `Tracer` is the one that is tracked in the current
 `Context` by the `Tracer`. An inactive `Span` is not currently tracked in any
 `Context`.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -120,19 +120,18 @@ mechanism, for instance the `ServiceLoader` class in Java.
 
 ### Tracer operations
 
-The currently active `Span` for a `Tracer` is the one that is tracked in the current
-`Context` by the `Tracer`. An inactive `Span` is not currently tracked in any
-`Context`.
+The currently active `Span` is the one that is tracked in the current `Context`
+by the `Tracer`. An inactive `Span` is not currently tracked in any `Context`.
 
 The `Tracer` MUST provide functions to:
 
 - Start a new active `Span`
 - Start a new inactive `Span`
+- Make a given `Span` active
 
 The `Tracer` SHOULD provide methods to:
 
 - Get the currently active `Span`
-- Make a given `Span` active
 
 The `Tracer` MUST internally leverage the `Context` in order to get and set the
 currently active `Span` and how `Span`s are passed across process boundaries. A

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -138,7 +138,7 @@ currently active `Span` and how `Span`s are passed across process boundaries. A
 `Span` that is started but inactive is not tracked in the `Context` by the
 `Tracer`, but it still MUST have a start timestamp set at the time of creation.
 
-A common case where starting an inactive `Span` is used is with asynchronous
+A common case of starting an inactive `Span` is with asynchronous
 callbacks. Before the callback is set up, an inactive `Span` is started, with
 the currently active `Span`, if one exists, as the parent. This new `Span` is
 passed to the callback as an argument and to be set as active within the body of

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -120,20 +120,24 @@ mechanism, for instance the `ServiceLoader` class in Java.
 
 ### Tracer operations
 
+The currently active `Span` for a `Tracer` is one that is tracked in the current
+`Context` by the `Tracer`. An inactive `Span` is not currently tracked in any
+`Context`.
+
 The `Tracer` MUST provide functions to:
 
 - Start a new active `Span`
-- Create a new inactive `Span`
+- Start a new inactive `Span`
 
 The `Tracer` SHOULD provide methods to:
 
 - Get the currently active `Span`
-- Make a given `Span` as active
+- Make a given `Span` active
 
 The `Tracer` MUST internally leverage the `Context` in order to get and set the
 currently active `Span` and how `Span`s are passed across process boundaries. A
-`Span` that is created, as opposed to started, is not tracked in the `Context`
-by the `Tracer`, but it MUST have a start timestamp set at the time of creation.
+`Span` that is started but inactive is not tracked in the `Context` by the
+`Tracer`, but it still MUST have a start timestamp set at the time of creation.
 
 When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -125,12 +125,12 @@ by the `Tracer`. An inactive `Span` is not currently tracked in any `Context`.
 
 The `Tracer` MUST provide functions to:
 
-- Start a new active `Span`
+- Start a new inactive `Span`
 
 The `Tracer` SHOULD provide methods to:
 
+- Start a new active `Span`
 - Get the currently active `Span`
-- Start a new inactive `Span`
 - Make a given `Span` active
 
 The `Tracer` MUST internally leverage the `Context` in order to get and set the

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -142,18 +142,18 @@ currently active `Span` and how `Span`s are passed across process boundaries. A
 When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.
 
-When starting or creating a new `Span`, the `Tracer` MUST allow the caller to
-specify the new `Span`'s parent in the form of a `Span` or `SpanContext`. The
-`Tracer` SHOULD create each new `Span` as a child of its active `Span` unless an
-explicit parent is provided or the option to create a span without a parent is
-selected, or the current active `Span` is invalid. Last the `Tracer` would check
-if `Context` has an extracted `SpanContext`. See [Determining the Parent Span
-from a Context](#determining-the-parent-span-from-a-context).
+When starting a new `Span`, the `Tracer` MUST allow the caller to specify the
+new `Span`'s parent in the form of a `Span` or `SpanContext`. The `Tracer`
+SHOULD create each new `Span` as a child of its active `Span` unless an explicit
+parent is provided or the option to create a span without a parent is selected,
+or the current active `Span` is invalid. Last the `Tracer` would check if
+`Context` has an extracted `SpanContext`. See [Determining the Parent Span from
+a Context](#determining-the-parent-span-from-a-context).
 
 The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
 convenience functions to manage a `Span`'s lifetime and the scope in which a
 `Span` is active. When an active `Span` is made inactive, the previously-active
-`Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end
+`Span` SHOULD be made active. A `Span` may be finished (i.e. have a non-null end
 time) but still active. A `Span` may be active on one thread after it has been
 made inactive on another.
 
@@ -258,12 +258,12 @@ active `Span` by default. While starting a `Span` through a `Tracer` MUST
 set the `Span` as the currently active `Span`.
 
 A common case where creating a `Span` but not making it active is in the use of
-async callbacks. Before the callback is setup a `Span` is created, with the
+async callbacks. Before the callback is set up, a `Span` is created, with the
 currently active `Span`, if one exists, as the parent. This new `Span` is passed
 to the callback as an argument and to be set as active within the body of the
 callback when it is run.
 
-The API functions for starting and creating a `Span` MUST accept the following parameters:
+The API functions for starting a `Span` MUST accept the following parameters:
 
 - The span name. This is a required parameter.
 - The parent `Span` or a `Context` containing a parent `Span` or `SpanContext`,

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -126,17 +126,16 @@ by the `Tracer`. An inactive `Span` is not currently tracked in any `Context`.
 The `Tracer` MUST provide functions to:
 
 - Start a new active `Span`
-- Start a new inactive `Span`
-- Make a given `Span` active
 
 The `Tracer` SHOULD provide methods to:
 
 - Get the currently active `Span`
+- Start a new inactive `Span`
+- Make a given `Span` active
 
 The `Tracer` MUST internally leverage the `Context` in order to get and set the
 currently active `Span` and how `Span`s are passed across process boundaries. A
-`Span` that is started but inactive is not tracked in the `Context` by the
-`Tracer`, but it still MUST have a start timestamp set at the time of creation.
+`Span` that is started but inactive is not tracked in the `Context`.
 
 A common case of starting an inactive `Span` is with asynchronous
 callbacks. Before the callback is set up, an inactive `Span` is started, with
@@ -148,12 +147,9 @@ When getting the current span, the `Tracer` MUST return a placeholder `Span`
 with an invalid `SpanContext` if there is no currently active `Span`.
 
 When starting a new `Span`, the `Tracer` MUST allow the caller to specify the
-new `Span`'s parent in the form of a `Span` or `SpanContext`. The `Tracer`
-SHOULD create each new `Span` as a child of its active `Span` unless an explicit
-parent is provided or the option to create a span without a parent is selected,
-or the current active `Span` is invalid. Last the `Tracer` would check if
-`Context` has an extracted `SpanContext`. See [Determining the Parent Span from
-a Context](#determining-the-parent-span-from-a-context).
+new `Span`'s parent in the form of a `Span` or `SpanContext`.  See [Determining
+the Parent Span from a Context](#determining-the-parent-span-from-a-context) for
+how parent is deteremined if it is not provided as an argument.
 
 The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
 convenience functions to manage a `Span`'s lifetime and the scope in which a
@@ -193,7 +189,6 @@ TraceID and a non-zero SpanID.
 
 `IsRemote` is a boolean flag which returns true if the SpanContext was propagated
 from a remote parent.
-When creating children from remote spans, their IsRemote flag MUST be set to false.
 
 Please review the W3C specification for details on the [Tracestate
 field](https://www.w3.org/TR/trace-context/#tracestate-field).


### PR DESCRIPTION
Includes a note about async callbacks which are a common use case
for creating an inactive span.

Closes #469 