### PR TITLE
Remove Span.Status per OTEP-134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ New:
 - Add Span API and semantic conventions for recording exceptions
   ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
   [#874](https://github.com/open-telemetry/opentelemetry-specification/pull/874))
+- Remove `Span.Status` as per [OTEP-134](https://github.com/open-telemetry/oteps/pull/134)
+ (#918[https://github.com/open-telemetry/opentelemetry-specification/pull/918])
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ New:
   ([#697](https://github.com/open-telemetry/opentelemetry-specification/pull/697),
   [#874](https://github.com/open-telemetry/opentelemetry-specification/pull/874))
 - Remove `Span.Status` as per [OTEP-134](https://github.com/open-telemetry/oteps/pull/134)
- (#918[https://github.com/open-telemetry/opentelemetry-specification/pull/918])
+  ([#918](https://github.com/open-telemetry/opentelemetry-specification/pull/918))
 
 Updates:
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -35,6 +35,7 @@ status of the feature is not known.
 |End                                           | + | +  | +     | +    | +  | +    | + | +  |   | +  |
 |End with timestamp                            | + | +  | +     | +    | +  | +    | + | -  |   | +  |
 |IsRecording                                   | + | +  | +     | +    | +  | +    | + |    |   | +  |
+|Set status (REMOVED)                          | + | +  | +     | +    | +  | +    | + | +  |   | +  |
 |Safe for concurrent calls                     | + | +  | +     |      | +  | +    | + | +  |   | +  |
 |[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
 |SetAttribute                                  | + | +  | +     | +    | +  | +    | + | +  |   | +  |
@@ -136,6 +137,7 @@ status of the feature is not known.
 |InstrumentationLibrary mapping                |   | +  | -     | -    |    | -    | - | -  |   |    |
 |Boolean attributes                            | + | +  | +     | +    |    | +    | + | +  |   |    |
 |Array attributes                              | + | +  | +     | -    |    | +    | + | +  |   |    |
+|Status mapping (REMOVED)                      | + | -  | +     | -    |    | +    | + | +  |   |    |
 |Event attributes mapping to Annotations       | + |    | +     | +    |    | +    | + | +  |   |    |
 |Fractional microseconds in timestamps         | + | -  | +     | -    |    | -    | - | -  |   |    |
 |Jaeger|

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -35,7 +35,6 @@ status of the feature is not known.
 |End                                           | + | +  | +     | +    | +  | +    | + | +  |   | +  |
 |End with timestamp                            | + | +  | +     | +    | +  | +    | + | -  |   | +  |
 |IsRecording                                   | + | +  | +     | +    | +  | +    | + |    |   | +  |
-|Set status                                    | + | +  | +     | +    | +  | +    | + | +  |   | +  |
 |Safe for concurrent calls                     | + | +  | +     |      | +  | +    | + | +  |   | +  |
 |[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
 |SetAttribute                                  | + | +  | +     | +    | +  | +    | + | +  |   | +  |
@@ -137,7 +136,6 @@ status of the feature is not known.
 |InstrumentationLibrary mapping                |   | +  | -     | -    |    | -    | - | -  |   |    |
 |Boolean attributes                            | + | +  | +     | +    |    | +    | + | +  |   |    |
 |Array attributes                              | + | +  | +     | -    |    | +    | + | +  |   |    |
-|Status mapping                                | + | -  | +     | -    |    | +    | + | +  |   |    |
 |Event attributes mapping to Annotations       | + |    | +     | +    |    | +    | + | +  |   |    |
 |Fractional microseconds in timestamps         | + | -  | +     | -    |    | -    | - | -  |   |    |
 |Jaeger|

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -26,17 +26,10 @@ Table of Contents
     * [IsRecording](#isrecording)
     * [Set Attributes](#set-attributes)
     * [Add Events](#add-events)
-    * [Set Status](#set-status)
     * [UpdateName](#updatename)
     * [End](#end)
     * [Record Exception](#record-exception)
   * [Span lifetime](#span-lifetime)
-* [Status](#status)
-  * [StatusCanonicalCode](#statuscanonicalcode)
-  * [Status creation](#status-creation)
-  * [GetCanonicalCode](#getcanonicalcode)
-  * [GetDescription](#getdescription)
-  * [GetIsOk](#getisok)
 * [SpanKind](#spankind)
 * [Concurrency](#concurrency)
 * [Included Propagators](#included-propagators)
@@ -226,7 +219,6 @@ the entire operation and, optionally, one or more sub-spans for its sub-operatio
 - [`Attributes`](../common/common.md#attributes)
 - A list of [`Link`s](#add-links) to other `Span`s
 - A list of timestamped [`Event`s](#add-events)
-- A [`Status`](#set-status).
 
 The _span name_ concisely identifies the work represented by the Span,
 for example, an RPC method name, a function name,
@@ -371,8 +363,8 @@ Links SHOULD preserve the order in which they're set.
 
 ### Span operations
 
-With the exception of the function to retrieve the `Span`'s `SpanContext` and
-recording status, none of the below may be called after the `Span` is finished.
+With the exception of the function to retrieve the `Span`'s `SpanContext`,
+none of the below may be called after the `Span` is finished.
 
 #### Get Context
 
@@ -385,8 +377,7 @@ The Span interface MUST provide:
 #### IsRecording
 
 Returns true if this `Span` is recording information like events with the
-`AddEvent` operation, attributes using `SetAttributes`, status with `SetStatus`,
-etc.
+`AddEvent` operation, attributes using `SetAttributes`, etc.
 
 There should be no parameter.
 
@@ -453,19 +444,6 @@ keys"](semantic_conventions/README.md) which have prescribed semantic meanings.
 
 Note that [`RecordException`](#record-exception) is a specialized variant of
 `AddEvent` for recording exception events.
-
-#### Set Status
-
-Sets the [`Status`](#status) of the `Span`. If used, this will override the
-default `Span` status, which is `OK`.
-
-Only the value of the last call will be recorded, and implementations are free
-to ignore previous calls.
-
-The Span interface MUST provide:
-
-- An API to set the `Status` where the new status is the only argument. This
-  SHOULD be called `SetStatus`.
 
 #### UpdateName
 
@@ -535,90 +513,6 @@ timestamps to the Span object:
 
 Start and end time as well as Event's timestamps MUST be recorded at a time of a
 calling of corresponding API.
-
-## Status
-
-`Status` interface represents the status of a finished `Span`. It's composed of
-a canonical code in conjunction with an optional descriptive message.
-
-### StatusCanonicalCode
-
-`StatusCanonicalCode` represents the canonical set of status codes of a finished
-`Span`, following the [Standard GRPC
-codes](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md):
-
-- `Ok`
-  - The operation completed successfully.
-- `Cancelled`
-  - The operation was cancelled (typically by the caller).
-- `Unknown`
-  - An unknown error.
-- `InvalidArgument`
-  - Client specified an invalid argument. Note that this differs from
-    `FailedPrecondition`. `InvalidArgument` indicates arguments that are problematic
-    regardless of the state of the system.
-- `DeadlineExceeded`
-  - Deadline expired before operation could complete. For operations that change the
-    state of the system, this error may be returned even if the operation has
-    completed successfully.
-- `NotFound`
-  - Some requested entity (e.g., file or directory) was not found.
-- `AlreadyExists`
-  - Some entity that we attempted to create (e.g., file or directory) already exists.
-- `PermissionDenied`
-  - The caller does not have permission to execute the specified operation.
-    `PermissionDenied` must not be used if the caller cannot be identified (use
-    `Unauthenticated1` instead for those errors).
-- `ResourceExhausted`
-  - Some resource has been exhausted, perhaps a per-user quota, or perhaps the
-    entire file system is out of space.
-- `FailedPrecondition`
-  - Operation was rejected because the system is not in a state required for the
-    operation's execution.
-- `Aborted`
-  - The operation was aborted, typically due to a concurrency issue like sequencer
-    check failures, transaction aborts, etc.
-- `OutOfRange`
-  - Operation was attempted past the valid range. E.g., seeking or reading past end
-    of file. Unlike `InvalidArgument`, this error indicates a problem that may be
-    fixed if the system state changes.
-- `Unimplemented`
-  - Operation is not implemented or not supported/enabled in this service.
-- `Internal`
-  - Internal errors. Means some invariants expected by underlying system has been
-    broken.
-- `Unavailable`
-  - The service is currently unavailable. This is a most likely a transient
-    condition and may be corrected by retrying with a backoff.
-- `DataLoss`
-  - Unrecoverable data loss or corruption.
-- `Unauthenticated`
-  - The request does not have valid authentication credentials for the operation.
-
-### Status creation
-
-API MUST provide a way to create a new `Status`.
-
-Required parameters
-
-- `StatusCanonicalCode` of this `Status`.
-
-Optional parameters
-
-- Description of this `Status`.
-
-### GetCanonicalCode
-
-Returns the `StatusCanonicalCode` of this `Status`.
-
-### GetDescription
-
-Returns the description of this `Status`.
-Languages should follow their usual conventions on whether to return `null` or an empty string here if no description was given.
-
-### GetIsOk
-
-Returns true if the canonical code of this `Status` is `Ok`, otherwise false.
 
 ## SpanKind
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -34,10 +34,6 @@ OpenTelemetry Span's `InstrumentationLibrary` MUST be reported as span `tags` to
 
 TBD
 
-### Status
-
-TBD
-
 ### Events
 
 TBD

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -22,7 +22,6 @@ and Zipkin.
 | Span.Attributes          | Span.Tags        | See [Attributes](../../common/common.md#attributes) for data types for the mapping.            |
 | Span.Events              | Span.Annotations | See [Events](#events) for the mapping format.                                                 |
 | Span.Links               | TBD              | TBD                                                                                           |
-| Span.Status              | Add to Span.Tags | See [Status](#status) for tag names to use.                                                   |
 | Span.LocalChildSpanCount | TBD              | TBD                                                                                           |
 
 TBD : This is work in progress document and it is currently doesn't specify
@@ -135,20 +134,6 @@ Array values MUST be serialized to string like a JSON list as mentioned in
 [semantic conventions](../../overview.md#semantic-conventions).
 
 TBD: add examples
-
-### Status
-
-Span `Status` MUST be reported as a key-value pair in `tags` to Zipkin.
-
-The following table defines the OpenTelemetry `Status` to Zipkin `tags` mapping.
-
-| Status|Tag Key| Tag Value |
-|--|--|--|
-|Code | `ot.status_code` | Name of the code, for example: `OK` |
-|Message *(optional)* | `ot.status_description` | `{message}` |
-
-The `ot.status_code` tag value MUST follow the [Standard GRPC Code
-Names](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md).
 
 ### Events
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -13,7 +13,6 @@ This document defines how to describe remote procedure calls
     + [Service name](#service-name)
   * [Distinction from HTTP spans](#distinction-from-http-spans)
 - [gRPC](#grpc)
-  * [Status](#status)
   * [Events](#events)
 
 <!-- tocstop -->

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -20,7 +20,7 @@ This document defines how to describe remote procedure calls
 
 ## Common remote procedure call conventions
 
-A remote procedure calls is described by two separate spans, one on the client-side and one on the server-side.
+A remote procedure calls are described by two separate spans, one on the client-side and one on the server-side.
 
 For outgoing requests, the `SpanKind` MUST be set to `CLIENT` and for incoming requests to `SERVER`.
 
@@ -89,16 +89,12 @@ Note that _method_ in this context is about the called remote procedure and _not
 
 For remote procedure calls via [gRPC][], additional conventions are described in this section.
 
-`rpc.system` MUST be set to `"grpc"`.
+| Attribute name |                          Notes and examples                            | Required? |
+| -------------- | ---------------------------------------------------------------------- | --------- |
+| `rpc.system`   | MUST be set to `"grpc"`       | Yes |
+| `rpc.status`  | Canonical status code of the gRPC call's response    | Yes |
 
 [gRPC]: https://grpc.io/
-
-### Status
-
-Implementations MUST set status which MUST be the same as the gRPC client/server
-status. The mapping between gRPC canonical codes and OpenTelemetry status codes
-is 1:1 as OpenTelemetry canonical codes is just a snapshot of grpc codes which
-can be found [here](https://github.com/grpc/grpc-go/blob/master/codes/codes.go).
 
 ### Events
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -92,7 +92,7 @@ For remote procedure calls via [gRPC][], additional conventions are described in
 | Attribute name |                          Notes and examples                            | Required? |
 | -------------- | ---------------------------------------------------------------------- | --------- |
 | `rpc.system`   | MUST be set to `"grpc"`       | Yes |
-| `rpc.status`  | Canonical status code of the gRPC call's response    | Yes |
+| `rpc.grpc.status`  | Canonical status code of the gRPC call's response    | Yes |
 
 [gRPC]: https://grpc.io/
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -19,7 +19,7 @@ This document defines how to describe remote procedure calls
 
 ## Common remote procedure call conventions
 
-A remote procedure calls are described by two separate spans, one on the client-side and one on the server-side.
+A remote procedure call is described by two separate spans, one on the client-side and one on the server-side.
 
 For outgoing requests, the `SpanKind` MUST be set to `CLIENT` and for incoming requests to `SERVER`.
 


### PR DESCRIPTION
Fixes #706

## Changes

Remove `Span.Status` as per [OTEP-134](https://github.com/open-telemetry/oteps/pull/134)