### PR TITLE
Add specification/implementation compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -1,15 +1,16 @@
-# Implementation Compliance with Specification
+# Compliance of Implementations with Specification
 
-The following table shows which features are implemented by each OpenTelemetry
+The following tables show which features are implemented by each OpenTelemetry
 language implementation.
 
 `+` means the feature is supported, `-` means it is not supported, `N/A` means
-the feature is not applicable to the particular SDK, blank cell means the status
-of the feature is not known.
+the feature is not applicable to the particular language, blank cell means the
+status of the feature is not known.
+
+## Traces
 
 |Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
-|**Traces API**|
 |[TracerProvider](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracerprovider-operations)|
 |Create TracerProvider                         |  |    |       |      |    |      |   |    |   |    |
 |Get a Tracer                                  |  |    |       |      |    |      |   |    |   |    |
@@ -58,17 +59,39 @@ of the feature is not known.
 |[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
 |RecordException                               |  |    |       |      |    |      |   |    |   |    |
 |RecordException with extra parameters         |  |    |       |      |    |      |   |    |   |    |
-|**Metrics API**|
+
+## Metrics
+
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
 |TBD|
-|**Resource**|
+
+## Resource
+
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
 |TBD|
-|**Context Propagation**|
+
+## Context Propagation
+
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
 |TBD|
-|**Error Handling**|
+
+## Error Handling
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
 |TBD|
-|**Environment Variables**|
+
+## Environment Variables
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
 |TBD|
-|**Exporters**|
+
+## Exporters
+
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
 |Standard output (logging)                     |  |    |       |      |    |      |   |    |   |    |
 |In-memory (mock exporter)                     |  |    |       |      |    |      |   |    |   |    |
 |[OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/otlp.md)|

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -1,0 +1,103 @@
+# SDK Compliance with Specification
+
+The following table shows which features are implemented by each OpenTelemetry
+language SDK.
+
+`+` means the feature is supported, `-` means it is not supported, `N/A` means
+the feature is not applicable to the particular SDK, blank cell means the status
+of the feature is not known.
+
+|Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
+|----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
+|**Traces API**|
+|[TracerProvider](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracerprovider-operations)|
+|Create TracerProvider                         |  |    |       |      |    |      |   |    |   |    |
+|Get a Tracer                                  |  |    |       |      |    |      |   |    |   |    |
+|Safe for concurrent calls                     |  |    |       |      |    |      |   |    |   |    |
+|[Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracer-operations)|
+|Create a new Span                             |  |    |       |      |    |      |   |    |   |    |
+|Get active Span                               |  |    |       |      |    |      |   |    |   |    |
+|Mark Span active                              |  |    |       |      |    |      |   |    |   |    |
+|Safe for concurrent calls                     |  |    |       |      |    |      |   |    |   |    |
+|[SpanContext](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext)|
+|IsValid                                       |  |    |       |      |    |      |   |    |   |    |
+|IsRemote                                      |  |    |       |      |    |      |   |    |   |    |
+|Conforms to the W3C TraceContext spec         |  |    |       |      |    |      |   |    |   |    |
+|[Span](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span)|
+|Create root span                              |  |    |       |      |    |      |   |    |   |    |
+|Create with default parent (active span)      |  |    |       |      |    |      |   |    |   |    |
+|Create with parent from Context               |  |    |       |      |    |      |   |    |   |    |
+|Create with explicit parent Span              |  |    |       |      |    |      |   |    |   |    |
+|Create with explicit parent SpanContext       |  |    |       |      |    |      |   |    |   |    |
+|UpdateName                                    |  |    |       |      |    |      |   |    |   |    |
+|User-defined start timestamp                  |  |    |       |      |    |      |   |    |   |    |
+|End                                           |  |    |       |      |    |      |   |    |   |    |
+|End with timestamp                            |  |    |       |      |    |      |   |    |   |    |
+|Set/Get status                                |  |    |       |      |    |      |   |    |   |    |
+|Set/Get span kind                             |  |    |       |      |    |      |   |    |   |    |
+|Safe for concurrent calls                     |  |    |       |      |    |      |   |    |   |    |
+|[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
+|SetAttribute                                  |  |    |       |      |    |      |   |    |   |    |
+|Set order preserved                           |  |    |       |      |    |      |   |    |   |    |
+|String type                                   |  |    |       |      |    |      |   |    |   |    |
+|Boolean type                                  |  |    |       |      |    |      |   |    |   |    |
+|Double floating-point type                    |  |    |       |      |    |      |   |    |   |    |
+|Signed int64 type                             |  |    |       |      |    |      |   |    |   |    |
+|Array of primitives (homogeneous)             |  |    |       |      |    |      |   |    |   |    |
+|Unicode support for keys and string values    |  |    |       |      |    |      |   |    |   |    |
+|[Span linking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-links)|
+|AddLink                                       |  |    |       |      |    |      |   |    |   |    |
+|AddLazyLink                                   |  |    |       |      |    |      |   |    |   |    |
+|Safe for concurrent calls                     |  |    |       |      |    |      |   |    |   |    |
+|[Span events](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events)|
+|AddEvent                                      |  |    |       |      |    |      |   |    |   |    |
+|AddLazyEvent                                  |  |    |       |      |    |      |   |    |   |    |
+|Add order preserved                           |  |    |       |      |    |      |   |    |   |    |
+|Span events                                   |  |    |       |      |    |      |   |    |   |    |
+|Safe for concurrent calls                     |  |    |       |      |    |      |   |    |   |    |
+|[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
+|RecordException                               |  |    |       |      |    |      |   |    |   |    |
+|RecordException with extra parameters         |  |    |       |      |    |      |   |    |   |    |
+|**Metrics API**|
+|TBD|
+|**Resource**|
+|TBD|
+|**Context Propagation**|
+|TBD|
+|**Error Handling**|
+|TBD|
+|**Environment Variables**|
+|TBD|
+|**Exporters**|
+|Standard output (logging)                     |  |    |       |      |    |      |   |    |   |    |
+|In-memory (mock exporter)                     |  |    |       |      |    |      |   |    |   |    |
+|[OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/otlp.md)|
+|OTLP/gRPC Exporter                            |  |    |       |      |    |      |   |    |   |    |
+|OTLP/HTTP binary Protobuf Exporter            |  |    |       |      |    |      |   |    |   |    |
+|OTLP/HTTP JSON Protobuf Exporter              |  |    |       |      |    |      |   |    |   |    |
+|OTLP/HTTP gzip Content-Encoding support       |  |    |       |      |    |      |   |    |   |    |
+|Concurrent sending                            |  |    |       |      |    |      |   |    |   |    |
+|Honors retryable responses with backoff       |  |    |       |      |    |      |   |    |   |    |
+|Honors non-retryable responses                |  |    |       |      |    |      |   |    |   |    |
+|Honors throttling response                    |  |    |       |      |    |      |   |    |   |    |
+|Multi-destination spec compliance             |  |    |       |      |    |      |   |    |   |    |
+|[Zipkin](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md)|
+|Zipkin V1 JSON                                |  |    |       |      |    |      |   |    |   |    |
+|Zipkin V1 Thrift                              |  |    |       |      |    |      |   |    |   |    |
+|Zipkin V2 JSON                                |  |    |       |      |    |      |   |    |   |    |
+|Zipkin V2 Protobuf                            |  |    |       |      |    |      |   |    |   |    |
+|Service name mapping                          |  |    |       |      |    |      |   |    |   |    |
+|SpanKind mapping                              |  |    |       |      |    |      |   |    |   |    |
+|InstrumentationLibrary mapping                |  |    |       |      |    |      |   |    |   |    |
+|Boolean attributes                            |  |    |       |      |    |      |   |    |   |    |
+|Array attributes                              |  |    |       |      |    |      |   |    |   |    |
+|Status mapping                                |  |    |       |      |    |      |   |    |   |    |
+|Event attributes mapping to Annotations       |  |    |       |      |    |      |   |    |   |    |
+|Fractional microseconds in timestamps         |  |    |       |      |    |      |   |    |   |    |
+|Service name mapping                          |  |    |       |      |    |      |   |    |   |    |
+|[Jaeger]()|
+|TBD|
+|[OpenCensus]()|
+|TBD|
+|[Prometheus]()|
+|TBD|

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -1,7 +1,7 @@
-# SDK Compliance with Specification
+# Implementation Compliance with Specification
 
 The following table shows which features are implemented by each OpenTelemetry
-language SDK.
+language implementation.
 
 `+` means the feature is supported, `-` means it is not supported, `N/A` means
 the feature is not applicable to the particular SDK, blank cell means the status


### PR DESCRIPTION
This commit introduces the compliance matrix. It is not yet a complete
list of features that we want to track. I marked several sections as
TBD. We will need to add features/rows in those sections in separate PRs.
In the meantime we can ask SIGs to add +, - or N/A in the sections
that are more or less ready (currently Traces API and OTLP, Zipkin Exporters).

If you see anything incorrect/missing in Traces API and OTLP or Zipkin Exporter
please suggest in this PR. Please do not suggest rows for the rest of the sections
since it will likely result in this PR staying for a very long time and I would like
to get the ball rolling with the SIGs first.

Suggestions to use a different format or approach to record this information
are welcome.

Related issues
https://github.com/open-telemetry/opentelemetry-specification/issues/827
