### PR TITLE
Remove wording about default interprocess propagator

### DIFF
--- a/specification/api-propagators.md
+++ b/specification/api-propagators.md
@@ -186,10 +186,7 @@ Required arguments:
 Implementations MAY provide global `Propagator`s for
 each supported `Format`.
 
-If offered, the global `Propagator`s should default to a composite `Propagator`
-containing W3C Trace Context and Correlation Context `Propagator`s,
-in order to provide propagation even in the presence of no-op
-OpenTelemetry implementations.
+The global `Propagator`s MUST default to a no-op `Propagator`.
 
 ### Get Global Propagator
 


### PR DESCRIPTION
Per conversation in gitter <https://gitter.im/open-telemetry/opentelemetry-specification?at=5e71667f2a459312318dd225>

The decision was made a long time ago that the API should not provide any propagation by default, but the wording was never removed from the spec.