### PR TITLE
Clean up Tracing API spec, clarify Tracer vs TracerProvider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the release.
 
 ## Unreleased
 
+- Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
+  * Configuration should be stored not per Tracer but in the TracerProvider.
+  * Active spans are not per Tracer.
+
 ## v0.5.0 (06-02-2020)
 
 - Define Log Data Model.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -142,9 +142,9 @@ The tracer is responsible for creating `Span`s.
 
 Note: Apart from the library name and version
 provided to the `TracerProvider` to get them,
-`Tracer`s are not usually expected to not have mutable state of their own
-(but they may contain a reference to shared mutable configuration that is
-expected to be owned by the `TracerProvider`).
+`Tracer`s will usually be stateless.
+They may contain a reference to shared mutable configuration that is
+expected to be owned by the `TracerProvider`, however.
 
 ### Tracer operations
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -72,8 +72,7 @@ A duration is the elapsed time between two events.
 `Tracer`s can be accessed with a `TracerProvider`.
 
 In implementations of the API, the `TracerProvider` is expected to be the
-stateful object that holds any configuration
-(such as SpanProcessors and Exporters in the default SDK).
+stateful object that holds any configuration.
 
 Normally, the `TracerProvider` is expected to be accessed from a central place.
 Thus, the API SHOULD provide a way to set/register and access

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -78,7 +78,9 @@ when creating the `TracerProvider`, or rely on external configuration, e.g. when
 using the provider pattern.
 
 Normally the `TracerProvider` is expected to be accessed as a singleton, i.e.,
-the API SHOULD provide a single global default `TracerProvider`.
+the API SHOULD provide a global default `TracerProvider`. However, there may be
+cases where more than one `TracerProvider` is required:
+see [below](#multi-tracerprovider).
 
 ### TracerProvider operations
 
@@ -110,16 +112,15 @@ returned `Tracer` instance). If configuration changes should be picked up by
 users, these changes SHOULD be reflected in already returned objects, not only
 if the user calls the API to get a `Tracer` again.
 
-Note: This could, for example, be implemented by
-storing any mutable configuration in the `TracerProvider` and
-having `Tracer` implementation objects have a reference to the `TracerProvider`
-that created them. If configuration must be stored per-tracer
-(such as disabling a certain tracer), the tracer could, for example, do a
-look-up with its name+version in a map in the `TracerProvider`, or the
-`TracerProvider` could maintain a registry of all returned `Tracer`s and
-actively update their configuration if it changes.
+Note: This could, for example, be implemented by storing any mutable
+configuration in the `TracerProvider` and having `Tracer` implementation objects
+have a reference to the `TracerProvider` that created them.
+If configuration must be stored per-tracer (such as disabling a certain tracer),
+the tracer could, for example, do a look-up with its name+version in a map in
+the `TracerProvider`, or the `TracerProvider` could maintain a registry of all
+returned `Tracer`s and actively update their configuration if it changes.
 
