### PR TITLE
Remove restriction that SpanContext must be a final class, specify creation.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -179,7 +179,7 @@ of key-value pairs. TraceState allows multiple tracing
 systems to participate in the same trace. It is fully described in the [W3C Trace Context
 specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 
-The API must provide methods to create a `SpanContext`. These methods SHOULD be the only way to
+The API must implement methods to create a `SpanContext`. These methods SHOULD be the only way to
 create a `SpanContext` There are three ways to create a `SpanContext`:
 
 - By generating a new `SpanId`, `TraceId`, and `TraceFlags` when there is no in-process or remote parent.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -182,7 +182,7 @@ specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 The API must provide methods to create `SpanContext`. There are three ways to create
 a `SpanContext`
 
-- By generating a new `SpanId` and `TraceId` when there is no in-process or remote parent.
+- By generating a new `SpanId`, `TraceId`, and `TraceFlags` when there is no in-process or remote parent.
 - By generating a new `SpanId` and copying the `TraceId`, `TraceFlags`, and `TraceState` from
 an in-process parent.
 - By accepting values for the `SpanId`, `TraceId`, `TraceFlags`, and `TraceState` for a remote

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -186,7 +186,7 @@ a `SpanContext`
 - By generating a new `SpanId` and copying the `TraceId`, `TraceFlags`, and `TraceState` from
 an in-process parent.
 - By accepting values for the `SpanId`, `TraceId`, `TraceFlags`, and `TraceState` for a remote
-parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and 
+parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and
 `TraceState` may be modified based on the rules for modification described [below](#TraceState).
 
 ### Retrieving the TraceId and SpanId

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -183,7 +183,7 @@ The API must provide methods to create `SpanContext`. There are three ways to cr
 a `SpanContext`
 
 - By generating a new `SpanId`, `TraceId`, and `TraceFlags` when there is no in-process or remote parent.
-- By generating a new `SpanId` and copying the `TraceId`, `TraceFlags`, and `TraceState` from
+- By generating a new `SpanId` and `TraceFlags` and copying the `TraceId` and `TraceState` from
 an in-process parent.
 - By accepting values for the `SpanId`, `TraceId`, `TraceFlags`, and `TraceState` for a remote
 parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -180,7 +180,7 @@ systems to participate in the same trace. It is fully described in the [W3C Trac
 specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 
 The API must implement methods to create a `SpanContext`. These methods SHOULD be the only way to
-create a `SpanContext` There are three ways to create a `SpanContext`:
+create a `SpanContext`:
 
 - By generating a new `SpanId`, `TraceId`, and `TraceFlags` when there is no in-process or remote parent.
 - By generating a new `SpanId` and `TraceFlags` and copying the `TraceId` and `TraceState` from

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -179,8 +179,8 @@ of key-value pairs. TraceState allows multiple tracing
 systems to participate in the same trace. It is fully described in the [W3C Trace Context
 specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 
-The API must provide methods to create `SpanContext`. There are three ways to create
-a `SpanContext`
+The API must provide methods to create a `SpanContext`. These methods SHOULD be the only way to
+create a `SpanContext` There are three ways to create a `SpanContext`:
 
 - By generating a new `SpanId`, `TraceId`, and `TraceFlags` when there is no in-process or remote parent.
 - By generating a new `SpanId` and `TraceFlags` and copying the `TraceId` and `TraceState` from

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -179,6 +179,16 @@ of key-value pairs. TraceState allows multiple tracing
 systems to participate in the same trace. It is fully described in the [W3C Trace Context
 specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 
+The API must provide methods to create `SpanContext`. There are three ways to create
+a `SpanContext`
+
+- By generating a new `SpanId` and `TraceId` when there is no in-process or remote parent.
+- By generating a new `SpanId` and copying the `TraceId`, `TraceFlags`, and `TraceState` from
+an in-process parent.
+- By accepting values for the `SpanId`, `TraceId`, `TraceFlags`, and `TraceState` for a remote
+parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and 
+`TraceState` may be modified based on the rules for modification described [below](#TraceState).
+
 ### Retrieving the TraceId and SpanId
 
 The API MUST allow retrieving the `TraceId` and `SpanId` in the following forms:

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -180,16 +180,8 @@ systems to participate in the same trace. It is fully described in the [W3C Trac
 specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 
 The API must implement methods to create a `SpanContext`. These methods SHOULD be the only way to
-create a `SpanContext`:
-
-- By generating a new `SpanId`, `TraceId`, and `TraceFlags` when there is no in-process or remote parent.
-- By generating a new `SpanId` and `TraceFlags` and copying the `TraceId` and `TraceState` from
-an in-process parent.
-- By accepting values for the `SpanId`, `TraceId`, `TraceFlags`, and `TraceState` for a remote
-parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and
-`TraceState` may be modified based on the rules for modification described below.
-
-This functionality MUST be fully implemented in the API, and SHOULD NOT be overridable.
+create a `SpanContext`. This functionality MUST be fully implemented in the API, and SHOULD NOT be
+overridable.
 
 ### Retrieving the TraceId and SpanId
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -158,7 +158,6 @@ the same `TracerProvider`.
 
 A `SpanContext` represents the portion of a `Span` which must be serialized and
 propagated along side of a distributed context. `SpanContext`s are immutable.
-`SpanContext` MUST be a final (sealed) class.
 
 The OpenTelemetry `SpanContext` representation conforms to the [W3C TraceContext
 specification](https://www.w3.org/TR/trace-context/). It contains two

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -179,7 +179,7 @@ of key-value pairs. TraceState allows multiple tracing
 systems to participate in the same trace. It is fully described in the [W3C Trace Context
 specification](https://www.w3.org/TR/trace-context/#tracestate-header).
 
-The API must implement methods to create a `SpanContext`. These methods SHOULD be the only way to
+The API MUST implement methods to create a `SpanContext`. These methods SHOULD be the only way to
 create a `SpanContext`. This functionality MUST be fully implemented in the API, and SHOULD NOT be
 overridable.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -189,6 +189,8 @@ an in-process parent.
 parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and
 `TraceState` may be modified based on the rules for modification described below.
 
+This functionality MUST be fully implemented in the API, and SHOULD NOT be overridable.
+
 ### Retrieving the TraceId and SpanId
 
 The API MUST allow retrieving the `TraceId` and `SpanId` in the following forms:

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -187,7 +187,7 @@ a `SpanContext`
 an in-process parent.
 - By accepting values for the `SpanId`, `TraceId`, `TraceFlags`, and `TraceState` for a remote
 parent. In this case, the `SpanId`, `TraceId`, and `TraceFlags` must be used as is, and
-`TraceState` may be modified based on the rules for modification described [below](#TraceState).
+`TraceState` may be modified based on the rules for modification described below.
 
 ### Retrieving the TraceId and SpanId
 


### PR DESCRIPTION
I know there's an OTEP that was rejected about this but I'm resurrecting this topic. The OTEP contends that it is important to allow extensibility to `SpanContext` to enable certain use cases such as lazy ID generation.

I'd like to propose that even outside of use-case concerns, this is too strict of a spec since it brings language concerns (class inheritance) into the cross-language spec. Languages may have a language-specific reason to allow a non-sealed `SpanContext`. For example, in Java, we have a need to hide the implementation of `SpanContext` from a user app to prevent compatibility issues between auto instrumentation and the app which without special care, can share classpath and have collisions. This can be done efficiently if `SpanContext` is an interface - two interfaces, one in the app, the other in the agent, but one implementation generated by the agent. Otherwise, we are stuck with two implementations, that copy between each other. In some sense, the fact that we rewrite the usage of `SpanContext` by a user through severe bytecode manipulation already seems to be incompliant with the spirit of this spec of wanting only one implementation of `SpanContext. This is an issue specific to Java instrumentation - I'd recommend the spec not be a blocker in creating solutions to such issues.

Additionally, I would be surprised if this can even be achieved in every language. Can JS or Ruby have sealed classes? I'd be surprised if we have very many compliant implementations - at first glance, I notice that JS actually uses an [interface](https://github.com/open-telemetry/opentelemetry-js/blob/master/packages/opentelemetry-api/src/trace/span_context.ts#L24) for `SpanContext` :) The spec should avoid digging too much into implementation details IMO because they often rely on a language's feature set and this should be left to the language authors to provide a good experience - the sealed nature of a class does not affect inter-language compatibility in any way.

Related issues #https://github.com/open-telemetry/opentelemetry-java/issues/1543

Related OTEPS: open-telemetry/oteps#58

Fixes #970
