### PR TITLE
Remove ZPagesProcessor mentioned in SDK spec

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -189,16 +189,16 @@ in the SDK:
 ```
   +-----+--------------+   +-------------------------+   +-------------------+
   |     |              |   |                         |   |                   |
-  |     |              |   | BatchExporterProcessor  |   |    SpanExporter   |
-  |     |              +---> SimpleExporterProcessor +--->  (JaegerExporter) |
+  |     |              |   | Batching Span Processor |   |    SpanExporter   |
+  |     |              +---> Simple Span Processor   +--->  (JaegerExporter) |
   |     |              |   |                         |   |                   |
   | SDK | Span.start() |   +-------------------------+   +-------------------+
   |     | Span.end()   |
-  |     |              |   +---------------------+
-  |     |              |   |                     |
-  |     |              +---> ZPagesProcessor     |
-  |     |              |   |                     |
-  +-----+--------------+   +---------------------+
+  |     |              |
+  |     |              |
+  |     |              |
+  |     |              |
+  +-----+--------------+
 ```
 
 ### Interface definition


### PR DESCRIPTION
The diagram was taken over from the OpenCensus spec and never updated, thus the OpenCensus ZPagesProcessor is still depicted there but not mentioned anywhere else in the spec.

There is currently an effort to get zPages into OTel as an experimental feature (see https://github.com/open-telemetry/oteps/blob/master/text/0110-z-pages.md), so this might be re-added in future once zPages makes it into the OTel spec as a standard feature.