### PR TITLE
Clarify semantic conventions around span start and end time

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -227,17 +227,20 @@ hypothetical account information:
 The `Span`'s start and end timestamps reflect the elapsed real time of the
 operation.
 
-For example, an http server span should start right when the request has begun being handled by the server, and end when the response has been completely sent.
-This would include the following, if they are present in that particular
-request-response cycle:
+For example, If a span represents a request-response cycle (e.g. HTTP or an RPC),
+the span should have a start time that corresponds to the start time of the
+first sub operations, and an end time of when the final sub operation is complete.
+This includes:
 
-- receiving the HTTP request
-- parsing of the HTTP request
-- parsing of the body of the HTTP request
-- any web server middleware that is applied
+- receiving the data from the request
+- parsing of the data (e.g. from a binary or json format)
+- any middleware or additional processing logic
 - business logic
-- construction of the HTTP response
-- sending of the HTTP response
+- construction of the response
+- sending of the response
+
+Child spans may be created to represent any sub-operations, to provide more
+granular observability.
 
 A `Span`'s start time SHOULD be set to the current time on [span
 creation](#span-creation). After the `Span` is created, it SHOULD be possible to

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -225,7 +225,21 @@ hypothetical account information:
 | `get_account/{accountId}` | Also good (using the "HTTP route") |
 
 The `Span`'s start and end timestamps reflect the elapsed real time of the
-operation. A `Span`'s start time SHOULD be set to the current time on [span
+operation.
+
+For example, an http server span should start right when the request has begun being handled by the server, and end when the response has been completely sent.
+This would include the following, if they are present in that particular
+request-response cycle:
+
+- receiving the HTTP request
+- parsing of the HTTP request
+- parsing of the body of the HTTP request
+- any web server middleware that is applied
+- business logic
+- construction of the HTTP response
+- sending of the HTTP response
+
+A `Span`'s start time SHOULD be set to the current time on [span
 creation](#span-creation). After the `Span` is created, it SHOULD be possible to
 change the its name, set its `Attribute`s, and add `Link`s and `Event`s. These
 MUST NOT be changed after the `Span`'s end time has been set.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -239,8 +239,10 @@ This includes:
 - construction of the response
 - sending of the response
 
-Child spans (or in some cases events) may be created to represent any sub-operations, to provide more
-granular observability.
+Child spans (or in some cases events) may be created to represent
+sub-operations which require more detailed observability. Child spans should
+measure the timing of the respective sub-operation, and may add additional
+attributes.
 
 A `Span`'s start time SHOULD be set to the current time on [span
 creation](#span-creation). After the `Span` is created, it SHOULD be possible to

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -227,9 +227,9 @@ hypothetical account information:
 The `Span`'s start and end timestamps reflect the elapsed real time of the
 operation.
 
-For example, If a span represents a request-response cycle (e.g. HTTP or an RPC),
+For example, if a span represents a request-response cycle (e.g. HTTP or an RPC),
 the span should have a start time that corresponds to the start time of the
-first sub operations, and an end time of when the final sub operation is complete.
+first sub-operation, and an end time of when the final sub-operation is complete.
 This includes:
 
 - receiving the data from the request
@@ -239,7 +239,7 @@ This includes:
 - construction of the response
 - sending of the response
 
-Child spans may be created to represent any sub-operations, to provide more
+Child spans (or in some cases events) may be created to represent any sub-operations, to provide more
 granular observability.
 
 A `Span`'s start time SHOULD be set to the current time on [span

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -96,12 +96,6 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 If set, `http.url` must be the originally requested URL,
 before any HTTP-redirects that may happen when executing the request.
 
-The span start time SHOULD be as close as possible to the time the client began
-the request.
-
-The span end time SHOULD be as close as possible to the time the client finished
-receiving the response to the request.
-
 One of the following sets of attributes is required (in order of usual preference unless for a particular web client/framework it is known that some other set is preferable for some reason; all strings must be non-empty):
 
 * `http.url`
@@ -186,12 +180,6 @@ Given an inbound request for a route (e.g. `"/users/:userID?"`) the `name` attri
 If the route does not include the application root, it SHOULD be prepended to the span name.
 
 If the route cannot be determined, the `name` attribute MUST be set as defined in the general semantic conventions for HTTP.
-
-The span start time SHOULD be as close as possible to the time the server began
-handling the request.
-
-The span end time SHOULD be as close as possible to the time the server completed
-the response.
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -96,6 +96,9 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 If set, `http.url` must be the originally requested URL,
 before any HTTP-redirects that may happen when executing the request.
 
+The span start and send times SHOULD be as close to the time the client began sending the request
+and the time the client completes the request as possible.
+
 One of the following sets of attributes is required (in order of usual preference unless for a particular web client/framework it is known that some other set is preferable for some reason; all strings must be non-empty):
 
 * `http.url`
@@ -180,6 +183,9 @@ Given an inbound request for a route (e.g. `"/users/:userID?"`) the `name` attri
 If the route does not include the application root, it SHOULD be prepended to the span name.
 
 If the route cannot be determined, the `name` attribute MUST be set as defined in the general semantic conventions for HTTP.
+
+The span start and send times SHOULD be as close to the time the server began handling the request
+and the time the server completes the request as possible.
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -96,8 +96,11 @@ For an HTTP client span, `SpanKind` MUST be `Client`.
 If set, `http.url` must be the originally requested URL,
 before any HTTP-redirects that may happen when executing the request.
 
-The span start and send times SHOULD be as close to the time the client began sending the request
-and the time the client completes the request as possible.
+The span start time SHOULD be as close as possible to the time the client began
+the request.
+
+The span end time SHOULD be as close as possible to the time the client finished
+receiving the response to the request.
 
 One of the following sets of attributes is required (in order of usual preference unless for a particular web client/framework it is known that some other set is preferable for some reason; all strings must be non-empty):
 
@@ -184,8 +187,11 @@ If the route does not include the application root, it SHOULD be prepended to th
 
 If the route cannot be determined, the `name` attribute MUST be set as defined in the general semantic conventions for HTTP.
 
-The span start and send times SHOULD be as close to the time the server began handling the request
-and the time the server completes the request as possible.
+The span start time SHOULD be as close as possible to the time the server began
+handling the request.
+
+The span end time SHOULD be as close as possible to the time the server completed
+the response.
 
 | Attribute name | Notes and examples                                           | Required? |
 | :------------- | :----------------------------------------------------------- | --------- |


### PR DESCRIPTION
Fixes #591.

Adding semantic conventions for http start and end times. This has previously caused some ambiguity in the start / end times that instrumentations should target.