### PR TITLE
Add ParentReferenceType.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -38,6 +38,7 @@ Table of Contents
   * [GetDescription](#getdescription)
   * [GetIsOk](#getisok)
 * [SpanKind](#spankind)
+* [ParentReferenceKind](#parentreferencekind)
 * [Concurrency](#concurrency)
 * [Included Propagators](#included-propagators)
 
@@ -303,6 +304,8 @@ The API MUST accept the following parameters:
   option for implicit parenting from the current context as a default behavior.
   See [Determining the Parent Span from a Context](#determining-the-parent-span-from-a-context)
   for guidance on `Span` parenting from explicit and implicit `Context`s.
+- [`ParentReferenceKind`](#parentreferencekind), default to
+  `ParentReferenceKind.CHILD_OF` if not specified.
 - [`SpanKind`](#spankind), default to `SpanKind.Internal` if not specified.
 - [`Attributes`](../common/common.md#attributes). Additionally,
   these attributes may be used to make a sampling decision as noted in [sampling
@@ -358,6 +361,8 @@ description](../overview.md#links-between-spans).
 A `Link` is defined by the following properties:
 
 - (Required) `SpanContext` of the `Span` to link to.
+- (Optional) `ParentReferenceKind`, default to `ParentReferenceKind.CHILD_OF`
+  if not specified.
 - (Optional) One or more `Attribute`s as defined [here](../common/common.md#attributes).
 
 The `Link` SHOULD be an immutable type.
@@ -675,6 +680,28 @@ To summarize the interpretation of these kinds:
 | `PRODUCER` | | yes | | maybe |
 | `CONSUMER` | | yes | maybe | |
 | `INTERNAL` | | | | |
+
+## ParentReferenceKind
+
+`ParentReferenceKind` describes an additional property of the causal relationship
+between the `Span` and its parent. Similarly to `SpanKind`, it describes a property
+that benefit tracing systems during analysis.
+
+The property described by `ParentReferenceKind` reflects whether the parent `Span`
+depends on the child `Span` or not, and can be used to calculate the critical
+path.
+
+These are the possible `ParentReferenceKind`s:
+
+* `CHILD_OF` Indicates the parent `Span` depends on the outcome of the child
+  `Span` in some capacity. Observe the child `Span` may run synchronously or
+  asynchronously, but ultimately the parent depends on its outcome. Although
+  it is expected the child `Span` completes before the parent, this is not
+  always the case. For example, the parent may timeout before the child
+  completes, thus ignoring the child's pending outcome.
+* `FOLLOWS_FROM` Indicates the parent `Span` does not depend in any way in the
+  result of the child `Span`. The child `Span` may or may not complete
+  before the parent is done.
 
 ## Concurrency
 


### PR DESCRIPTION
Fixes #65 

This adds a new `ParentReferenceType` field to both `Span` (direct parent usage) and `Link` (additional parents usage), in order to support OpenTracing's `CHILD_OF` and `FOLLOWS_FROM` references.

The current design is not enough, as described in [this comment](https://github.com/open-telemetry/opentelemetry-specification/issues/65#issuecomment-498472762). Also, in order to facilitate (hopefully) fast merge, I decided to go with the names used by OpenTracing.

The **first question** (mostly for @yurishkuro ) is whether we should keep this `ParentReferenceType` enum open for future types - @yurishkuro mentioned this in the aforementioned comment that we should probably stick to support what exists now (if we decide to keep it open, we should probably rename its name to not have the `Parent` suffix).

The **second question** (mostly for @bogdandrutu) is whether, under this paradigm, `Links` are always expected to be `FOLLOWS_FROM` (i.e. the parent does not depend on their outcome).