-### Runtimes with multiple deployments/applications
+### Runtimes with multiple deployments/applications <a name="multi-tracerprovider"></a>
 
 Some applications may have to use multiple `TracerProvider` instances, e.g.
 to have different settings (e.g. `SpanProcessor`s) to each (and
@@ -164,15 +165,14 @@ When getting the current `Span` while there is none that is currently active,
 the `Tracer` MUST return a placeholder `Span` with an invalid `SpanContext`
 and `IsRecording` being false.
 
-For any two `Tracer`s returned from the same `TracerProvider`
-and queried at the same time in the same logical execution unit
-(see [Context](../context/Context.md)), the active Span
-MUST be the same unless at least one them returns the placeholder span
-(see above).
-Note: This means that implementations are allowed to "disable" a `Tracer` such
-that it has no active `Span`. Such `Tracer`s are expected but not required to
-also return placeholder `Span`s when creating a new `Span` and to do nothing if
-requested to set the current `Span`.
+For any two `Tracer`s returned from the same `TracerProvider` and queried at the
+time in the same logical execution unit (see [Context](../context/Context.md)),
+the active Span MUST be the same unless at least one them
+returns the placeholder span (see above).
+Note: This means that implementations are allowed to "disable" a `Tracer`
+such that it has no active `Span`.
+Such `Tracer`s would typically also return placeholder `Span`s when creating a
+new `Span` and to do nothing if requested to set the current `Span`.
 
 The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
 convenience functions to manage a `Span`'s lifetime and the scope in which a

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -78,10 +78,15 @@ Implementations might require the user to specify such configuration properties
 when creating the `TracerProvider`, or rely on external configuration, e.g. when
 using the provider pattern.
 
-Normally, the `TracerProvider` is expected to be accessed as a singleton, i.e.,
-the API SHOULD provide a global default `TracerProvider`. However, there may be
-cases where more than one `TracerProvider` is required:
-see [below](#multi-tracerprovider).
+Normally, the `TracerProvider` is expected to be accessed from a central place.
+Thus, the API SHOULD provide a way to set/register and access
+a global default `TracerProvider`.
+However, some applications may want to or have to use multiple `TracerProvider`
+instances, e.g. to have different settings (like `SpanProcessor`s) for each (and
+consequently to the `Tracer`s obtained from them), or because its easier with
+dependency injection frameworks.
+Thus, implementations of `TracerProvider` SHOULD allow creating an arbitrary
+number of instances.
 
 ### TracerProvider operations
 
@@ -119,22 +124,6 @@ If configuration must be stored per-tracer (such as disabling a certain tracer),
 the tracer could, for example, do a look-up with its name+version in a map in
 the `TracerProvider`, or the `TracerProvider` could maintain a registry of all
 returned `Tracer`s and actively update their configuration if it changes.
-
-### Runtimes with multiple deployments/applications <a name="multi-tracerprovider"></a>
-
-Some applications may have to use multiple `TracerProvider` instances, e.g.
-to have different settings (like `SpanProcessor`s) for each (and
-consequently to the `Tracer`s obtained from them).
-
-For example, runtimes that support multiple deployments or applications might need to
-provide a different `TracerProvider` instance to each deployment. To support this,
-a global `TracerProvider` registry may delegate calls to create new instances of
-`TracerProvider` to a separate `Provider` component, and the runtime may include
-its own `Provider` implementation which returns a different `TracerProvider` for
-each deployment.
-
-`Provider` instances are registered with the API via some language-specific
-mechanism, for instance the `ServiceLoader` class in Java.
 
 ## Tracer
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -158,7 +158,7 @@ The `Tracer` SHOULD provide methods to:
 - Make a given `Span` as active
 
 The `Tracer` MUST use the [`Context`](../context/context.md)
-in order to get and set the current `Span` state and to decide how `Span`s
+in order to get and set the current `Span` and to decide how `Span`s
 are passed across process boundaries.
 
 When getting the current `Span` while there is none that is currently active,

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -157,7 +157,7 @@ The `Tracer` SHOULD provide methods to:
 - Get the currently active `Span`
 - Make a given `Span` as active
 
-The `Tracer` MUST use the [`Context`](../context/Context.md)
+The `Tracer` MUST use the [`Context`](../context/context.md)
 in order to get and set the current `Span` state and to decide how `Span`s
 are passed across process boundaries.
 
@@ -166,7 +166,7 @@ the `Tracer` MUST return a placeholder `Span` with an invalid `SpanContext`
 and `IsRecording` being false.
 
 For any two `Tracer`s returned from the same `TracerProvider` and queried at the
-time in the same logical execution unit (see [Context](../context/Context.md)),
+time in the same logical execution unit (see [Context](../context/context.md)),
 the active Span MUST be the same unless at least one them
 returns the placeholder span (see above).
 Note: This means that implementations are allowed to "disable" a `Tracer`

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -74,9 +74,6 @@ A duration is the elapsed time between two events.
 In implementations of the API, the `TracerProvider` is expected to be the
 stateful object that holds any configuration
 (such as SpanProcessors and Exporters in the default SDK).
-Implementations might require the user to specify such configuration properties
-when creating the `TracerProvider`, or rely on external configuration, e.g. when
-using the provider pattern.
 
 Normally, the `TracerProvider` is expected to be accessed from a central place.
 Thus, the API SHOULD provide a way to set/register and access

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -38,7 +38,8 @@ Table of Contents
 
 Tracing API consist of these main classes:
 
-- [`TracerProvider`](#tracerprovider) is the entry point of the API. It creates `Tracer`s.
+- [`TracerProvider`](#tracerprovider) is the entry point of the API.
+  It provides access to `Tracer`s.
 - [`Tracer`](#tracer) is the class responsible for creating `Span`s.
 - [`Span`](#span) is the API to trace an operation.
 
@@ -68,7 +69,7 @@ A duration is the elapsed time between two events.
 
 ## TracerProvider
 
-New `Tracer` instances can be created via a `TracerProvider`.
+`Tracer`s can be accessed with a `TracerProvider`.
 
 In implementations of the API, the `TracerProvider` is expected to be the
 stateful object that holds any configuration
@@ -114,7 +115,7 @@ if the user calls the API to get a `Tracer` again.
 
 Note: This could, for example, be implemented by storing any mutable
 configuration in the `TracerProvider` and having `Tracer` implementation objects
-have a reference to the `TracerProvider` that created them.
+have a reference to the `TracerProvider` from which they were obtained.
 If configuration must be stored per-tracer (such as disabling a certain tracer),
 the tracer could, for example, do a look-up with its name+version in a map in
 the `TracerProvider`, or the `TracerProvider` could maintain a registry of all
@@ -124,7 +125,7 @@ returned `Tracer`s and actively update their configuration if it changes.
 
 Some applications may have to use multiple `TracerProvider` instances, e.g.
 to have different settings (e.g. `SpanProcessor`s) to each (and
-consequently to the `Tracer`s created by them).
+consequently to the `Tracer`s obtained from them).
 
 For example, runtimes that support multiple deployments or applications might need to
 provide a different `TracerProvider` instance to each deployment. To support this,

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -107,11 +107,10 @@ That API MUST accept the following parameters:
 It is unspecified whether or under which conditions the same or different
 `Tracer` instances are returned from this functions.
 
-Implementations of this function MUST be prepared that a user calls the
-function only once per name+version combination (i.e. caches and re-uses the
-returned `Tracer` instance). If the implementation wants configuration changes to be picked up by
-users, these changes SHOULD be reflected in already returned objects, not only
-if the user calls the API to get a `Tracer` again.
+Implementations MUST NOT require users to repeatedly obtain a `Tracer` again
+with the same name+version to pick up configuration changes.
+This can be achieved either by allowing to work with an outdated configuration or
+by ensuring that new configuration applies also to previously returned `Tracer`s.
 
 Note: This could, for example, be implemented by storing any mutable
 configuration in the `TracerProvider` and having `Tracer` implementation objects

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -104,7 +104,7 @@ That API MUST accept the following parameters:
 It is unspecified whether or under which conditions the same or different
 `Tracer` instances are returned from this functions.
 
-Implementations of this function MUST be prepared that an user calls the
+Implementations of this function MUST be prepared that a user calls the
 function only once per name+version combination (i.e. caches and re-uses the
 returned `Tracer` instance). If configuration changes should be picked up by
 users, these changes SHOULD be reflected in already returned objects, not only
@@ -123,7 +123,7 @@ actively update their configuration if it changes.
 
 Some applications may have to use multiple `TracerProvider` instances, e.g.
 to have different settings (e.g. `SpanProcessor`s) to each (and
-consequently to the `Tracer`s crated by them).
+consequently to the `Tracer`s created by them).
 
 For example, runtimes that support multiple deployments or applications might need to
 provide a different `TracerProvider` instance to each deployment. To support this,
@@ -277,9 +277,9 @@ A Span MUST ONLY be created via a [`Tracer`](#tracer).
 
 When creating a new `Span`, the `Tracer` MUST allow the caller to specify the
 new `Span`'s parent in the form of a `Span` or `SpanContext`. The `Tracer`
-SHOULD create each new `Span` as a child of its active `Span` unless an
+SHOULD create each new `Span` as a child of its active `Span`, unless an
 explicit parent is provided or the option to create a span without a parent is
-selected, or the current active `Span` is invalid.
+selected, or the currently active `Span` is invalid.
 
 `Span` creation MUST NOT set the newly created `Span` as the currently
 active `Span` by default, but this functionality MAY be offered additionally

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -36,7 +36,7 @@ Table of Contents
 
 </details>
 
-Tracing API consist of these main classes:
+The Tracing API consist of these main classes:
 
 - [`TracerProvider`](#tracerprovider) is the entry point of the API.
   It provides access to `Tracer`s.
@@ -78,7 +78,7 @@ Implementations might require the user to specify such configuration properties
 when creating the `TracerProvider`, or rely on external configuration, e.g. when
 using the provider pattern.
 
-Normally the `TracerProvider` is expected to be accessed as a singleton, i.e.,
+Normally, the `TracerProvider` is expected to be accessed as a singleton, i.e.,
 the API SHOULD provide a global default `TracerProvider`. However, there may be
 cases where more than one `TracerProvider` is required:
 see [below](#multi-tracerprovider).
@@ -124,7 +124,7 @@ returned `Tracer`s and actively update their configuration if it changes.
 ### Runtimes with multiple deployments/applications <a name="multi-tracerprovider"></a>
 
 Some applications may have to use multiple `TracerProvider` instances, e.g.
-to have different settings (e.g. `SpanProcessor`s) to each (and
+to have different settings (like `SpanProcessor`s) for each (and
 consequently to the `Tracer`s obtained from them).
 
 For example, runtimes that support multiple deployments or applications might need to
@@ -143,9 +143,9 @@ The tracer is responsible for creating `Span`s.
 
 Note: Apart from the library name and version
 provided to the `TracerProvider` to get them,
-`Tracer`s are not usually expected to not have mutable state on their own
+`Tracer`s are not usually expected to not have mutable state of their own
 (but they may contain a reference to shared mutable configuration that is
-expected to be owned by the TracerProvider).
+expected to be owned by the `TracerProvider`).
 
 ### Tracer operations
 
@@ -167,8 +167,8 @@ the `Tracer` MUST return a placeholder `Span` with an invalid `SpanContext`
 and `IsRecording` being false.
 
 For any two `Tracer`s returned from the same `TracerProvider` and queried at the
-time in the same logical execution unit (see [Context](../context/context.md)),
-the active Span MUST be the same unless at least one them
+same time in the same logical execution unit (see [Context](../context/context.md)),
+the active Span MUST be the same unless at least one of the `Tracer`s
 returns the placeholder span (see above).
 Note: This means that implementations are allowed to "disable" a `Tracer`
 such that it has no active `Span`.
@@ -179,7 +179,7 @@ The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
 convenience functions to manage a `Span`'s lifetime and the scope in which a
 `Span` is active. When an active `Span` is made inactive, the previously-active
 `Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end
-time) but still active. A `Span` may be active in one logical execution unit
+time) but still be active. A `Span` may be active in one logical execution unit
 after it has been made inactive on another.
 
 ## SpanContext

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -177,7 +177,7 @@ new `Span` and to do nothing if requested to set the current `Span`.
 The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
 convenience functions to manage a `Span`'s lifetime and the scope in which a
 `Span` is active. When an active `Span` is made inactive, the previously-active
-`Span` SHOULD be made active. A `Span` maybe finished (i.e. have a non-null end
+`Span` SHOULD be made active. A `Span` may be finished (i.e. have a non-null end
 time) but still be active. A `Span` may be active in one logical execution unit
 after it has been made inactive on another.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -239,7 +239,7 @@ directly. All `Span`s MUST be created via a `Tracer`.
 
 ### Span Creation
 
-A Span MUST ONLY be created via a [`Tracer`](#tracer).
+There MUST NOT be any API for creating a `Span` other than with a [`Tracer`](#tracer).
 
 When creating a new `Span`, the `Tracer` MUST allow the caller to specify the
 new `Span`'s parent in the form of a `Span` or `SpanContext`. The `Tracer`

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -109,7 +109,7 @@ It is unspecified whether or under which conditions the same or different
 
 Implementations of this function MUST be prepared that a user calls the
 function only once per name+version combination (i.e. caches and re-uses the
-returned `Tracer` instance). If configuration changes should be picked up by
+returned `Tracer` instance). If the implementation wants configuration changes to be picked up by
 users, these changes SHOULD be reflected in already returned objects, not only
 if the user calls the API to get a `Tracer` again.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -155,14 +155,15 @@ The `Tracer` MUST provide functions to:
 The `Tracer` SHOULD provide methods to:
 
 - Get the currently active `Span`
-- Make a given `Span` as active
+- Mark a given `Span` as active
 
 The `Tracer` MUST use the [`Context`](../context/context.md)
 in order to get and set the current `Span` and to decide how `Span`s
 are passed across process boundaries.
 
-When getting the current `Span` while there is none that is currently active,
-the `Tracer` MUST return a placeholder `Span` with an invalid `SpanContext`
+If there is no currently active `Span`
+and the `Tracer` is asked for the current `Span`,
+it MUST return a placeholder `Span` with an invalid `SpanContext`
 and `IsRecording` being false.
 
 For any two `Tracer`s returned from the same `TracerProvider` and queried at the

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -36,7 +36,7 @@ Table of Contents
 
 </details>
 
-Tracing API consist of a these main classes:
+Tracing API consist of these main classes:
 
 - [`TracerProvider`](#tracerprovider) is the entry point of the API. It creates `Tracer`s.
 - [`Tracer`](#tracer) is the class responsible for creating `Span`s.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -266,7 +266,7 @@ When creating a new `Span`, the `Tracer` MUST allow the caller to specify the
 new `Span`'s parent in the form of a `Span` or `SpanContext`. The `Tracer`
 SHOULD create each new `Span` as a child of its active `Span`, unless an
 explicit parent is provided or the option to create a span without a parent is
-selected, or the currently active `Span` is invalid.
+selected.
 
 `Span` creation MUST NOT set the newly created `Span` as the currently
 active `Span` by default, but this functionality MAY be offered additionally

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -140,30 +140,12 @@ The `Tracer` SHOULD provide methods to:
 - Get the currently active `Span`
 - Mark a given `Span` as active
 
-The `Tracer` MUST use the [`Context`](../context/context.md)
-in order to get and set the current `Span` and to decide how `Span`s
-are passed across process boundaries.
-
-If there is no currently active `Span`
-and the `Tracer` is asked for the current `Span`,
-it MUST return a placeholder `Span` with an invalid `SpanContext`
-and `IsRecording` being false.
-
-For any two `Tracer`s returned from the same `TracerProvider` and queried at the
-same time in the same logical execution unit (see [Context](../context/context.md)),
-the active Span MUST be the same unless at least one of the `Tracer`s
-returns the placeholder span (see above).
-Note: This means that implementations are allowed to "disable" a `Tracer`
-such that it has no active `Span`.
-Such `Tracer`s would typically also return placeholder `Span`s when creating a
-new `Span` and to do nothing if requested to set the current `Span`.
-
-The `Tracer` SHOULD provide a way to update its active `Span` and MAY provide
-convenience functions to manage a `Span`'s lifetime and the scope in which a
-`Span` is active. When an active `Span` is made inactive, the previously-active
-`Span` SHOULD be made active. A `Span` may be finished (i.e. have a non-null end
-time) but still be active. A `Span` may be active in one logical execution unit
-after it has been made inactive on another.
+The `Tracer` MUST delegate to the [`Context`](../context/context.md) to perform
+these tasks, i.e. the above methods MUST do the same as a single equivalent
+method of the Context management system.
+In particular, this implies that the active span MUST not depend on the `Tracer`
+that it is queried from/was set to, as long as the tracers were obtained from
+the same `TracerProvider`.
 
 ## SpanContext
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -77,12 +77,14 @@ stateful object that holds any configuration.
 Normally, the `TracerProvider` is expected to be accessed from a central place.
 Thus, the API SHOULD provide a way to set/register and access
 a global default `TracerProvider`.
-However, some applications may want to or have to use multiple `TracerProvider`
-instances, e.g. to have different settings (like `SpanProcessor`s) for each (and
-consequently to the `Tracer`s obtained from them), or because its easier with
-dependency injection frameworks.
+
+Notwithstanding any global `TracerProvider`, some applications may want to or
+have to use multiple `TracerProvider` instances,
+e.g. to have different configuration (like `SpanProcessor`s) for each
+(and consequently for the `Tracer`s obtained from them),
+or because its easier with dependency injection frameworks.
 Thus, implementations of `TracerProvider` SHOULD allow creating an arbitrary
-number of instances.
+number of `TracerProvider` instances.
 
 ### TracerProvider operations
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -126,11 +126,8 @@ returned `Tracer`s and actively update their configuration if it changes.
 
 The tracer is responsible for creating `Span`s.
 
-Note: Apart from the library name and version
-provided to the `TracerProvider` to get them,
-`Tracer`s will usually be stateless.
-They may contain a reference to shared mutable configuration that is
-expected to be owned by the `TracerProvider`, however.
+Note that `Tracers` should usually *not* be responsible for configuration.
+This should be the responsibility of the `TracerProvider` instead.
 
 ### Tracer operations
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -147,10 +147,18 @@ supplied to the `TracerProvider` must be used to create an
 [`InstrumentationLibrary`][otep-83] instance which is stored on the created
 `Tracer`.
 
-All configuration objects (SDK specific) and extension points (span processors,
-propagators) must be provided to the `TracerProvider`. `Tracer` instances must
-not duplicate this data (unless for read-only access) to avoid that different
-`Tracer` instances of a `TracerProvider` have different versions of these data.
+Configuration (i.e., [Span processors](#span-processor) and [`Sampler`](#sampling))
+MUST be managed solely by the `TracerProvider` and it MUST provide some way to
+configure them, at least when creating or initializing it.
+
+The TracerProvider MAY provide methods to update the configuration. If
+configuration is updated (e.g., adding a `SpanProcessor`),
+the updated configuration MUST also apply to all already returned `Tracers`
+(i.e. it MUST NOT matter whether a `Tracer` was obtained from the
+`TracerProvider` before or after the configuration change).
+Note: Implementation-wise, this could mean that `Tracer` instances have a
+reference to their `TracerProvider` and access configuration only via this
+reference.
 
 The readable representations of all `Span` instances created by a `Tracer` must
 provide a `getInstrumentationLibrary` method that returns the
@@ -167,16 +175,6 @@ exportable representation and passing batches to exporters.
 
 Span processors can be registered directly on SDK `TracerProvider` and they are
 invoked in the same order as they were registered.
-
-All `Tracer` instances created by a `TracerProvider` share the same span processors.
-Changes to this collection reflect in all `Tracer` instances.
-Implementation-wise, this could mean that `Tracer` instances have a reference to
-their `TracerProvider` and can access span processor objects only via this
-reference.
-
-Manipulation of the span processors collection must only happen on `TracerProvider`
-instances. This means methods like `addSpanProcessor` must be implemented on
-`TracerProvider`.
 
 Each processor registered on `TracerProvider` is a start of pipeline that consist
 of span processor and optional exporter. SDK MUST allow to end each pipeline with

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -142,7 +142,7 @@ TODO: Split out the parent handling.
 ## Tracer Creation
 
 New `Tracer` instances are always created through a `TracerProvider` (see
-[API](api.md#TracerProvicer)). The `name` and `version` arguments
+[API](api.md#tracerprovicer)). The `name` and `version` arguments
 supplied to the `TracerProvider` must be used to create an
 [`InstrumentationLibrary`][otep-83] instance which is stored on the created
 `Tracer`.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -142,7 +142,7 @@ TODO: Split out the parent handling.
 ## Tracer Creation
 
 New `Tracer` instances are always created through a `TracerProvider` (see
-[API](api.md#obtaining-a-tracer)). The `name` and `version` arguments
+[API](api.md#TracerProvicer)). The `name` and `version` arguments
 supplied to the `TracerProvider` must be used to create an
 [`InstrumentationLibrary`][otep-83] instance which is stored on the created
 `Tracer`.


### PR DESCRIPTION
This cleans up the tracing API spec, and clarifies what TracerProviders/Tracers are (not) allowed to do for different Tracers.

It also removes some wording regarding propagators that seems obsolete by now (OTEP66).