### PR TITLE
Remove default keys from metrics spec

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -8,7 +8,6 @@
   * [Meter Interface](#meter-interface)
   * [Aggregations](#aggregations)
   * [Time](#time)
-  * [WithRecommendedKeys declaration on metric instruments](#withrecommendedkeys-declaration-on-metric-instruments)
   * [Metric Event Format](#metric-event-format)
 - [Three kinds of instrument](#three-kinds-of-instrument)
   * [Counter](#counter)
@@ -197,38 +196,6 @@ series of metric events as a _time series_. However, we reserve the
 use of this term for the SDK specification, to refer to parts of a
 data format that express explicitly timestamped values, in a sequence,
 resulting from an aggregation of raw measurements over time.
-
-### WithRecommendedKeys declaration on metric instruments
-
-A standard feature of metric SDKs is to pre-aggregate metric events
-according to a specified set of label keys (i.e., dimensions).  To
-perform this task, the SDK must aggregate metric events over the
-collection interval: (1) across time, (2) across key dimensions in
-_label space_.
-
-When aggregating across spatial dimensions, metric events for different sets of
-labels are combined into an aggregated value for each distinct "group" of
-values for the key dimensions.  It means that measurements are combined for all
-metric events having the same values for selected keys, explicitly disregarding
-any additional labels with keys not in the set of aggregation keys.  Some
-exporters are known to require pre-specifying the label keys used for
-aggregation (e.g., Prometheus).
-
-For example, if `[ak1, ak2]` are the aggregation keys and `[ik1,
-ik2]` are the ignored keys, then a metric event having labels
-`{ak1=A, ak2=B, ik1=C, ik1=D}` will be combined with a metric
-event having labels `{ak1=A, ak2=B, ik1=Y, ik1=Z}` because they
-have identical label values for all of the aggregation keys.
-
-The API provides a `WithRecommendedKeys` option for the user to declare the
-recommended aggregation keys when declaring new metric instruments,
-intended as the default way to configure an exporter for
-pre-aggregation, if it is expected.  Since this is only expected in
-some exporters, it is regarded as an option relevant to the exporter,
-whether keys configured through `WithRecommendedKeys` are applied for aggregation
-purposes or not.  This allows the user to influence the standard
-implementation behavior, especially for exporters that require
-pre-specified aggregation keys.
 
 ### Metric Event Format
 


### PR DESCRIPTION
Resolves #463 

We are still planning to support the capability to reduce the set of labels that are recorded during instrumentation but will do that using the Views. By default we will use all provided labels when we build the aggregation.