### PR TITLE
Add peer.service semantic convention to indicate the name of a target…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ the release.
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.
-=======
 - Add semantic conventions for process resource.
 - Add peer.service to provide a user-configured name for a remote service
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the release.
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.
+- Add peer.service to provide a user-configured name for a remote service
 
 ## v0.5.0 (06-02-2020)
 

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -1,0 +1,15 @@
+# Experimental features
+
+This folder will be used to develop experimental features. Experimental status allows to develop components that are on trajectory to become a part of a main project while allowing a faster cadence of merges and collaboration.
+
+Experimental features must be:
+
+- Implementable as a plugin to OpenTelemetry components (API, SDK, collector, etc.).
+- Be in active development or testing.
+- Approved as a general direction via OTEP process.
+
+All files in experimental folder must have a note about it's experimental status to avoid any confusion.
+
+Experimental status precedes the alpha version. All changes in the experimental folder go through the regular review process. Changes are allowed to be merged faster as completeness of a solution is not a requirement. Approval means that proposed changes are OK for experimentation.
+
+When the feature or parts of it are developed far enough to declare them as an alpha version of a main project and move out of the experimental status, it must go through a **new** OTEP PR and it must be expected that design and APIs will be changed. In fact, the same people who approved the experiment may likely be the most critical reviewers. It demonstrates an interest and involvement, not critique.

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -69,7 +69,8 @@ On the server process receiving and handling the remote procedure call, the serv
 
 As an example, given a process deployed as `QuoteService`, this would be the name that goes into the `service.name` resource attribute which applies to the entire process.
 This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc.service`) with a method called `getMeanRate` (= `rpc.method`) and the other endpoint called `StockQuotes`  (= `rpc.service`) with two methods `getCurrentBid` and `getLastClose` (= `rpc.method`).
-The same applies for `peer.service`, and generally, a user SHOULD NOT set `peer.service` to a fully qualified RPC service name.
+In this example, spans representing client request should have their `peer.service` attribute set to `QuoteService` as well to match the server's `service.name` resource attribute.
+Generally, a user SHOULD NOT set `peer.service` to a fully qualified RPC service name.
 
 [network attributes]: span-general.md#general-network-connection-attributes
 [net.transport]: span-general.md#nettransport-attribute

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -65,7 +65,9 @@ Furthermore, setting [net.transport][] is required for non-IP connection like na
 
 #### Service name
 
-On the server process receiving and handling the remote procedure call, the service name provided in `rpc.service` does not necessarily have to match the [`service.name`][] or [`peer.service`][] resource attributes. One process can expose multiple RPC endpoints and thus have multiple RPC service names. From a deployment perspective, as expressed by the `service.*` resource attributes, it will be treated as one deployed service with one `service.name`.
+On the server process receiving and handling the remote procedure call, the service name provided in `rpc.service` does not necessarily have to match the [`service.name`][] resource attribute.
+One process can expose multiple RPC endpoints and thus have multiple RPC service names. From a deployment perspective, as expressed by the `service.*` resource attributes, it will be treated as one deployed service with one `service.name`.
+Likewise, on clients sending RPC requests to a server, the service name provided in `rpc.service` does not have to match the [`peer.service`][] span attribute.
 
 As an example, given a process deployed as `QuoteService`, this would be the name that goes into the `service.name` resource attribute which applies to the entire process.
 This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc.service`) with a method called `getMeanRate` (= `rpc.method`) and the other endpoint called `StockQuotes`  (= `rpc.service`) with two methods `getCurrentBid` and `getLastClose` (= `rpc.method`).

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -69,8 +69,7 @@ On the server process receiving and handling the remote procedure call, the serv
 
 As an example, given a process deployed as `QuoteService`, this would be the name that goes into the `service.name` resource attribute which applies to the entire process.
 This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc.service`) with a method called `getMeanRate` (= `rpc.method`) and the other endpoint called `StockQuotes`  (= `rpc.service`) with two methods `getCurrentBid` and `getLastClose` (= `rpc.method`).
-
-Generally, a user SHOULD not set `peer.service` to a fully qualified RPC service name as that will be redundant with `rpc.service`.
+The same applies for `peer.service`, and generally, a user SHOULD NOT set `peer.service` to a fully qualified RPC service name.
 
 [network attributes]: span-general.md#general-network-connection-attributes
 [net.transport]: span-general.md#nettransport-attribute

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -65,14 +65,17 @@ Furthermore, setting [net.transport][] is required for non-IP connection like na
 
 #### Service name
 
-On the server process receiving and handling the remote procedure call, the service name provided in `rpc.service` does not necessarily have to match the [`service.name` resource attribute][]. One process can expose multiple RPC endpoints and thus have multiple RPC service names. From a deployment perspective, as expressed by the `service.*` resource attributes, it will be treated as one deployed service with one `service.name`.
+On the server process receiving and handling the remote procedure call, the service name provided in `rpc.service` does not necessarily have to match the [`service.name`][] or [`peer.service`][] resource attributes. One process can expose multiple RPC endpoints and thus have multiple RPC service names. From a deployment perspective, as expressed by the `service.*` resource attributes, it will be treated as one deployed service with one `service.name`.
 
 As an example, given a process deployed as `QuoteService`, this would be the name that goes into the `service.name` resource attribute which applies to the entire process.
 This process could expose two RPC endpoints, one called `CurrencyQuotes` (= `rpc.service`) with a method called `getMeanRate` (= `rpc.method`) and the other endpoint called `StockQuotes`  (= `rpc.service`) with two methods `getCurrentBid` and `getLastClose` (= `rpc.method`).
 
+Generally, a user SHOULD not set `peer.service` to a fully qualified RPC service name as that will be redundant with `rpc.service`.
+
 [network attributes]: span-general.md#general-network-connection-attributes
 [net.transport]: span-general.md#nettransport-attribute
-[`service.name` resource attribute]: ../../resource/semantic_conventions/README.md#service
+[`service.name`]: ../../resource/semantic_conventions/README.md#service
+[`peer.service`]: span-general.md#general-remote-service-attributes
 
 ### Distinction from HTTP spans
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -72,8 +72,9 @@ the name should explicitly be set to the empty string to distinguish it from the
 
 ## General remote service attributes
 
-These attributes may be used for any operation that accesses some remote service. Users can define what the name of a service is based on their particular semantics in their distributed system.
-Instrumentation is expected to provide a way for users to configure this name.
+This attribute may be used for any operation that accesses some remote service.
+Users can define what the name of a service is based on their particular semantics in their distributed system.
+Instrumentations SHOULD provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -69,12 +69,12 @@ the name should explicitly be set to the empty string to distinguish it from the
 
 ## General remote service attributes
 
-These attributes may be used for any remote operation that applies to a service. Users can define what the name of a service is based on their particular semantics in their distributed system.
+These attributes may be used for any operation that accesses some remote service. Users can define what the name of a service is based on their particular semantics in their distributed system.
 Instrumentation is expected to provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |
-| `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. |
+| `peer.service`  | The (hypothetical) [`service.name`](../../resources/resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any. |
 
 Examples of `peer.service` that users may specify:
 - A Redis cache of auth tokens. `peer.service=AuthTokenCache`.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -77,8 +77,8 @@ Instrumentation is expected to provide a way for users to configure this name.
 | `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. Generally, a user SHOULD not set this to a fully qualified RPC service name as it would be a duplicate of `rpc.service`. |
 
 Examples of `peer.service` that users may specify:
-- A Redis cache of auth tokens, `AuthTokenCache`.
-- A gRPC service `io.opentelemetry.AuthService` may be hosted in both a gateway, `ExternalApiService` and a backend, `AuthService`.
+- A Redis cache of auth tokens. `peer.service=AuthTokenCache`.
+- A gRPC service `rpc.service=io.opentelemetry.AuthService` may be hosted in both a gateway, `peer.service=ExternalApiService` and a backend, `peer.service=AuthService`.
 
 ## General identity attributes
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -74,7 +74,7 @@ Instrumentation is expected to provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |
-| `peer.service`  | The (hypothetical) [`service.name`](../../resources/resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any. |
+| `peer.service`  | The (hypothetical) [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any. |
 
 Examples of `peer.service` that users may specify:
 - A Redis cache of auth tokens. `peer.service=AuthTokenCache`.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -77,7 +77,7 @@ Instrumentation is expected to provide a way for users to configure this name.
 | `peer.service`  | The [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any. |
 
 Examples of `peer.service` that users may specify:
-- A Redis cache of auth tokens. `peer.service=AuthTokenCache`.
+- A Redis cache of auth tokens as `peer.service="AuthTokenCache"`.
 - A gRPC service `rpc.service=io.opentelemetry.AuthService` may be hosted in both a gateway, `peer.service=ExternalApiService` and a backend, `peer.service=AuthService`.
 
 ## General identity attributes

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -78,7 +78,7 @@ Instrumentation is expected to provide a way for users to configure this name.
 
 Examples of `peer.service` that users may specify:
 - A Redis cache of auth tokens as `peer.service="AuthTokenCache"`.
-- A gRPC service `rpc.service=io.opentelemetry.AuthService` may be hosted in both a gateway, `peer.service=ExternalApiService` and a backend, `peer.service=AuthService`.
+- A gRPC service `rpc.service="io.opentelemetry.AuthService"` may be hosted in both a gateway, `peer.service="ExternalApiService"` and a backend, `peer.service="AuthService"`.
 
 ## General identity attributes
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -69,12 +69,12 @@ the name should explicitly be set to the empty string to distinguish it from the
 
 ## General remote service attributes
 
-These attributes may be used for any remote operation that applies to a target service. Users will generally define what a service is, though instrumentation
+These attributes may be used for any remote operation that applies to a service. Users will generally define what a service is, though instrumentation
 may provide a fallback when not user-controlled based on instrumentation-specific behavior.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |
-| `peer.service`  | Remote service name, indicating a semantic name for the target of the request. For example, for a Redis cache of auth tokens, this may be `AuthCache`. Note that this usually does not relate to transport-level names like `net.*.name` attributes above, for example when the service is sharded and accessible from several endpoints. |
+| `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. |
 
 ## General identity attributes
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -74,7 +74,7 @@ Instrumentation is expected to provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |
-| `peer.service`  | The (hypothetical) [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any. |
+| `peer.service`  | The [`service.name`](../../resource/semantic_conventions/README.md#service) of the remote service. SHOULD be equal to the actual `service.name` resource attribute of the remote service if any. |
 
 Examples of `peer.service` that users may specify:
 - A Redis cache of auth tokens. `peer.service=AuthTokenCache`.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -9,6 +9,9 @@ Particular operations may refer to or require some of these attributes.
 <!-- toc -->
 
 - [General network connection attributes](#general-network-connection-attributes)
+  * [`net.transport` attribute](#nettransport-attribute)
+  * [`net.*.name` attributes](#netname-attributes)
+- [General remote service attributes](#general-remote-service-attributes)
 - [General identity attributes](#general-identity-attributes)
 
 <!-- tocstop -->

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -70,6 +70,7 @@ the name should explicitly be set to the empty string to distinguish it from the
 ## General remote service attributes
 
 These attributes may be used for any remote operation that applies to a service. Users can define what the name of a service is based on their particular semantics in their distributed system.
+Instrumentation is expected to provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -69,8 +69,7 @@ the name should explicitly be set to the empty string to distinguish it from the
 
 ## General remote service attributes
 
-These attributes may be used for any remote operation that applies to a service. Users will generally define what a service is, though instrumentation
-may provide a fallback when not user-controlled based on instrumentation-specific behavior.
+These attributes may be used for any remote operation that applies to a service. Users can define what the name of a service is based on their particular semantics in their distributed system.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -74,7 +74,11 @@ Instrumentation is expected to provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |
-| `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. |
+| `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. Generally, a user SHOULD not set this to a fully qualified RPC service name as it would be a duplicate of `rpc.service`. |
+
+Examples of `peer.service` that users may specify:
+- A Redis cache of auth tokens, `AuthTokenCache`.
+- A gRPC service `io.opentelemetry.AuthService` may be hosted in both a gateway, `ExternalApiService` and a backend, `AuthService`.
 
 ## General identity attributes
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -67,6 +67,15 @@ If `net.transport` is `"unix"` or `"pipe"`, the absolute path to the file repres
 If there is no such file (e.g., anonymous pipe),
 the name should explicitly be set to the empty string to distinguish it from the case where the name is just unknown or not covered by the instrumentation.
 
+## General remote service attributes
+
+These attributes may be used for any remote operation that applies to a target service. Users will generally define what a service is, though instrumentation
+may provide a fallback when not user-controlled based on instrumentation-specific behavior,
+
+|  Attribute name |                                 Notes and examples                                |
+| :-------------- | :-------------------------------------------------------------------------------- |
+| `peer.service`    | Remote service name, indicating a semantic name for the target of the request. For example, for a Redis cache of auth tokens, this may be `AuthCache`. Note that this usually does not relate to transport-level names like `net.*.names` attributes above, for example when the service is sharded and accessible from several endpoints. |
+
 ## General identity attributes
 
 These attributes may be used for any operation with an authenticated and/or authorized enduser.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -74,7 +74,7 @@ Instrumentation is expected to provide a way for users to configure this name.
 
 |  Attribute name |                                 Notes and examples                                |
 | :-------------- | :-------------------------------------------------------------------------------- |
-| `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. Generally, a user SHOULD not set this to a fully qualified RPC service name as it would be a duplicate of `rpc.service`. |
+| `peer.service`  | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. |
 
 Examples of `peer.service` that users may specify:
 - A Redis cache of auth tokens. `peer.service=AuthTokenCache`.


### PR DESCRIPTION
… remote service.

This adds an attribute to indicate the name of a remote service. While a service will often know its own name locally, a client generally does not, only having something like a hostname. But a hostname doesn't have a 1:1 mapping with a remote service because services can be exposed on multiple hostnames. Allowing the client to provide a service name is especially important for services that are not themselves traced, often a database such as Redis. There would be no way to render features like a service graph for such cases without this attribute.

I know `OpenTracing` left the actual meaning of `service` somewhat ambiguous - I can see why since it is hard to define :) I tried to add a bit more explanation, but let me know if it makes sense, any tips that could make it more clear, or on the flip side whether it makes sense to just leave it ambiguous and up to users completely.

Fixes #648 