### PR TITLE
Explicitly use notation conventions in trace API for SpanContext implementations

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -183,7 +183,7 @@ details on this field.
 
 ### Retrieving the TraceId and SpanId
 
-The API must allow retrieving the `TraceId` and `SpanId` in the following forms:
+The API MUST allow retrieving the `TraceId` and `SpanId` in the following forms:
 
 * Hex - returns the lowercase [hex encoded](https://tools.ietf.org/html/rfc4648#section-8)
 `TraceId` (result MUST be a 32-hex-character lowercase string) or `SpanId`


### PR DESCRIPTION
Change syntax to reflect the requirement that all `SpanContext` implementations need to allow retrieving the `TraceId` and `SpanId` in defined forms.