### PR TITLE
Add SeverityNumber to Span Events

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -440,6 +440,11 @@ An `Event` is defined by the following properties:
 - (Optional) One or more `Attribute`s with the same restrictions as defined for
   [Span Attributes](#set-attributes).
 - (Optional) Timestamp for the event.
+- (Optional) SeverityNumber of the event as defined in
+  [log data model](https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md#field-severitynumber).
+  If unspecified SeverityNumber is set to INFO. The SeverityNumber has the same
+  [error semantics](https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md#error-semantics)
+  as defined in log data model.
 
 The `Event` SHOULD be an immutable type.
 


### PR DESCRIPTION
The log data model introduced the notion of SeverityNumber [1] that
can be recorded for individual log records.

I believe it is equally useful for events recorded for Spans. Adding
SeverityNumber to the Span events also makes it more uniform with
standalone log model which is aligned with our understanding that
Span events are another form of log records [2].

[1] https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md#field-severitynumber
[2] https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/glossary.md#embedded-log