### PR TITLE
Add IsRecording, remove Get for Status. and Set/Get for Kind in Spec Compliance Matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -35,8 +35,7 @@ status of the feature is not known.
 |End                                           |  |    |       |      |    |      |   | +  |   |    |
 |End with timestamp                            |  |    |       |      |    |      |   | -  |   |    |
 |IsRecording                                   |  |    |       |      |    |      |   |    |   |    |
-|Get status                                    |  |    |       |      |    |      |   | +  |   |    |
-|Get span kind                                 |  |    |       |      |    |      |   | +  |   |    |
+|Set status                                    |  |    |       |      |    |      |   | +  |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |
 |[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
 |SetAttribute                                  |  |    |       |      |    |      |   | +  |   |    |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -52,7 +52,6 @@ status of the feature is not known.
 |[Span events](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events)|
 |AddEvent                                      |  |    |       |      |    |      |   | +  |   |    |
 |Add order preserved                           |  |    |       |      |    |      |   | +  |   |    |
-|Span events                                   |  |    |       |      |    |      |   |    |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |
 |[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
 |RecordException                               |  |    |       |      |    |      |   | +  |   |    |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -34,8 +34,9 @@ status of the feature is not known.
 |User-defined start timestamp                  |  |    |       |      |    |      |   | +  |   |    |
 |End                                           |  |    |       |      |    |      |   | +  |   |    |
 |End with timestamp                            |  |    |       |      |    |      |   | -  |   |    |
-|Set/Get status                                |  |    |       |      |    |      |   | +  |   |    |
-|Set/Get span kind                             |  |    |       |      |    |      |   | +  |   |    |
+|IsRecording                                   |  |    |       |      |    |      |   |    |   |    |
+|Get status                                    |  |    |       |      |    |      |   | +  |   |    |
+|Get span kind                                 |  |    |       |      |    |      |   | +  |   |    |
 |Safe for concurrent calls                     |  |    |       |      |    |      |   | +  |   |    |
 |[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
 |SetAttribute                                  |  |    |       |      |    |      |   | +  |   |    |


### PR DESCRIPTION
IsRecording was missing.

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
