### PR TITLE
Remove duplicate hostname attribute

### DIFF
--- a/specification/resource/semantic_conventions/host.md
+++ b/specification/resource/semantic_conventions/host.md
@@ -6,7 +6,6 @@
 
 | Attribute  | Description  | Example  |
 |---|---|---|
-| host.hostname | Hostname of the host.<br/> It contains what the `hostname` command returns on the host machine. | `opentelemetry-test` |
 | host.id | Unique host id.<br/> For Cloud this must be the instance_id assigned by the cloud provider | `opentelemetry-test` |
 | host.name | Name of the host.<br/> It may contain what `hostname` returns on Unix systems, the fully qualified, or a name specified by the user. | `opentelemetry-test` |
 | host.type | Type of host.<br/> For Cloud this must be the machine type.| `n1-standard-1` |

--- a/specification/resource/semantic_conventions/host.md
+++ b/specification/resource/semantic_conventions/host.md
@@ -7,7 +7,7 @@
 | Attribute  | Description  | Example  |
 |---|---|---|
 | host.id | Unique host id.<br/> For Cloud this must be the instance_id assigned by the cloud provider | `opentelemetry-test` |
-| host.name | Name of the host.<br/> It may contain what `hostname` returns on Unix systems, the fully qualified, or a name specified by the user. | `opentelemetry-test` |
+| host.name | Name of the host.<br/>On Unix systems, it may contain what the `hostname` command returns, or the fully qualified hostname, or another name specified by the user. | `opentelemetry-test` |
 | host.type | Type of host.<br/> For Cloud this must be the machine type.| `n1-standard-1` |
 | host.image.name | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`, `CentOS-8-x86_64-1905` |
 | host.image.id | VM image id. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/787

Idea from the issue is that we should use `host.name` with either of the proposed values.
