### PR TITLE
Add semantic convention for telemetry.auto.version

### DIFF
--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -80,6 +80,7 @@ The identifier SHOULD be stable across different versions of an implementation.
 | telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry` | No |
 | telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
 | telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
+| telemetry.auto.version | The version string of the auto instrumentation agent, if used, as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
 
 ## Compute Unit
 


### PR DESCRIPTION
## Changes

In addition to the version of the SDK, I propose to add a resource semantic convention for the optional version of the auto instrumentation agent if that is used.