### PR TITLE
Trace SDK: Provide definitions for readable and read/write span.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ the release.
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.
+- Provide clear definitions for readable and read/write span.
+  * SpanProcessors must provide read/write access at least in OnStart.
 
 ## v0.5.0 (06-02-2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ the release.
 
 ## Unreleased
 
-
 New:
 
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ the release.
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.
-- Provide clear definitions for readable and read/write span.
+- Provide clear definitions for readable and read/write span interfaces in the SDK.
   * SpanProcessors must provide read/write access at least in OnStart.
 
 ## v0.5.0 (06-02-2020)

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -182,7 +182,7 @@ separate objects that are passed together to give full read/write capabilities
 (when chosing this implemenation technique,
 changes through one object should be reflected in the other
 objects immediately if they are observable through them at all
-to avoid introducing suble gotchas).
+to avoid introducing subtle gotchas).
 Second, these are abstract requirements for interfaces. Not all
 places in the spec that talk about a readable span need to be implemented by the
 same concrete interface. For example, this allows using a different interface

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -172,6 +172,8 @@ Thus, the SDK specification defines two new terms:
 * **Readable span**: A span interface that MUST allow to retrieve all information
   that was added to the span (e.g. all attributes, events, (parent) `SpanContext`,
   etc.).
+  The readable span MUST provide a method called `getInstrumentationLibrary` (or similar),
+  that returns the `InstrumentationLibrary` information held by the `Tracer` that created the span.
   A readable span MAY be identical to a read/write span, i.e., SDKs are not
   required to have a read-only interface.
   SDKs are also allowed to use a read/write span instead of a different readable interface

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -164,7 +164,7 @@ reference.
 
 The [API-level definition for Span's interface](api.md#span-operations)
 only defines write-only access to the span.
-This is good because instrumentations and applications are not to use the data
+This is good because instrumentations and applications are not meant to use the data
 stored in a span for application logic.
 However, the SDK needs to eventually read back the data in some locations.
 Thus, the SDK specification defines two new terms:
@@ -242,7 +242,7 @@ the execution thread, therefore it should not block or throw an exception.
 * `Span` - a [readable span object](#additional-span-interfaces) for the started span.
   Note: Since multiple SpanProcessors may be involved, and OnEnd is typically used
   for sending data to exporters, SpanProcessors should rather not modify spans
-  in `OnEnd`, since the resulting behavior would be sensitive to the order of
+  in `OnEnd`, even if the passed object would allow this, since the resulting behavior would be sensitive to the order of
   `SpanProcessors`'s `OnEnd` calls.
 
 **Returns:** `Void`
@@ -339,7 +339,7 @@ and backend the spans are being sent to.
 
 batch - a batch of telemetry data. The exact data type of the batch is language
 specific, typically it is a list of [readable spans](#additional-span-interfaces),
-e.g. for spans in Java it will be typically `Collection<ExportableSpan>`.
+e.g. for spans in Java it will be typically `Collection<SpanData>`.
 
 **Returns:** ExportResult:
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -6,6 +6,7 @@
 
 * [Sampling](#sampling)
 * [Tracer Creation](#tracer-creation)
+* [Additional Span Interfaces](#additional-span-interfaces)
 * [Span Processor](#span-processor)
 * [Span Exporter](#span-exporter)
 
@@ -160,7 +161,7 @@ Note: Implementation-wise, this could mean that `Tracer` instances have a
 reference to their `TracerProvider` and access configuration only via this
 reference.
 
-## Additional Span interfaces
+## Additional Span Interfaces
 
 The [API-level definition for Span's interface](api.md#span-operations)
 only defines write-only access to the span.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -177,7 +177,13 @@ Thus, the SDK specification defines two new terms:
   
 Note: First, these requirements use "interface" in the most abstract sense --
 it does not need to be an actual Java `interface` for example but could also be
-a `final` POJO. Second, these are abstract requirements for interfaces. Not all
+a `final` POJO, or, especially in the case of read/write span, even two (or more)
+separate objects that are passed together to give full read/write capabilities
+(when chosing this implemenation technique,
+changes through one object should be reflected in the other
+objects immediately if they are observable through them at all
+to avoid introducing suble gotchas).
+Second, these are abstract requirements for interfaces. Not all
 places in the spec that talk about a readable span need to be implemented by the
 same concrete interface. For example, this allows using a different interface
 for the readable span passed to an exporter than for the readable span passed

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -184,7 +184,7 @@ Thus, the SDK specification defines two new terms:
 The readable span interface MAY be identical to the read/write interface,
 i.e., SDKs are not required to have a read-only interface.
 SDKs are also allowed to use a read/write span instead of a different readable interface
-only in some places where the SDK requires a readable span.
+only in some places where the specification requires a readable span.
 
 ## Span processor
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -178,7 +178,7 @@ Thus, the SDK specification defines two new terms:
   only in some places where the SDK requires a readable span.
 * **Read/write span**: A span that provides both the full API as defined in the
   [API-level definition for span's interface](api.md#span-operations) and
-  additionally the same interface as for Readable spans
+  additionally the same interface as for readable spans
   as defined in the above bullet point.
 
 ## Span processor

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -174,7 +174,7 @@ Thus, the SDK specification defines two new terms:
   etc.).
   A readable span MAY be identical to a read/write span, i.e., SDKs are not
   required to have a read-only interface.
-  SDKs are also allowed to use a read/write span instead of a different readable
+  SDKs are also allowed to use a read/write span instead of a different readable interface
   only in some places where the SDK requires a readable span.
 * **Read/write span**: A span that provides both the full API as defined in the
   [API-level definition for Span's interface](api.md#span-operations) and

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -175,7 +175,7 @@ Thus, the SDK specification defines two new terms:
   
   The readable span MUST provide a method called `getInstrumentationLibrary` (or similar),
   that returns the `InstrumentationLibrary` information held by the `Tracer` that created the span.
-* **Read/write span**: A span that provides both the full API as defined in the
+* **Read/write span**: A span that provides both the full span API as defined in the
   [API-level definition for span's interface](api.md#span-operations) and
   additionally the same interface as for readable spans
   as defined in the above bullet point.
@@ -238,16 +238,15 @@ exceptions.
 
 #### OnEnd(Span)
 
-`OnEnd` is called when a span is ended. This method is called synchronously on
-the execution thread, therefore it should not block or throw an exception.
+`OnEnd` is called after a span is ended (i.e., the end timestamp is already set).
+This method MUST be called synchronously within the [`Span.End()` API](api.md#end),
+therefore it should not block or throw an exception.
 
 **Parameters:**
 
-* `Span` - a [readable span object](#additional-span-interfaces) for the started span.
-  Note: Since multiple SpanProcessors may be involved, and OnEnd is typically used
-  for sending data to exporters, SpanProcessors should rather not modify spans
-  in `OnEnd`, even if the passed object would allow this, since the resulting behavior would be sensitive to the order of
-  `SpanProcessors`'s `OnEnd` calls.
+* `Span` - a [readable span object](#additional-span-interfaces) for the ended span.
+  Note: Even if the passed Span may be technically writable,
+  since it's already ended at this point, modifying it is not allowed.
 
 **Returns:** `Void`
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -163,21 +163,21 @@ reference.
 ## Additional Span interfaces
 
 The [API-level definition for Span's interface](api.md#span-operations)
-only defines write-only access to the Span.
+only defines write-only access to the span.
 This is good because instrumentations and applications are not to use the data
 stored in a span for application logic.
 However, the SDK needs to eventually read back the data in some locations.
 Thus, the SDK specification defines two new terms:
 
 * **Readable span**: A span interface that MUST allow to retrieve all information
-  that was added to the span (e.g. all attributes, events, (parent) SpanContext,
+  that was added to the span (e.g. all attributes, events, (parent) `SpanContext`,
   etc.).
   A readable span MAY be identical to a read/write span, i.e., SDKs are not
   required to have a read-only interface.
   SDKs are also allowed to use a read/write span instead of a different readable interface
   only in some places where the SDK requires a readable span.
 * **Read/write span**: A span that provides both the full API as defined in the
-  [API-level definition for Span's interface](api.md#span-operations) and
+  [API-level definition for span's interface](api.md#span-operations) and
   additionally the same interface as for Readable spans
   as defined in the above bullet point.
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -170,21 +170,27 @@ stored in a span for application logic.
 However, the SDK needs to eventually read back the data in some locations.
 Thus, the SDK specification defines two new terms:
 
-* **Readable span**: A span interface that MUST allow to retrieve all information
+* **Readable span**: A span interface satisfies the requirements of being a
+  readable span if it allows to retrieve all information
   that was added to the span (e.g. all attributes, events, (parent) `SpanContext`,
   etc.).
   
-  The readable span MUST provide a method called `getInstrumentationLibrary` (or similar),
+  A readable span interface MUST provide a method called `getInstrumentationLibrary` (or similar),
   that returns the `InstrumentationLibrary` information held by the `Tracer` that created the span.
-* **Read/write span**: A span that provides both the full span API as defined in the
+* **Read/write span**: A span interface satisfies this requirement of being a
+  read/write span if it provides both the full span API as defined in the
   [API-level definition for span's interface](api.md#span-operations) and
-  additionally the same interface as for readable spans
+  additionally satisfies the requirements for being a readable span
   as defined in the above bullet point.
   
-The readable span interface MAY be identical to the read/write interface,
-i.e., SDKs are not required to have a read-only interface.
-SDKs are also allowed to use a read/write span instead of a different readable interface
-only in some places where the specification requires a readable span.
+Note: First, these requirements use "interface" in the most abstract sense --
+it does not need to be an actual Java `interface` for example but could also be
+a `final` POJO. Second, these are abstract requirements for interfaces. Not all
+places in the spec that talk about a readable span need to be implemented by the
+same concrete interface. For example, this allows using a different interface
+for the readable span passed to an exporter than for the readable span passed
+to a SpanProcessor's OnEnd. On the other hand,
+it allows implementing a readable span as a read/write span.
 
 ## Span processor
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -172,16 +172,18 @@ Thus, the SDK specification defines two new terms:
 * **Readable span**: A span interface that MUST allow to retrieve all information
   that was added to the span (e.g. all attributes, events, (parent) `SpanContext`,
   etc.).
+  
   The readable span MUST provide a method called `getInstrumentationLibrary` (or similar),
   that returns the `InstrumentationLibrary` information held by the `Tracer` that created the span.
-  A readable span MAY be identical to a read/write span, i.e., SDKs are not
-  required to have a read-only interface.
-  SDKs are also allowed to use a read/write span instead of a different readable interface
-  only in some places where the SDK requires a readable span.
 * **Read/write span**: A span that provides both the full API as defined in the
   [API-level definition for span's interface](api.md#span-operations) and
   additionally the same interface as for readable spans
   as defined in the above bullet point.
+  
+The readable span interface MAY be identical to the read/write interface,
+i.e., SDKs are not required to have a read-only interface.
+SDKs are also allowed to use a read/write span instead of a different readable interface
+only in some places where the SDK requires a readable span.
 
 ## Span processor
 
@@ -339,8 +341,8 @@ and backend the spans are being sent to.
 
 **Parameters:**
 
-batch - a batch of telemetry data. The exact data type of the batch is language
-specific, typically it is a list of [readable spans](#additional-span-interfaces),
+batch - a batch of [readable spans](#additional-span-interfaces). The exact data type of the batch is language
+specific, typically it is some kind of list,
 e.g. for spans in Java it will be typically `Collection<SpanData>`.
 
 **Returns:** ExportResult:


### PR DESCRIPTION
Resolves #663 "Allow for global processing of spans in SpanProcessor".
Required for #158 "Describe proto.Span class".

- OnStart must be read/write.
- OnEnd must be readable ~, may additionally be writable~.

Also clean up related wording for span exporters that couldn't decide whether they want to work for different kinds of telemetry data or only spans (they work only for spans).