### PR TITLE
Clarify span name criteria (resolves #557).

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -216,13 +216,16 @@ the entire operation and, optionally, one or more sub-spans for its sub-operatio
 - A list of timestamped [`Event`s](#add-events)
 - A [`Status`](#set-status).
 
-The _span name_ is a human-readable string which concisely identifies the work
-represented by the Span, for example, an RPC method name, a function name,
-or the name of a subtask or stage within a larger computation. The span name
-should be the most general string that identifies a (statistically) interesting
-_class of Spans_, rather than individual Span instances. That is, "get_user" is
-a reasonable name, while "get_user/314159", where "314159" is a user ID, is not
-a good name due to its high cardinality.
+The _span name_ concisely identifies the work represented by the Span,
+for example, an RPC method name, a function name,
+or the name of a subtask or stage within a larger computation.
+The span name SHOULD be the most general string that identifies a
+(statistically) interesting _class of Spans_,
+rather than individual Span instances.
+That is, "get_user" is a reasonable name, while "get_user/314159",
+where "314159" is a user ID, is not a good name due to its high cardinality.
+While a human-readable span name can be useful, one SHOULD NOT compromise
+on the generality of the span name to improve human-readability.
 
 For example, here are potential span names for an endpoint that gets a
 hypothetical account information:

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -221,11 +221,11 @@ for example, an RPC method name, a function name,
 or the name of a subtask or stage within a larger computation.
 The span name SHOULD be the most general string that identifies a
 (statistically) interesting _class of Spans_,
-rather than individual Span instances.
+rather than individual Span instances while still being human-readable.
 That is, "get_user" is a reasonable name, while "get_user/314159",
 where "314159" is a user ID, is not a good name due to its high cardinality.
-While a human-readable span name can be useful, one SHOULD NOT compromise
-on the generality of the span name to improve human-readability.
+Generality SHOULD be prioritized over human-readability.
+
 
 For example, here are potential span names for an endpoint that gets a
 hypothetical account information:


### PR DESCRIPTION
Resolves #557.

## Rationale

(quoted from https://github.com/open-telemetry/opentelemetry-specification/pull/810#issuecomment-674710718)

1. Why a guideline at all? It streamlines discussion and avoids inconsistencies. For example, it would decide #548. There does not need to be a trade-off with human-readability here, since we could have both if we really wanted (see next point).
2. Why not prefer human-readability? Because a good display name can be synthesized without much trouble on the backend. This argument was one of the main reasons for declining #730 (see https://github.com/open-telemetry/opentelemetry-specification/pull/730#discussion_r459694652 by @yurishkuro) and I think it is a sound argument. On the other hand, a grouping key can be utilized for agent-side sampling (e.g. have a sampler that is rate-limiting per span name).

## Changes

* Clarifies that generality of the span name is more important than human-readability.