### PR TITLE
Remove SpanBuilder from Concurrency as its not defined anywhere else.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -672,11 +672,6 @@ be called concurrently.
 
 **Tracer** - all methods are safe to be called concurrently.
 
-**SpanBuilder** - It is not safe to concurrently call any methods of the
-same SpanBuilder instance. Different instances of SpanBuilder can be safely
-used concurrently by different threads/coroutines, provided that no single
-SpanBuilder is used by more than one thread/coroutine.
-
 **Span** - All methods of Span are safe to be called concurrently.
 
 **Event** - Events are immutable and safe to be used concurrently.


### PR DESCRIPTION
## Changes
SpanBuilder was specified in Concurrency section, but "SpanBuilder" term is never defined elsewhere. Removing this to avoid confusion.

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
