### PR TITLE
Describe association between Sampler and TracerProvider.

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -45,6 +45,8 @@ The flag combination `SampledFlag == true` and `IsRecording == false`
 could cause gaps in the distributed trace, and because of this OpenTelemetry API
 MUST NOT allow this combination.
 
+<a name="recording-sampled-reaction-table"></a>
+
 The following table summarizes the expected behavior for each combination of
 `IsRecording` and `SampledFlag`.
 
@@ -56,7 +58,10 @@ The following table summarizes the expected behavior for each combination of
 | false         | false          | false                         | false                        |
 
 The SDK defines the interface [`Sampler`](#sampler) as well as a set of
-[built-in samplers](#built-in-samplers).
+[built-in samplers](#built-in-samplers) and associates a `Sampler` with each [`TracerProvider`].
+
+When asked to create a Span, the SDK MUST query the `Sampler`'s [`ShouldSample`](#shouldsample) method before actually creating the span, and act accordingly
+(see description of [`ShouldSample`'s](#shouldsample) return value below for how to set `IsRecording` and `Sampled` on the Span, and the [table above](#recording-sampled-reaction-table) on whether to pass the `Span` to `SpanProcessor`s.  A non-recording span MAY be implemented using the same mechanism as when a `Span` is created with no API-implementation installed (`NoOpSpan` or `DefaultSpan`).
 
 ### Sampler
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -60,8 +60,11 @@ The following table summarizes the expected behavior for each combination of
 The SDK defines the interface [`Sampler`](#sampler) as well as a set of
 [built-in samplers](#built-in-samplers) and associates a `Sampler` with each [`TracerProvider`].
 
-When asked to create a Span, the SDK MUST query the `Sampler`'s [`ShouldSample`](#shouldsample) method before actually creating the span, and act accordingly
-(see description of [`ShouldSample`'s](#shouldsample) return value below for how to set `IsRecording` and `Sampled` on the Span, and the [table above](#recording-sampled-reaction-table) on whether to pass the `Span` to `SpanProcessor`s.  A non-recording span MAY be implemented using the same mechanism as when a `Span` is created with no API-implementation installed (`NoOpSpan` or `DefaultSpan`).
+When asked to create a Span, the SDK MUST query the `Sampler`'s [`ShouldSample`](#shouldsample) method before actually creating the span, and act accordingly:
+see description of [`ShouldSample`'s](#shouldsample) return value below for how to set `IsRecording` and `Sampled` on the Span,
+and the [table above](#recording-sampled-reaction-table) on whether to pass the `Span` to `SpanProcessor`s. 
+A non-recording span MAY be implemented using the same mechanism as when a `Span` is created with no API-implementation installed
+(sometimes called a `NoOpSpan` or `DefaultSpan`).
 
 ### Sampler
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -62,7 +62,7 @@ The SDK defines the interface [`Sampler`](#sampler) as well as a set of
 
 When asked to create a Span, the SDK MUST query the `Sampler`'s [`ShouldSample`](#shouldsample) method before actually creating the span, and act accordingly:
 see description of [`ShouldSample`'s](#shouldsample) return value below for how to set `IsRecording` and `Sampled` on the Span,
-and the [table above](#recording-sampled-reaction-table) on whether to pass the `Span` to `SpanProcessor`s. 
+and the [table above](#recording-sampled-reaction-table) on whether to pass the `Span` to `SpanProcessor`s.
 A non-recording span MAY be implemented using the same mechanism as when a `Span` is created with no API-implementation installed
 (sometimes called a `NoOpSpan` or `DefaultSpan`).
 


### PR DESCRIPTION
Fixes #781.

Note that how span and trace IDs are (not) to be generated is currently unspecified, see #864 

## Changes

* Describes association of Sampler with TracerProvider. This is hopefully how everyone already implemented this.