### PR TITLE
Adding OTLP Exporter

### DIFF
--- a/specification/correlationcontext/api.md
+++ b/specification/correlationcontext/api.md
@@ -103,7 +103,7 @@ OPTIONAL parameters:
 
 ### Serialization
 
-Until the [W3C Correlation Context](https://w3c.github.io/correlation-context/) specification is recommended for use, OpenTelemetry `CorrelationContext` implementations MUST be serialized according to the [editor's draft of W3C Correlation Context as of March 27, 2020](https://github.com/w3c/correlation-context/blob/c974664b9ab4d33af6355f1f7f03a2d52c89a99e/correlation_context/HTTP_HEADER_FORMAT.md) using a vendor-specific header name to avoid collisions with the W3C Correlation Context specification should it change in the future.
+Until the [W3C Correlation Context](https://w3c.github.io/baggage/) specification is recommended for use, OpenTelemetry `CorrelationContext` implementations MUST be serialized according to the [editor's draft of W3C Correlation Context as of March 27, 2020](https://github.com/w3c/correlation-context/blob/c974664b9ab4d33af6355f1f7f03a2d52c89a99e/correlation_context/HTTP_HEADER_FORMAT.md) using a vendor-specific header name to avoid collisions with the W3C Correlation Context specification should it change in the future.
 
 #### Header Name
 

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -8,9 +8,9 @@ The configuration options are configurable separately for the `SpanExporter` and
 
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
-| Endpoint             | Target to which the exporter is going to send spans or metrics. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Endpoint             | Target to which the exporter is going to send spans or metrics. This MAY be configured to include a path (e.g. `example.com/v1/traces`). | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
 | Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto`. | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
-| Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
+| Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
 | Headers              | The headers associated with gRPC or HTTP requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
 | Compression          | Compression key for supported compression types within collector. Supported compression: `gzip`| no compression              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -13,7 +13,7 @@ The configuration options are configurable separately for the `SpanExporter` and
 | Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
 | Headers              | The headers associated with gRPC or HTTP requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
-| Compression          | Compression key for supported compression types within collector. | gzip              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
+| Compression          | Compression key for supported compression types within collector. Supported compression: `gzip`| no compression              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
 | Timeout              | Max waiting time for the collector to process each spans or metrics batch. | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
 
 ## Retry

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -18,10 +18,10 @@ The configuration options are configurable separately for the `SpanExporter` and
 
 ## Retry
 
-[Transient errors](#transient-errors) MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
+[Transient errors](#transient-errors) MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered. 
 
 ## Transient Errors
-Transient errors are errors which expect the backend to recover. These are defined per protocol:
+Transient errors are errors which expect the backend to recover. The following status codes are defined as transient errors:
 
 | HTTP Status Code | Description |
 | ---------------- | ----------- |
@@ -39,3 +39,5 @@ Transient errors are errors which expect the backend to recover. These are defin
 | 14 | Unavailable |
 | 15 | Data Loss |
 | 16 | Unauthenticated |
+
+Additional details on transient errors can be found in [otep-35](https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md#export-response) for gRPC and [otep-99](https://github.com/open-telemetry/oteps/blob/master/text/0099-otlp-http.md#failures) for HTTP

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -12,7 +12,7 @@ The configuration options are configurable separately for the `SpanExporter` and
 | Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto`. | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
 | Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
-| Headers              | The headers associated with gRPC requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
+| Headers              | The headers associated with gRPC or HTTP requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
 | Compression          | Compression key for supported compression types within collector. | gzip              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
 | Timeout              | Max waiting time for the collector to process each spans or metrics batch. | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
 

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Protocol Collector Exporter
 
-This document specifies the configuration options available to the OpenTelemetry Protocol (OTLP) Collector `SpanExporter` and `MetricsExporter` as well as the retry behavior.
+This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/opentelemetry-proto)) Collector `SpanExporter` and `MetricsExporter` as well as the retry behavior.
 
 ## Configuration Options
 
@@ -9,6 +9,7 @@ The configuration options are configurable separately for the `SpanExporter` and
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
 | Endpoint             | Target to which the exporter is going to send spans or metrics using the gRPC protocol. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto` | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
 | Insecure             | Whether to enable client transport security for the exporter's gRPC connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
 | Headers              | The headers associated with gRPC requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -8,7 +8,7 @@ The configuration options are configurable separately for the `SpanExporter` and
 
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
-| Endpoint             | Target to which the exporter is going to send spans or metrics using the gRPC protocol. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Endpoint             | Target to which the exporter is going to send spans or metrics. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
 | Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto` | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
 | Insecure             | Whether to enable client transport security for the exporter's gRPC connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
@@ -18,5 +18,24 @@ The configuration options are configurable separately for the `SpanExporter` and
 
 ## Retry
 
-Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
+[Transient errors](#transient-errors) MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
 
+## Transient Errors
+Transient errors are errors which expect the backend to recover. These are defined per protocol:
+
+| HTTP Status Code | Description |
+| ---------------- | ----------- |
+| 408 | Request Timeout |
+| 5xx | Server Errors |
+
+| gRPC Status Code | Description |
+| ---------------- | ----------- |
+| 1  | Cancelled |
+| 4  | Deadline Exceeded |
+| 7  | Permission Denied |
+| 8  | Resource Exhausted |
+| 10 | Aborted |
+| 10 | Out of Range |
+| 14 | Unavailable |
+| 15 | Data Loss |
+| 16 | Unauthenticated |

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
-# OpenTelemetry Protocol Collector Exporter
+# OpenTelemetry Protocol Exporter
 
-This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md)) [Collector](https://github.com/open-telemetry/opentelemetry-collector) `SpanExporter` and `MetricsExporter` as well as the retry behavior.
+This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md)) `SpanExporter` and `MetricsExporter` as well as the retry behavior.
 
 ## Configuration Options
 
@@ -9,12 +9,12 @@ The configuration options are configurable separately for the `SpanExporter` and
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
 | Endpoint             | Target to which the exporter is going to send spans or metrics. This MAY be configured to include a path (e.g. `example.com/v1/traces`). | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
-| Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto`. | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
+| Protocol             | The protocol used to transmit the data. One of `grpc`,`http/json`,`http/proto`. | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
 | Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
 | Headers              | The headers associated with gRPC or HTTP requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
-| Compression          | Compression key for supported compression types within collector. Supported compression: `gzip`| no compression              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
-| Timeout              | Max waiting time for the collector to process each spans or metrics batch. | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
+| Compression          | Compression key for supported compression types. Supported compression: `gzip`| no compression              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
+| Timeout              | Max waiting time for the backend to process each spans or metrics batch. | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
 
 ## Retry
 

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -1,0 +1,21 @@
+# OpenTelemetry Protocol Collector Exporter
+
+This document specifies the configuration options available to the OpenTelemetry Protocol (OTLP) Collector `SpanExporter` and `MetricsExporter` as well as the retry behavior.
+
+## Configuration Options
+
+The configuration options are configurable separately for the `SpanExporter` and the `MetricsExporter`.
+
+| Configuration Option | Description                                                  | Default           | Env variable                                                 |
+| -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
+| Endpoint             | target to which the exporter is going to send spans or metrics using the gRPC protocol. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Insecure             | whether to enable client transport security for the exporter's gRPC connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
+| Certificate File     | certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
+| Headers              | the headers associated with gRPC requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
+| Compression          | compression key for supported compression types within collector | gzip              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
+| Timeout              | max waiting time for the collector to process each spans or metrics batch | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
+
+## Retry
+
+Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
+

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Protocol Collector Exporter
 
-This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/opentelemetry-proto)) [Collector](https://github.com/open-telemetry/opentelemetry-collector) `SpanExporter` and `MetricsExporter` as well as the retry behavior.
+This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md)) [Collector](https://github.com/open-telemetry/opentelemetry-collector) `SpanExporter` and `MetricsExporter` as well as the retry behavior.
 
 ## Configuration Options
 

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -8,9 +8,9 @@ The configuration options are configurable separately for the `SpanExporter` and
 
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
-| Endpoint             | Target to which the exporter is going to send spans or metrics. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
-| Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto` | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
-| Insecure             | Whether to enable client transport security for the exporter's gRPC connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
+| Endpoint             | Target to which the exporter is going to send spans or metrics. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Protocol             | The protocol used to send data to the collector. One of `grpc`,`http/json`,`http/proto`. | `grpc`               | `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
+| Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
 | Headers              | The headers associated with gRPC requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
 | Compression          | Compression key for supported compression types within collector. | gzip              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -8,12 +8,12 @@ The configuration options are configurable separately for the `SpanExporter` and
 
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
-| Endpoint             | target to which the exporter is going to send spans or metrics using the gRPC protocol. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
-| Insecure             | whether to enable client transport security for the exporter's gRPC connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
-| Certificate File     | certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
-| Headers              | the headers associated with gRPC requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
-| Compression          | compression key for supported compression types within collector | gzip              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
-| Timeout              | max waiting time for the collector to process each spans or metrics batch | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
+| Endpoint             | Target to which the exporter is going to send spans or metrics using the gRPC protocol. The valid syntax is described at https://github.com/grpc/grpc/blob/master/doc/naming.md. | `localhost:55680` | `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Insecure             | Whether to enable client transport security for the exporter's gRPC connection. See [grpc.WithInsecure()](https://godoc.org/google.golang.org/grpc#WithInsecure). | `false`           | `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
+| Certificate File     | Certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
+| Headers              | The headers associated with gRPC requests.                   | n/a               | `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
+| Compression          | Compression key for supported compression types within collector. | gzip              | `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
+| Timeout              | Max waiting time for the collector to process each spans or metrics batch. | 60s               | `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
 
 ## Retry
 

--- a/specification/trace/sdk_exporters/otlp.md
+++ b/specification/trace/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Protocol Collector Exporter
 
-This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/opentelemetry-proto)) Collector `SpanExporter` and `MetricsExporter` as well as the retry behavior.
+This document specifies the configuration options available to the OpenTelemetry Protocol ([OTLP](https://github.com/open-telemetry/opentelemetry-proto)) [Collector](https://github.com/open-telemetry/opentelemetry-collector) `SpanExporter` and `MetricsExporter` as well as the retry behavior.
 
 ## Configuration Options
 


### PR DESCRIPTION
This PR adds configuration and retry behaviour specification for the OTLP exporter. Most of the configuration options are based off of the opentelemetry-collector configuration and the environment variables proposed are based on #666 

Fixes #681 