### PR TITLE
Add README describing use of semantic convention YAML models

### DIFF
--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -1,0 +1,22 @@
+# YAML Model for Semantic Conventions
+
+The YAML descriptions of semantic convention contained in this directory are intended to
+be used by the various language OpenTelemetry language implementations to aid in automatic
+generation of semantics-related code.
+
+## Generation
+
+Using these YAML models, and the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions)
+found in the OpenTelemetry build tools repository, it is possible to generate
+consistently-formatted Markdown tables for all of our semantic conventions,
+and to generate code for use in OpenTelemetry language projects.
+
+See also:
+* [Markdown Tables](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions#markdown-tables)
+* [Code Generator](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions#code-generator)
+
+## Description of the model
+
+The fields and their expected values are presented in [allowed_syntax.md](./allowed_syntax.md).
+
+For a basic attribute description, refer to the [General Attributes example](./trace/general.yaml).

--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -1,22 +1,28 @@
 # YAML Model for Semantic Conventions
 
 The YAML descriptions of semantic convention contained in this directory are intended to
-be used by the various language OpenTelemetry language implementations to aid in automatic
+be used by the various OpenTelemetry language implementations to aid in automatic
 generation of semantics-related code.
 
 ## Generation
 
-Using these YAML models, and the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions)
-found in the OpenTelemetry build tools repository, it is possible to generate
-consistently-formatted Markdown tables for all of our semantic conventions,
-and to generate code for use in OpenTelemetry language projects.
+These YAML files are used by the make target `table-generation` to generate consistently
+formattted Markdown tables for all semantic conventions in the specification. Run it from the root of this repository using the command
+
+```
+make table-generation
+```
+
+For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions)
+in the OpenTelemetry build tools repository.
+Using this build tool, it is also possible to generate code for use in OpenTelemetry
+language projects.
 
 See also:
+
 * [Markdown Tables](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions#markdown-tables)
 * [Code Generator](https://github.com/open-telemetry/build-tools/tree/master/semantic-conventions#code-generator)
 
 ## Description of the model
 
-The fields and their expected values are presented in [allowed_syntax.md](./allowed_syntax.md).
-
-For a basic attribute description, refer to the [General Attributes example](./trace/general.yaml).
+The fields and their expected values are presented in [syntax.md](./syntax.md).


### PR DESCRIPTION
Fixes #979

## Changes

This PR doesn't change any existing files, it only adds a new README to the semantic_conventions directory at the root of this repo.
I've verified that the addition of this readme does not affect the functioning of the semantic convention build tool.
