### PR TITLE
Do not write a value in Context upon failed extraction.

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -105,7 +105,7 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
 If a value can not be parsed from the carrier for a cross-cutting concern,
-the implementation MUST NOT throw an exception. It MUST NOT store a new value in the `Context`,
+the implementation MUST NOT throw an exception and MUST NOT store a new value in the `Context`,
 in order to preserve any previously existing valid value.
 
 Required arguments:

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -105,8 +105,8 @@ The implemenation SHOULD preserve casing (e.g. it should not transform `Content-
 Extracts the value from an incoming request. For example, from the headers of an HTTP request.
 
 If a value can not be parsed from the carrier for a cross-cutting concern,
-the implementation MUST NOT throw an exception. It MUST store a value in the `Context`
-that the implementation can recognize as a null or empty value.
+the implementation MUST NOT throw an exception. It MUST NOT store a new value in the `Context`,
+in order to preserve any previously existing valid value.
 
 Required arguments:
 


### PR DESCRIPTION
This is partially related to #496 as how to proceed when an extraction failed - currently we set a `null`/`empty` value, but it can be very useful to retain any previously existing value, as it would help with:

1. Reducing `Context` allocations for failed extractions.
2. Make things simpler for a `StackPropagator` (which handles multiple signal formats, such as B3 + W3C), as the prototype in #496 shows.

On the other hand, putting a `null`/`empty` value in `Context` upon extraction clears any previously leaked value, but that's an error in itself anyway.

cc @dyladan @Oberon00 