### PR TITLE
Rename HTTPText to Text Propagator.

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -11,7 +11,7 @@ Table of Contents
   - [Operations](#operations)
     - [Inject](#inject)
     - [Extract](#extract)
-- [HTTPText Propagator](#httptext-propagator)
+- [Text Propagator](#text-propagator)
   - [Fields](#fields)
   - [Inject](#inject-1)
     - [Setter argument](#setter-argument)
@@ -49,7 +49,7 @@ and is bound to a data type, in order to propagate in-band context data across p
 
 The Propagators API currently defines one `Propagator` type:
 
-- `HTTPTextPropagator` is a type that inject values into and extracts values
+- `TextPropagator` is a type that inject values into and extracts values
   from carriers as string key/value pairs.
 
 A binary `Propagator` type will be added in the future (see [#437](https://github.com/open-telemetry/opentelemetry-specification/issues/437)).
@@ -95,9 +95,9 @@ Returns a new `Context` derived from the `Context` passed as argument,
 containing the extracted value, which can be a `SpanContext`,
 `CorrelationContext` or another cross-cutting concern context.
 
-## HTTPText Propagator
+## Text Propagator
 
-`HTTPTextPropagator` performs the injection and extraction of a cross-cutting concern
+`TextPropagator` performs the injection and extraction of a cross-cutting concern
 value as string key/values pairs into carriers that travel in-band across process boundaries.
 
 The carrier of propagated data on both the client (injector) and server (extractor) side is
@@ -127,7 +127,7 @@ The use cases of this are:
 - allow pre-allocation of fields, especially in systems like gRPC Metadata
 - allow a single-pass over an iterator
 
-Returns list of fields that will be used by the `HttpTextPropagator`.
+Returns list of fields that will be used by the `TextPropagator`.
 
 ### Inject
 
@@ -143,7 +143,7 @@ Optional arguments:
 
 Setter is an argument in `Inject` that sets values into given fields.
 
-`Setter` allows a `HttpTextPropagator` to set propagated fields into a carrier.
+`Setter` allows a `TextPropagator` to set propagated fields into a carrier.
 
 One of the ways to implement it is `Setter` class with `Set` method as described below.
 
@@ -175,7 +175,7 @@ Returns a new `Context` derived from the `Context` passed as argument.
 
 Getter is an argument in `Extract` that get value from given field
 
-`Getter` allows a `HttpTextPropagator` to read propagated fields from a carrier.
+`Getter` allows a `TextPropagator` to read propagated fields from a carrier.
 
 One of the ways to implement it is `Getter` class with `Get` method as described below.
 
@@ -208,7 +208,7 @@ A composite propagator can be built from a list of propagators, or a list of
 injectors and extractors. The resulting composite `Propagator` will invoke the `Propagator`s, `Injector`s, or `Extractor`s, in the order they were specified.
 
 Each composite `Propagator` will implement a specific `Propagator` type, such
-as `HttpTextPropagator`, as different `Propagator` types will likely operate on different
+as `TextPropagator`, as different `Propagator` types will likely operate on different
 data types.
 
 There MUST be functions to accomplish the following operations.

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -247,7 +247,7 @@ imposed by a specific transport and bound to a data type.
 
 The Propagators API currently defines one `Propagator` type:
 
-- `HTTPTextPropagator` injects values into and extracts values from carriers as text.
+- `TextPropagator` injects values into and extracts values from carriers as text.
 
 ## Collector
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -693,4 +693,4 @@ implementer of these links.
 
 The API layer MAY include the following `Propagator`s:
 
-* A `HTTPTextPropagator` implementing the [W3C TraceContext Specification](https://www.w3.org/TR/trace-context/).
+* A `TextPropagator` implementing the [W3C TraceContext Specification](https://www.w3.org/TR/trace-context/).


### PR DESCRIPTION
Fixes #317 

`HttpText` is renamed to `Text` for the Propagator component.

I remember we barely discussing the possibility of renaming it to `AsciiText` instead (or similar), but wanted to try out `Text` first, as it's simpler, but I'm open to feedback ;)