### PR TITLE
resources: define string values and keys as urlencoded

### DIFF
--- a/specification/sdk-resource.md
+++ b/specification/sdk-resource.md
@@ -37,6 +37,9 @@ Required parameters:
 - a collection of name/value attributes, where name is a string and value can be one
   of: string, int64, double, bool.
 
+The key and value, if value is a string, are trimmed, url encoded strings and
+case sensitive.
+
 ### Merge
 
 The interface MUST provide a way for a primary resource to merge with a


### PR DESCRIPTION
As discussed in the last Spec SIG meeting Resource will use urlencoded strings like [CorrelationContext](https://w3c.github.io/correlation-context/) for keys and values.

This will show its usefulness most in parsing the OS environment variable with Resource attributes, but there isn't a spec for that yet (I think?).