### PR TITLE
[meta] Exclude github.com from markdown-link-check

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -1,0 +1,7 @@
+{
+  "ignorePatterns": [
+      {
+          "pattern": "^https://github\\.com"
+      }
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ install-markdown-link-check:
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	@for f in $(ALL_DOCS); do $(MARKDOWN_LINK_CHECK) --quiet $$f; done
+	@for f in $(ALL_DOCS); do $(MARKDOWN_LINK_CHECK) --quiet --config .markdown_link_check_config.json $$f; done
 
 .PHONY: install-markdown-lint
 install-markdown-lint:


### PR DESCRIPTION
Temporary workaround to get our spec builds green again until #668 is resolved properly.