### PR TITLE
Add semantic conventions for container id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the release.
 - Extend semantic conventions for RPC and allow non-gRPC calls ([#604](https://github.com/open-telemetry/opentelemetry-specification/pull/604))
 - Add span attribute to indicate cold starts of Function as a Service executions ([#650](https://github.com/open-telemetry/opentelemetry-specification/pull/650))
 - Added conventions for naming of exporter packages
+- Add semantic conventions for container id
 - Clarify Tracer vs TracerProvider in tracing API and SDK spec. Most importantly:
   * Configuration should be stored not per Tracer but in the TracerProvider.
   * Active spans are not per Tracer.

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -96,6 +96,7 @@ Attributes defining a compute unit (e.g. Container, Process, Function as a Servi
 | container.image.name | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` |
 | container.image.tag | Container image tag. | `0.1` |
 
+[identify Docker containers]: https://docs.docker.com/engine/reference/run/#container-identification
 ### Function as a Service
 
 **type:** `faas`

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -92,6 +92,7 @@ Attributes defining a compute unit (e.g. Container, Process, Function as a Servi
 | Attribute  | Description  | Example  |
 |---|---|---|
 | container.name | Container name. | `opentelemetry-autoconf` |
+| container.id | Container id. | `a3bf90e006b2` |
 | container.image.name | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` |
 | container.image.tag | Container image tag. | `0.1` |
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -92,7 +92,7 @@ Attributes defining a compute unit (e.g. Container, Process, Function as a Servi
 | Attribute  | Description  | Example  |
 |---|---|---|
 | container.name | Container name. | `opentelemetry-autoconf` |
-| container.id | Container id. | `a3bf90e006b2` |
+| container.id | Container id. Usually a UUID, as for example used to [identify Docker containers][]. The UUID might be abbreviated. | `a3bf90e006b2` |
 | container.image.name | Name of the image the container was built on. | `gcr.io/opentelemetry/operator` |
 | container.image.tag | Container image tag. | `0.1` |
 


### PR DESCRIPTION
Currently Container Attributes in Resource have only `container.name` to represent the container instance. I am proposing adding `container.id` as a Container attribute.
Refer to docker documentation [Container identification](https://docs.docker.com/engine/reference/run/#container-identification), Container's `full-id`, `short-id` and `name` are equivalent in docker CLI like 'docker info <id>'. `name` is usually human readable and can be changed by command ['docker rename'](https://docs.docker.com/engine/reference/commandline/rename/#examples) during runtime. 

And [AWS X-ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-sdk-java-configuration.html#xray-sdk-java-configuration-plugins) uses `container.id` represent the container instance in ECS, adding `container.id` in OpenTelemetry would be great helpful for X-Ray.

 