### PR TITLE
fixing env var section of the spec matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -88,13 +88,13 @@ status of the feature is not known.
 
 |Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
-|OTEL_RESOURCE_ATTRIBUTES|                     |  |    | +     | +    |    | -    |   |    |   |    |
-|OTEL_LOG_LEVEL|                               |  |    | +     | -    |    | -    |   |    |   |    |
-|OTEL_PROPAGATORS|                             |  |    |       | -    |    | -    |   |    |   |    |
-|OTEL_BSP_*|                                   |  |    |       | -    |    | -    |   |    |   |    |
-|OTEL_EXPORTER_OTLP_*|                         |  |    |       | -    |    | -    |   |    |   |    |
-|OTEL_EXPORTER_JAEGER_*|                       |  |    |       | -    |    | -    |   |    |   |    |
-|OTEL_EXPORTER_ZIPKIN_*|                       |  |    |       | -    |    | -    |   |    |   |    |
+|OTEL_RESOURCE_ATTRIBUTES                      |  |    | +     | +    |    | -    |   |    |   |    |
+|OTEL_LOG_LEVEL                                |  |    | +     | -    |    | -    |   |    |   |    |
+|OTEL_PROPAGATORS                              |  |    |       | -    |    | -    |   |    |   |    |
+|OTEL_BSP_*                                    |  |    |       | -    |    | -    |   |    |   |    |
+|OTEL_EXPORTER_OTLP_*                          |  |    |       | -    |    | -    |   |    |   |    |
+|OTEL_EXPORTER_JAEGER_*                        |  |    |       | -    |    | -    |   |    |   |    |
+|OTEL_EXPORTER_ZIPKIN_*                        |  |    |       | -    |    | -    |   |    |   |    |
 
 ## Exporters
 


### PR DESCRIPTION
A trailing `|` was causing incorrect column to header alignment
