### PR TITLE
Semantic conventions for when to record exceptions

### DIFF
--- a/specification/data-error-semantic-conversions.md
+++ b/specification/data-error-semantic-conversions.md
@@ -3,7 +3,8 @@
 This document defines semantic conventions for recording logs and errors.
 
 ## Recording an Error
-Errors and exceptions SHOULD be recorded any time an unhandled exception or error leaves the boundary of a span. 
 
-An error event created by an API call SHOULD be associated with the current span from which the API call is made. 
+Errors and exceptions SHOULD be recorded any time an unhandled exception or error leaves the boundary of a span.
+
+An error event created by an API call SHOULD be associated with the current span from which the API call is made.
 

--- a/specification/data-error-semantic-conversions.md
+++ b/specification/data-error-semantic-conversions.md
@@ -1,0 +1,9 @@
+# Semantic conventions for errors
+
+This document defines semantic conventions for recording logs and errors.
+
+## Recording an Error
+Errors and exceptions SHOULD be recorded any time an unhandled exception or error leaves the boundary of a span. 
+
+An error event created by an API call SHOULD be associated with the current span from which the API call is made. 
+


### PR DESCRIPTION
This PR is not meant to compete with the the following PR's: 
https://github.com/open-telemetry/opentelemetry-specification/pull/427
https://github.com/open-telemetry/opentelemetry-specification/pull/432

This addition is only intended to spec out when to instrument errors. Java currently uses this behavior. 