### PR TITLE
Update compliance matrix for C++

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -12,50 +12,50 @@ status of the feature is not known.
 |Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|
 |[TracerProvider](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracerprovider-operations)|
-|Create TracerProvider                         | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Get a Tracer                                  | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  |   | +  |
+|Create TracerProvider                         | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Get a Tracer                                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  | + | +  |
 |[Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracer-operations)|
-|Create a new Span                             | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Get active Span                               | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Mark Span active                              | + | +  | + | +    | +  | +    | + | +  |   | -  |
-|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  |   | +  |
+|Create a new Span                             | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Get active Span                               | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Mark Span active                              | + | +  | + | +    | +  | +    | + | +  | - | -  |
+|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  | + | +  |
 |[SpanContext](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext)|
-|IsValid                                       | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|IsRemote                                      | - | +  | + | +    | +  | +    | + | +  |   | +  |
-|Conforms to the W3C TraceContext spec         | + | +  | + | +    | +  | +    |   | -  |   | +  |
+|IsValid                                       | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|IsRemote                                      | - | +  | + | +    | +  | +    | + | +  | + | +  |
+|Conforms to the W3C TraceContext spec         | + | +  | + | +    | +  | +    |   | -  | + | +  |
 |[Span](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#span)|
-|Create root span                              | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Create with default parent (active span)      | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Create with parent from Context               | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Create with explicit parent Span              | + | +  | + | +    | +  | +    | + | -  |   | +  |
-|Create with explicit parent SpanContext       | - | +  | + | +    | +  | +    |   | -  |   | +  |
-|UpdateName                                    | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|User-defined start timestamp                  | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|End                                           | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|End with timestamp                            | + | +  | + | +    | +  | +    | + | -  |   | +  |
-|IsRecording                                   | + | +  | + | +    | +  | +    | + |    |   | +  |
-|Set status                                    | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  |   | +  |
+|Create root span                              | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Create with default parent (active span)      | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Create with parent from Context               | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Create with explicit parent Span              | + | +  | + | +    | +  | +    | + | -  | + | +  |
+|Create with explicit parent SpanContext       | - | +  | + | +    | +  | +    |   | -  | + | +  |
+|UpdateName                                    | + | +  | + | +    | +  | +    | + | +  | - | +  |
+|User-defined start timestamp                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|End                                           | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|End with timestamp                            | + | +  | + | +    | +  | +    | + | -  | + | +  |
+|IsRecording                                   | + | +  | + | +    | +  | +    | + |    | + | +  |
+|Set status                                    | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  | + | +  |
 |[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
-|SetAttribute                                  | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Set order preserved                           | + | -  | + | +    | +  | +    | + | +  |   | +  |
-|String type                                   | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Boolean type                                  | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Double floating-point type                    | + | +  | + | +    | +  | +    | - | +  |   | +  |
-|Signed int64 type                             | + | +  | + | +    | +  | +    | - | +  |   | +  |
-|Array of primitives (homogeneous)             | + | +  | + | +    | +  | -    | + | +  |   | +  |
-|Unicode support for keys and string values    | + | +  | + | +    | +  | +    | + | +  |   | +  |
+|SetAttribute                                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Set order preserved                           | + | -  | + | +    | +  | +    | + | +  | + | +  |
+|String type                                   | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Boolean type                                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Double floating-point type                    | + | +  | + | +    | +  | +    | - | +  | + | +  |
+|Signed int64 type                             | + | +  | + | +    | +  | +    | - | +  | + | +  |
+|Array of primitives (homogeneous)             | + | +  | + | +    | +  | -    | + | +  | + | +  |
+|Unicode support for keys and string values    | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |[Span linking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-links)|
-|AddLink                                       | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Safe for concurrent calls                     | + | +  | + | +    | +  | +    | + | +  |   | +  |
+|AddLink                                       | + | +  | + | +    | +  | +    | + | +  | - | +  |
+|Safe for concurrent calls                     | + | +  | + | +    | +  | +    | + | +  | - | +  |
 |[Span events](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-events)|
-|AddEvent                                      | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Add order preserved                           | + | +  | + | +    | +  | +    | + | +  |   | +  |
-|Safe for concurrent calls                     | + | +  | + | +    | +  | +    | + | +  |   | +  |
+|AddEvent                                      | + | +  | + | +    | +  | +    | + | +  | - | +  |
+|Add order preserved                           | + | +  | + | +    | +  | +    | + | +  | - | +  |
+|Safe for concurrent calls                     | + | +  | + | +    | +  | +    | + | +  | - | +  |
 |[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
-|RecordException                               | - | +  | + | +    | +  | -    |   | +  |   | +  |
-|RecordException with extra parameters         | - | -  | + | -    | -  | -    |   | +  |   | +  |
+|RecordException                               | - | +  | + | +    | +  | -    |   | +  | - | +  |
+|RecordException with extra parameters         | - | -  | + | -    | -  | -    |   | +  | - | +  |
 
 ## Metrics
 
@@ -103,23 +103,23 @@ status of the feature is not known.
 
 |Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|
-|OTEL_RESOURCE_ATTRIBUTES                      | + |    | + | +    |    | -    |   |    |   | -  |
-|OTEL_LOG_LEVEL                                |   |    | + | -    |    | -    |   |    |   | -  |
-|OTEL_PROPAGATORS                              |   |    |   | -    |    | -    |   |    |   | -  |
-|OTEL_BSP_*                                    |   |    |   | -    |    | -    |   |    |   | -  |
-|OTEL_EXPORTER_OTLP_*                          |   |    |   | -    |    | -    |   |    |   | -  |
-|OTEL_EXPORTER_JAEGER_*                        |   |    |   | -    |    | -    |   |    |   | -  |
-|OTEL_EXPORTER_ZIPKIN_*                        |   |    |   | -    |    | -    |   |    |   | -  |
+|OTEL_RESOURCE_ATTRIBUTES                      | + |    | + | +    |    | -    |   |    | - | -  |
+|OTEL_LOG_LEVEL                                |   |    | + | -    |    | -    |   |    | - | -  |
+|OTEL_PROPAGATORS                              |   |    |   | -    |    | -    |   |    | - | -  |
+|OTEL_BSP_*                                    |   |    |   | -    |    | -    |   |    | - | -  |
+|OTEL_EXPORTER_OTLP_*                          |   |    |   | -    |    | -    |   |    | - | -  |
+|OTEL_EXPORTER_JAEGER_*                        |   |    |   | -    |    | -    |   |    | - | -  |
+|OTEL_EXPORTER_ZIPKIN_*                        |   |    |   | -    |    | -    |   |    | - | -  |
 
 ## Exporters
 
 |Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|
-|Standard output (logging)                     | + | +  | + | +    | +  | +    | - | +  |   | +  |
-|In-memory (mock exporter)                     | + | +  | + | +    | +  | +    | - | -  |   | -  |
+|Standard output (logging)                     | + | +  | + | +    | +  | +    | - | +  | + | +  |
+|In-memory (mock exporter)                     | + | +  | + | +    | +  | +    | - | -  | - | -  |
 |[OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/otlp.md)|
-|OTLP/gRPC Exporter                            | + | +  | + | +    |    | +    |   | +  |   | +  |
-|OTLP/HTTP binary Protobuf Exporter            | - | -  | + | -    |    | +    |   |    |   | +  |
+|OTLP/gRPC Exporter                            | + | +  | + | +    |    | +    |   | +  | + | +  |
+|OTLP/HTTP binary Protobuf Exporter            | - | -  | + | -    |    | +    |   |    | + | +  |
 |OTLP/HTTP JSON Protobuf Exporter              | - | -  | + | -    |    | -    |   |    |   |    |
 |OTLP/HTTP gzip Content-Encoding support       | - | -  | + | -    |    | -    |   |    |   |    |
 |Concurrent sending                            | - |    | + | -    |    | -    |   | +  |   |    |


### PR DESCRIPTION
Updated the spec compliance matrix to reflect the status of OpenTelemetry C++.

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
