### PR TITLE
Clarify that Links can be added at Span creation time only

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -354,7 +354,7 @@ During the `Span` creation user MUST have the ability to record links to other `
 Linked `Span`s can be from the same or a different trace. See [Links
 description](../overview.md#links-between-spans).
 
-There is no ability to add new `Link` after Span creation.
+`Link`s cannot be added after Span creation.
 
 A `Link` is defined by the following properties:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -354,6 +354,8 @@ During the `Span` creation user MUST have the ability to record links to other `
 Linked `Span`s can be from the same or a different trace. See [Links
 description](../overview.md#links-between-spans).
 
+There is no ability to add new `Link` after Span creation.
+
 A `Link` is defined by the following properties:
 
 - (Required) `SpanContext` of the `Span` to link to.


### PR DESCRIPTION
## Changes
The current spec text says "During the Span creation user MUST have the ability to record links to other Spans.". It is not clear if span creation is the only time when one can add Links, or it can be added after creation as well (similar to SetAttribute).

This PR just make it explicit that Link can be added at Span creation time only. Hopefully this was the original intention, and this PR is just clarifying it, not introducing or proposing any behavior change.

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
