### PR TITLE
Add clarification on the no-op nature of the metric API.

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -89,6 +89,14 @@ logging systems.  For this reason, [OpenTelemetry requires a separation of the
 API from the SDK](../library-guidelines.md#requirements), so that different SDKs
 can be configured at run time.
 
+### Behavior of the API in the absence of an installed SDK
+
+In the absence of an installed Metrics SDK, the Metrics API MUST consist only
+of no-ops. None of the calls on any part of the API can have any side effects
+or do anything meaningful. Meters MUST return no-op implementations of any
+instruments. The API MUST NOT throw exceptions or cause any problems for
+users.
+
 ### Measurements
 
 The term _capture_ is used in this document to describe the action

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -94,8 +94,9 @@ can be configured at run time.
 In the absence of an installed Metrics SDK, the Metrics API MUST consist only
 of no-ops. None of the calls on any part of the API can have any side effects
 or do anything meaningful. Meters MUST return no-op implementations of any
-instruments. The API MUST NOT throw exceptions or cause any problems for
-users.
+instruments. From a user's perspective, calls to these should be ignored without raising errors
+(i.e., *no* `null` references MUST be returned in languages where accessing these results in errors).
+The API MUST NOT throw exceptions on any calls made to it.
 
 ### Measurements
 


### PR DESCRIPTION
## Changes

Update the Metric API specification to explicitly describe the no-op nature of the API.

Related issues #719 

