### PR TITLE
Extend semantic conventions for RPC and allow non-gRPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ the release.
 
 ## Unreleased
 
+- Extend semantic conventions for RPC and allow non-gRPC calls ([#604](https://github.com/open-telemetry/opentelemetry-specification/pull/604))
 - Added conventions for naming of exporter packages
 
 ## v0.5.0 (06-02-2020)

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -34,7 +34,7 @@ The _span name_ MUST be the full RPC method name formatted as:
 $package.$service/$method
 ```
 
-(where $service must not contain dots)
+(where $service must not contain dots and $method must not contain slashes)
 
 If there is no package name or if it is unknown, the `$package.` part (including the period) is omitted.
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -29,7 +29,9 @@ The _span name_ MUST be the full RPC method name formatted as:
 $package.$service/$method
 ```
 
-(where $service must not contain dots).
+(where $service must not contain dots)
+
+If no package applies or it is known, the `$package.` part (including the period) is omitted.
 
 Examples of span names:
 
@@ -37,13 +39,14 @@ Examples of span names:
 - `com.example.ExampleRmiService/exampleMethod`
 - `MyCalcService.Calculator/Add` reported by the server and  
   `MyServiceReference.ICalculator/Add` reported by the client for .NET WCF calls
+- `MyServiceWithNoPackage/theMethod`
 
 ### Attributes
 
 | Attribute name |                          Notes and examples                            | Required? |
 | -------------- | ---------------------------------------------------------------------- | --------- |
 | `rpc.system`   | A string identifying the remoting system, e.g., `"grpc"`, `"java_rmi"` or `"wcf"`.       | Yes |
-| `rpc.service`  | The service name, must be equal to the $service part in the span name.                   | Yes |
+| `rpc.service`  | The full name of the service being called, including its package name, if applicable.    | Yes |
 | `rpc.method`   | The name of the method being called, must be equal to the $method part in the span name. | Yes |
 | `net.peer.ip`   | See [network attributes][]. | See below |
 | `net.peer.name` | See [network attributes][]. | See below |

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -51,7 +51,7 @@ Examples of span names:
 | `net.transport` | See [network attributes][]. | See below |
 
 At least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
-For client-side spans `net.peer.port` is required if the connection is IP-based (it describes the server port they are connecting to).
+For client-side spans `net.peer.port` is required if the connection is IP-based and the port is available (it describes the server port they are connecting to).
 For server-side spans `net.peer.port` is optional (it describes the port the client is connecting from).
 Furthermore, setting [net.transport][] is required for non-IP connection like named pipe bindings.
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -36,7 +36,7 @@ $package.$service/$method
 
 (where $service must not contain dots)
 
-If the package name does not apply or is unknown, the `$package.` part (including the period) is omitted.
+If there is no package name or if it is unknown, the `$package.` part (including the period) is omitted.
 
 Examples of span names:
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -11,6 +11,7 @@ This document defines how to describe remote procedure calls
   * [Span name](#span-name)
   * [Attributes](#attributes)
     + [Service name](#service-name)
+  * [Distinction from HTTP spans](#distinction-from-http-spans)
 - [gRPC](#grpc)
   * [Status](#status)
   * [Events](#events)
@@ -20,7 +21,10 @@ This document defines how to describe remote procedure calls
 ## Common remote procedure call conventions
 
 A remote procedure calls is described by two separate spans, one on the client-side and one on the server-side.
+
 For outgoing requests, the `SpanKind` MUST be set to `CLIENT` and for incoming requests to `SERVER`.
+
+Remote procedure calls can only be represented with these semantic conventions, when the names of the called service and method are known and available.
 
 ### Span name
 
@@ -69,6 +73,12 @@ This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc
 [network attributes]: span-general.md#general-network-connection-attributes
 [net.transport]: span-general.md#nettransport-attribute
 [`service.name` resource attribute]: ../../resource/semantic_conventions/README.md#service
+
+### Distinction from HTTP spans
+
+HTTP calls can generally be represented using [HTTP spans](./http.md) only.
+If they address a particular remote service and method known to the caller, i.e., when it is a remote procedure call transported over HTTP, the `rpc.*` attributes might be added additionally on that span, or in a separate RPC span surrounding the transporting HTTP call.
+Note that _method_ in this context is about the called remote procedure and _not_ the HTTP verb (GET, POST, etc.).
 
 ## gRPC
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -48,12 +48,15 @@ Examples of span names:
 | `net.peer.ip`   | See [network attributes][]. | See below |
 | `net.peer.name` | See [network attributes][]. | See below |
 | `net.peer.port` | See [network attributes][]. | See below |
+| `net.transport` | See [network attributes][]. | See below |
 
 At least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
-For client-side spans `net.peer.port` is required (it describes the server port they are connecting to).
+For client-side spans `net.peer.port` is required if the connection is IP-based (it describes the server port they are connecting to).
 For server-side spans `net.peer.port` is optional (it describes the port the client is connecting from).
+Furthermore, setting [net.transport][] is required for non-IP connection like named pipe bindings.
 
 [network attributes]: span-general.md#general-network-connection-attributes
+[net.transport]: span-general.md#nettransport-attribute
 
 ## gRPC
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -7,41 +7,60 @@ This document defines how to describe remote procedure calls
 
 <!-- toc -->
 
-- [gRPC](#grpc)
+- [Common remote procedure call conventions](#common-remote-procedure-call-conventions)
+  * [Span name](#span-name)
   * [Attributes](#attributes)
+- [gRPC](#grpc)
   * [Status](#status)
   * [Events](#events)
 
 <!-- tocstop -->
 
-## gRPC
+## Common remote procedure call conventions
 
-Implementations MUST create a span, when the gRPC call starts, one for
-client-side and one for server-side. Outgoing requests should be a span `kind`
-of `CLIENT` and incoming requests should be a span `kind` of `SERVER`.
+A remote procedure calls is described by two separate spans, one on the client-side and one on the server-side.
+For outgoing requests, the `SpanKind` MUST be set to `CLIENT` and for incoming requests to `SERVER`.
 
-Span `name` MUST be full gRPC method name formatted as:
+### Span name
+
+The _span name_ MUST be the full RPC method name formatted as:
 
 ```
 $package.$service/$method
 ```
 
-Examples of span name: `grpc.test.EchoService/Echo`.
+(where $service must not contain dots).
+
+Examples of span names:
+
+- `grpc.test.EchoService/Echo`
+- `com.example.ExampleRmiService/exampleMethod`
+- `MyCalcService.Calculator/Add` reported by the server and  
+  `MyServiceReference.ICalculator/Add` reported by the client for .NET WCF calls
 
 ### Attributes
 
-| Attribute name | Notes and examples                                           | Required? |
-| -------------- | ------------------------------------------------------------ | --------- |
-| `rpc.service`  | The service name, must be equal to the $service part in the span name. | Yes |
-| `net.peer.ip`  | See [network attributes][]. | See below |
-| `net.peer.name`  | See [network attributes][]. | See below |
-| `net.peer.port`  | See [network attributes][]. | See below |
+| Attribute name |                          Notes and examples                            | Required? |
+| -------------- | ---------------------------------------------------------------------- | --------- |
+| `rpc.system`   | A string identifying the remoting system, e.g., `"grpc"`, `"java_rmi"` or `"wcf"`.       | Yes |
+| `rpc.service`  | The service name, must be equal to the $service part in the span name.                   | Yes |
+| `net.peer.ip`   | See [network attributes][]. | See below |
+| `net.peer.name` | See [network attributes][]. | See below |
+| `net.peer.port` | See [network attributes][]. | See below |
 
 At least one of [network attributes][] `net.peer.name` or `net.peer.ip` is required.
 For client-side spans `net.peer.port` is required (it describes the server port they are connecting to).
 For server-side spans `net.peer.port` is optional (it describes the port the client is connecting from).
 
 [network attributes]: span-general.md#general-network-connection-attributes
+
+## gRPC
+
+For remote procedure calls via [gRPC][], additional conventions are described in this section.
+
+`rpc.system` MUST be set to `"grpc"`.
+
+[gRPC]: https://grpc.io/
 
 ### Status
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -52,7 +52,7 @@ Examples of span names:
 | -------------- | ---------------------------------------------------------------------- | --------- |
 | `rpc.system`   | A string identifying the remoting system, e.g., `"grpc"`, `"java_rmi"` or `"wcf"`.       | Yes |
 | `rpc.service`  | The full name of the service being called, including its package name, if applicable.    | Yes |
-| `rpc.method`   | The name of the method being called, must be equal to the $method part in the span name. | Yes |
+| `rpc.method`   | The name of the method being called, must be equal to the $method part in the span name. | No, but recommended |
 | `net.peer.ip`   | See [network attributes][]. | See below |
 | `net.peer.name` | See [network attributes][]. | See below |
 | `net.peer.port` | See [network attributes][]. | See below |

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -36,7 +36,7 @@ $package.$service/$method
 
 (where $service must not contain dots)
 
-If no package applies or it is known, the `$package.` part (including the period) is omitted.
+If the package name does not apply or is unknown, the `$package.` part (including the period) is omitted.
 
 Examples of span names:
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -51,7 +51,7 @@ Examples of span names:
 | Attribute name |                          Notes and examples                            | Required? |
 | -------------- | ---------------------------------------------------------------------- | --------- |
 | `rpc.system`   | A string identifying the remoting system, e.g., `"grpc"`, `"java_rmi"` or `"wcf"`.       | Yes |
-| `rpc.service`  | The full name of the service being called, including its package name, if applicable.    | Yes |
+| `rpc.service`  | The full name of the service being called, including its package name, if applicable.    | No, but recommended |
 | `rpc.method`   | The name of the method being called, must be equal to the $method part in the span name. | No, but recommended |
 | `net.peer.ip`   | See [network attributes][]. | See below |
 | `net.peer.name` | See [network attributes][]. | See below |

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -44,6 +44,7 @@ Examples of span names:
 | -------------- | ---------------------------------------------------------------------- | --------- |
 | `rpc.system`   | A string identifying the remoting system, e.g., `"grpc"`, `"java_rmi"` or `"wcf"`.       | Yes |
 | `rpc.service`  | The service name, must be equal to the $service part in the span name.                   | Yes |
+| `rpc.method`   | The name of the method being called, must be equal to the $method part in the span name. | Yes |
 | `net.peer.ip`   | See [network attributes][]. | See below |
 | `net.peer.name` | See [network attributes][]. | See below |
 | `net.peer.port` | See [network attributes][]. | See below |

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -76,8 +76,8 @@ This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc
 
 ### Distinction from HTTP spans
 
-HTTP calls can generally be represented using [HTTP spans](./http.md) only.
-If they address a particular remote service and method known to the caller, i.e., when it is a remote procedure call transported over HTTP, the `rpc.*` attributes might be added additionally on that span, or in a separate RPC span surrounding the transporting HTTP call.
+HTTP calls can generally be represented using just [HTTP spans](./http.md).
+If they address a particular remote service and method known to the caller, i.e., when it is a remote procedure call transported over HTTP, the `rpc.*` attributes might be added additionally on that span, or in a separate RPC span that is a parent of the transporting HTTP call.
 Note that _method_ in this context is about the called remote procedure and _not_ the HTTP verb (GET, POST, etc.).
 
 ## gRPC

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -10,6 +10,7 @@ This document defines how to describe remote procedure calls
 - [Common remote procedure call conventions](#common-remote-procedure-call-conventions)
   * [Span name](#span-name)
   * [Attributes](#attributes)
+    + [Service name](#service-name)
 - [gRPC](#grpc)
   * [Status](#status)
   * [Events](#events)
@@ -58,8 +59,16 @@ For client-side spans `net.peer.port` is required if the connection is IP-based 
 For server-side spans `net.peer.port` is optional (it describes the port the client is connecting from).
 Furthermore, setting [net.transport][] is required for non-IP connection like named pipe bindings.
 
+#### Service name
+
+On the server process receiving and handling the remote procedure call, the service name provided in `rpc.service` does not necessarily have to match the [`service.name` resource attribute][]. One process can expose multiple RPC endpoints and thus have multiple RPC service names. From a deployment perspective, as expressed by the `service.*` resource attributes, it will be treated as one deployed service with one `service.name`.
+
+As an example, given a process deployed as `QuoteService`, this would be the name that goes into the `service.name` resource attribute which applies to the entire process.
+This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc.service`) with a method called `getMeanRate` (= `rpc.method`) and the other endpoint called `StockQuotes`  (= `rpc.service`) with two methods `getCurrentBid` and `getLastClose` (= `rpc.method`).
+
 [network attributes]: span-general.md#general-network-connection-attributes
 [net.transport]: span-general.md#nettransport-attribute
+[`service.name` resource attribute]: ../../resource/semantic_conventions/README.md#service
 
 ## gRPC
 


### PR DESCRIPTION
I generalized the semantic conventions to allow RPC systems other than gRPC.
Therefore, I added an attribute `rpc.system` (like we have for messaging systems as `messaging.system` [here](https://github.com/open-telemetry/opentelemetry-specification/blob/27e5c89075d3eeb5981e79bf8ab94d78aea5481d/specification/trace/semantic_conventions/messaging.md#messaging-attributes)) to identify the RPC system being used and added a section for gRPC, defining `rpc.system="grpc"` in this case.
Once we use proper YAML definitions, we can add a list of well-known descriptors to be used in addition to the ones I mentioned as examples.

Additionally, I added the method name as an attribute so that it doesn't have to be parsed out of the span name. This also makes it available for sampling decisions since the span name is not reliable to use here (#468).

By requiring the `net.transport` attribute to be set for non-IP connections we ensure that connections via named pipe bindings, for example, can be properly detected.

I didn't touch the `rpc.service` attribute already present but was wondering if we should change it to be the fully-qualified service name including $package, rather than just the unqualified name. What do you think?

I'm also considering to add an attribute for the logical endpoint which might be different from the physical endpoint described using the `net.peer.*` attributes. This would be particularly significant in scenarios where a service registry is used to resolve endpoints. We can either add it here or discuss it separately on a follow-up PR.

Resolves #27.