### PR TITLE
[build] Improve markdown-link-check output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Run Tools
           command: |
             make markdown-lint
-            make enforce-markdown-link-check
+            make markdown-link-check
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install-markdown-link-check:
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	find . -name \*.md -print0 | xargs -0 -n1 $(MARKDOWN_LINK_CHECK) -q
+	find . -name \*.md -print0 | xargs -0 -n1 $(MARKDOWN_LINK_CHECK) --quiet
 
 .PHONY: install-markdown-lint
 install-markdown-lint:

--- a/Makefile
+++ b/Makefile
@@ -27,14 +27,7 @@ markdown-link-check:
 
 .PHONY: enforce-markdown-link-check
 enforce-markdown-link-check:
-	@LINKCHECKOUT=`find . -name \*.md -exec $(MARKDOWN_LINK_CHECK) {} 2>&1 >/dev/null \;`; \
-		if [ "$$LINKCHECKOUT" ]; then \
-			echo "$(MARKDOWN_LINK_CHECK) FAILED => errors:\n"; \
-			echo "Run 'make $(MARKDOWN_LINK_CHECK)' to see the errors"; \
-			exit 1; \
-		else \
-			echo "Check markdown links finished successfully"; \
-		fi
+	find . -name \*.md -print0 | xargs -0 -n1 $(MARKDOWN_LINK_CHECK) -q
 
 .PHONY: install-markdown-lint
 install-markdown-lint:

--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ install-markdown-link-check:
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	find . -name \*.md -exec $(MARKDOWN_LINK_CHECK) {} \;
-
-.PHONY: enforce-markdown-link-check
-enforce-markdown-link-check:
 	find . -name \*.md -print0 | xargs -0 -n1 $(MARKDOWN_LINK_CHECK) -q
 
 .PHONY: install-markdown-lint

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -82,7 +82,7 @@ Note that the items marked with [1] are different from the mapping defined in th
 
 It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-[network attributes]: span-general.md#general-network-connection-attributes
+[network attributes]: span-generall.md#general-network-connection-attributes
 [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
 [HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
 [User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
@@ -187,11 +187,11 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
 
-[HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
+[HTTP request line]: https://tools.ietf.orgg/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
 [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 
-**[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/148>).
+**[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/14800>).
 It is thus preferred to supply the raw data that *is* available.
 Namely, one of the following sets is required (in order of usual preference unless for a particular web server/framework it is known that some other set is preferable for some reason; all strings must be non-empty):
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -82,7 +82,7 @@ Note that the items marked with [1] are different from the mapping defined in th
 
 It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-[network attributes]: span-generall.md#general-network-connection-attributes
+[network attributes]: span-general.md#general-network-connection-attributes
 [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
 [HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
 [User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
@@ -187,11 +187,11 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | `http.route` | The matched route (path template). (TODO: Define whether to prepend application root) E.g. `"/users/:userID?"`. | No |
 | `http.client_ip` | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For][]). Note that this is not necessarily the same as `net.peer.ip`, which would identify the network-level peer, which may be a proxy. | No |
 
-[HTTP request line]: https://tools.ietf.orgg/html/rfc7230#section-3.1.1
+[HTTP request line]: https://tools.ietf.org/html/rfc7230#section-3.1.1
 [HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
 [X-Forwarded-For]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 
-**[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/14800>).
+**[1]**: `http.url` is usually not readily available on the server side but would have to be assembled in a cumbersome and sometimes lossy process from other information (see e.g. <https://github.com/open-telemetry/opentelemetry-python/pull/148>).
 It is thus preferred to supply the raw data that *is* available.
 Namely, one of the following sets is required (in order of usual preference unless for a particular web server/framework it is known that some other set is preferable for some reason; all strings must be non-empty):
 


### PR DESCRIPTION
The current build output is not really helpful, one would have to setup the build and execute it locally to figure out what failed.

before:
```
markdown-link-check FAILED => errors:

Run 'make markdown-link-check' to see the errors
Makefile:30: recipe for target 'enforce-markdown-link-check' failed
make: *** [enforce-markdown-link-check] Error 1

Exited with code exit status 2
```

after:
```
FILE: ./specification/trace/semantic_conventions/http.md
[✖] https://tools.ietf.orgg/html/rfc7230#section-3.1.1
[✖] span-generall.md#general-network-connection-attributes
[✖] https://github.com/open-telemetry/opentelemetry-python/pull/14800

31 links checked.

ERROR: 3 dead links found!
[✖] https://tools.ietf.orgg/html/rfc7230#section-3.1.1 → Status: 0
[✖] span-generall.md#general-network-connection-attributes → Status: 400
[✖] https://github.com/open-telemetry/opentelemetry-python/pull/14800 → Status: 404

...

Makefile:30: recipe for target 'enforce-markdown-link-check' failed
make: *** [enforce-markdown-link-check] Error 123

Exited with code exit status 2
```