### PR TITLE
Define `null` as an invalid value for attributes and declare attempts to set `null` as undefined behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ Updates:
   ([#914](https://github.com/open-telemetry/opentelemetry-specification/pull/914))
 - Remove obsolete `http.status_text` from semantic conventions
   ([#972](https://github.com/open-telemetry/opentelemetry-specification/pull/972))
+- Define `null` as an invalid value for attributes and declare attempts to set
+  `null` as undefined behavior
+  ([#992](https://github.com/open-telemetry/opentelemetry-specification/pull/992))
 - SDK: Rename the `Decision` values for `SamplingResult`s to `DROP`, `RECORD_ONLY`
   and `RECORD_AND_SAMPLE` for consistency
   ([#938](https://github.com/open-telemetry/opentelemetry-specification/pull/938),

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -45,6 +45,7 @@ status of the feature is not known.
 |Double floating-point type                    | + | +  | + | +    | +  | +    | - | +  | + | +  |
 |Signed int64 type                             | + | +  | + | +    | +  | +    | - | +  | + | +  |
 |Array of primitives (homogeneous)             | + | +  | + | +    | +  | -    | + | +  | + | +  |
+|`null` values documented as invalid/undefined |   |    |   |      |    |      |   |    |   |    |
 |Unicode support for keys and string values    | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |[Span linking](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#add-links)|
 |AddLink                                       | + | +  | + | +    | +  | +    | + | +  | - | +  |

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -25,10 +25,12 @@ Attributes SHOULD preserve the order in which they're set.
 
 Attribute values expressing a numerical value of zero, an empty string, or an
 empty array are considered meaningful and MUST be stored and passed on to
-processors / exporters. Attribute values of `null` are considered to be not set
-and get discarded as if that `Attribute` has never been created.
-As an exception to this, if overwriting of values is supported, this results in
-removing the attribute.
+processors / exporters.
+
+Attribute values of `null` are not valid and attempting to set a `null` value is
+undefined behavior.
+If `null` values may occur for the _value_ parameter of calls for setting attributes,
+users of the API MUST add `null` checks to prevent passing `null` values.
 
 `null` values within arrays MUST be preserved as-is (i.e., passed on to span
 processors / exporters as `null`). If exporters do not support exporting `null`

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -29,8 +29,6 @@ processors / exporters.
 
 Attribute values of `null` are not valid and attempting to set a `null` value is
 undefined behavior.
-If `null` values may occur for the _value_ parameter of calls for setting attributes,
-users of the API MUST add `null` checks to prevent passing `null` values.
 
 `null` values within arrays MUST be preserved as-is (i.e., passed on to span
 processors / exporters as `null`). If exporters do not support exporting `null`


### PR DESCRIPTION
Resolves #797.
Closes #971.

## Changes

This is an alternative proposal to #971 as requested in yesterday's SIG spec meeting.
This defines attempts to set `null` as undefined behavior and removes the current behavior that setting `null` removes any previously set attribute, which was opposed on #797.
Declaring it as undefined allows for non-breaking definitions of this behavior in future. Future options include ignoring such calls with or without deleting any previously set attribute for that key, or preserving `null` as a valid value, with or without preserving its type, if any.