### PR TITLE
Allow injectors and extractors to be separate interfaces

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -139,14 +139,22 @@ Required arguments:
 
 The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text `Format` implementions MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
 
+## Injectors and Extractors as Separate Interfaces
+
+Languages can choose to implement a `Propagator` for a format as a single object
+exposing `Inject` and `Extract` methods, or they can opt to divide the
+responsibilities further into individual `Injector`s and `Extractor`s. A
+`Propagator` can be implemented by composing individual `Injector`s and
+`Extractors`.
+
 ## Composite Propagator
 
 Implementations MUST offer a facility to group multiple `Propagator`s
 from different cross-cutting concerns in order to leverage them as a
 single entity.
 
-The resulting composite `Propagator` will invoke the `Propagators`
-in the order they were specified.
+A composite propagator can be built from a list of propagators, or a list of
+injectors and extractors. The resulting composite `Propagator` will invoke the `Propagator`s, `Injector`s, or `Extractor`s, in the order they were specified.
 
 Each composite `Propagator` will be bound to a specific `Format`, such
 as `HttpTextFormat`, as different `Format`s will likely operate on different
@@ -161,7 +169,7 @@ There MUST be functions to accomplish the following operations.
 
 Required arguments:
 
-- A list of `Propagator`s.
+- A list of `Propagator`s or a list of `Injector`s and `Extractor`s.
 
 Returns a new composite `Propagator` with the specified `Propagator`s.
 


### PR DESCRIPTION
[OTEP-66](https://github.com/open-telemetry/oteps/pull/66) originally had the propagator interface divided into separate `Injector`s and `Extractor`s. In OpenTelemetry Ruby we found some advantages to this division. For example, you can have asymmetry in the formats that are injected / extracted, and there are situations where order matters. By dividing `Propagator`s into `Injector`s and `Extractor`s you can still implement the `Propagator` and `CompositePropagator` interfaces by composing individual `Injector`s and `Extractor`s. This PR updates the [api-propagators spec](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md) to allow for that possibility.

Addresses #479.
