### PR TITLE
Describe in-band and out-of-band terms

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -45,6 +45,7 @@ or by another [Instrumentation Library](#instrumentation-library).
 
 Example: `org.mongodb.client`.
 
+<a name="instrumenting_library"></a>
 <a name="instrumentation_library"></a>
 ### Instrumentation Library
 
@@ -63,7 +64,8 @@ Synonyms: *Instrumenting Library*.
 ### Tracer Name / Meter Name
 
 This refers to the `name` and (optional) `version` arguments specified when
-creating a new `Tracer` or `Meter` (see [Obtaining a Tracer](trace/api.md#obtaining-a-tracer)/[Obtaining a Meter](metrics/api.md#meter-interface)). The name/version pair identifies the [Instrumentation Library](#instrumentation-library).
+creating a new `Tracer` or `Meter` (see [Obtaining a Tracer](trace/api.md#obtaining-a-tracer)/[Obtaining a Meter](metrics/api.md#meter-interface)).
+The name/version pair identifies the [Instrumentation Library](#instrumentation-library).
 
 ## Logs
 
@@ -73,7 +75,7 @@ A recording of an event. Typically the record includes a timestamp indicating
 when the event happened as well as other data that describes what happened,
 where it happened, etc.
 
-Also known as Log Entry.
+Synonyms: *Log Entry*.
 
 ### Log
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -5,6 +5,25 @@ specification.
 
 ## Common
 
+<a name="in-band"></a>
+<a name="out-of-band"></a>
+
+### In-band and Out-of-band Data
+
+> In telecommunications, **in-band signaling** is the sending of control information within the same band or channel used for data such as voice or video. This is in contrast to **out-of-band signaling** which is sent over a different channel, or even over a separate network ([Wikipedia](https://en.wikipedia.org/wiki/In-band_signaling)).
+
+In OpenTelemetry we refer to **in-band data** as data that is passed
+between components of a distributed system as part of business messages,
+for example, when trace or correlation contexts are included
+in the HTTP requests in the form of HTTP headers.
+Such data usually does not contain the telemetry,
+but is used to correlate and join the telemetry produced by various components.
+The telemetry itself is referred to as **out-of-band data**:
+it is transmitted from applications via dedicated messages,
+usually asynchronously by background routines
+rather than from the critical path of the business logic.
+Metrics, logs, and traces exported to telemetry backends are examples of out-of-band data.
+
 ### Telemetry SDK
 
 Denotes the library that implements the *OpenTelemetry API*.
@@ -44,24 +63,6 @@ Example: `io.opentelemetry.contrib.mongodb`.
 Synonyms: *Instrumenting Library*
 
 <a name="instrumentation_library"></a>
-
-<a name="in-band"></a>
-<a name="out-of-band"></a>
-
-### In-band and Out-of-band Data
-
-> In telecommunications, **in-band** signaling is the sending of control information within the same band or channel used for data such as voice or video. This is in contrast to **out-of-band** signaling which is sent over a different channel, or even over a separate network ([Wikipedia](https://en.wikipedia.org/wiki/In-band_signaling)).
-
-In OpenTelemetry we refer to **in-band data** as data
-that is passed between components of a distributed system as part of the business requests,
-for example, when trace or correlation contexts are included in the requests in the form of HTTP headers.
-Such data usually does not contain the telemetry,
-but is used to correlate and join the telemetry produced by various components.
-The telemetry itself is referred to as **out-of-band data**:
-it is transferred from applications in dedicated requests,
-usually asynchronously by background routines,
-rather than from the critical path of the business logic.
-Metrics, logs, and traces exported to telemetry backends are examples of out-of-band data.
 
 ### Tracer Name / Meter Name
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -52,7 +52,16 @@ Synonyms: *Instrumenting Library*
 
 > In telecommunications, **in-band** signaling is the sending of control information within the same band or channel used for data such as voice or video. This is in contrast to **out-of-band** signaling which is sent over a different channel, or even over a separate network ([Wikipedia](https://en.wikipedia.org/wiki/In-band_signaling)).
 
-In OpenTelemetry we refer to **in-band data** as data that is passed between components of a distributed system as part of the business requests, for example, when trace or correlation contexts are included in the requests in the form of HTTP headers. Such data usually does not contain the telemetry, but is used to correlate and join the telemetry produced by various components. The telemetry itself is referred to as **out-of-band data**, because it is exported from applications asynchronously, usually by background routines, rather than from the critical path of the business logic. Metrics, logs, and traces exported to telemetry backends are the examples of out-of-band data.
+In OpenTelemetry we refer to **in-band data** as data
+that is passed between components of a distributed system as part of the business requests,
+for example, when trace or correlation contexts are included in the requests in the form of HTTP headers.
+Such data usually does not contain the telemetry,
+but is used to correlate and join the telemetry produced by various components.
+The telemetry itself is transferred as **out-of-band data**:
+it is transferred from applications in dedicated requests,
+usually asynchronously by background routines,
+rather than from the critical path of the business logic.
+Metrics, logs, and traces exported to telemetry backends are examples of out-of-band data.
 
 ### Tracer Name / Meter Name
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -7,7 +7,6 @@ specification.
 
 <a name="in-band"></a>
 <a name="out-of-band"></a>
-
 ### In-band and Out-of-band Data
 
 > In telecommunications, **in-band signaling** is the sending of control information within the same band or channel used for data such as voice or video. This is in contrast to **out-of-band signaling** which is sent over a different channel, or even over a separate network ([Wikipedia](https://en.wikipedia.org/wiki/In-band_signaling)).
@@ -24,32 +23,29 @@ usually asynchronously by background routines
 rather than from the critical path of the business logic.
 Metrics, logs, and traces exported to telemetry backends are examples of out-of-band data.
 
+<a name="telemetry_sdk"></a>
 ### Telemetry SDK
 
 Denotes the library that implements the *OpenTelemetry API*.
 
 See [Library Guidelines](library-guidelines.md#sdk-implementation) and
-[Library resource semantic conventions](resource/semantic_conventions/README.md#telemetry-sdk)
+[Library resource semantic conventions](resource/semantic_conventions/README.md#telemetry-sdk).
 
-<a name="telemetry_sdk"></a>
-
+<a name="exporter_library"></a>
 ### Exporter Library
 
 Libraries which are compatible with the [Telemetry SDK](glossary.md#telemetry-sdk) and provide functionality to emit telemetry to consumers.
-
-<a name="exporter_library"></a>
 
 ### Instrumented Library
 
 Denotes the library for which the telemetry signals (traces, metrics, logs) are gathered.
 
 The calls to the OpenTelemetry API can be done either by the Instrumented Library itself,
-or by another [Instrumenting Library](#instrumenting_library).
+or by another [Instrumentation Library](#instrumentation-library).
 
 Example: `org.mongodb.client`.
 
-<a name="instrumenting_library"></a>
-
+<a name="instrumentation_library"></a>
 ### Instrumentation Library
 
 Denotes the library that provides the instrumentation for a given [Instrumented Library](#instrumented-library).
@@ -60,14 +56,14 @@ See [Overview](overview.md#instrumentation-libraries) for a more detailed defini
 
 Example: `io.opentelemetry.contrib.mongodb`.
 
-Synonyms: *Instrumenting Library*
+Synonyms: *Instrumenting Library*.
 
-<a name="instrumentation_library"></a>
-
+<a name="tracer-name"></a>
+<a name="meter-name"></a>
 ### Tracer Name / Meter Name
 
 This refers to the `name` and (optional) `version` arguments specified when
-creating a new `Tracer` or `Meter` (see [Obtaining a Tracer](trace/api.md#obtaining-a-tracer)/[Obtaining a Meter](metrics/api.md#meter-interface)). It identifies the [Instrumenting Library](#instrumenting_library).
+creating a new `Tracer` or `Meter` (see [Obtaining a Tracer](trace/api.md#obtaining-a-tracer)/[Obtaining a Meter](metrics/api.md#meter-interface)). The name/version pair identifies the [Instrumentation Library](#instrumentation-library).
 
 ## Logs
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -34,7 +34,7 @@ See [Library Guidelines](library-guidelines.md#sdk-implementation) and
 <a name="exporter_library"></a>
 ### Exporter Library
 
-Libraries which are compatible with the [Telemetry SDK](glossary.md#telemetry-sdk) and provide functionality to emit telemetry to consumers.
+Libraries which are compatible with the [Telemetry SDK](#telemetry-sdk) and provide functionality to emit telemetry to consumers.
 
 ### Instrumented Library
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -57,7 +57,7 @@ that is passed between components of a distributed system as part of the busines
 for example, when trace or correlation contexts are included in the requests in the form of HTTP headers.
 Such data usually does not contain the telemetry,
 but is used to correlate and join the telemetry produced by various components.
-The telemetry itself is transferred as **out-of-band data**:
+The telemetry itself is referred to as **out-of-band data**:
 it is transferred from applications in dedicated requests,
 usually asynchronously by background routines,
 rather than from the critical path of the business logic.

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -45,10 +45,10 @@ Synonyms: *Instrumenting Library*
 
 <a name="instrumentation_library"></a>
 
-### In-band and Out-of-band Data
-
 <a name="in-band"></a>
 <a name="out-of-band"></a>
+
+### In-band and Out-of-band Data
 
 > In telecommunications, **in-band** signaling is the sending of control information within the same band or channel used for data such as voice or video. This is in contrast to **out-of-band** signaling which is sent over a different channel, or even over a separate network ([Wikipedia](https://en.wikipedia.org/wiki/In-band_signaling)).
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -45,6 +45,15 @@ Synonyms: *Instrumenting Library*
 
 <a name="instrumentation_library"></a>
 
+### In-band and Out-of-band Data
+
+<a name="in-band"></a>
+<a name="out-of-band"></a>
+
+> In telecommunications, **in-band** signaling is the sending of control information within the same band or channel used for data such as voice or video. This is in contrast to **out-of-band** signaling which is sent over a different channel, or even over a separate network ([Wikipedia](https://en.wikipedia.org/wiki/In-band_signaling)).
+
+In OpenTelemetry we refer to **in-band data** as data that is passed between components of a distributed system as part of the business requests, for example, when trace or correlation contexts are included in the requests in the form of HTTP headers. Such data usually does not contain the telemetry, but is used to correlate and join the telemetry produced by various components. The telemetry itself is referred to as **out-of-band data**, because it is exported from applications asynchronously, usually by background routines, rather than from the critical path of the business logic. Metrics, logs, and traces exported to telemetry backends are the examples of out-of-band data.
+
 ### Tracer Name / Meter Name
 
 This refers to the `name` and (optional) `version` arguments specified when


### PR DESCRIPTION
* Resolves #711 
* Fixes #715

The Markdown automatically add section anchors in the form `#section-caption-words`. Since this document contained old (redundant) anchors that used underscore between words I kept them for backwards compatibility.