### PR TITLE
Do not run auto-assign when reopen PR

### DIFF
--- a/.github/workflows/auto-assign-tc-members.yml
+++ b/.github/workflows/auto-assign-tc-members.yml
@@ -1,7 +1,7 @@
 name: 'Auto Assign'
 on: 
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened]
 
 jobs:
   add-owner:


### PR DESCRIPTION
See example of miss configuration here https://github.com/open-telemetry/opentelemetry-specification/pull/844
