### PR TITLE
Add semantic conventions for thread.name and thread.id span attributes

### DIFF
--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -150,3 +150,4 @@ Examples of where `thread.id` and `thread.name` can be extracted from:
 | Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
 | Ruby                  |                                        | `Thread.current.name`              |
 | C++                   | `std::this_thread::get_id()`             |                                    |
+| Erlang               | `erlang:system_info(scheduler_id)` |                                  |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -13,6 +13,7 @@ Particular operations may refer to or require some of these attributes.
   * [`net.*.name` attributes](#netname-attributes)
 - [General remote service attributes](#general-remote-service-attributes)
 - [General identity attributes](#general-identity-attributes)
+- [General thread attributes](#general-thread-attributes)
 
 <!-- tocstop -->
 
@@ -129,3 +130,22 @@ Examples of where the `enduser.id` value is extracted from:
 Given the sensitive nature of this information, SDKs and exporters SHOULD drop these attributes by
 default and then provide a configuration parameter to turn on retention for use cases where the
 information is required and would not violate any policies or regulations.
+
+## General thread attributes
+
+These attributes may be used for any operation to store information about
+a span's current execution thread.
+
+| Attribute name | Notes and examples                                       |
+|----------------|----------------------------------------------------------|
+| `thread.id`    | Current thread id, if exposed by the platform. E.g. `42` |
+| `thread.name`  | Current thread name. E.g. `main`                         |
+
+Examples of where `thread.id` and `thread.name` can be extracted from:
+
+| Launguage or platform | `thread.id`                            | `thread.name`                      |
+|-----------------------|----------------------------------------|------------------------------------|
+| JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()` |
+| .Net                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
+| Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
+| Ruby                  |                                        | `Thread.current.name`              |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -134,12 +134,12 @@ information is required and would not violate any policies or regulations.
 ## General thread attributes
 
 These attributes may be used for any operation to store information about
-a span's current execution thread.
+a thread that started a span.
 
-| Attribute name | Notes and examples                                       |
-|----------------|----------------------------------------------------------|
+| Attribute name | Notes and examples                                                  |
+|----------------|---------------------------------------------------------------------|
 | `thread.id`    | Current "managed" thread ID (as opposed to OS thread ID). E.g. `42` |
-| `thread.name`  | Current thread name. E.g. `main`                         |
+| `thread.name`  | Current thread name. E.g. `main`                                    |
 
 Examples of where `thread.id` and `thread.name` can be extracted from:
 
@@ -149,3 +149,4 @@ Examples of where `thread.id` and `thread.name` can be extracted from:
 | .Net                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
 | Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
 | Ruby                  |                                        | `Thread.current.name`              |
+| C++                   | `std::this_thread::get_id`             |                                    |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -149,4 +149,4 @@ Examples of where `thread.id` and `thread.name` can be extracted from:
 | .Net                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
 | Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
 | Ruby                  |                                        | `Thread.current.name`              |
-| C++                   | `std::this_thread::get_id`             |                                    |
+| C++                   | `std::this_thread::get_id()`             |                                    |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -138,7 +138,7 @@ a span's current execution thread.
 
 | Attribute name | Notes and examples                                       |
 |----------------|----------------------------------------------------------|
-| `thread.id`    | Current thread id, if exposed by the platform. E.g. `42` |
+| `thread.id`    | Current "managed" thread ID (as opposed to OS thread ID). E.g. `42` |
 | `thread.name`  | Current thread name. E.g. `main`                         |
 
 Examples of where `thread.id` and `thread.name` can be extracted from:


### PR DESCRIPTION
Fixes #788

## Changes

Added two new span attributes responsible for storing current thread information: `thread.name` and `thread.id`

Related issues: https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/942

