### PR TITLE
Use correct header name for Baggage in example

### DIFF
--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -129,7 +129,7 @@ Baggage:
 Header:
 
 ```
-otbaggages: user=foo%40example.com,name=Example%20Name
+otcorrelations: user=foo%40example.com,name=Example%20Name
 ```
 
 ## Conflict Resolution


### PR DESCRIPTION
## Changes

Changes the Baggage header name in the example to match the spec, at least until the header name is changed again (#879).

https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/baggage/api.md#header-name
> Baggage implementations MUST use the header name otcorrelations.