### PR TITLE
Remove duplicate service name mapping from matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -117,7 +117,6 @@ status of the feature is not known.
 |Status mapping                                |  |    |       |      |    |      |   | +  |   |    |
 |Event attributes mapping to Annotations       |  |    |       |      |    |      |   | +  |   |    |
 |Fractional microseconds in timestamps         |  |    |       |      |    |      |   | -  |   |    |
-|Service name mapping                          |  |    |       |      |    |      |   |    |   |    |
 |Jaeger|
 |TBD|
 |OpenCensus|


### PR DESCRIPTION
This removes the duplicate entry from the spec compliance matrix.