### PR TITLE
Support nested Attribute values (#376)

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -376,9 +376,10 @@ An `Attribute` is defined by the following properties:
 - (Required) The attribute key, which MUST be a non-`null` and non-empty string.
 - (Required) The attribute value, which is either:
   - A primitive type: string, boolean or numeric.
-  - A child Attribute
-  - An array of primitive type values or children Attributes. The array MUST be
-    homogeneous, i.e. it MUST NOT contain values of different types.
+  - An array of primitive type values. The array MUST be homogeneous,
+    i.e. it MUST NOT contain values of different types.
+  - An array of children attributes. The array MUST be homogeneous,
+    i.e. it MUST NOT be mixed with primitive type values.
 
 The Span interface MUST provide:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -376,8 +376,9 @@ An `Attribute` is defined by the following properties:
 - (Required) The attribute key, which MUST be a non-`null` and non-empty string.
 - (Required) The attribute value, which is either:
   - A primitive type: string, boolean or numeric.
-  - An array of primitive type values. The array MUST be homogeneous,
-    i.e. it MUST NOT contain values of different types.
+  - A child Attribute
+  - An array of primitive type values or children Attributes. The array MUST be
+    homogeneous, i.e. it MUST NOT contain values of different types.
 
 The Span interface MUST provide:
 


### PR DESCRIPTION
Related issue #376 

Nested Attribute is useful for representing multi-level values. For example, HTTP headers:
```
'http': {
    'headers': [
        'x-forwarded-for': 'foo.bar'
        'keep-alive': 'timeout=5'
    ]
}
``` 
Currently such cases are usually represented by a period delimited key chain (e.g. `'http.headers.x-forwarded-for': 'foo.bar'`). This does not work if any key contains a period itself. It is also difficult for SDKs to iterate the Attributes under a certain level.

This change allows nested Attributes by adding an Attribute value type - child Attribute. An attribute can also contain a homogeneous array of children attributes.

### Why not map?
1. `Map` is somehow a high level data structure. It has different definitions in different languages. In some languages putting a map value replaces the original value, while in other languages it becomes a sibling of the original value. 
2. Programming-wise, it is hard to keep the homogeneity in map values.

* Actually, the OT spec never used map in any span data type


