### PR TITLE
Remove version convention / semver prefix from versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Updates:
   ([#610](https://github.com/open-telemetry/opentelemetry-specification/pull/610))
 - Rename ProbabilitySampler to TraceIdRatioBasedSampler and add requirements
   ([#611](https://github.com/open-telemetry/opentelemetry-specification/pull/611))
+- Version attributes no longer have a prefix such as semver:
+  ([#873](https://github.com/open-telemetry/opentelemetry-specification/pull/873))
 
 ## v0.6.0 (07-01-2020)
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -426,7 +426,7 @@ Example 1
   },
   "Resource": {
     "service.name": "donut_shop",
-    "service.version": "semver:2.0.0",
+    "service.version": "2.0.0",
     "k8s.pod.uid": "1138528c-c36e-11e9-a1a7-42010a800198",
   },
   "TraceId": "f4dbb3edd765f620", // this is a byte sequence

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -347,7 +347,7 @@ arguments:
   In case an invalid name (null or empty string) is specified, a working default `Meter` implementation is returned as a fallback
   rather than returning null or throwing an exception.
   A `MeterProvider` could also return a no-op `Meter` here if application owners configure the SDK to suppress telemetry produced by this library.
-- `version` (optional): Specifies the version of the instrumentation library (e.g. `semver:1.0.0`).
+- `version` (optional): Specifies the version of the instrumentation library (e.g. `1.0.0`).
 
 Each distinctly named `Meter` establishes a separate namespace for its
 metric instruments, making it possible for multiple instrumentation

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -14,6 +14,7 @@ This document defines standard attributes for resources. These attributes are ty
 - [Compute Unit](#compute-unit)
 - [Compute Instance](#compute-instance)
 - [Environment](#environment)
+- [Version attributes](#version-attributes)	
 
 <!-- tocstop -->
 
@@ -106,6 +107,6 @@ Attributes defining a running environment (e.g. Operating System, Cloud, Data Ce
 
 ## Version attributes
 
-Version attributes, such as `service.version` and `library.version` are values of type `string`. They are
+Version attributes, such as `service.version`, are values of type `string`. They are
 the exact version used to identify an artifact. This may be a semantic version, e.g., `1.2.3`, git hash, e.g.,
 `8ae73a`, or an arbitrary version string, e.g., `0.1.2.20210101`, whatever was used when building the artifact.

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -14,7 +14,6 @@ This document defines standard attributes for resources. These attributes are ty
 - [Compute Unit](#compute-unit)
 - [Compute Instance](#compute-instance)
 - [Environment](#environment)
-- [Version Attributes](#version-attributes)
 
 <!-- tocstop -->
 
@@ -78,8 +77,8 @@ The identifier SHOULD be stable across different versions of an implementation.
 |---|---|---|---|
 | telemetry.sdk.name | The name of the telemetry SDK as defined above. | `opentelemetry` | No |
 | telemetry.sdk.language | The language of the telemetry SDK.<br/> One of the following values MUST be used, if one applies: "cpp", "dotnet", "erlang", "go", "java", "nodejs", "php", "python", "ruby", "webjs" | `java` | No |
-| telemetry.sdk.version | The version string of the telemetry SDK as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
-| telemetry.auto.version | The version string of the auto instrumentation agent, if used, as defined in [Version Attributes](#version-attributes). | `semver:1.2.3` | No |
+| telemetry.sdk.version | The version string of the telemetry SDK. | `1.2.3` | No |
+| telemetry.auto.version | The version string of the auto instrumentation agent, if used. | `1.2.3` | No |
 
 ## Compute Unit
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -103,3 +103,9 @@ Attributes defining a running environment (e.g. Operating System, Cloud, Data Ce
 - Deployment:
   - [Environment](./deployment_environment.md)
   - [Kubernetes](./k8s.md)
+
+## Version attributes
+
+Version attributes, such as `service.version` and `library.version` are values of type `string`. They are
+the exact version used to identify an artifact. This may be a semantic version, e.g., `1.2.3`, git hash, e.g.,
+`8ae73a`, or an arbitrary version string, e.g., `0.1.2.20210101`, whatever was used when building the artifact.

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -14,7 +14,7 @@ This document defines standard attributes for resources. These attributes are ty
 - [Compute Unit](#compute-unit)
 - [Compute Instance](#compute-instance)
 - [Environment](#environment)
-- [Version attributes](#version-attributes)	
+- [Version attributes](#version-attributes)
 
 <!-- tocstop -->
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -43,7 +43,7 @@ Certain attribute groups in this document have a **Required** column. For these 
 | service.name | Logical name of the service. <br/> MUST be the same for all instances of horizontally scaled services. | `shoppingcart` | Yes |
 | service.namespace | A namespace for `service.name`.<br/>A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. The field is optional. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace. | `Shop` | No |
 | service.instance.id | The string ID of the service instance. <br/>MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations). | `627cc493-f310-47de-96bd-71410b7dec09` | Yes |
-| service.version | The version string of the service API or implementation as defined in [Version Attributes](#version-attributes). | `semver:2.0.0` | No |
+| service.version | The version string of the service API or implementation. | `2.0.0` | No |
 
 Note: `service.namespace` and `service.name` are not intended to be concatenated for the purpose of forming a single globally unique name for the service. For example the following 2 sets of attributes actually describe 2 different services (despite the fact that the concatenation would result in the same string):
 
@@ -104,14 +104,3 @@ Attributes defining a running environment (e.g. Operating System, Cloud, Data Ce
 - Deployment:
   - [Environment](./deployment_environment.md)
   - [Kubernetes](./k8s.md)
-
-## Version Attributes
-
-Version attributes such as `service.version` and `library.version` are values of type `string`,
-with naming schemas hinting at the type of a version, such as the following:
-
-- `semver:1.2.3` (a semantic version)
-- `git:8ae73a` (a git sha hash)
-- `0.0.4.2.20190921` (a untyped version)
-
-The type and version value MUST be separated by a colon character `:`.

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -8,7 +8,7 @@
 |---|---|---|--|
 | faas.name | The name of the function being executed. | `my-function` | Yes |
 | faas.id | The unique name of the function being executed. <br /> For example, in AWS Lambda this field corresponds to the [ARN] value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory] field. | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Yes |
-| faas.version | The version string of the function being executed as defined in [Version Attributes](./README.md#version-attributes) | `semver:2.0.0` | No |
+| faas.version | The version string of the function being executed. | `2.0.0` | No |
 | faas.instance | The execution environment ID as a string. | `my-function:instance-0001` | No |
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).

--- a/specification/resource/semantic_conventions/host.md
+++ b/specification/resource/semantic_conventions/host.md
@@ -11,4 +11,4 @@
 | host.type | Type of host.<br/> For Cloud this must be the machine type.| `n1-standard-1` |
 | host.image.name | Name of the VM image or OS install the host was instantiated from. | `infra-ami-eks-worker-node-7d4ec78312`, `CentOS-8-x86_64-1905` |
 | host.image.id | VM image id. For Cloud, this value is from the provider. | `ami-07b06b442921831e5` |
-| host.image.version | The version string of the VM image as defined in [Version Attributes](./README.md#version-attributes). | `0.1` |
+| host.image.version | The version string of the VM image. | `0.1` |

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -112,7 +112,7 @@ That API MUST accept the following parameters:
   A TracerProvider could also return a no-op Tracer here if application owners configure
   the SDK to suppress telemetry produced by this library.
 - `version` (optional): Specifies the [version](../resource/semantic_conventions/README.md#version-attributes) of the instrumentation library
-  (e.g. `semver:1.0.0`).
+  (e.g. `1.0.0`).
 
 It is unspecified whether or under which conditions the same or different
 `Tracer` instances are returned from this functions.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -111,8 +111,7 @@ That API MUST accept the following parameters:
   functionality (e.g. an implementation which is not even observability-related).
   A TracerProvider could also return a no-op Tracer here if application owners configure
   the SDK to suppress telemetry produced by this library.
-- `version` (optional): Specifies the [version](../resource/semantic_conventions/README.md#version-attributes) of the instrumentation library
-  (e.g. `1.0.0`).
+- `version` (optional): Specifies the version of the instrumentation library (e.g. `1.0.0`).
 
 It is unspecified whether or under which conditions the same or different
 `Tracer` instances are returned from this functions.


### PR DESCRIPTION
Fixes #802

## Changes

Removes the convention of prefixing version numbers with things like `semver:`, `git:`. This comes from the idea that the version is the version, adding prefixes makes it something that isn't the version, nor a duck. If a user queries their data for a version number, it is very unintuitive to have to prefix queries with `semver:`, or otherwise every single data store that stores this data needs to natively understand our spec well enough to do this for them which doesn't seem like a worthwhile restriction.

I didn't add a separate attribute for the version type - in the issue, no one championed for it. I can add it if it seems very useful. Need to do it now instead of later since then it needs to be `foo.version.id` + `foo.version.type`, we can't have `foo.version` + `foo.version.type` based on our conventions for attribute key namespaces.
