### PR TITLE
Document special Zipkin conversion cases

### DIFF
--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -115,7 +115,6 @@ omitted from the payload when they are empty in the OpenTelemetry `Span`.
 For example, an OpenTelemetry `Span` without any `Event` should not have an
 `annotations` field in the Zipkin payload.
 
-
 ## Special cases
 
 These special cases might only apply to Zipkin [Thrift format](https://github.com/openzipkin/zipkin-api/tree/master/thrift).

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -121,18 +121,10 @@ Zipkin's v2 [json](https://github.com/openzipkin/zipkin-api/blob/master/zipkin2-
 
 Frameworks made before then use a more complex v1 [Thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift) or [json](https://github.com/openzipkin/zipkin-api/blob/master/zipkin-api.yaml) format that notably differs in so far as it uses terminology such as Binary Annotation, and repeats endpoint information on each attribute.
 
-Below is the conversion process of v1 format into OpenTelemetry format.
+Consider using [V1SpanConverter.java](https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin2/v1/V1SpanConverter.java) as a reference implementation for converting v1 model to OpenTelemetry.
 
-### Missing start time
+Follows a list of cases that require special handling:
 
-Missing span start time (`null`) should be derived from the Annotations in the following order:
-
-1. use timestamp from client send annotation `cs`
-2. use timestamp from server receive annotation `sr`
-
-### Missing duration
-
-Missing span duration (`null`) should be derived from the Annotations in the following order:
-
-1. the timestamp difference between client receive `cr` and client send `cs` annotations
-2. the timestamp difference between the last and first annotation
+* Missing start time
+* Missing duration
+* TBD

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -123,8 +123,4 @@ Frameworks made before then use a more complex v1 [Thrift](https://github.com/op
 
 Consider using [V1SpanConverter.java](https://github.com/openzipkin/zipkin/blob/master/zipkin/src/main/java/zipkin2/v1/V1SpanConverter.java) as a reference implementation for converting v1 model to OpenTelemetry.
 
-Follows a list of cases that require special handling:
-
-* Missing start time
-* Missing duration
-* TBD
+The span timestamp and duration were late additions to the V1 format. As in the code link above, it is possible to heuristically derive them from annotations.

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -115,9 +115,13 @@ omitted from the payload when they are empty in the OpenTelemetry `Span`.
 For example, an OpenTelemetry `Span` without any `Event` should not have an
 `annotations` field in the Zipkin payload.
 
-## Special cases
+## Considerations for Legacy (v1) Format
 
-These special cases might only apply to Zipkin [Thrift format](https://github.com/openzipkin/zipkin-api/tree/master/thrift).
+Zipkin's v2 [json](https://github.com/openzipkin/zipkin-api/blob/master/zipkin2-api.yaml) format was defined in 2017, followed up by a [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format in 2018.
+
+Frameworks made before then use a more complex v1 [Thrift](https://github.com/openzipkin/zipkin-api/blob/master/thrift/zipkinCore.thrift) or [json](https://github.com/openzipkin/zipkin-api/blob/master/zipkin-api.yaml) format that notably differs in so far as it uses terminology such as Binary Annotation, and repeats endpoint information on each attribute.
+
+Below is the conversion process of v1 format into OpenTelemetry format.
 
 ### Missing start time
 

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -129,7 +129,7 @@ Missing span start time (`null`) should be derived from the Annotations in the f
 
 ### Missing duration
 
-Missing span duration (`null`)should be derived tom the Annotations in the following order:
+Missing span duration (`null`) should be derived from the Annotations in the following order:
 
 1. the timestamp difference between client receive `cr` and client send `cs` annotations
-2. the timestamp difference between the last and first annotations
+2. the timestamp difference between the last and first annotation

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -114,3 +114,22 @@ omitted from the payload when they are empty in the OpenTelemetry `Span`.
 
 For example, an OpenTelemetry `Span` without any `Event` should not have an
 `annotations` field in the Zipkin payload.
+
+
+## Special cases
+
+These special cases might only apply to Zipkin [Thrift format](https://github.com/openzipkin/zipkin-api/tree/master/thrift).
+
+### Missing start time
+
+Missing span start time (`null`) should be derived from the Annotations in the following order:
+
+1. use timestamp from client send annotation `cs`
+2. use timestamp from server receive annotation `sr`
+
+### Missing duration
+
+Missing span duration (`null`)should be derived tom the Annotations in the following order:
+
+1. the timestamp difference between client receive `cr` and client send `cs` annotations
+2. the timestamp difference between the last and first annotations


### PR DESCRIPTION
This proposal is mostly related to OTEL collector as I assume it is the only one collecting Zipkin data in thrift format. I am not sure if this could also happen in JSON or proto (probably not). 

In Jaeger we have a set of span sanitizers https://github.com/jaegertracing/jaeger/blob/master/cmd/collector/app/sanitizer/zipkin/span_sanitizer.go that properly set some span fields if the values are missing. I think it might be worth documenting these as we saw that old Zipkin instrumentations/clients might send spans with missing fields (start time, duration).

The only missing sanitizer is for span errors. Errors in Zipkin spans might have the following format `error=some error`. This will have to also be transformed to OTEL format. It is blocked by https://github.com/open-telemetry/opentelemetry-specification/pull/427. 


Signed-off-by: Pavol Loffay <ploffay@redhat.com>