### PR TITLE
Add exception.event event attribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New:
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))
 - Add Span API and semantic conventions for exceptions
   ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
-  [#???](https://github.com/open-telemetry/opentelemetry-specification/pull/???))
+  [#747](https://github.com/open-telemetry/opentelemetry-specification/pull/747))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ the release.
 New:
 
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))
+- Add Span API and semantic conventions for exceptions
+  ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
+  [#???](https://github.com/open-telemetry/opentelemetry-specification/pull/???))
 
 Updates:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -510,8 +510,8 @@ MUST record an exception as an `Event` with the conventions outlined in the
 
 Examples:
 
-- `RecordException(exception: Exception)`
-- `RecordException(type: String, message: String, stacktrace: String)`
+- `RecordException(exception: Exception, event: ExceptionEvent)`
+- `RecordException(type: String, message: String, stacktrace: String, event: ExceptionEvent)`
 
 ### Span lifetime
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -58,6 +58,8 @@ grained information from a stacktrace, if necessary.
 [go-stacktrace]: https://golang.org/pkg/runtime/debug/#Stack
 [telemetry-sdk-resource]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#telemetry-sdk
 
+<a name="exception.event"></a>
+
 ### exception.event
 
 This string describes what event occurred. It MUST be one of the following strings:

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -68,7 +68,9 @@ This string describes what event occurred. It MUST be one of the following strin
 * `translated`: A special case of `handled`:
   If the exception was translated into some non-exception error indicator
   (e.g. a `KeyNotFoundException` was caught and translated into an HTTP 404 status code).
-  If possible, instrumentations SHOULD NOT record a `handled` for the same exception immediately preceding this.
+  This can typically only be detected on a case-by-case basis for certain libraries
+  (like a HTTP framework instrumentation).
+  A generic exception instrumentation would not use this.
 * `thrown`: The exception was thrown (or rethrown).
   This is expected to be the most commonly recorded event.
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -79,7 +79,7 @@ This string describes what event occurred. It MUST be one of the following strin
   Instrumentations may not be able distinguish this from `thrown` and SHOULD use `thrown` if in doubt.
 
 Note that instrumentations are not expected to record all exception events.
-Typically, `thrown` is the most important events.
+Typically, `thrown` is the most important event.
 `rethrown` may also be useful especially if the original `thrown` event was not instrumented.
 Instrumentations should use good judgment of when to record `translated` and especially `handled` events.
 They may often not be that interesting and exception events can be relatively heavyweight.


### PR DESCRIPTION
Exceptions themselves are objects, not events, but several events related to them can happen. This PR adds a required semantic convention attribute to describe which one it was.

Be sure to read the discussion at https://github.com/open-telemetry/opentelemetry-specification/pull/697#discussion_r452853785.