### PR TITLE
B3 clarification

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -312,11 +312,17 @@ Required parameters:
 The official list of propagators that MUST be maintained by the OpenTelemetry
 organization and MUST be distributed as OpenTelemetry extension packages:
 
-- [B3](https://github.com/openzipkin/b3-propagation)
-  - MUST support extracting context from both single and multi-header encodings
-  - MUST default to injecting context using the multi-header encoding, but
-    MAY provide configuration to change the default
-- [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format)
+* [B3](https://github.com/openzipkin/b3-propagation)
+* [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format)
+
+### B3 Requirements
+
+B3 has both single and multi-header encodings. To ensure consistent behavior
+between OpenTelemetry libraries, B3 propagators:
+
+* MUST support extracting context from both single and multi-header encodings
+* MUST default to injecting context using the multi-header encoding, but
+  MAY provide configuration to change the default
 
 Additional `Propagator`s implementing vendor-specific protocols such as
 AWS X-Ray trace header protocol are encouraged to be maintained and distributed by

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -317,12 +317,25 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 
 ### B3 Requirements
 
-B3 has both single and multi-header encodings. To ensure consistent behavior
-between OpenTelemetry libraries, B3 propagators:
+B3 has both single and multi-header encodings. To maximize compatibility between
+implementations, the following guidelines have been established for B3
+propagation in OpenTelemetry.
 
-* MUST support extracting context from both single and multi-header encodings
-* MUST default to injecting context using the multi-header encoding, but
-  MAY provide configuration to change the default
+#### Extract
+
+Propagators MUST attempt to extract B3 encoded using single and multi-header
+formats. When extracting, the single-header variant takes precedence over
+the multi-header version.
+
+#### Inject
+
+When injecting B3, propagators:
+
+* MUST default to injecting B3 using the single-header format
+* MUST provide configuration to change the default injection format to B3
+  multi-header
+
+### Vendor-specific propagators
 
 Additional `Propagator`s implementing vendor-specific protocols such as
 AWS X-Ray trace header protocol are encouraged to be maintained and distributed by

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -312,8 +312,11 @@ Required parameters:
 The official list of propagators that MUST be maintained by the OpenTelemetry
 organization and MUST be distributed as OpenTelemetry extension packages:
 
-* [B3](https://github.com/openzipkin/b3-propagation)
-* [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format)
+- [B3](https://github.com/openzipkin/b3-propagation)
+  - MUST support extracting context from both single and multi-header encodings
+  - MUST default to injecting context using the multi-header encoding, but
+    MAY provide configuration to change the default
+- [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format)
 
 Additional `Propagator`s implementing vendor-specific protocols such as
 AWS X-Ray trace header protocol are encouraged to be maintained and distributed by


### PR DESCRIPTION
Fixes #960

## Changes

This PR clarifies expectations around B3 context propagation. Specifically, B3 propagators:

* MUST support extracting context from both single and multi-header encodings
* MUST default to injecting context using the multi-header encoding, but
  MAY provide configuration to change the default

Additionally, it relaxes the requirement that b3 and jaeger propagators need to distributed as extension packages, making it possible to distribute them as part of the SDK if a language chooses.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
