### PR TITLE
Add Context items for the Compliance Matrix.

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -76,7 +76,19 @@ status of the feature is not known.
 
 |Feature                                       |Go|Java|Node.js|Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|--|----|-------|------|----|------|---|----|---|----|
-|TBD|
+|Create Context Key                            |  |    |       |      |    |      |   |    |   |    |
+|Get value from Context                        |  |    |       |      |    |      |   |    |   |    |
+|Set value for Context                         |  |    |       |      |    |      |   |    |   |    |
+|Attach Context                                |  |    |       |      |    |      |   |    |   |    |
+|Detach Context                                |  |    |       |      |    |      |   |    |   |    |
+|Get current Context                           |  |    |       |      |    |      |   |    |   |    |
+|Composite Propagator support                  |  |    |       |      |    |      |   |    |   |    |
+|Global Propagator support                     |  |    |       |      |    |      |   |    |   |    |
+|[TextMapPropagator](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#textmap-propagator)|
+|Fields                                        |  |    |       |      |    |      |   |    |   |    |
+|Setter argument                               |  |    |       |      |    |      |   |    |   |    |
+|Getter argument                               |  |    |       |      |    |      |   |    |   |    |
+|Getter argument returning Keys                |  |    |       |      |    |      |   |    |   |    |
 
 ## Error Handling
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -82,8 +82,11 @@ status of the feature is not known.
 |Attach Context                                |  |    |       |      |    |      |   |    |   |    |
 |Detach Context                                |  |    |       |      |    |      |   |    |   |    |
 |Get current Context                           |  |    |       |      |    |      |   |    |   |    |
-|Composite Propagator support                  |  |    |       |      |    |      |   |    |   |    |
-|Global Propagator support                     |  |    |       |      |    |      |   |    |   |    |
+|Composite Propagator                          |  |    |       |      |    |      |   |    |   |    |
+|Global Propagator                             |  |    |       |      |    |      |   |    |   |    |
+|TraceContext Propagator                       |  |    |       |      |    |      |   |    |   |    |
+|B3 Propagator                                 |  |    |       |      |    |      |   |    |   |    |
+|Jaeger Propagator                             |  |    |       |      |    |      |   |    |   |    |
 |[TextMapPropagator](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#textmap-propagator)|
 |Fields                                        |  |    |       |      |    |      |   |    |   |    |
 |Setter argument                               |  |    |       |      |    |      |   |    |   |    |


### PR DESCRIPTION
As discussed in the latest Spec SIG call, we need to add Context Propagation items.