### PR TITLE
add initial env var draft specification

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -43,7 +43,6 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | - |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | - |
-| OTEL_EXPORTER_JAEGER_TAGS       | Jaeger process tags                               | - |
 | OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | - |
 
 ## Zipkin Exporter

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -4,11 +4,11 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## General SDK Configuration
 
-| Name                 | Description                                      | Notes                                                                                           | Default                           |
-| -------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- |
-| OTEL_RESOURCE_LABELS | Key-value pairs to be used as resource labels    | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |                                   |
-| OTEL_LOG_LEVEL       | Log level used by the SDK logger                 |                                                                                                 | "info"                            |
-| OTEL_PROPAGATORS     | Propagators to be used as a comma separated list |                                                                                                 | "tracecontext,correlationcontext" |
+| Name                 | Description                                      | Default                           | Notes                                                                                           |
+| -------------------- | ------------------------------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------- |
+| OTEL_RESOURCE_LABELS | Key-value pairs to be used as resource labels    |                                   | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |
+| OTEL_LOG_LEVEL       | Log level used by the SDK logger                 | "info"                            |                                                                                                 |
+| OTEL_PROPAGATORS     | Propagators to be used as a comma separated list | "tracecontext,correlationcontext" |                                                                                                 |
 
 ## Batch Span Processor
 
@@ -35,13 +35,13 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## Jaeger Exporter
 
-| Name                            | Description Default                               |
-| ------------------------------- | ------------------------------------------------- |
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     | "localhost" |
-| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                         | 6832 |
+| Name                            | Description                                       | Default                                                                                          |
+| ------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     | "localhost"                                                                                      |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                         | 6832                                                                                             |
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
-| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | - |
-| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | - |
+| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                                                                                |
+| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                                                                                |
 
 ## Zipkin Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -4,50 +4,50 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## General SDK Configuration
 
-| Name                      | Description                                      | Notes                                                                                           |
-| ------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| OTEL_RESOURCE_LABELS      | Key-value pairs to be used as resource labels    | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |
-| OTEL_SAMPLING_PROBABILITY | Probability to be used by the ProbabiltySampler  | default: 1                                                                                      |
-| OTEL_LOG_LEVEL            | Log level used by the SDK logger                 | default: "info"                                                                                 |
-| OTEL_PROPAGATORS          | Propagators to be used as a comma separated list | default: "tracecontext,correlationcontext"                                                      |
+| Name                      | Description                                      | Notes                                                                                           | Default                           |
+| ------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- |
+| OTEL_RESOURCE_LABELS      | Key-value pairs to be used as resource labels    | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |                                   |
+| OTEL_SAMPLING_PROBABILITY | Probability to be used by the ProbabiltySampler  |                                                                                                 | 1                                 |
+| OTEL_LOG_LEVEL            | Log level used by the SDK logger                 |                                                                                                 | "info"                            |
+| OTEL_PROPAGATORS          | Propagators to be used as a comma separated list |                                                                                                 | "tracecontext,correlationcontext" |
 
 ## Batch Span Processor
 
-| Name                      | Description                                    | Notes |
-| ------------------------- | ---------------------------------------------- | ----- |
-| OTEL_BSP_SCHEDULE_DELAY   | Delay interval between two consecutive exports | -     |
-| OTEL_BSP_MAX_QUEUE        | Maximum queue size                             | -     |
-| OTEL_BSP_MAX_EXPORT_BATCH | Maximum batch size                             | -     |
-| OTEL_BSP_EXPORT_TIMEOUT   | Maximum allowed time to export data            | -     |
+| Name                      | Description                                    | Default |
+| ------------------------- | ---------------------------------------------- | ------- |
+| OTEL_BSP_SCHEDULE_DELAY   | Delay interval between two consecutive exports | -       |
+| OTEL_BSP_MAX_QUEUE        | Maximum queue size                             | -       |
+| OTEL_BSP_MAX_EXPORT_BATCH | Maximum batch size                             | -       |
+| OTEL_BSP_EXPORT_TIMEOUT   | Maximum allowed time to export data            | -       |
 
 ## OTLP Span Exporter
 
-| Name                             | Description                                                   | Notes |
-| -------------------------------- | ------------------------------------------------------------- | ----- |
-| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time for the collector to process each span batch | -     |
-| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans                                | -     |
+| Name                             | Description                                                   | Default |
+| -------------------------------- | ------------------------------------------------------------- | ------- |
+| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time for the collector to process each span batch | -       |
+| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans                                | -       |
 
 ## OTLP Metric Exporter
 
