### PR TITLE
Add semantic conventions for process resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ the release.
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.
+- Add semantic conventions for process resource.
 
 ## v0.5.0 (06-02-2020)
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -8,6 +8,7 @@ This document defines standard attributes for resources. These attributes are ty
 - [Compute Unit](#compute-unit)
   * [Container](#container)
   * [Function as a Service](#function-as-a-service)
+  * [Process](#process)
 - [Deployment Service](#deployment-service)
   * [Kubernetes](#kubernetes)
 - [Compute Instance](#compute-instance)
@@ -19,7 +20,7 @@ This document defines standard attributes for resources. These attributes are ty
 
 ## TODOs
 
-* Add more compute units: Process, AppEngine unit, etc.
+* Add more compute units: AppEngine unit, etc.
 * Add Device (mobile) and Web Browser.
 * Decide if lower case strings only.
 * Consider to add optional/required for each attribute and combination of attributes
@@ -112,6 +113,23 @@ Note: The resource attribute `faas.instance` differs from the span attribute `fa
 
 [ARN]:https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 [FunctionDirectory]: https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function
+
+### Process
+
+**type:** `process`
+
+**Description:** An operating system process.
+
+| Attribute  | Description  | Example  | Required |
+|---|---|---|--|
+| process.pid | Process identifier (PID). | `1234` | Yes |
+| process.executable.name | The name of the process executable. On Unix based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` | See below |
+| process.executable.path | The full path to the process executable. On Unix based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` | See below |
+| process.command | The command used to launch the process (i.e. the command name). On Unix based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`. | `cmd/otelcol` | See below |
+| process.command_line | The full command used to launch the process. The value can be either a list of strings representing the ordered list of arguments, or a single string representing the full command. On Unix based systems, can be set to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. On Windows, can be set to the result of `GetCommandLineW`. | Unix: `[ cmd/otecol, --config=config.yaml ]`, Windows: `cmd/otecol --config=config.yaml` | See below |
+| process.owner | The username of the user that owns the process. | `root` | No |
+
+At least one of `process.executable.name`, `process.executable.path`, `process.command`, or `process.command_line` is required.
 
 ## Deployment Service
 


### PR DESCRIPTION
Adds semantic conventions for `process` as a resource which represents a regular operating system process.