### PR TITLE
Add OTEL_EXPORTER environment variable

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -110,6 +110,7 @@ status of the feature is not known.
 |OTEL_EXPORTER_OTLP_*                          |   |    |   | -    |    | -    |   |    | - | -  |
 |OTEL_EXPORTER_JAEGER_*                        |   |    |   | -    |    | -    |   |    | - | -  |
 |OTEL_EXPORTER_ZIPKIN_*                        |   |    |   | +    |    | -    |   |    | - | -  |
+|OTEL_EXPORTER                                 |   |    |   |      |    |      |   |    |   |    |
 
 ## Exporters
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -19,19 +19,25 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_BSP_MAX_QUEUE_SIZE        | Maximum queue size                             | 2048    |                                                       |
 | OTEL_BSP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                             | 512     | Must be less than or equal to OTEL_BSP_MAX_QUEUE_SIZE |
 
+## OTLP Exporters
+
+| Name                        | Description                                     | Default |
+| --------------------------- | ----------------------------------------------- | ------- |
+| OTEL_EXPORTER_OTLP_ENDPOINT | Ingest endpoint for both OTLP spans and metrics | -       |
+
 ## OTLP Span Exporter
 
-| Name                             | Description                                | Default |
-| -------------------------------- | ------------------------------------------ | ------- |
-| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time to export each span batch | -       |
-| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans             | -       |
+| Name                             | Description                                | Default | Notes                                              |
+| -------------------------------- | ------------------------------------------ | ------- | -------------------------------------------------- |
+| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time to export each span batch | -       |                                                    |
+| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans             | -       | Overrides OTEL_EXPORTER_OTLP_ENDPOINT if non-empty |
 
 ## OTLP Metric Exporter
 
-| Name                               | Description                                  | Default |
-| ---------------------------------- | -------------------------------------------- | ------- |
-| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time to export each metric batch | -       |
-| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics             | -       |
+| Name                               | Description                                  | Default | Notes                                              |
+| ---------------------------------- | -------------------------------------------- | ------- | -------------------------------------------------- |
+| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time to export each metric batch | -       |                                                    |
+| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics             | -       | Overrides OTEL_EXPORTER_OTLP_ENDPOINT if non-empty |
 
 ## Jaeger Exporter
 
@@ -48,6 +54,12 @@ The goal of this specification is to unify the environment variable names betwee
 | Name                          | Description                | Default                                                                                                      |
 | ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
+
+## Exporter Selection
+
+| Name          | Description                                                                  | Default | Notes                                                              |
+| ------------- | ---------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------ |
+| OTEL_EXPORTER | Exporter to be used, can be a comma-separated list to use multiple exporters | "otlp"  | Other known values: "jaeger", "zipkin", "otlp_span", "otlp_metric" |
 
 ## Language Specific Environment Variables
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -19,25 +19,9 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_BSP_MAX_QUEUE_SIZE        | Maximum queue size                             | 2048    |                                                       |
 | OTEL_BSP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                             | 512     | Must be less than or equal to OTEL_BSP_MAX_QUEUE_SIZE |
 
-## OTLP Exporters
+## OTLP Exporter
 
-| Name                        | Description                                     | Default |
-| --------------------------- | ----------------------------------------------- | ------- |
-| OTEL_EXPORTER_OTLP_ENDPOINT | Ingest endpoint for both OTLP spans and metrics | -       |
-
-## OTLP Span Exporter
-
-| Name                             | Description                                | Default | Notes                                              |
-| -------------------------------- | ------------------------------------------ | ------- | -------------------------------------------------- |
-| OTEL_EXPORTER_OTLP_SPAN_TIMEOUT  | Max waiting time to export each span batch | -       |                                                    |
-| OTEL_EXPORTER_OTLP_SPAN_ENDPOINT | Ingest endpoint for OTLP spans             | -       | Overrides OTEL_EXPORTER_OTLP_ENDPOINT if non-empty |
-
-## OTLP Metric Exporter
-
-| Name                               | Description                                  | Default | Notes                                              |
-| ---------------------------------- | -------------------------------------------- | ------- | -------------------------------------------------- |
-| OTEL_EXPORTER_OTLP_METRIC_TIMEOUT  | Max waiting time to export each metric batch | -       |                                                    |
-| OTEL_EXPORTER_OTLP_METRIC_ENDPOINT | Ingest endpoint for OTLP metrics             | -       | Overrides OTEL_EXPORTER_OTLP_ENDPOINT if non-empty |
+See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.md).
 
 ## Jaeger Exporter
 
@@ -57,9 +41,11 @@ The goal of this specification is to unify the environment variable names betwee
 
 ## Exporter Selection
 
-| Name          | Description                                                                  | Default | Notes                                                              |
-| ------------- | ---------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------ |
-| OTEL_EXPORTER | Exporter to be used, can be a comma-separated list to use multiple exporters | "otlp"  | Other known values: "jaeger", "zipkin", "otlp_span", "otlp_metric" |
+| Name          | Description                                                                  | Default |
+| ------------- | ---------------------------------------------------------------------------- | ------- |
+| OTEL_EXPORTER | Exporter to be used, can be a comma-separated list to use multiple exporters | "otlp"  |
+
+Known values for OTEL_EXPORTER are: "otlp", "jaeger", "zipkin", "prometheus", "otlp_span", "otlp_metric".
 
 ## Language Specific Environment Variables
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -47,6 +47,8 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 Known values for OTEL_EXPORTER are: "otlp", "jaeger", "zipkin", "prometheus", "otlp_span", "otlp_metric".
 
+Note: "otlp" is equivalent to "otlp_span,otlp_metric".
+
 ## Language Specific Environment Variables
 
 To ensure consistent naming across projects, this specification recommends that language specific environment variables are formed using the following convention:


### PR DESCRIPTION
Fixes #710

## Changes

Adds `OTEL_EXPORTER` environment variable to select the exporter to be used.

Adds `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to configure the ingest endpoint for both OTLP spans and metrics.

## Notes

1. I added `OTEL_EXPORTER_OTLP_ENDPOINT` in this PR because I think it makes the default value `OTEL_EXPORTER=otlp` make more sense.

   (It also happens to be the env var that the Java SDK uses currently, and seems simpler for most OTLP users, who will be sending spans and metrics to the same endpoint)

   An alternative would be to specify the default value as `OTEL_EXPORTER=otlp_span,otlp_metric`.

2. I went with the singular `OTEL_EXPORTER` over the plural `OTEL_EXPORTERS`, since the common use case is to configure just one exporter and so this seems less confusing.