### PR TITLE
SpanContext.IsRemote is false on remote children

### DIFF
--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -178,7 +178,7 @@ the same trace.
 TraceID and a non-zero SpanID.
 
 `IsRemote` is a boolean flag which returns true if the SpanContext was propagated
-from a remote parent.
+from a remote parent. A child of a remote span should have IsRemote set to false.
 
 Please review the W3C specification for details on the [Tracestate
 field](https://www.w3.org/TR/trace-context/#tracestate-field).

--- a/specification/api-tracing.md
+++ b/specification/api-tracing.md
@@ -178,7 +178,8 @@ the same trace.
 TraceID and a non-zero SpanID.
 
 `IsRemote` is a boolean flag which returns true if the SpanContext was propagated
-from a remote parent. A child of a remote span should have IsRemote set to false.
+from a remote parent.
+When creating children from remote spans, their IsRemote flag MUST be set to false.
 
 Please review the W3C specification for details on the [Tracestate
 field](https://www.w3.org/TR/trace-context/#tracestate-field).


### PR DESCRIPTION
The IsRemote flag should be false on children of remote spans,
as the span itself was created locally.

Fixes #523 