### PR TITLE
Add issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/context.md
+++ b/.github/ISSUE_TEMPLATE/context.md
@@ -1,0 +1,13 @@
+---
+name: Context
+about: Issues related to the specification/context directory
+labels: spec:context
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/correlationcontext.md
+++ b/.github/ISSUE_TEMPLATE/correlationcontext.md
@@ -1,0 +1,13 @@
+---
+name: CorrelationContext
+about: Issues related to the specification/correlationcontext directory
+labels: spec:correlationcontext
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/logs.md
+++ b/.github/ISSUE_TEMPLATE/logs.md
@@ -1,0 +1,13 @@
+---
+name: Logs
+about: Issues related to the specification/logs directory
+labels: spec:logs
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/metrics.md
+++ b/.github/ISSUE_TEMPLATE/metrics.md
@@ -1,0 +1,13 @@
+---
+name: Metrics
+about: Issues related to the specification/metrics directory
+labels: spec:metrics
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/miscellaneous.md
+++ b/.github/ISSUE_TEMPLATE/miscellaneous.md
@@ -1,7 +1,7 @@
 ---
 name: Miscellaneous (anything else)
 about: Issues that do not fit into other categories
-labels: area:miscellaneous
+labels: spec:miscellaneous
 ---
 
 **What are you trying to achieve?**

--- a/.github/ISSUE_TEMPLATE/miscellaneous.md
+++ b/.github/ISSUE_TEMPLATE/miscellaneous.md
@@ -1,0 +1,13 @@
+---
+name: Miscellaneous (anything else)
+about: Issues that do not fit into other categories
+labels: area:miscellaneous
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/protocol.md
+++ b/.github/ISSUE_TEMPLATE/protocol.md
@@ -1,0 +1,13 @@
+---
+name: Protocol
+about: Issues related to the specification/protocol directory
+labels: spec:protocol
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/resource.md
+++ b/.github/ISSUE_TEMPLATE/resource.md
@@ -1,0 +1,13 @@
+---
+name: Resource
+about: Issues related to the specification/resource directory
+labels: spec:resource
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/ISSUE_TEMPLATE/trace.md
+++ b/.github/ISSUE_TEMPLATE/trace.md
@@ -1,0 +1,13 @@
+---
+name: Trace
+about: Issues related to the specification/trace directory
+labels: spec:trace
+---
+
+**What are you trying to achieve?**
+
+What did you expect to see?
+
+**Additional context.**
+
+Add any other context about the problem here. If you followed an existing documentation, please share the link to it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Fixes #
+
+## Changes
+
+Please provide a brief description of the changes here.
+
+Related issues #
+
+Related [oteps](https://github.com/open-telemetry/oteps) #


### PR DESCRIPTION
Follow up on the 7/14/20 SIG meeting, adding the issue/PR templates to make triage easier.