### PR TITLE
Unify the batch span processor parameters

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -270,7 +270,7 @@ configured `SpanExporter`.
   dropped. The default value is `2048`.
 * `scheduledDelayMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
-* `exporterTimeoutMillis` - how long the export can run before it is cancelled.
+* `exportTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
   smaller or equal to `maxQueueSize`. The default value is `512`.


### PR DESCRIPTION
The parameter `maxExportBatchSize` refers to "export", but `exporterTimeoutMillis` refers to the "exporter".  This unifies on "export" since they are both in reference to the same process.