### PR TITLE
Update codeowners to support area owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,7 +12,7 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-# Global owners, will be the owners for everything in the repo.
+# Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/master/community-members.md 
 *   @specs-approvers
 
 # Trace owners (global + trace)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,4 +12,17 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-*  @bogdandrutu @carlosalberto @SergeyKanzhelev @yurishkuro @tedsuo @iredelmeier @arminru @c24t @reyang @tigrannajaryan @jmacd
+# Global owners, will be the owners for everything in the repo.
+*   @specs-approvers
+
+# Trace owners (global + trace)
+experimental/trace/    @specs-approvers @specs-trace-approvers
+specification/trace/   @specs-approvers @specs-trace-approvers
+
+# Metrics owners (global + metrics)
+experimental/metrics/    @specs-approvers @specs-metrics-approvers
+specification/metrics/   @specs-approvers @specs-metrics-approvers
+
+# Logs owners (global + logs)
+experimental/logs/    @specs-approvers @specs-logs-approvers
+specification/logs/   @specs-approvers @specs-logs-approvers


### PR DESCRIPTION
This proposal was reviewed by the @open-telemetry/technical-committee. We will update the teams accordingly to the following schema:

# Approvers for the entire repo:
*  @bogdandrutu @carlosalberto @SergeyKanzhelev @yurishkuro @reyang @tigrannajaryan @jmacd 
 
# Approvers for trace only:
@arminru @Oberon00 @tedsuo

# Approvers for metrics only:
@MrAlias @jkwatson @lzchen @cijothomas

# Approvers for logs only:
TBD (@tigrannajaryan to propose the initial list)


**NOTE:** This PR will be copied in otep and proto repositories