### PR TITLE
Move context utils outside of the Tracer

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -235,7 +235,7 @@ or a util class e.g. `TracingContextUtils`) to:
 
 * Get the currently active Span
 * Get/Set a Span from/to a Context
-* Make a given Span as active
+* Make a given Span active
 
 The API MUST internally leverage the Context in order to get and set the current
 Span state and how Spans are passed across process boundaries.

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -231,7 +231,7 @@ provide default Propagators which support transferring span context across
 process boundaries.
 
 The API MUST provide methods (or, depending on the language, global functions
-or util class e.g. `TracingContextUtils`) to:
+or a util class e.g. `TracingContextUtils`) to:
 
 * Get the currently active Span
 * Get/Set a Span from/to a Context

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -69,7 +69,7 @@ A duration is the elapsed time between two events.
 
 ## Tracer
 
-The `Tracer` main responsibility it to allow creating `Spans`.
+The `Tracer`'s main responsibility it to allow creating `Spans`.
 
 ### Obtaining a Tracer
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -238,7 +238,7 @@ or a util class e.g. `TracingContextUtils`) to:
 * Make a given Span active
 
 The API MUST internally leverage the Context in order to get and set the current
-Span state and how Spans are passed across process boundaries.
+Span and for passing Spans across process boundaries.
 
 When getting the current span, the API MUST return a placeholder Span with an
 invalid SpanContext if there is no currently active Span.

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -69,7 +69,7 @@ A duration is the elapsed time between two events.
 
 ## Tracer
 
-The `Tracer`'s main responsibility it to allow creating `Spans`.
+The `Tracer`'s main responsibility is to allow creating `Spans`.
 
 ### Obtaining a Tracer
 

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -243,10 +243,6 @@ Span state and how Spans are passed across process boundaries.
 When getting the current span, the API MUST return a placeholder Span with an
 invalid SpanContext if there is no currently active Span.
 
-When an active Span is made inactive, the previously-active Span SHOULD be made
-active. A Span maybe finished (i.e. have a non-null end time) but still active.
-A Span may be active on one thread after it has been made inactive on another.
-
 ### Span Creation
 
 Implementations MUST provide a way to create `Span`s via a `Tracer`. By default,

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -221,15 +221,20 @@ directly. All `Span`s MUST be created via a `Tracer`.
 The OpenTelemetry library achieves in-process context propagation of `Span`s by
 way of the [Context](./context.md).
 
+An `active Span` referes to a Span that is set to an
+[Attached Context](./context.md#attach-context). This applies only to languages
+using `Context` implicitly.
+
 Tracing API is responsible to provide functionality to track the currently
 active Span, and exposes functionality to activate new Spans. The API MAY
 provide default Propagators which support transferring span context across
 process boundaries.
 
-The API MUST provide methods to (depending on the language, global functions
-or util class e.g. `TracingContextUtils`):
+The API MUST provide methods (or, depending on the language, global functions
+or util class e.g. `TracingContextUtils`) to:
 
 * Get the currently active Span
+* Get/Set a Span from/to a Context
 * Make a given Span as active
 
 The API MUST internally leverage the Context in order to get and set the current

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -225,7 +225,7 @@ An `active Span` referes to a Span that is set to an
 [Attached Context](./context.md#attach-context). This applies only to languages
 using `Context` implicitly.
 
-Tracing API is responsible to provide functionality to track the currently
+The API is responsible to provide functionality to track the currently
 active Span, and exposes functionality to activate new Spans. The API MAY
 provide default Propagators which support transferring span context across
 process boundaries.


### PR DESCRIPTION
Rational:
* Context is now a standalone concept in OpenTelemetry and we don't need to provide abstractions on top of context interactions, so no need to have `getCurrentSpan` an interface.
* Remove duplicate APIs in some languages like Java where there is an util class to allow context interactions and also the methods on the tracer.
* Simplify context interaction by not requiring to pass a Tracer to classes/functions where no need to create a new Span.

Fixes: https://github.com/open-telemetry/opentelemetry-specification/issues/455