### PR TITLE
Inconsistent Sampling Result Names

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -93,10 +93,10 @@ Returns the sampling Decision for a `Span` to be created.
 It produces an output called `SamplingResult` which contains:
 
 * A sampling `Decision`. One of the following enum values:
-  * `NOT_RECORDED` - `IsRecording() == false`, span will not be recorded and all events and attributes
+  * `IGNORE` - `IsRecording() == false`, span will not be recorded and all events and attributes
   will be dropped.
-  * `RECORDED` - `IsRecording() == true`, but `Sampled` flag MUST NOT be set.
-  * `RECORDED_AND_SAMPLED` - `IsRecording() == true` AND `Sampled` flag` MUST be set.
+  * `RECORD_ONLY` - `IsRecording() == true`, but `Sampled` flag MUST NOT be set.
+  * `RECORD_AND_SAMPLE` - `IsRecording() == true` AND `Sampled` flag` MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 
@@ -115,12 +115,12 @@ The default sampler is `ParentBased(root=AlwaysOn)`.
 
 #### AlwaysOn
 
-* Returns `RECORDED_AND_SAMPLED` always.
+* Returns `RECORD_AND_SAMPLE` always.
 * Description MUST be `AlwaysOnSampler`.
 
 #### AlwaysOff
 
-* Returns `NOT_RECORDED` always.
+* Returns `IGNORE` always.
 * Description MUST be `AlwaysOffSampler`.
 
 #### TraceIdRatioBased

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -85,10 +85,10 @@ Returns the sampling Decision for a `Span` to be created.
 It produces an output called `SamplingResult` which contains:
 
 * A sampling `Decision`. One of the following enum values:
-  * `NOT_RECORD` - `IsRecording() == false`, span will not be recorded and all events and attributes
+  * `NOT_RECORDED` - `IsRecording() == false`, span will not be recorded and all events and attributes
   will be dropped.
-  * `RECORD` - `IsRecording() == true`, but `Sampled` flag MUST NOT be set.
-  * `RECORD_AND_SAMPLED` - `IsRecording() == true` AND `Sampled` flag` MUST be set.
+  * `RECORDED` - `IsRecording() == true`, but `Sampled` flag MUST NOT be set.
+  * `RECORDED_AND_SAMPLED` - `IsRecording() == true` AND `Sampled` flag` MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 
@@ -107,12 +107,12 @@ The default sampler is `ParentBased(root=AlwaysOn)`.
 
 #### AlwaysOn
 
-* Returns `RECORD_AND_SAMPLED` always.
+* Returns `RECORDED_AND_SAMPLED` always.
 * Description MUST be `AlwaysOnSampler`.
 
 #### AlwaysOff
 
-* Returns `NOT_RECORD` always.
+* Returns `NOT_RECORDED` always.
 * Description MUST be `AlwaysOffSampler`.
 
 #### TraceIdRatioBased


### PR DESCRIPTION
### Current Names
- `NOT_RECORD`
- `RECORD`
- `RECORD_AND_SAMPLED`

Seems like we should pick between present tense or past tense and make it consistent. I am proposing that we use past tense as in it's a decision that has already been made.

`NOT_RECORD` doesn't make sense. It is not correct English.

### Proposed Names
- `NOT_RECORDED`
- `RECORDED`
- `RECORDED_AND_SAMPLED`

Related: https://github.com/open-telemetry/opentelemetry-dotnet/issues/1255