### PR TITLE
remove warnings for trace.UpdateName

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -456,20 +456,10 @@ The Span interface MUST provide:
 Updates the `Span` name. Upon this update, any sampling behavior based on `Span`
 name will depend on the implementation.
 
-It is highly discouraged to update the name of a `Span` after its creation.
-`Span` name is often used to group, filter and identify the logical groups of
-spans. And often, filtering logic will be implemented before the `Span` creation
-for performance reasons. Thus the name update may interfere with this logic.
-
 The function name is called `UpdateName` to differentiate this function from the
 regular property setter. It emphasizes that this operation signifies a major
 change for a `Span` and may lead to re-calculation of sampling or filtering
 decisions made previously depending on the implementation.
-
-Alternatives for the name update may be late `Span` creation, when Span is
-started with the explicit timestamp from the past at the moment where the final
-`Span` name is known, or reporting a `Span` with the desired name as a child
-`Span`.
 
 Required parameters:
 

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -120,6 +120,12 @@ These are the default samplers implemented in the OpenTelemetry SDK:
   should be configuration to change this to "root spans only", or "all spans".
   * Description MUST be `ProbabilitySampler{0.000100}`.
 
+#### Sampler Design Considerations
+
+Sampling algorithms should consider the fact that many attributes of the span
+are mutable after it's initial creation, including span attributes and the
+span name.
+
 #### Probability Sampler algorithm
 
 TODO: Add details about how the probability sampler is implemented as a function

--- a/specification/sdk-tracing.md
+++ b/specification/sdk-tracing.md
@@ -123,7 +123,7 @@ These are the default samplers implemented in the OpenTelemetry SDK:
 #### Sampler Design Considerations
 
 Sampling algorithms should consider the fact that many attributes of the span
-are mutable after it's initial creation, including span attributes and the
+are mutable after its initial creation, including span attributes and the
 span name.
 
 #### Probability Sampler algorithm


### PR DESCRIPTION
Fixes #468

The section discouraging trace.UpdateName clear in terms of the reasoning,
but practically it's common for consumers to not read the full specification
or documentation. As such, one should expect that UpdateName use will not
be uncommon, and those who process spans cannot rely on the span name being
immutable.

Removing the section discouraging it, and adding a section to the samplers
themselves to ensure that samplers are aware of mutable span names.