### PR TITLE
Add semantic conventions for http content size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the release.
 - Extend semantic conventions for RPC and allow non-gRPC calls ([#604](https://github.com/open-telemetry/opentelemetry-specification/pull/604))
 - Add span attribute to indicate cold starts of Function as a Service executions ([#650](https://github.com/open-telemetry/opentelemetry-specification/pull/650))
 - Added conventions for naming of exporter packages
+- Add semantic conventions for HTTP content length
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -79,6 +79,11 @@ Note that the items marked with [1] are different from the mapping defined in th
 | `http.status_text` | [HTTP reason phrase][]. E.g. `"OK"` | No |
 | `http.flavor` | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |  No |
 | `http.user_agent` | Value of the HTTP [User-Agent][] header sent by the client. | No |
+| `http.request_content_length` | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length][] header. For requests using transport encoding, this should be the compressed size. | No |
+| `http.request_uncompressed_content_length` | The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used. | No |
+| `http.response_content_length` | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length][] header. For requests using transport encoding, this should be the compressed size. | No |
+| `http.response_uncompressed_content_length` | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | No |
+
 
 It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
@@ -86,6 +91,7 @@ It is recommended to also use the general [network attributes][], especially `ne
 [HTTP response status code]: https://tools.ietf.org/html/rfc7231#section-6
 [HTTP reason phrase]: https://tools.ietf.org/html/rfc7230#section-3.1.2
 [User-Agent]: https://tools.ietf.org/html/rfc7231#section-5.5.3
+[Content-Length]: https://tools.ietf.org/html/rfc7230#section-3.3.2
 
 ## HTTP client
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -80,9 +80,9 @@ Note that the items marked with [1] are different from the mapping defined in th
 | `http.flavor` | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |  No |
 | `http.user_agent` | Value of the HTTP [User-Agent][] header sent by the client. | No |
 | `http.request_content_length` | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length][] header. For requests using transport encoding, this should be the compressed size. | No |
-| `http.request_uncompressed_content_length` | The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used. | No |
+| `http.request_content_length_uncompressed` | The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used. | No |
 | `http.response_content_length` | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length][] header. For requests using transport encoding, this should be the compressed size. | No |
-| `http.response_uncompressed_content_length` | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | No |
+| `http.response_content_length_uncompressed` | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | No |
 
 
 It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.


### PR DESCRIPTION
This adds attributes for the payload size of HTTP requests / responses. I looked at [messaging](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md) too for inspiration but have ended up being inconsistent to better match HTTP conventions Whereas messaging has payload and compressed_payload, here I use content_length and raw_content_length. This is because the concept of content length for HTTP is defined by spec so matching it (i.e., using compressed size as content length for compressed payloads) seems to be clearer for users. But I'm happy to tweak as needed.

Fixes #640