### PR TITLE
Clarify messaging.system  (remove confusing "vendor" terminology).

### DIFF
--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -53,7 +53,7 @@ The processor of the message should set the kind to `CONSUMER`, unless it always
 
 | Attribute name |                          Notes and examples                            | Required? |
 | -------------- | ---------------------------------------------------------------------- | --------- |
-| `messaging.system` | A string identifying the messaging system vendor such as `kafka`, `rabbitmq` or `activemq`. | Yes |
+| `messaging.system` | A string identifying the messaging system such as `kafka`, `rabbitmq` or `activemq`. | Yes |
 | `messaging.destination` | The message destination name, e.g. `MyQueue` or `MyTopic`. This might be equal to the span name but is required nevertheless. | Yes |
 | `messaging.destination_kind` | The kind of message destination: Either `queue` or `topic`. | Yes, if either of them applies. |
 | `messaging.temp_destination` | A boolean that is `true` if the message destination is temporary. | If temporary (assumed to be `false` if missing). |


### PR DESCRIPTION
I'm not sure what this should have to do with vendors, according to the examples, this would be the actual system names themselves. Otherwise the vendor for kafka would probably be "Apache", for example.

CC @arminru 