### PR TITLE
Consistency between Span and Resource attributes

### DIFF
--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -20,6 +20,13 @@ Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have 
     i.e. it MUST NOT contain values of different types. For protocols that do
     not natively support array values such values SHOULD be represented as JSON strings.
 
+Attribute values expressing a numerical value of zero, an empty string, or an
+empty array are considered meaningful and MUST be stored and passed on to
+processors / exporters. Attribute values of `null` are considered to be not set
+and get discarded as if that `Attribute` was never been created.
+As an exception to this, if overwriting of values is supported, this results in
+clearing the previous value and dropping the attribute key from the set of attributes.
+
 `null` values within arrays MUST be preserved as-is (i.e., passed on to span
 processors / exporters as `null`). If exporters do not support exporting `null`
 values, they MAY replace those values by 0, `false`, or empty strings.

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -27,7 +27,7 @@ empty array are considered meaningful and MUST be stored and passed on to
 processors / exporters. Attribute values of `null` are considered to be not set
 and get discarded as if that `Attribute` has never been created.
 As an exception to this, if overwriting of values is supported, this results in
-clearing the previous value and dropping the attribute key from the set of attributes.
+removing the attribute.
 
 `null` values within arrays MUST be preserved as-is (i.e., passed on to span
 processors / exporters as `null`). If exporters do not support exporting `null`

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -20,10 +20,12 @@ Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have 
     i.e. it MUST NOT contain values of different types. For protocols that do
     not natively support array values such values SHOULD be represented as JSON strings.
 
+Attributes SHOULD preserve the order in which they're set.
+
 Attribute values expressing a numerical value of zero, an empty string, or an
 empty array are considered meaningful and MUST be stored and passed on to
 processors / exporters. Attribute values of `null` are considered to be not set
-and get discarded as if that `Attribute` was never been created.
+and get discarded as if that `Attribute` has never been created.
 As an exception to this, if overwriting of values is supported, this results in
 clearing the previous value and dropping the attribute key from the set of attributes.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -402,9 +402,8 @@ The Span interface MUST provide:
   as arguments. This MAY be called `SetAttribute`. To avoid extra allocations some
   implementations may offer a separate API for each of the possible value types.
 
-Attributes SHOULD preserve the order in which they're set. Setting an attribute
-with the same key as an existing attribute SHOULD overwrite the existing
-attribute's value.
+Setting an attribute with the same key as an existing attribute SHOULD overwrite
+the existing attribute's value.
 
 Note that the OpenTelemetry project documents certain ["standard
 attributes"](semantic_conventions/README.md) that have prescribed semantic meanings.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -406,13 +406,6 @@ Attributes SHOULD preserve the order in which they're set. Setting an attribute
 with the same key as an existing attribute SHOULD overwrite the existing
 attribute's value.
 
-Attribute values expressing a numerical value of zero, an empty string, or an empty array are
-considered meaningful and MUST be stored and passed on to span processors / exporters.
-Attribute values of `null` are considered to be not set and get discarded as if
-that `SetAttribute` call had never been made.
-As an exception to this, if overwriting of values is supported, this results in
-clearing the previous value and dropping the attribute key from the set of attributes.
-
 Note that the OpenTelemetry project documents certain ["standard
 attributes"](semantic_conventions/README.md) that have prescribed semantic meanings.
 


### PR DESCRIPTION
Fixes #763 

## Changes

The requirements for Resource and Span attributes are now consistent w.r.t.:
- empty values are not discarded
- `null` values are dropped and can remove an existing attribute iff overwriting is possible 