-| Name                               | Description                                                     | Notes |
-| ---------------------------------- | --------------------------------------------------------------- | ----- |
-| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time for the collector to process each metric batch | -     |
-| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics                                | -     |
+| Name                               | Description                                                     | Default |
+| ---------------------------------- | --------------------------------------------------------------- | ------- |
+| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time for the collector to process each metric batch | -       |
+| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics                                | -       |
 
 ## Jaeger Exporter
 
-| Name                            | Description                                       | Notes                                                                                                    |
-| ------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     |                                                                                                          |
-| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                         |                                                                                                          |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable -->default: "http://localhost:14250"<!-- markdown-link-check-enable --> |
-| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                                                                                        |
-| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                                                                                        |
-| OTEL_EXPORTER_JAEGER_TAGS       | Jaeger process tags                               | -                                                                                                        |
-| OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | -                                                                                                        |
+| Name                            | Description Default                               |
+| ------------------------------- | ------------------------------------------------- |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     | "localhost" |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                         | 6832 |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | - |
+| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | - |
+| OTEL_EXPORTER_JAEGER_TAGS       | Jaeger process tags                               | - |
+| OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | - |
 
 ## Zipkin Exporter
 
-| Name                          | Description                | Notes                                                                                                                |
-| ----------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable -->default: "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
+| Name                          | Description                | Default                                                                                                      |
+| ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -36,18 +36,18 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## Jaeger Exporter
 
-| Name                            | Description                                       | Notes                             |
-| ------------------------------- | ------------------------------------------------- | --------------------------------- |
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     |                                   |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | default: "http://localhost:14250" |
-| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                 |
-| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                 |
-| OTEL_EXPORTER_JAEGER_TAGS       | Jeager process tags                               | -                                 |
-| OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | -                                 |
+| Name                            | Description                                       | Notes                                                                                                    |
+| ------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     |                                                                                                          |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable -->default: "http://localhost:14250"<!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                                                                                        |
+| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                                                                                        |
+| OTEL_EXPORTER_JAEGER_TAGS       | Jeager process tags                               | -                                                                                                        |
+| OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | -                                                                                                        |
 
 ## Zipkin Exporter
 
-| Name                              | Description                | Notes                                         |
-| --------------------------------- | -------------------------- | --------------------------------------------- |
-| OTEL_EXPORTER_ZIPKIN_ENDPOINT     | Endpoint for Zipkin traces | default: "http://localhost:9411/api/v2/spans" |
-| OTEL_EXPORTER_ZIPKIN_SERVICE_NAME | The Zipkin service name    | -                                             |
+| Name                              | Description                | Notes                                                                                                                |
+| --------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| OTEL_EXPORTER_ZIPKIN_ENDPOINT     | Endpoint for Zipkin traces | <!-- markdown-link-check-disable -->default: "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_ZIPKIN_SERVICE_NAME | The Zipkin service name    | -                                                                                                                    |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -50,3 +50,11 @@ The goal of this specification is to unify the environment variable names betwee
 | Name                          | Description                | Default                                                                                                      |
 | ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
+
+## Language Specific Environment Variables
+
+To ensure consistent naming across projects, this specification recommends that language specific environment variables are formed using the following convention:
+
+```
+OTEL_{LANGUAGE}_{FEATURE}
+```

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -4,12 +4,11 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## General SDK Configuration
 
-| Name                      | Description                                      | Notes                                                                                           | Default                           |
-| ------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- |
-| OTEL_RESOURCE_LABELS      | Key-value pairs to be used as resource labels    | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |                                   |
-| OTEL_SAMPLING_PROBABILITY | Probability to be used by the ProbabiltySampler  |                                                                                                 | 1                                 |
-| OTEL_LOG_LEVEL            | Log level used by the SDK logger                 |                                                                                                 | "info"                            |
-| OTEL_PROPAGATORS          | Propagators to be used as a comma separated list |                                                                                                 | "tracecontext,correlationcontext" |
+| Name                 | Description                                      | Notes                                                                                           | Default                           |
+| -------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- | --------------------------------- |
+| OTEL_RESOURCE_LABELS | Key-value pairs to be used as resource labels    | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |                                   |
+| OTEL_LOG_LEVEL       | Log level used by the SDK logger                 |                                                                                                 | "info"                            |
+| OTEL_PROPAGATORS     | Propagators to be used as a comma separated list |                                                                                                 | "tracecontext,correlationcontext" |
 
 ## Batch Span Processor
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -42,7 +42,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable -->default: "http://localhost:14250"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                                                                                        |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                                                                                        |
-| OTEL_EXPORTER_JAEGER_TAGS       | Jeager process tags                               | -                                                                                                        |
+| OTEL_EXPORTER_JAEGER_TAGS       | Jaeger process tags                               | -                                                                                                        |
 | OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | -                                                                                                        |
 
 ## Zipkin Exporter

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -21,17 +21,17 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## OTLP Span Exporter
 
