### PR TITLE
And semantic conventions for Display Hints

### DIFF
--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -37,7 +37,9 @@ are set.
 
 The value of `display.attribute` MUST match another attribute key, with the expectation that 
 the value of that attribute will be used as the span name in the display. If both 
-`display.name` and `display.attribute` are set, `display.name` should take precedence.
+`display.name` and `display.attribute` are set, `display.name` should take precedence. If 
+the value of the attribute `display.attribute` points to is unset or empty, this field 
+should be ignored.
 
 The `display.type` field may match an appropriate namespace (db, http, faas, etc) or be 
 completely custom.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -44,6 +44,25 @@ should be ignored.
 The `display.type` field may match an appropriate namespace (db, http, faas, etc) or be 
 completely custom.
 
+### Example 
+Imagine instrumenting a simple http client, HipClient, which does not have a concept 
+of routes or handlers. In this case, the span name would default to a low cardinaility grouping
+such as "HTTP {METHOD_NAME}". This may be useful for grouping, but it is not nearly as helpful as 
+the url, or potentially method name plus the url. It may also be helpful to display to the user
+that the type of http request was a HipClient request.
+
+In this example, the low cardinality span name could be replaced with something more readable:
+
+* **Span Name**: "HTTP GET"
+* **display.name**: "GET /account/123"
+* **display.type**: "HipClient"
+
+Alternatively, if the `http.url` attribute has been set on the span, it could be referenced 
+for the display name:
+* **Span Name**: "HTTP GET"
+* **display.attribute**: "http.url"
+* **display.type**: "HipClient"
+
 ## General network connection attributes
 
 These attributes may be used for any network related operation.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -7,7 +7,7 @@ Particular operations may refer to or require some of these attributes.
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 
 <!-- toc -->
-
+- [Display hints for spans](#display-hints)
 - [General network connection attributes](#general-network-connection-attributes)
   * [`net.transport` attribute](#nettransport-attribute)
   * [`net.*.name` attributes](#netname-attributes)
@@ -15,6 +15,36 @@ Particular operations may refer to or require some of these attributes.
 - [General identity attributes](#general-identity-attributes)
 
 <!-- tocstop -->
+
+## Display hints
+
+UIs are expected to utilize all available semantic conventions when choosing how to 
+display a span, and to make their own decisions about what information is most important. 
+However, there are cases when display hints can be helpful, especially when the spans 
+represent a non-standard operation or have a span name which is useful for grouping but 
+poor for human readability.
+
+| Attribute name | Notes and examples                                                  |
+| :------------- | :------------------------------------------------------------------ |
+|`display.name`  | a custom span name to display instead of the span name              |
+|`display.field` | the key to the attribute which should be used as the display name   |
+|`display.type`  | clarifies the type of operation being performed                     |
+
+
+All display hints are optional. These display hints are not required to be set by 
+instrumentation, and it is not required that UIs respect their values, even when they 
+are set.
+
+The value of `display.field` MUST match another attribute key, with the expectation that 
+the value of that field will be used as the span name in the display. If both 
+`display.name` and `display.field` are set, `display.name` should take precedence.
+
+The `display.type` field may match an appropriate namespace (db, http, faas, etc) or be 
+completely custom.
+
+
+
+
 
 ## General network connection attributes
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -24,11 +24,11 @@ However, there are cases when display hints can be helpful, especially when the 
 represent a non-standard operation or have a span name which is useful for grouping but 
 poor for human readability.
 
-| Attribute name | Notes and examples                                                  |
-| :------------- | :------------------------------------------------------------------ |
-|`display.name`  | a custom span name to display instead of the span name              |
+| Attribute name     | Notes and examples                                                  |
+| :----------------- | :------------------------------------------------------------------ |
+|`display.name`      | a custom span name to display instead of the span name              |
 |`display.attribute` | the key to the attribute which should be used as the display name   |
-|`display.type`  | clarifies the type of operation being performed                     |
+|`display.type`      | clarifies the type of operation being performed                     |
 
 
 All display hints are optional. These display hints are not required to be set by 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -27,7 +27,7 @@ poor for human readability.
 | Attribute name | Notes and examples                                                  |
 | :------------- | :------------------------------------------------------------------ |
 |`display.name`  | a custom span name to display instead of the span name              |
-|`display.field` | the key to the attribute which should be used as the display name   |
+|`display.attribute` | the key to the attribute which should be used as the display name   |
 |`display.type`  | clarifies the type of operation being performed                     |
 
 
@@ -35,9 +35,9 @@ All display hints are optional. These display hints are not required to be set b
 instrumentation, and it is not required that UIs respect their values, even when they 
 are set.
 
-The value of `display.field` MUST match another attribute key, with the expectation that 
-the value of that field will be used as the span name in the display. If both 
-`display.name` and `display.field` are set, `display.name` should take precedence.
+The value of `display.attribute` MUST match another attribute key, with the expectation that 
+the value of that attribute will be used as the span name in the display. If both 
+`display.name` and `display.attribute` are set, `display.name` should take precedence.
 
 The `display.type` field may match an appropriate namespace (db, http, faas, etc) or be 
 completely custom.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -42,10 +42,6 @@ the value of that field will be used as the span name in the display. If both
 The `display.type` field may match an appropriate namespace (db, http, faas, etc) or be 
 completely custom.
 
-
-
-
-
 ## General network connection attributes
 
 These attributes may be used for any network related operation.


### PR DESCRIPTION
This PR adds several display hints to resolve issues related to identifying spans in a UI. 

* `display.name` for overriding the span name with a custom name.
* `display.attribute` for overriding the span name with the value of another attribute.
* `display.type` for an additional display grouping, adding back in the functionality formerly provided by the `component` tag from OpenTracing.

These hints are optional; there is no requirement that instrumentation provide them, or that UIs respect them.

### Related issues
https://github.com/open-telemetry/opentelemetry-specification/issues/531
https://github.com/open-telemetry/opentelemetry-specification/issues/557

