### PR TITLE
Link from trace (and metric) semantic conventions to resources

### DIFF
--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -1,3 +1,7 @@
 # Metrics Semantic Conventions
 
 TODO: Add semantic conventions for metric names and labels.
+
+Apart from semantic conventions for metrics and [traces](../../trace/semantic_conventions/README.md),
+OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own
+[Resource Semantic Conventions](../../resource/semantic_conventions/README.md).

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -19,3 +19,7 @@ The following semantic conventions for spans are defined:
 * [RPC/RMI](rpc.md): Spans for remote procedure calls (e.g., gRPC).
 * [Messaging](messaging.md): Spans for interaction with messaging systems (queues, publish/subscribe, etc.).
 * [FaaS](faas.md): Spans for Function as a Service (e.g., AWS Lambda).
+
+Apart from semantic conventions for traces and [metrics](../../metrics/semantic_conventions/README.md),
+OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own
+[Resource Semantic Conventions](../../resource/semantic_conventions/README.md).


### PR DESCRIPTION
Currently the resource semantic conventions are easy to miss as brought up on #593.