### PR TITLE
Remove SpanId from Sampler input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ the release.
 
 ## Unreleased
 
+- Remove SpanId from Sampler input.
+
 ## v0.3.0 (02-21-2020)
 
 - [OTEP-0059](https://github.com/open-telemetry/oteps/blob/master/text/trace/0059-otlp-trace-data-format.md) Add OTLP Trace Data Format specification.
@@ -29,7 +31,6 @@ the release.
 - Provide guidelines for low-cardinality span names.
 - SDK Tracer: Replace TracerFactory with TracerProvider.
 - Update Resource to be in the SDK.
-- Remove SpanId from Sampler input.
 
 ## v0.2.0 (10-22-2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ the release.
 - Provide guidelines for low-cardinality span names.
 - SDK Tracer: Replace TracerFactory with TracerProvider.
 - Update Resource to be in the SDK.
+- Remove SpanId from Sampler input.
 
 ## v0.2.0 (10-22-2019)
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -69,7 +69,6 @@ Returns the sampling Decision for a `Span` to be created.
 * `TraceId` of the `Span` to be created. It can be different from the `TraceId`
   in the `SpanContext`. Typically in situations when the `Span` to be created
   starts a new Trace.
-* `SpanId` of the `Span` to be created.
 * Name of the `Span` to be created.
 * `SpanKind`
 * Initial set of `Attributes` for the `Span` being constructed


### PR DESCRIPTION
Discussed during the 05/26/2020 specification SIG meeting.

Do we want SpanId as an input to a sampler?
* As of now ID of to be created span is required: https://github.com/open-telemetry/opentelemetry-specification/blob/5b78ee1adf437bb6c151d8992129f22970a96677/specification/trace/sdk.md#sampler
  * Asked around and nobody recalled why we had SpanID in the first place, and there is no outstanding use case.
  * Agreed to remove it from the spec.
  * Resolution: @reyang will propose removing SpanID from sampling, to reduce overhead.
* History https://github.com/open-telemetry/opentelemetry-specification/pull/81
* Discussion https://github.com/open-telemetry/opentelemetry-dotnet/pull/683#discussion_r429062646
* Related & new: https://github.com/open-telemetry/opentelemetry-specification/issues/620 Sampling decison is too late to gain much performance