### PR TITLE
add finishing the currently active span to tracer operations

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -126,8 +126,9 @@ The `Tracer` MUST provide functions to:
 
 The `Tracer` SHOULD provide methods to:
 
+- Finish the currently active `Span`
 - Get the currently active `Span`
-- Make a given `Span` as active
+- Make a given `Span` active
 
 The `Tracer` MUST internally leverage the `Context` in order to get and set the
 current `Span` state and how `Span`s are passed across process boundaries.

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -126,7 +126,7 @@ The `Tracer` MUST provide functions to:
 
 The `Tracer` SHOULD provide methods to:
 
-- Finish the currently active `Span`
+- End the currently active `Span`
 - Get the currently active `Span`
 - Make a given `Span` active
 


### PR DESCRIPTION
The current API Tracing spec includes:

> When an active `Span` is made inactive, the previously-active `Span` SHOULD be made active.

but has no Tracer operation defined that would result in needing this defined. I believe it was intended for specifying what happens when the Tracer ends a Span, which is the addition made in this commit.

Similar to my PR #485 I believe this change reflects OTEP-66 and operating on the context, as an example in the otep shows: `Tracer::EndSpan(context)`.

It may be better under `MUST` but I put it under `SHOULD` for now.