### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ install-markdown-link-check:
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	$(MARKDOWN_LINK_CHECK) --quiet $(ALL_DOCS)
+	@for f in $(ALL_DOCS); do $(MARKDOWN_LINK_CHECK) --quiet $$f; done
 
 .PHONY: install-markdown-lint
 install-markdown-lint:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ ALL_DOCS := $(shell find . -name '*.md' -type f | grep -v ^./node_modules | sort
 TOOLS_DIR := ./.tools
 MISSPELL_BINARY=$(TOOLS_DIR)/misspell
 MARKDOWN_LINK_CHECK=markdown-link-check
+MARKDOWN_LINT=markdownlint
 
 .PHONY: install-misspell
 install-misspell:
@@ -31,4 +32,4 @@ install-markdown-lint:
 
 .PHONY: markdown-lint
 markdown-lint:
-	markdownlint -c .markdownlint.yaml '**/*.md'
+	@for f in $(ALL_DOCS); do echo $$f; $(MARKDOWN_LINT) -c .markdownlint.yaml $$f; done

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # All documents to be used in spell check.
-ALL_DOC := $(shell find . -name '*.md' -type f | sort)
+ALL_DOCS := $(shell find . -name '*.md' -type f | grep -v ^./node_modules | sort)
 
 TOOLS_DIR := ./.tools
 MISSPELL_BINARY=$(TOOLS_DIR)/misspell
@@ -23,7 +23,7 @@ install-markdown-link-check:
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	find . -name \*.md -print0 | xargs -0 -n1 $(MARKDOWN_LINK_CHECK) --quiet
+	$(MARKDOWN_LINK_CHECK) --quiet $(ALL_DOCS)
 
 .PHONY: install-markdown-lint
 install-markdown-lint:

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -137,7 +137,7 @@ Required arguments:
 - the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text `Format` implementions MUST ensure to always use the canonical casing for their attributes. NOTE: Cannonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
+The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive. To improve compatibility with other text-based protocols, text `Format` implementions MUST ensure to always use the canonical casing for their attributes. NOTE: Canonical casing for HTTP headers is usually title case (e.g. `Content-Type` instead of `content-type`).
 
 ## Injectors and Extractors as Separate Interfaces
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -91,7 +91,7 @@ kinds of measurement.
 The term _additive_ is used to specify a characteristic of some
 measurements, meant to indicate that only the sum is considered useful
 information.  These are measurements that you would naturally combine
-using arithmethic addition, usually real quantities of something
+using arithmetic addition, usually real quantities of something
 (e.g., number of bytes).
 
 Non-additive measurements are used when the set of values, also known
@@ -367,7 +367,7 @@ instruments can be configured with even more expensive aggregators.
 Monotonicity applies only to additive instruments.  `Counter` and
 `SumObserver` instruments are defined as monotonic because the sum
 captured by either instrument is non-decreasing.  The `UpDown-`
-varations of these two instruments are non-monotonic, meaning the sum
+variations of these two instruments are non-monotonic, meaning the sum
 can increase, decrease, or remain constant without any guarantees.
 
 Monotonic instruments are commonly used to capture information about a


### PR DESCRIPTION
The Makefile isn't running the spelling and link-check tools correctly. This fixes it.