### PR TITLE
Remove LazyEvent and LazyLink as they got removed from spec.

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -48,9 +48,11 @@ status of the feature is not known.
 |Unicode support for keys and string values    |  |    |       |      |    |      |   | +  |   |    |
 |[Span linking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-links)|
 |AddLink                                       |  |    |       |      |    |      |   | +  |   |    |
+|AddLazyLink                                   |  |    |       |      |    |      |   | -  |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |
 |[Span events](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events)|
 |AddEvent                                      |  |    |       |      |    |      |   | +  |   |    |
+|AddLazyEvent                                  |  |    |       |      |    |      |   | -  |   |    |
 |Add order preserved                           |  |    |       |      |    |      |   | +  |   |    |
 |Span events                                   |  |    |       |      |    |      |   |    |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -48,11 +48,9 @@ status of the feature is not known.
 |Unicode support for keys and string values    |  |    |       |      |    |      |   | +  |   |    |
 |[Span linking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-links)|
 |AddLink                                       |  |    |       |      |    |      |   | +  |   |    |
-|AddLazyLink                                   |  |    |       |      |    |      |   | -  |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |
 |[Span events](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events)|
 |AddEvent                                      |  |    |       |      |    |      |   | +  |   |    |
-|AddLazyEvent                                  |  |    |       |      |    |      |   | -  |   |    |
 |Add order preserved                           |  |    |       |      |    |      |   | +  |   |    |
 |Span events                                   |  |    |       |      |    |      |   |    |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |


### PR DESCRIPTION
## Changes
Remove LazyEvent and LazyLink as they got removed from spec in https://github.com/open-telemetry/opentelemetry-specification/pull/840

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
