### PR TITLE
Address ambiguity in zipkin formatting

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -139,7 +139,7 @@ status of the feature is not known.
 |Array attributes                              | + | +  | + | -    |    | +    | + | +  |   |    |
 |Status mapping                                | + | -  | + | -    |    | +    | + | +  |   |    |
 |Event attributes mapping to Annotations       | + |    | + | +    |    | +    | + | +  |   |    |
-|Fractional microseconds in timestamps         | + | -  | + | -    |    | -    | - | -  |   |    |
+|Integer microseconds in timestamps            |   |    |   |      |    |      |   |    |   |    |
 |Jaeger|
 |TBD|
 |OpenCensus|

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -163,8 +163,8 @@ include attribute values like this:
 ### Unit of Time
 
 Zipkin times like `timestamp`, `duration` and `annotation.timestamp` MUST be
-reported in microseconds as whole numbers and rounded up. For example, `duration`
-of 234 nanoseconds will be represented as 1 microsecond.
+reported in microseconds as whole numbers. For example, `duration`
+of 1234 nanoseconds will be represented as 1 microsecond.
 
 ## Request Payload
 

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -163,8 +163,8 @@ include attribute values like this:
 ### Unit of Time
 
 Zipkin times like `timestamp`, `duration` and `annotation.timestamp` MUST be
-reported in microseconds with decimal accuracy. For example, `duration` of 1234
-nanoseconds will be represented as 1.234 microseconds.
+reported in microseconds as whole numbers and rounded up. For example, `duration`
+of 234 nanoseconds will be represented as 1 microsecond.
 
 ## Request Payload
 


### PR DESCRIPTION
Fixes #568

## Changes

The Zipkin exporter specification suggests sending timestamps in fractions, while the Zipkin swagger documentation specifies integers https://github.com/openzipkin/zipkin-api/blob/master/zipkin2-api.yaml. This change removes the ambiguity and adheres to the Zipkin spec. 

The spec compliance matrix has been updated to reflect this change.
