### PR TITLE
Specify how probability sampler is used with ParentOrElse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Updates:
 
 - Add semantic convention for NGINX custom HTTP 499 status code.
 - Adapt semantic conventions for the span name of messaging systems ([#690](https://github.com/open-telemetry/opentelemetry-specification/pull/690))
+- Specify how `Probability` sampler is used with `ParentOrElse` sampler.
 
 ## v0.6.0 (07-01-2020)
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -109,16 +109,12 @@ Description MUST NOT change over time and caller can cache the returned value.
 
 #### Probability
 
-* The default behavior should be to trust the parent `SampledFlag`. However
-  there should be configuration to change this.
-* The default behavior is to apply the sampling probability only for Spans
-  that are root spans (no parent) and Spans with remote parent. However there
-  should be configuration to change this to "root spans only", or "all spans".
+* The `ProbabilitySampler` MUST ignore the parent `SampledFlag`.
+  To respect the parent `SampledFlag`, the `ProbabilitySampler` should be used as a delegate of the `ParentOrElse` sampler specified below.
 * Description MUST be `ProbabilitySampler{0.000100}`.
 
-TODO: Add details about how the probability sampler is implemented as a function
+TODO: Add details about how the `ProbabilitySampler` is implemented as a function
 of the `TraceID`.
-TODO: Split out the parent handling.
 
 #### ParentOrElse
 


### PR DESCRIPTION
I noticed that the `Probability` sampler specification still specifies parent handling, but that it is superseded by the existence of the `ParentOrElse` sampler. This change makes it clear that parent handling should be done by `ParentOrElse` sampler and that `Probability` sampler does only probability.
