### PR TITLE
Specify LastValue for ValueObserver, TBD for ValueRecorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ Updates:
   [#956](https://github.com/open-telemetry/opentelemetry-specification/pull/956))
 - Metrics SDK: Specify LastValue default aggregation for ValueObserver
   ([#834](https://github.com/open-telemetry/opentelemetry-specification/pull/834)
+- Metrics SDK: Specify TBD default aggregation for ValueRecorder
+  ([#625](https://github.com/open-telemetry/opentelemetry-specification/pull/625)
 
 ## v0.6.0 (07-01-2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,9 @@ Updates:
   ([#938](https://github.com/open-telemetry/opentelemetry-specification/pull/938),
   [#956](https://github.com/open-telemetry/opentelemetry-specification/pull/956))
 - Metrics SDK: Specify LastValue default aggregation for ValueObserver
-  ([#834](https://github.com/open-telemetry/opentelemetry-specification/pull/834)
+  ([#984](https://github.com/open-telemetry/opentelemetry-specification/pull/984)
 - Metrics SDK: Specify TBD default aggregation for ValueRecorder
-  ([#625](https://github.com/open-telemetry/opentelemetry-specification/pull/625)
+  ([#984](https://github.com/open-telemetry/opentelemetry-specification/pull/984)
 
 ## v0.6.0 (07-01-2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ Updates:
   and `RECORD_AND_SAMPLE` for consistency
   ([#938](https://github.com/open-telemetry/opentelemetry-specification/pull/938),
   [#956](https://github.com/open-telemetry/opentelemetry-specification/pull/956))
+- Metrics SDK: Specify LastValue default aggregation for ValueObserver
+  ([#834](https://github.com/open-telemetry/opentelemetry-specification/pull/834)
 
 ## v0.6.0 (07-01-2020)
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -250,11 +250,13 @@ distinction between synchronous and asynchronous instruments is
 crucial to specifying how exporters work, a topic that is covered in
 the [SDK specification (WIP)](https://github.com/open-telemetry/opentelemetry-specification/pull/347).
 
-The non-additive instruments (`ValueRecorder`, `ValueObserver`) use
-a MinMaxSumCount aggregation, by default.  This aggregation keeps track
-of the minimum value, the maximum value, the sum of values, and the
-count of values.  These four values support monitoring the range of
-values, the rate of events, and the average event value.
+The `ValueRecorder` instrument uses [TBD issue
+636](https://github.com/open-telemetry/opentelemetry-specification/issues/636)
+aggregation by default.
+
+The `ValueObserver` instrument uses LastValue aggregation by default.
+This aggregation keeps track of the last value that was observed and
+its timestamp.
 
 Other standard aggregations are available, especially for non-additive
 instruments, where we are generally interested in a variety of
@@ -457,8 +459,8 @@ are inexpensively aggregated into a single number per collection interval
 without loss of information.  This property makes additive instruments
 higher performance, in general, than non-additive instruments.
 
-Non-additive instruments use a relatively inexpensive aggregation
-method default (MinMaxSumCount), but still more expensive than the
+Non-additive instruments use a relatively inexpensive aggregation,
+by default, compared with recording full data, but still more expensive aggregation than the
 default for additive instruments (Sum).  Unlike additive instruments,
 where only the sum is of interest by definition, non-additive
 instruments can be configured with even more expensive aggregators.
@@ -699,10 +701,10 @@ individual instruments is summarized in the table below.
 | ----------------------- | ----- | --------- | ------------- | --- |
 | **Counter**             | Synchronous additive monotonic | Add(increment) | Sum | Per-request, part of a monotonic sum |
 | **UpDownCounter**       | Synchronous additive | Add(increment) | Sum | Per-request, part of a non-monotonic sum |
-| **ValueRecorder**       | Synchronous  | Record(value) | MinMaxSumCount  | Per-request, any non-additive measurement |
+| **ValueRecorder**       | Synchronous  | Record(value) | [TBD issue 636](https://github.com/open-telemetry/opentelemetry-specification/issues/636)  | Per-request, any non-additive measurement |
 | **SumObserver**         | Asynchronous additive monotonic | Observe(sum) | Sum | Per-interval, reporting a monotonic sum |
 | **UpDownSumObserver**   | Asynchronous additive | Observe(sum) | Sum | Per-interval, reporting a non-monotonic sum |
-| **ValueObserver**       | Asynchronous | Observe(value) | MinMaxSumCount  | Per-interval, any non-additive measurement |
+| **ValueObserver**       | Asynchronous | Observe(value) | LastValue  | Per-interval, any non-additive measurement |
 
 ### Constructors
 


### PR DESCRIPTION
Fixes #834.

## Changes

Apply the decision in #834.  The ValueObserver instrument should use LastValue aggregation by default, since those are the semantics of the instrument itself. Clarify that #625 has not been decided. See also #982. 
