### PR TITLE
Clean up glossary and overview (resolves #528).

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -2,7 +2,7 @@
 
 This document defines some terms that are used across this specification.
 
-Some other fundamental terms are documented in the [Overview](overview.md).
+Some other fundamental terms are documented in the [overview document](overview.md).
 
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -1,7 +1,30 @@
 # Glossary
 
-Below are a list of some OpenTelemetry specific terms that are used across this
-specification.
+This document defines some terms that are used across this specification.
+
+Some other fundamental terms are documented in the [Overview](overview.md).
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [Common](#common)
+  * [In-band and Out-of-band Data](#in-band-and-out-of-band-data)
+  * [Telemetry SDK](#telemetry-sdk)
+  * [Exporter Library](#exporter-library)
+  * [Instrumented Library](#instrumented-library)
+  * [Instrumentation Library](#instrumentation-library)
+  * [Tracer Name / Meter Name](#tracer-name--meter-name)
+- [Logs](#logs)
+  * [Log Record](#log-record)
+  * [Log](#log)
+  * [Embedded Log](#embedded-log)
+  * [Standalone Log](#standalone-log)
+  * [Log Attributes](#log-attributes)
+  * [Structured Logs](#structured-logs)
+  * [Flat File Logs](#flat-file-logs)
+
+<!-- tocstop -->
 
 ## Common
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -1,5 +1,44 @@
 # Overview
 
+<details>
+<summary>
+Table of Contents
+</summary>
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [Distributed Tracing](#distributed-tracing)
+  * [Trace](#trace)
+  * [Span](#span)
+  * [SpanContext](#spancontext)
+  * [Links between spans](#links-between-spans)
+- [Metrics](#metrics)
+  * [Recording raw measurements](#recording-raw-measurements)
+    + [Measure](#measure)
+    + [Measurement](#measurement)
+  * [Recording metrics with predefined aggregation](#recording-metrics-with-predefined-aggregation)
+  * [Metrics data model and SDK](#metrics-data-model-and-sdk)
+- [Logs](#logs)
+  * [Data model](#data-model)
+- [CorrelationContext](#correlationcontext)
+- [Resources](#resources)
+- [Context Propagation](#context-propagation)
+- [Propagators](#propagators)
+- [Collector](#collector)
+- [Instrumentation Libraries](#instrumentation-libraries)
+- [Code injecting adapters](#code-injecting-adapters)
+- [Semantic Conventions](#semantic-conventions)
+
+<!-- tocstop -->
+
+</details>
+
+This document provides an overview of the pillars of telemetry that
+OpenTelemetry supports and defines important fundamental terms.
+
+Additional term definitions can be found in the [glossary](glossary.md).
+
 ## Distributed Tracing
 
 A distributed trace is a set of events, triggered as a result of a single
@@ -289,10 +328,6 @@ name itself. Examples include:
 
 * opentelemetry-instrumentation-flask (Python)
 * @opentelemetry/instrumentation-grpc (Javascript)
-
-## Code injecting adapters
-
-TODO: fill out as a result of SIG discussion.
 
 ## Semantic Conventions
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -27,7 +27,6 @@ Table of Contents
 - [Propagators](#propagators)
 - [Collector](#collector)
 - [Instrumentation Libraries](#instrumentation-libraries)
-- [Code injecting adapters](#code-injecting-adapters)
 - [Semantic Conventions](#semantic-conventions)
 
 <!-- tocstop -->


### PR DESCRIPTION
Fixes #528.

## Changes

* Add link from overview to glossary and vice versa
* Add TOC to overview and glossary (overview has it folded in `<details>`, glossary has it expanded as no one is gonna read it top to bottom).