### PR TITLE
Add requirements for how the Trace API should behave in the absence of an SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ the release.
 New:
 
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))
+- Clarification of the behavior of the Trace API, re: context propagation, in the absence of an installed SDK
 - Add Span API and semantic conventions for recording exceptions
   ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697))
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -714,5 +714,5 @@ requested parent SpanContext:
 context for the newly created `Span`. This means that a `SpanContext` that has been provided by a configured `Propagator`
 will be propagated through to any child span, but that no new `SpanContext`s will be created.
 * No valid `SpanContext` is specified as the parent of the new `Span`: The API MUST create an non-valid
-(both SpanID and TradeID are all zeros) `Span` for use
+(both SpanID and TradeID are equivalent to being all zeros) `Span` for use
 by the API caller. This means that both the `TraceID` and the `SpanID` should be invalid.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -712,7 +712,7 @@ requested parent SpanContext:
 
 * A valid `SpanContext` is specified as the parent of the new `Span`: The API MUST treat this parent context as the
 context for the newly created `Span`. This means that a `SpanContext` that has been provided by a configured `Propagator`
-will be propagated through the resulting call stack, but that no new `SpanContext`s will be created.
+will be propagated through to any child span, but that no new `SpanContext`s will be created.
 * No valid `SpanContext` is specified as the parent of the new `Span`: The API MUST create an non-valid
 (both SpanID and TradeID are all zeros) `Span` for use
 by the API caller. This means that both the `TraceID` and the `SpanID` should be invalid.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -704,14 +704,14 @@ The API layer MAY include the following `Propagator`s:
 ## Behavior of the API in the absence of an installed SDK
 
 In general, in the absence of an installed SDK, the Trace API is intended to a "no-op" API.
-This means that operations on a Tracer should have no side effects and do nothing. However, there
+This means that operations on a Tracer, or on Spans, should have no side effects and do nothing. However, there
 is one important exception to this general rule, and that is related to propagation of a SpanContext.
 
-Several cases must be considered when a new Span is requested to be created, especially in relation to the
+The following cases must be considered when a new Span is requested to be created, especially in relation to the
 requested parent SpanContext:
 
-* A valid SpanContext is specified as the parent of the new Span: The API MUST treat this parent context as the
-context for the newly created Span. This means that a SpanContext that has been provided by a configured Propagator
-will be propagated through the resulting call stack, but that no new Spans will be created.
-* No valid SpanContext is specified as the parent of the new Span: The API MUST create an invalid Span for use
-by the API caller. This means that both the TraceID and the SpanID should be invalid.
+* A valid `SpanContext` is specified as the parent of the new `Span`: The API MUST treat this parent context as the
+context for the newly created `Span`. This means that a `SpanContext` that has been provided by a configured `Propagator`
+will be propagated through the resulting call stack, but that no new `SpanContext`s will be created.
+* No valid `SpanContext` is specified as the parent of the new `Span`: The API MUST create an invalid `Span` for use
+by the API caller. This means that both the `TraceID` and the `SpanID` should be invalid.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -703,7 +703,7 @@ The API layer MAY include the following `Propagator`s:
 
 ## Behavior of the API in the absence of an installed SDK
 
-In general, in the absence of an installed SDK, the Trace API is intended to a "no-op" API.
+In general, in the absence of an installed SDK, the Trace API is a "no-op" API.
 This means that operations on a Tracer, or on Spans, should have no side effects and do nothing. However, there
 is one important exception to this general rule, and that is related to propagation of a SpanContext.
 
@@ -713,5 +713,6 @@ requested parent SpanContext:
 * A valid `SpanContext` is specified as the parent of the new `Span`: The API MUST treat this parent context as the
 context for the newly created `Span`. This means that a `SpanContext` that has been provided by a configured `Propagator`
 will be propagated through the resulting call stack, but that no new `SpanContext`s will be created.
-* No valid `SpanContext` is specified as the parent of the new `Span`: The API MUST create an invalid `Span` for use
+* No valid `SpanContext` is specified as the parent of the new `Span`: The API MUST create an non-valid
+(both SpanID and TradeID are all zeros) `Span` for use
 by the API caller. This means that both the `TraceID` and the `SpanID` should be invalid.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -476,8 +476,8 @@ The Span interface MUST provide:
 Updates the `Span` name. Upon this update, any sampling behavior based on `Span`
 name will depend on the implementation.
 
-Note that [Samplers](sdk.md#sampler) can only consider information already 
-present during span creation. Any changes done later, including updated span 
+Note that [Samplers](sdk.md#sampler) can only consider information already
+present during span creation. Any changes done later, including updated span
 name, cannot change their decisions.
 
 Alternatives for the name update may be late `Span` creation, when Span is
@@ -700,3 +700,18 @@ implementer of these links.
 The API layer MAY include the following `Propagator`s:
 
 * A `HTTPTextPropagator` implementing the [W3C TraceContext Specification](https://www.w3.org/TR/trace-context/).
+
+## Behavior of the API in the absence of an installed SDK
+
+In general, in the absence of an installed SDK, the Trace API is intended to a "no-op" API.
+This means that operations on a Tracer should have no side effects and do nothing. However, there
+is one important exception to this general rule, and that is related to propagation of a SpanContext.
+
+Several cases must be considered when a new Span is requested to be created, especially in relation to the
+requested parent SpanContext:
+
+* A valid SpanContext is specified as the parent of the new Span: The API MUST treat this parent context as the
+context for the newly created Span. This means that a SpanContext that has been provided by a configured Propagator
+will be propagated through the resulting call stack, but that no new Spans will be created.
+* No valid SpanContext is specified as the parent of the new Span: The API MUST create an invalid Span for use
+by the API caller. This means that both the TraceID and the SpanID should be invalid.


### PR DESCRIPTION
Clarifies the behavior of the Trace API, in the absence of an installed SDK, especially with respect to context propagation.

Fixes #689 

## Changes

Adds requirements for Trace API behavior in the absence of an SDK.

