### PR TITLE
Clarify telemetry library resource attributes

### DIFF
--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -73,7 +73,7 @@ This value should be stable across different versions of an implementation.
 | Attribute  | Description  | Example  | Required? |
 |---|---|---|---|
 | telemetry.sdk.name | The name of the telemetry SDK. | `opentelemetry-sdk` | No |
-| telemetry.sdk.language | The language of telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
+| telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
 | telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
 
 ## Compute Unit

--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -63,16 +63,18 @@ service.name = Shop.shoppingcart
 
 **Description:** The SDK used to produce telemetry data.
 
-In OpenTelemetry, this is the OpenTelemetry SDK implementation being used.  
-If the default SDK provided by the OpenTelemetry project is used, `telemetry.sdk.name` MUST
-be set to `opentelemetry-sdk`.  
-If another SDK, like a fork or a vendor-provided SDK is used, `telemetry.sdk.name` MUST be set
-to the fully-qualified class or module name of that SDK's main entry point, depending on the language.
-This value should be stable across different versions of an implementation.
+If the default OpenTelemetry SDK provided by the OpenTelemetry project is used,
+`telemetry.sdk.name` MUST be set to `opentelemetry-sdk`.
+
+If another SDK, like a fork or a vendor-provided implementation, is used, `telemetry.sdk.name`
+MUST be set to the fully-qualified class or module name of that SDK's main entry point
+or another suitable identifier depending on the language.
+The identifier `opentelemetry-sdk` is reserved and MUST NOT be used in this case.
+The identifier SHOULD be stable across different versions of an implementation.
 
 | Attribute  | Description  | Example  | Required? |
 |---|---|---|---|
-| telemetry.sdk.name | The name of the telemetry SDK. | `opentelemetry-sdk` | No |
+| telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry-sdk` | No |
 | telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
 | telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
 

--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -64,17 +64,17 @@ service.name = Shop.shoppingcart
 **Description:** The SDK used to produce telemetry data.
 
 If the default OpenTelemetry SDK provided by the OpenTelemetry project is used,
-`telemetry.sdk.name` MUST be set to `opentelemetry-sdk`.
+`telemetry.sdk.name` MUST be set to `opentelemetry`.
 
 If another SDK, like a fork or a vendor-provided implementation, is used, `telemetry.sdk.name`
 MUST be set to the fully-qualified class or module name of that SDK's main entry point
 or another suitable identifier depending on the language.
-The identifier `opentelemetry-sdk` is reserved and MUST NOT be used in this case.
+The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
 The identifier SHOULD be stable across different versions of an implementation.
 
 | Attribute  | Description  | Example  | Required? |
 |---|---|---|---|
-| telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry-sdk` | No |
+| telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry` | No |
 | telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
 | telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
 

--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -63,11 +63,11 @@ service.name = Shop.shoppingcart
 
 **Description:** The telemetry SDK used to capture data recorded by the instrumentation libraries.
 
-If the default OpenTelemetry SDK provided by the OpenTelemetry project is used,
-`telemetry.sdk.name` MUST be set to `opentelemetry`.
+The default OpenTelemetry SDK provided by the OpenTelemetry project MUST set `telemetry.sdk.name`
+to the value `opentelemetry`.
 
-If another SDK, like a fork or a vendor-provided implementation, is used, `telemetry.sdk.name`
-MUST be set to the fully-qualified class or module name of that SDK's main entry point
+If another SDK, like a fork or a vendor-provided implementation, is used, this SDK MUST set the attribute
+`telemetry.sdk.name` to the fully-qualified class or module name of this SDK's main entry point
 or another suitable identifier depending on the language.
 The identifier `opentelemetry` is reserved and MUST NOT be used in this case.
 The identifier SHOULD be stable across different versions of an implementation.

--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -4,7 +4,7 @@ This document defines standard attributes for resources. These attributes are ty
 [OpenCensus Resource standard](https://github.com/census-instrumentation/opencensus-specs/blob/master/resource/StandardResources.md).
 
 * [Service](#service)
-* [Library](#library)
+* [Telemetry SDK](#telemetry-sdk)
 * [Compute Unit](#compute-unit)
   * [Container](#container)
 * [Deployment Service](#deployment-service)
@@ -57,17 +57,24 @@ namespace = Company
 service.name = Shop.shoppingcart
 ```
 
-## Library
+## Telemetry SDK
 
-**type:** `library`
+**type:** `telemetry.sdk`
 
-**Description:** Telemetry library information.
+**Description:** The SDK used to produce telemetry data.
+
+In OpenTelemetry, this is the OpenTelemetry SDK implementation being used.  
+If the default SDK provided by the OpenTelemetry project is used, `telemetry.sdk.name` MUST
+be set to `opentelemetry-sdk`.  
+If another SDK, like a fork or a vendor-provided SDK is used, `telemetry.sdk.name` MUST be set
+to the fully-qualified class or module name of that SDK's main entry point, depending on the language.
+This value should be stable across different versions of an implementation.
 
 | Attribute  | Description  | Example  | Required? |
 |---|---|---|---|
-| library.name | The name of the telemetry library. | `opentelemetry` | No |
-| library.language | The language of telemetry library and of the code instrumented with it. <br/> The following spelling SHOULD be used for language strings: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
-| library.version | The version string of the library as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
+| telemetry.sdk.name | The name of the telemetry SDK. | `opentelemetry-sdk` | No |
+| telemetry.sdk.language | The language of telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
+| telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
 
 ## Compute Unit
 

--- a/specification/data-resource-semantic-conventions.md
+++ b/specification/data-resource-semantic-conventions.md
@@ -61,7 +61,7 @@ service.name = Shop.shoppingcart
 
 **type:** `telemetry.sdk`
 
-**Description:** The SDK used to produce telemetry data.
+**Description:** The telemetry SDK used to capture data recorded by the instrumentation libraries.
 
 If the default OpenTelemetry SDK provided by the OpenTelemetry project is used,
 `telemetry.sdk.name` MUST be set to `opentelemetry`.


### PR DESCRIPTION
Resolves #484.

I renamed the attributes since calling them just `library` is highly ambiguous as we realized in the last SIG spec meeting.
By introducing a nested set of keys in `telemetry.sdk.*`, we could neatly introduce something like `telemetry.api.*` in future if we also want to keep track of the OpenTelemetry API version being used. This is, however, out of scope of this PR since this is only to clarify the current intention of the status quo.
I defined a hard-coded string for the OpenTelemetry default SDK in order to have a single uniform value across all language implementations. This makes it easier in case someone wants to build handling around that in a backend.