### PR TITLE
Close stale PRs

### DIFF
--- a/.github/workflows/state-pr.yaml
+++ b/.github/workflows/state-pr.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days'
+        stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
         close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
         days-before-stale: 14
         days-before-close: 7

--- a/.github/workflows/state-pr.yaml
+++ b/.github/workflows/state-pr.yaml
@@ -1,0 +1,17 @@
+name: "Close stale pull requests"
+on:
+  schedule:
+    - cron: "12 3 * * *" # arbitrary time not to DDOS GitHub
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-pr-message: 'This PR was marked stale due to lack of inactivity. It will be closed in 7 days'
+        close-pr-message: 'Closed as inactive'
+        days-before-stale: 14
+        days-before-close: 7
+        debug-only: true

--- a/.github/workflows/state-pr.yaml
+++ b/.github/workflows/state-pr.yaml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-pr-message: 'This PR was marked stale due to lack of inactivity. It will be closed in 7 days'
+        stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days'
         close-pr-message: 'Closed as inactive'
         days-before-stale: 14
         days-before-close: 7

--- a/.github/workflows/state-pr.yaml
+++ b/.github/workflows/state-pr.yaml
@@ -11,7 +11,7 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days'
-        close-pr-message: 'Closed as inactive'
+        close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
         days-before-stale: 14
         days-before-close: 7
         debug-only: true


### PR DESCRIPTION
As discussed during today's maintainers meeting, this PR adds stale bot to the specification repo to close stale PRs.

For now I suggest running it in debug mode, without actually closing PRs. In a few days, when I verify it seems to be working (testing in production FTW), I will submit second PR removing debug mode.