### PR TITLE
Fix CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 #
 
 # Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/master/community-members.md 
-*   @specs-approvers
+*   @open-telemetry/specs-approvers
 
 # Trace owners (global + trace)
 experimental/trace/     @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,13 +16,13 @@
 *   @specs-approvers
 
 # Trace owners (global + trace)
-experimental/trace/    @specs-approvers @specs-trace-approvers
-specification/trace/   @specs-approvers @specs-trace-approvers
+experimental/trace/     @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers
+specification/trace/    @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers
 
 # Metrics owners (global + metrics)
-experimental/metrics/    @specs-approvers @specs-metrics-approvers
-specification/metrics/   @specs-approvers @specs-metrics-approvers
+experimental/metrics/   @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers
+specification/metrics/  @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers
 
 # Logs owners (global + logs)
-experimental/logs/    @specs-approvers @specs-logs-approvers
-specification/logs/   @specs-approvers @specs-logs-approvers
+experimental/logs/      @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers
+specification/logs/     @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers


### PR DESCRIPTION
The current CODEOWNERS definition doesn't work (see #669, where no reviewers were added, I requested @open-telemetry/specs-trace-approvers manually). Teams have to be mentioned as `@org/team-name` (see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax).