### PR TITLE
Allow samplers to modify tracestate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ New:
   * `exception.escaped` semantic span event attribute was added
     ([#784](https://github.com/open-telemetry/opentelemetry-specification/pull/784),
     [#946](https://github.com/open-telemetry/opentelemetry-specification/pull/946))
+- Allow samplers to modify tracestate
+  ([#856](https://github.com/open-telemetry/opentelemetry-specification/pull/988/))
 
 Updates:
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -100,7 +100,7 @@ It produces an output called `SamplingResult` which contains:
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 * A `Tracestate` that will be associated with the `Span` through the new
-  `SpanContext`. 
+  `SpanContext`.
   Note: If the sampler returns an empty `Tracestate` here, the `Tracestate` will be cleared,
   so samplers should normally return the passed-in `Tracestate` if they do not intend
   to change it.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -99,6 +99,9 @@ It produces an output called `SamplingResult` which contains:
   * `RECORD_AND_SAMPLE` - `IsRecording() == true` AND `Sampled` flag` MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
+* A `Tracestate` that will be assigned to `Span`. If non-empty `Tracestate` was
+  passed in `SpanContext`, it MUST be populated on the `SamplingResult` even if
+  tracestate was not changed by sampler.
 
 #### GetDescription
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -99,9 +99,10 @@ It produces an output called `SamplingResult` which contains:
   * `RECORD_AND_SAMPLE` - `IsRecording() == true` AND `Sampled` flag` MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
-* A `Tracestate` that will be assigned to `Span`. If non-empty `Tracestate` was
-  passed in `SpanContext`, it MUST be populated on the `SamplingResult` even if
-  tracestate was not changed by sampler.
+* A `Tracestate` that will be associated with the `Span` through the new
+  `SpanContext`. If non-empty `Tracestate` was passed in `SpanContext`,
+  it MUST be populated on the `SamplingResult` even if tracestate was not
+  changed by sampler.
 
 #### GetDescription
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -100,9 +100,10 @@ It produces an output called `SamplingResult` which contains:
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 * A `Tracestate` that will be associated with the `Span` through the new
-  `SpanContext`. If non-empty `Tracestate` was passed in `SpanContext`,
-  it MUST be populated on the `SamplingResult` even if tracestate was not
-  changed by sampler.
+  `SpanContext`. 
+  Note: If the sampler returns an empty `Tracestate` here, the `Tracestate` will be cleared,
+  so samplers should normally return the passed-in `Tracestate` if they do not intend
+  to change it.
 
 #### GetDescription
 


### PR DESCRIPTION
Fixes #856

## Changes
Added `Tracestate` to `SamplingResult`

Related [oteps](https://github.com/open-telemetry/oteps) https://github.com/open-telemetry/oteps/pull/135
