### PR TITLE
Remove warnings about Span.UpdateName

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -415,6 +415,11 @@ clearing the previous value and dropping the attribute key from the set of attri
 Note that the OpenTelemetry project documents certain ["standard
 attributes"](semantic_conventions/README.md) that have prescribed semantic meanings.
 
+Note that [samplers](sdk.md#sampler) can only consider information already
+present during span creation. Any changes done later, including new or changed
+attributes, cannot be considered for sampling.
+
+
 #### Add Events
 
 A `Span` MUST have the ability to add events. Events have a time associated
@@ -464,15 +469,9 @@ The Span interface MUST provide:
 Updates the `Span` name. Upon this update, any sampling behavior based on `Span`
 name will depend on the implementation.
 
-It is highly discouraged to update the name of a `Span` after its creation.
-`Span` name is often used to group, filter and identify the logical groups of
-spans. And often, filtering logic will be implemented before the `Span` creation
-for performance reasons. Thus the name update may interfere with this logic.
-
-The function name is called `UpdateName` to differentiate this function from the
-regular property setter. It emphasizes that this operation signifies a major
-change for a `Span` and may lead to re-calculation of sampling or filtering
-decisions made previously depending on the implementation.
+Note that [samplers](sdk.md#sampler) can only consider information already 
+present during span creation. Any changes done later, including updated span 
+name, cannot be considered for sampling.
 
 Alternatives for the name update may be late `Span` creation, when Span is
 started with the explicit timestamp from the past at the moment where the final

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -415,7 +415,7 @@ clearing the previous value and dropping the attribute key from the set of attri
 Note that the OpenTelemetry project documents certain ["standard
 attributes"](semantic_conventions/README.md) that have prescribed semantic meanings.
 
-Note that [samplers](sdk.md#sampler) can only consider information already
+Note that [Samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any changes done later, including new or changed
 attributes, cannot change their decisions.
 
@@ -469,7 +469,7 @@ The Span interface MUST provide:
 Updates the `Span` name. Upon this update, any sampling behavior based on `Span`
 name will depend on the implementation.
 
-Note that [samplers](sdk.md#sampler) can only consider information already 
+Note that [Samplers](sdk.md#sampler) can only consider information already 
 present during span creation. Any changes done later, including updated span 
 name, cannot change their decisions.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -417,7 +417,7 @@ attributes"](semantic_conventions/README.md) that have prescribed semantic meani
 
 Note that [samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any changes done later, including new or changed
-attributes, cannot be considered for sampling.
+attributes, cannot change their decisions.
 
 
 #### Add Events
@@ -471,7 +471,7 @@ name will depend on the implementation.
 
 Note that [samplers](sdk.md#sampler) can only consider information already 
 present during span creation. Any changes done later, including updated span 
-name, cannot be considered for sampling.
+name, cannot change their decisions.
 
 Alternatives for the name update may be late `Span` creation, when Span is
 started with the explicit timestamp from the past at the moment where the final


### PR DESCRIPTION
Fixes #468 

Remove warnings against using `Span.UpdateName`. Adds notes about Samplers being unable to recalculate their decision after `Span.UpdateName` or `Span.SetAttribute`.

This PR somewhat duplicates #506 submitted by @toumorokoshi . I made new PR because that one gone stale and author does not answer.

Citing myself from https://github.com/open-telemetry/opentelemetry-specification/pull/506#issuecomment-662279351

>Please, can we keep the scope of our discussion to the scope of this PR?
>
>I support the opinion that we cannot remove Span.updateName completely, because doing that will make many instrumentations much more complicated. As was demonstrated several times both in this PR and in the related task, there are valid use-case where "good" span name is unknown until after span is created.
>
>I don't think that span name differs in any way from any other span attribute from Sampler perspective. So if sampler deals somehow with attribute changes, it has to deal with span name change as well.
>
>This comment from @c24t summarises it very nicely:
>
>>it's better for the spec to describe how implementations ought to be written than how users ought to use them. That is, if we provide an UpdateName API method the onus should be on the author of the sampler to explain that changes to the name won't affect the sampling decision, not on the user to know not to use that particular method.
>
>For these reasons I think we have to merge this PR. As long as we have Span.updateName method in our API we should NOT discourage its usage. If later we decide to remove that method, that will be done in later and separately. Current PR does not depend on that future potential.
