### PR TITLE
Clean up R/W span spec.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -194,6 +194,7 @@ A `Span` represents a single operation within a trace. Spans can be nested to
 form a trace tree. Each trace contains a root span, which typically describes
 the entire operation and, optionally, one or more sub-spans for its sub-operations.
 
+<a name="span-data-members"></a>
 `Span`s encapsulate:
 
 - The span name

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -188,10 +188,11 @@ Thus, the SDK specification defines sets of possible requirements for
   additionally must be able to retrieve all information that was added to the span
   (as with *readable span*).
 
-  It MUST be possible for functions being called with this to somehow obtain
-  the same `Span` instance and type that the span creation API returned
-  (or will return) to the user (e.g. the `Span` could be one of the parameters
-  passed to such a function, or a getter could be provided).
+  It MUST be possible for functions being called with this
+  to somehow obtain the same `Span` instance and type
+  that the [span creation API](api.md#span-creation) returned (or will return) to the user
+  (for example, the `Span` could be one of the parameters passed to such a function,
+  or a getter could be provided).
   
 ## Span processor
 
@@ -243,8 +244,8 @@ exceptions.
 * `Span` - a [read/write span object](#additional-span-interfaces) for the started span.
   It SHOULD be possible to keep a reference to this span object and updates to the span
   SHOULD be reflected in it.
-  (for example, this is useful for creating a SpanProcessor that periodically
-  evaluates/prints information about all active span from a background thread)
+  For example, this is useful for creating a SpanProcessor that periodically
+  evaluates/prints information about all active span from a background thread.
 
 **Returns:** `Void`
 


### PR DESCRIPTION
Follow-up to https://github.com/open-telemetry/opentelemetry-specification/pull/669#issuecomment-667148933

## Changes

* Adds a SHOULD requirement that for spans passed to OnStart, updates should be reflected.
* Makes the convoluted definitions of read/write and readable span easier to read.