### PR TITLE
update circleci to use go 1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2
 jobs:
   misspell:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.14
     steps:
       - checkout
       - run:


### PR DESCRIPTION
With the release of [go 1.14 in 2020-02-25](https://golang.org/doc/devel/release.html#go1.14), go 1.12 is no longer supported. This PR updates circleci jobs to use the go 1.14 docker container.