### PR TITLE
k8s: Differentiate container spec name and container name

### DIFF
--- a/specification/resource/semantic_conventions/k8s.md
+++ b/specification/resource/semantic_conventions/k8s.md
@@ -50,6 +50,23 @@ containers on your cluster.
 | k8s.pod.uid | The uid of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | k8s.pod.name | The name of the Pod. | `opentelemetry-pod-autoconf` |
 
+## Container
+
+A container specification in a Pod template. This type is intended to be used to
+capture information such as name of a container in a Pod template which is different
+from the name of the running container.
+
+Note: This type is different from [container](./container.md), which corresponds
+to a running container.
+
+**type:** `k8s.container`
+
+**Description:** A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
+
+| Attribute  | Description  | Example  |
+|---|---|---|
+| k8s.container.name | The name of the Container in a Pod template. | `redis` |
+
 ## ReplicaSet
 
 A ReplicaSet’s purpose is to maintain a stable set of replica Pods running at


### PR DESCRIPTION
## Context

Ability to differentiate between container name in a Pod template vs name of a running container created as a result of the template in semantic convention. 

Let's take for example the following spec for a Job that specifies container name to be `hello`. 

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: hello
spec:
  template:
    # This is the pod template
    spec:
      containers:
        - name: hello
          image: busybox
          command: ['sh', '-c', 'echo "Hello, Kubernetes!" && sleep 3600']
      restartPolicy: OnFailure
```

Example obtained from [here](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).

On applying the above spec, the container that's created will not necessarily have `hello` as its name. The container name set by the container engine could be different from the one specified in the pod template.

## Changes

Add a `k8s.container` type to capture this information in `k8s.container.name`.

As a result, a container resource created within a k8s deployment would have both `container.name` (see [here](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/resource/semantic_conventions/container.md) for details) and `k8s.container.name`, where the former would be the container name set by the container engine and the latter would the name from the pod template.
