### PR TITLE
Fix Ruby stacktrace link reference in exceptions.md

### DIFF
--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -52,7 +52,7 @@ grained information from a stacktrace, if necessary.
 [java-stacktrace]: https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#printStackTrace%28%29
 [python-stacktrace]: https://docs.python.org/3/library/traceback.html#traceback.format_exc
 [js-stacktrace]: https://v8.dev/docs/stack-trace-api
-[ruby-stacktrace]: https://ruby-doc.org/core-2.7.1/Exception.html#method-i-full_message
+[ruby-full-message]: https://ruby-doc.org/core-2.7.1/Exception.html#method-i-full_message
 [csharp-stacktrace]: https://docs.microsoft.com/en-us/dotnet/api/system.exception.tostring
 [go-stacktrace]: https://golang.org/pkg/runtime/debug/#Stack
 [telemetry-sdk-resource]: https://github.com/open-telemetry/opentelemetry-specification/tree/master/specification/resource/semantic_conventions#telemetry-sdk


### PR DESCRIPTION
The link reference is broken:

![image](https://user-images.githubusercontent.com/7052238/92006048-87cadf00-ed44-11ea-8ea1-a4a83f82bce5.png)
