### PR TITLE
Shorten otel.instrumentation_library.* attribute names

### DIFF
--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -27,8 +27,8 @@ OpenTelemetry Span's `InstrumentationLibrary` MUST be reported as span `tags` to
 
 | OpenTelemetry | Jaeger |
 | ------------- | ------ |
-| `InstrumentationLibrary.name`|`otel.instrumentation_library.name`|
-| `InstrumentationLibrary.version`|`otel.instrumentation_library.version`|
+| `InstrumentationLibrary.name`|`otel.library.name`|
+| `InstrumentationLibrary.version`|`otel.library.version`|
 
 ### Attribute
 

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -84,8 +84,8 @@ OpenTelemetry Span's `InstrumentationLibrary` MUST be reported as `tags` to Zipk
 
 | OpenTelemetry | Zipkin
 | ------------- | ------ |
-| `InstrumentationLibrary.name`|`otel.instrumentation_library.name`|
-| `InstrumentationLibrary.version`|`otel.instrumentation_library.version`|
+| `InstrumentationLibrary.name`|`otel.library.name`|
+| `InstrumentationLibrary.version`|`otel.library.version`|
 
 ### Remote endpoint
 


### PR DESCRIPTION
otel.instrumentation_library.name and otel.instrumentation_library.version
are quite long. The keys increase the size of the wire data (and they are present
for every span emitted by OpenTelemetry).

Long keys may also cause trouble when formatting in the UI.

This change uses a shorter "otel.library" prefix. I think this does not create
any ambiguity, it appears that this is the only "library" OpenTelemetry-emitted
span should refer to.

I am not attached to any particular name, open to any other naming suggestions
as long as they are reasonably short.