### PR TITLE
Setting naming convention for exporter packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ the release.
 ## Unreleased
 
 - Remove SpanId from Sampler input.
+- Added conventions for naming of exporter packages
 
 ## v0.3.0 (02-21-2020)
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -43,7 +43,7 @@ Example: `io.opentelemetry.contrib.mongodb`.
 
 Synonyms: *Instrumenting Library*
 
-<a name="name"></a>
+<a name="instrumentation_library"></a>
 
 ### Tracer Name / Meter Name
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -12,7 +12,13 @@ Denotes the library that implements the *OpenTelemetry API*.
 See [Library Guidelines](library-guidelines.md#sdk-implementation) and
 [Library resource semantic conventions](resource/semantic_conventions/README.md#telemetry-sdk)
 
-<a name="instrumented_library"></a>
+<a name="telemetry_sdk"></a>
+
+### Exporter Library
+
+Libraries which are compatible with the [Telemetry SDK](glossary.md#telemetry-sdk) and provide functionality to emit telemetry to consumers.
+
+<a name="exporter_library"></a>
 
 ### Instrumented Library
 

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -83,6 +83,9 @@ Vendors are encouraged to keep protocol-specific exporters as simple as possible
 
 End users should be given the flexibility of making many of the decisions regarding the queuing, retrying, tagging, batching functionality that make the most sense for their application. For example, if an application's telemetry data must be delivered to a remote backend that has no guaranteed availability the end user may choose to use a persistent local queue and an `Exporter` to retry sending on failures. As opposed to that for an application that sends telemetry to a locally running Agent daemon, the end user may prefer to have a simpler exporting configuration without retrying or queueing.
 
+If additional exporters for the sdk are provided as separate libraries, the
+name of the library should be prefixed with opentelemetry-exporter. For example, "opentelemetry-exporter-jaeger".
+
 ### Alternative Implementations
 
 The end-user application may decide to take a dependency on alternative implementation.

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -82,11 +82,13 @@ Vendors are encouraged to keep protocol-specific exporters as simple as possible
 
 End users should be given the flexibility of making many of the decisions regarding the queuing, retrying, tagging, batching functionality that make the most sense for their application. For example, if an application's telemetry data must be delivered to a remote backend that has no guaranteed availability the end user may choose to use a persistent local queue and an `Exporter` to retry sending on failures. As opposed to that for an application that sends telemetry to a locally running Agent daemon, the end user may prefer to have a simpler exporting configuration without retrying or queueing.
 
-If additional exporters for the OpenTelemetry SDK are provided as separate libraries, the
-name of the library should be prefixed with opentelemetry, then exporter, using the namespacing conventions of the particular language. For example:
+If additional exporters for the sdk are provided as separate libraries, the
+name of the library should be prefixed with the terms "OpenTelemetry" and "Exporter" in accordance with the naming conventions of the respective technology.
 
-- python: opentelemetry-exporter-jaeger
-- javascript: @opentelemetry/exporter-jeager
+For example:
+
+- Python and Java: opentelemetry-exporter-jaeger
+- Javascript: @opentelemetry/exporter-jeager
 
 ### Alternative Implementations
 

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -82,7 +82,7 @@ Vendors are encouraged to keep protocol-specific exporters as simple as possible
 
 End users should be given the flexibility of making many of the decisions regarding the queuing, retrying, tagging, batching functionality that make the most sense for their application. For example, if an application's telemetry data must be delivered to a remote backend that has no guaranteed availability the end user may choose to use a persistent local queue and an `Exporter` to retry sending on failures. As opposed to that for an application that sends telemetry to a locally running Agent daemon, the end user may prefer to have a simpler exporting configuration without retrying or queueing.
 
-If additional exporters for the sdk are provided as separate libraries, the
+If additional exporters for the OpenTelemetry SDK are provided as separate libraries, the
 name of the library should be prefixed with opentelemetry, then exporter, using the namespacing conventions of the particular language. For example:
 
 - python: opentelemetry-exporter-jaeger

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -84,7 +84,10 @@ Vendors are encouraged to keep protocol-specific exporters as simple as possible
 End users should be given the flexibility of making many of the decisions regarding the queuing, retrying, tagging, batching functionality that make the most sense for their application. For example, if an application's telemetry data must be delivered to a remote backend that has no guaranteed availability the end user may choose to use a persistent local queue and an `Exporter` to retry sending on failures. As opposed to that for an application that sends telemetry to a locally running Agent daemon, the end user may prefer to have a simpler exporting configuration without retrying or queueing.
 
 If additional exporters for the sdk are provided as separate libraries, the
-name of the library should be prefixed with opentelemetry-exporter. For example, "opentelemetry-exporter-jaeger".
+name of the library should be prefixed with opentelemetry, then exporter, using the namespacing conventions of the particular language. For example:
+
+- python: opentelemetry-exporter-jaeger
+- javascript: @opentelemetry/exporter-jeager
 
 ### Alternative Implementations
 

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -54,7 +54,7 @@ and Zipkin.
 
 Zipkin service name MUST be set to the value of the
 [resource attribute](../../resource/semantic_conventions/README.md):
-`service.name`. In Zipkin it is important that the service name is consistent 
+`service.name`. In Zipkin it is important that the service name is consistent
 for all spans in a local root. Otherwise service graph and aggregations would
 not work properly. OpenTelemetry doesn't provide this consistency guarantee.
 Exporter may chose to override the value for service name based on a local root


### PR DESCRIPTION
There is an implicit convention around exporter packages in several
language instrumentations. Adding the convention to the spec standardizes
the convention.