-| Name                             | Description                                                   | Default |
-| -------------------------------- | ------------------------------------------------------------- | ------- |
-| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time for the collector to process each span batch | -       |
-| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans                                | -       |
+| Name                             | Description                                | Default |
+| -------------------------------- | ------------------------------------------ | ------- |
+| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time to export each span batch | -       |
+| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans             | -       |
 
 ## OTLP Metric Exporter
 
-| Name                               | Description                                                     | Default |
-| ---------------------------------- | --------------------------------------------------------------- | ------- |
-| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time for the collector to process each metric batch | -       |
-| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics                                | -       |
+| Name                               | Description                                  | Default |
+| ---------------------------------- | -------------------------------------------- | ------- |
+| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time to export each metric batch | -       |
+| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics             | -       |
 
 ## Jaeger Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -4,11 +4,11 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## General SDK Configuration
 
-| Name                 | Description                                      | Default                           | Notes                                                                                           |
-| -------------------- | ------------------------------------------------ | --------------------------------- | ----------------------------------------------------------------------------------------------- |
-| OTEL_RESOURCE_LABELS | Key-value pairs to be used as resource labels    |                                   | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |
-| OTEL_LOG_LEVEL       | Log level used by the SDK logger                 | "info"                            |                                                                                                 |
-| OTEL_PROPAGATORS     | Propagators to be used as a comma separated list | "tracecontext,correlationcontext" |                                                                                                 |
+| Name                 | Description                                      | Default                           | Notes                                                                                       |
+| -------------------- | ------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------------------- |
+| OTEL_RESOURCE_LABELS | Key-value pairs to be used as resource labels    |                                   | Spec details TBD. Proposal in [OTEP-111](https://github.com/open-telemetry/oteps/pull/111). |
+| OTEL_LOG_LEVEL       | Log level used by the SDK logger                 | "info"                            |                                                                                             |
+| OTEL_PROPAGATORS     | Propagators to be used as a comma separated list | "tracecontext,correlationcontext" |                                                                                             |
 
 ## Batch Span Processor
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -39,6 +39,7 @@ The goal of this specification is to unify the environment variable names betwee
 | Name                            | Description                                       | Notes                                                                                                    |
 | ------------------------------- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
 | OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     |                                                                                                          |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                         |                                                                                                          |
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable -->default: "http://localhost:14250"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                                                                                        |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                                                                                        |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -13,12 +13,12 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## Batch Span Processor
 
-| Name                      | Description                                    | Default |
-| ------------------------- | ---------------------------------------------- | ------- |
-| OTEL_BSP_SCHEDULE_DELAY   | Delay interval between two consecutive exports | -       |
-| OTEL_BSP_MAX_QUEUE        | Maximum queue size                             | -       |
-| OTEL_BSP_MAX_EXPORT_BATCH | Maximum batch size                             | -       |
-| OTEL_BSP_EXPORT_TIMEOUT   | Maximum allowed time to export data            | -       |
+| Name                           | Description                                    | Default | Notes                                                 |
+| ------------------------------ | ---------------------------------------------- | ------- | ----------------------------------------------------- |
+| OTEL_BSP_SCHEDULE_DELAY_MILLIS | Delay interval between two consecutive exports | 5000    |                                                       |
+| OTEL_BSP_EXPORT_TIMEOUT_MILLIS | Maximum allowed time to export data            | 30000   |                                                       |
+| OTEL_BSP_MAX_QUEUE_SIZE        | Maximum queue size                             | 2048    |                                                       |
+| OTEL_BSP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                             | 512     | Must be less than or equal to OTEL_BSP_MAX_QUEUE_SIZE |
 
 ## OTLP Span Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -48,7 +48,6 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## Zipkin Exporter
 
-| Name                              | Description                | Notes                                                                                                                |
-| --------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| OTEL_EXPORTER_ZIPKIN_ENDPOINT     | Endpoint for Zipkin traces | <!-- markdown-link-check-disable -->default: "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
-| OTEL_EXPORTER_ZIPKIN_SERVICE_NAME | The Zipkin service name    | -                                                                                                                    |
+| Name                          | Description                | Notes                                                                                                                |
+| ----------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable -->default: "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -1,0 +1,53 @@
+# OpenTelemetry Environment Variable Specification
+
+The goal of this specification is to unify the environment variable names between different OpenTelemetry SDK implementations. SDKs MAY choose to allow configuration via the environment variables in this specification, but are not required to. If they do, they SHOULD use the names listed in this document.
+
+## General SDK Configuration
+
+| Name                      | Description                                      | Notes                                                                                           |
+| ------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| OTEL_RESOURCE_LABELS      | Key-value pairs to be used as resource labels    | Final name and value format TBD by [OTEP-111](https://github.com/open-telemetry/oteps/pull/111) |
+| OTEL_SAMPLING_PROBABILITY | Probability to be used by the ProbabiltySampler  | default: 1                                                                                      |
+| OTEL_LOG_LEVEL            | Log level used by the SDK logger                 | default: "info"                                                                                 |
+| OTEL_PROPAGATORS          | Propagators to be used as a comma separated list | default: "tracecontext,correlationcontext"                                                      |
+
+## Batch Span Processor
+
+| Name                      | Description                                    | Notes |
+| ------------------------- | ---------------------------------------------- | ----- |
+| OTEL_BSP_SCHEDULE_DELAY   | Delay interval between two consecutive exports | -     |
+| OTEL_BSP_MAX_QUEUE        | Maximum queue size                             | -     |
+| OTEL_BSP_MAX_EXPORT_BATCH | Maximum batch size                             | -     |
+| OTEL_BSP_EXPORT_TIMEOUT   | Maximum allowed time to export data            | -     |
+
+## OTLP Span Exporter
+
+| Name                             | Description                                                   | Notes |
+| -------------------------------- | ------------------------------------------------------------- | ----- |
+| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time for the collector to process each span batch | -     |
+| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans                                | -     |
+
+## OTLP Metric Exporter
+
+| Name                               | Description                                                     | Notes |
+| ---------------------------------- | --------------------------------------------------------------- | ----- |
+| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time for the collector to process each metric batch | -     |
+| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics                                | -     |
+
+## Jaeger Exporter
+
+| Name                            | Description                                       | Notes                             |
+| ------------------------------- | ------------------------------------------------- | --------------------------------- |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                     |                                   |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | default: "http://localhost:14250" |
+| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                 |
+| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                 |
+| OTEL_EXPORTER_JAEGER_TAGS       | Jeager process tags                               | -                                 |
+| OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | -                                 |
+
+## Zipkin Exporter
+
+| Name                              | Description                | Notes                                         |
+| --------------------------------- | -------------------------- | --------------------------------------------- |
+| OTEL_EXPORTER_ZIPKIN_ENDPOINT     | Endpoint for Zipkin traces | default: "http://localhost:9411/api/v2/spans" |
+| OTEL_EXPORTER_ZIPKIN_SERVICE_NAME | The Zipkin service name    | -                                             |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -43,7 +43,6 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | - |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | - |
-| OTEL_EXPORTER_JAEGER_DISABLED   | Disables the Jaeger exporter when true            | - |
 
 ## Zipkin Exporter
 


### PR DESCRIPTION
Fixes #572.

This is an initial draft of an environment variable specification. As stated in the spec, the goal is to unify the names of environment variables between SDK implementations. SDKs are not required to add configuration for the variables specified, but if they do, they should align with names in this spec. 

This list was compiled from comments on https://github.com/open-telemetry/opentelemetry-specification/issues/572 and surveying a number of SDK implementations. Defaults have been provided where applicable and likely to be uncontroversial. The door is open to add more detail if we would like to.

Lastly, this is meant to be a starting to point document and align environment variable names going forward. To that end, if a SIG adds a new environment variable that is applicable across languages, it should be documented here. On the same note, if there are environment variables that are more widely applicable that were missed during the survey, add them in the comments and I'll update the PR.