### PR TITLE
Define `null` as a valid attribute value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Updates:
   and `RECORD_AND_SAMPLE` for consistency
   ([#938](https://github.com/open-telemetry/opentelemetry-specification/pull/938),
   [#956](https://github.com/open-telemetry/opentelemetry-specification/pull/956))
+- Define `null` as a valid span attribute value
+  ([#971](https://github.com/open-telemetry/opentelemetry-specification/pull/971))
 
 ## v0.6.0 (07-01-2020)
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -44,6 +44,7 @@ status of the feature is not known.
 |Boolean type                                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |Double floating-point type                    | + | +  | + | +    | +  | +    | - | +  | + | +  |
 |Signed int64 type                             | + | +  | + | +    | +  | +    | - | +  | + | +  |
+|Null values are recorded                      |   |    |   |      |    |      |   |    |   |    |
 |Array of primitives (homogeneous)             | + | +  | + | +    | +  | -    | + | +  | + | +  |
 |Unicode support for keys and string values    | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |[Span linking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-links)|

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -23,16 +23,19 @@ Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have 
 
 Attributes SHOULD preserve the order in which they're set.
 
-Attribute values expressing a numerical value of zero, an empty string, or an
+Attribute values expressing `null`, a numerical value of zero, an empty string, or an
 empty array are considered meaningful and MUST be stored and passed on to
-processors / exporters. Attribute values of `null` are considered to be not set
-and get discarded as if that `Attribute` has never been created.
-As an exception to this, if overwriting of values is supported, this results in
-removing the attribute.
+processors / exporters.
+
+If exporters do not support exporting `null` values, they SHOULD discard the attribute as if it was
+never there in the first place.
+They SHOULD NOT replace it with any value that would be valid for some non-null attribute type (using
+default values like an empty string, `0` or a `false`, for example, could cause wrong interpretations
+on the consumer side more likely than not sending the attribute at all).
 
 `null` values within arrays MUST be preserved as-is (i.e., passed on to span
 processors / exporters as `null`). If exporters do not support exporting `null`
-values, they MAY replace those values by 0, `false`, or empty strings.
+values in arrays, they MAY replace those values by 0, `false`, or empty strings.
 This is required for map/dictionary structures represented as two arrays with
 indices that are kept in sync (e.g., two attributes `header_keys` and `header_values`,
 both containing an array of strings to represent a mapping

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -26,9 +26,9 @@ Attributes SHOULD preserve the order in which they're set.
 Attribute values expressing `null`, a numerical value of zero, an empty string, or an
 empty array are considered meaningful and MUST be stored and passed on to
 processors / exporters.
-In languages with type systems where `null` can be of different types (e.g., a string or an array with a value of null),
-the type of `null` values MAY be ignored by the API and different types of `null` MAY not be distinguished by implementations,
-including exporters.
+In languages with type systems where `null` can be of different types (e.g., a null-valued string or array),
+the type of `null` values MAY be ignored by implementations and different types of `null` SHOULD NOT be
+distinguished by exporters as they are not deemed semantically different by this specification.
 
 If exporters do not support exporting `null` values, they SHOULD discard the attribute as if it was
 never there in the first place.

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -26,6 +26,9 @@ Attributes SHOULD preserve the order in which they're set.
 Attribute values expressing `null`, a numerical value of zero, an empty string, or an
 empty array are considered meaningful and MUST be stored and passed on to
 processors / exporters.
+In languages with type systems where `null` can be of different types (e.g., a string or an array with a value of null),
+the type of `null` values MAY be ignored by the API and different types of `null` MAY not be distinguished by implementations,
+including exporters.
 
 If exporters do not support exporting `null` values, they SHOULD discard the attribute as if it was
 never there in the first place.

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -16,7 +16,7 @@ Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have 
 
 - The attribute key, which MUST be a non-`null` and non-empty string.
 - The attribute value, which is either:
-  - A primitive type: string, boolean, double precision floating point (IEEE 754-1985) or signed 64 bit integer.
+  - A primitive type: string, boolean, double precision floating point (IEEE 754-1985), signed 64 bit integer, or null
   - An array of primitive type values. The array MUST be homogeneous,
     i.e. it MUST NOT contain values of different types. For protocols that do
     not natively support array values such values SHOULD be represented as JSON strings.


### PR DESCRIPTION
Resolves #797.
Closes #992.

See #992 for an alternative proposal.

## Changes

Specifies `null` as a valid attribute value.
As a consequence, attempting to set `null` no longer removes a previously set attribute but overwrites it with `null`.
Exporters will have to be adapted accordingly. OTLP already supports specifying null values (see [common.proto](https://github.com/open-telemetry/opentelemetry-proto/blob/30d237e1ff3ab7aa50e0922b5bebdd93505090af/opentelemetry/proto/common/v1/common.proto#L27-L29)).