### PR TITLE
Rename prefix for Zipkin attributes from OT to OTel

### DIFF
--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -144,10 +144,10 @@ The following table defines the OpenTelemetry `Status` to Zipkin `tags` mapping.
 
 | Status|Tag Key| Tag Value |
 |--|--|--|
-|Code | `ot.status_code` | Name of the code, for example: `OK` |
-|Message *(optional)* | `ot.status_description` | `{message}` |
+|Code | `otel.status_code` | Name of the code, for example: `OK` |
+|Message *(optional)* | `otel.status_description` | `{message}` |
 
-The `ot.status_code` tag value MUST follow the [Standard GRPC Code
+The `otel.status_code` tag value MUST follow the [Standard GRPC Code
 Names](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md).
 
 ### Events


### PR DESCRIPTION
The official rename of the acronym happened after this spec was made, but looks like we haven't updated it yet.