### PR TITLE
Specify which exceptions SHOULD be recorded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ the release.
 New:
 
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))
+- Add Span API and semantic conventions for unhandled exceptions
+  ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
+  [#???](https://github.com/open-telemetry/opentelemetry-specification/pull/???))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ the release.
 New:
 
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))
-- Add Span API and semantic conventions for unhandled exceptions
+- Add Span API and semantic conventions for recording exceptions
   ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
   [#761](https://github.com/open-telemetry/opentelemetry-specification/pull/761))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ New:
 - Add resource semantic conventions for operating systems ([#693](https://github.com/open-telemetry/opentelemetry-specification/pull/693))
 - Add Span API and semantic conventions for unhandled exceptions
   ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
-  [#???](https://github.com/open-telemetry/opentelemetry-specification/pull/???))
+  [#761](https://github.com/open-telemetry/opentelemetry-specification/pull/761))
 
 Updates:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -513,6 +513,9 @@ Examples:
 - `RecordException(exception: Exception)`
 - `RecordException(type: String, message: String, stacktrace: String)`
 
+Note that as per the semantic conventions, only exceptions leaving the scope of
+a span unhandled must be recorded.
+
 ### Span lifetime
 
 Span lifetime represents the process of recording the start and the end

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -510,8 +510,8 @@ MUST record an exception as an `Event` with the conventions outlined in the
 
 Examples:
 
-- `RecordException(exception: Exception, leftScope: boolean? = null)`
-- `RecordException(type: String, message: String, stacktrace: String, leftScope: boolean?)`
+- `RecordException(exception: Exception, escaped: boolean? = null)`
+- `RecordException(type: String, message: String, stacktrace: String, escaped: boolean?)`
 
 ### Span lifetime
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -516,8 +516,8 @@ MUST record an exception as an `Event` with the conventions outlined in the
 
 Examples:
 
-- `RecordException(exception: Exception, escaped: boolean? = null)`
-- `RecordException(type: String, message: String, stacktrace: String, escaped: boolean?)`
+- `RecordException(exception: Exception)`
+- `RecordException(type: String, message: String, stacktrace: String)`
 
 ### Span lifetime
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -510,11 +510,8 @@ MUST record an exception as an `Event` with the conventions outlined in the
 
 Examples:
 
-- `RecordException(exception: Exception)`
-- `RecordException(type: String, message: String, stacktrace: String)`
-
-Note that as per the semantic conventions, only exceptions leaving the scope of
-a span unhandled must be recorded.
+- `RecordException(exception: Exception, leftScope: boolean? = null)`
+- `RecordException(type: String, message: String, stacktrace: String, leftScope: boolean?)`
 
 ### Span lifetime
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -15,12 +15,16 @@ exceptions.
 
 An unhandled exception that leaves the scope of a span
 SHOULD be recorded as an `Event` on that span.
-Other (handled, not leaving a span's scope) exceptions MUST NOT be recorded.
 An exception is considered to leave the scope of a span if the span is ended
 while the exception is still "in flight"
 (special considerations may apply for Go, where exception semantic conventions are used for non-exceptions).
 
 The name of the event MUST be `"exception"`.
+
+Note that multiple events (on the same or different Spans)
+might be logged for the same exception object instance.
+E.g. one event might be logged in an instrumented exception constructor
+and another event might be logged when an exception leaves the scope of a span.
 
 ## Attributes
 
@@ -32,6 +36,7 @@ their types.
 | exception.type       | String | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. E.g. "java.net.ConnectException", "OSError"                                                                                                                                                                                                     | One of `exception.type` or `exception.message` is required |
 | exception.message    | String | The exception message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"`                                                                                                                                                                                                                                                                                                                                  | One of `exception.type` or `exception.message` is required |
 | exception.stacktrace | String | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. E.g. `"Exception in thread \"main\" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)"`. | No                                                         |
+| exception.left_scope | Bool | SHOULD be set to true if the exception event is recoded while observing the exception leaving the scope of the span. Note that an exception may still leave the scope of the span even if this was not set or set to false, if the event was recorded at an earlier time. | No |
 
 ### Stacktrace Representation
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -13,7 +13,7 @@ exceptions.
 
 ## Recording an Exception
 
-An unhandled exception that leaves the scope of a span
+An exception that leaves the scope of a span
 SHOULD be recorded as an `Event` on that span.
 An exception is considered to leave the scope of a span if the span is ended
 while the exception is still "in flight"
@@ -25,6 +25,20 @@ Note that multiple events (on the same or different Spans)
 might be logged for the same exception object instance.
 E.g. one event might be logged in an instrumented exception constructor
 and another event might be logged when an exception leaves the scope of a span.
+
+A typical template for an auto-instrumentation implementing this semantic convention
+could look like this:
+
+```java
+Span span = myTracer.startSpan(/*...*/);
+try {
+  // original code
+} catch (Throwable e) {
+ span.recordException(e, /*leftScope=*/true);
+} finally {
+ span.end();
+}
+```
 
 ## Attributes
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -13,7 +13,12 @@ exceptions.
 
 ## Recording an Exception
 
-An exception SHOULD be recorded as an `Event` on the span during which it occurred.
+An unhandled exception that leaves the scope of a span
+SHOULD be recorded as an `Event` on that span.
+Other (handled, not leaving a span's scope) exceptions MUST NOT be recorded.
+An exception is considered to leave the scope of a span if the span is ended
+because of stack unwinding caused by the exception.
+
 The name of the event MUST be `"exception"`.
 
 ## Attributes

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -13,8 +13,9 @@ exceptions.
 
 ## Recording an Exception
 
-An exception that escapes the scope of a span
-SHOULD be recorded as an `Event` on that span.
+An exception that escapes the scope of a span SHOULD be recorded
+as an `Event` on that span
+(of course, other exceptions that are deemed relevant may also be recorded).
 An exception is considered to have escaped the scope if the span is ended
 while the exception is still "in flight". Note:
 
@@ -28,9 +29,9 @@ while the exception is still "in flight". Note:
 
 The name of the event MUST be `"exception"`.
 
-Note that multiple events (on the same or different Spans)
-might be logged for the same exception object instance.
-E.g. one event might be logged in an instrumented exception constructor
+Note that multiple events (on the same or different Spans) might be logged
+for the same exception object instance.
+For example, one event might be logged in an instrumented exception constructor
 and another event might be logged when an exception leaves the scope of a span.
 
 <a name="exception-end-example"></a>

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -13,11 +13,18 @@ exceptions.
 
 ## Recording an Exception
 
-An exception that leaves the scope of a span
+An exception that escapes the scope of a span
 SHOULD be recorded as an `Event` on that span.
-An exception is considered to leave the scope of a span if the span is ended
-while the exception is still "in flight"
-(special considerations may apply for Go, where exception semantic conventions are used for non-exceptions).
+An exception is considered to have escaped the scope if the span is ended
+while the exception is still "in flight". Note:
+
+* While it is usually not possible to determine whether some exception thrown
+  now *will* escape the scope of a span, it is trivial to know that an exception
+  will escape, if one checks for an active exception just before ending the span.
+  See the [example below](#exception-end-example).
+* Special considerations may apply for Go, where exception semantic conventions
+  might be used for non-exceptions.
+  See [issue #764](https://github.com/open-telemetry/opentelemetry-specification/issues/764).
 
 The name of the event MUST be `"exception"`.
 
@@ -25,6 +32,8 @@ Note that multiple events (on the same or different Spans)
 might be logged for the same exception object instance.
 E.g. one event might be logged in an instrumented exception constructor
 and another event might be logged when an exception leaves the scope of a span.
+
+<a name="exception-end-example"></a>
 
 A typical template for an auto-instrumentation implementing this semantic convention
 could look like this:
@@ -34,7 +43,7 @@ Span span = myTracer.startSpan(/*...*/);
 try {
   // original code
 } catch (Throwable e) {
- span.recordException(e, /*leftScope=*/true);
+ span.recordException(e, /*escaped=*/true);
 } finally {
  span.end();
 }
@@ -50,7 +59,7 @@ their types.
 | exception.type       | String | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. E.g. "java.net.ConnectException", "OSError"                                                                                                                                                                                                     | One of `exception.type` or `exception.message` is required |
 | exception.message    | String | The exception message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"`                                                                                                                                                                                                                                                                                                                                  | One of `exception.type` or `exception.message` is required |
 | exception.stacktrace | String | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. E.g. `"Exception in thread \"main\" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)"`. | No                                                         |
-| exception.left_scope | Bool | SHOULD be set to true if the exception event is recoded while observing the exception leaving the scope of the span. Note that an exception may still leave the scope of the span even if this was not set or set to false, if the event was recorded at an earlier time. | No |
+| exception.escaped | Bool | SHOULD be set to true if the exception event is recoded at a point where it is known that the exception is escaping the scope of the span (e.g. if there is an exception active just before ending the Span). Note that an exception may still leave the scope of the span even if this was not set or set to false, if the event was recorded at an earlier time. | No |
 
 ### Stacktrace Representation
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -43,7 +43,7 @@ Span span = myTracer.startSpan(/*...*/);
 try {
   // original code
 } catch (Throwable e) {
- span.recordException(e, /*escaped=*/true);
+ span.recordException(e); // We know that the exception is escaping here.
  throw e;
 } finally {
  span.end();
@@ -60,7 +60,6 @@ their types.
 | exception.type       | String | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. E.g. "java.net.ConnectException", "OSError"                                                                                                                                                                                                     | One of `exception.type` or `exception.message` is required |
 | exception.message    | String | The exception message. E.g. `"Division by zero"`, `"Can't convert 'int' object to str implicitly"`                                                                                                                                                                                                                                                                                                                                  | One of `exception.type` or `exception.message` is required |
 | exception.stacktrace | String | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. E.g. `"Exception in thread \"main\" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)"`. | No                                                         |
-| exception.escaped | Bool | SHOULD be set to true if the exception event is recoded at a point where it is known that the exception is escaping the scope of the span (e.g. if there is an exception active just before ending the Span). Note that an exception may still leave the scope of the span even if this was not set or set to false, if the event was recorded at an earlier time. | No |
 
 ### Stacktrace Representation
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -17,7 +17,8 @@ An unhandled exception that leaves the scope of a span
 SHOULD be recorded as an `Event` on that span.
 Other (handled, not leaving a span's scope) exceptions MUST NOT be recorded.
 An exception is considered to leave the scope of a span if the span is ended
-because of stack unwinding caused by the exception.
+while the exception is still "in flight"
+(special considerations may apply for Go, where exception semantic conventions are used for non-exceptions).
 
 The name of the event MUST be `"exception"`.
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -44,6 +44,7 @@ try {
   // original code
 } catch (Throwable e) {
  span.recordException(e, /*escaped=*/true);
+ throw e;
 } finally {
  span.end();
 }


### PR DESCRIPTION
Replaces #521 "Semantic conventions for when to record exceptions.

Issues that came up in this PR but should be handled separately:
* #764 "Exception semantic conventions and Go error return values"

## Change summary

* State that exceptions that leave the scope of a Span SHOULD be recorded.

## Major changes this PR underwent

* This PR originally proposed that exceptions other than those that leave the scope of a span MUST NOT be recorded. This was replaced by adding the `exception.left_scope` attribute, now renamed to `exception.escaped`. Commit: 11f0543; Discussion: https://github.com/open-telemetry/opentelemetry-specification/pull/761#discussion_r466234754
* The `exception.escaped` (aka `exception.left_scope`) attribute was removed from this PR into #784 because it is not as important and more controversial than the rest of this PR. Commit: 80ea27d; Discussion: [SIG meeting \#61](https://docs.google.com/document/d/1-bCYkN-DWJq4jw1ybaDZYYmx-WAe6HnwfWbkm8d57v8/edit#heading=h.fyk5oh15kuih)