### PR TITLE
Remove custom header name for Baggage, use official header

### DIFF
--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -13,7 +13,6 @@ Table of Contents
   - [Remove baggage](#remove-baggage)
   - [Clear](#clear)
 - [Baggage Propagation](#baggage-propagation)
-  - [Serialization](#serialization)
 - [Conflict Resolution](#conflict-resolution)
 
 </details>
@@ -101,36 +100,9 @@ OPTIONAL parameters:
 `Baggage` MAY be propagated across process boundaries or across any arbitrary boundaries
 (process, $OTHER_BOUNDARY1, $OTHER_BOUNDARY2, etc) for various reasons.
 
-### Serialization
+The API layer MAY include the following `Propagator`s:
 
-Until the [W3C Baggage](https://w3c.github.io/baggage/) specification is recommended for use, OpenTelemetry `Baggage` implementations MUST be serialized according to the [editor's draft of W3C Correlation Context as of March 27, 2020](https://github.com/w3c/correlation-context/blob/c974664b9ab4d33af6355f1f7f03a2d52c89a99e/correlation_context/HTTP_HEADER_FORMAT.md) using a vendor-specific header name to avoid collisions with the W3C Baggage specification should it change in the future.
-
-#### Header Name
-
-`Baggage` implementations MUST use the header name `otelbaggage`.
-
-#### Header Value
-
-`Baggage` MUST be serialized according to the [editor's draft of W3C Correlation Context as of September 21, 2020](https://github.com/w3c/baggage/blob/0573bd79c0d93a779145fd26a7b3e532c912c783/baggage/HTTP_HEADER_FORMAT.md).
-
-`Baggage` values MUST be serialized as Percent-Encoded UTF-8 strings according to [RFC 3986 Section 2.1](https://tools.ietf.org/html/rfc3986#section-2.1).
-
-#### Example
-
-Baggage:
-
-```json
-{
-  "user": "foo@example.com",
-  "name": "Example Name"
-}
-```
-
-Header:
-
-```
-otcorrelations: user=foo%40example.com,name=Example%20Name
-```
+* A `TextMapPropagator` implementing the [W3C Baggage Specification](https://w3c.github.io/baggage).
 
 ## Conflict Resolution
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -288,7 +288,7 @@ unconfigured, although the trace context propagation was configured to enrich lo
 Platforms such as ASP.NET may pre-configure out-of-the-box
 propagators. If pre-configured, `Propagator`s SHOULD default to a composite
 `Propagator` containing the W3C Trace Context Propagator and the Baggage
-`Propagator` specified in [api-baggage.md](../baggage/api.md#baggage-propagation).
+`Propagator` specified in the [Baggage API](../baggage/api.md#baggage-propagation).
 These platforms MUST also allow pre-configured propagators to be disabled or overridden.
 
 ### Get Global Propagator

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -288,7 +288,7 @@ unconfigured, although the trace context propagation was configured to enrich lo
 Platforms such as ASP.NET may pre-configure out-of-the-box
 propagators. If pre-configured, `Propagator`s SHOULD default to a composite
 `Propagator` containing the W3C Trace Context Propagator and the Baggage
-`Propagator` specified in [api-baggage.md](../baggage/api.md#serialization).
+`Propagator` specified in [api-baggage.md](../baggage/api.md#baggage-propagation).
 These platforms MUST also allow pre-configured propagators to be disabled or overridden.
 
 ### Get Global Propagator


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/879

## Changes

During the w3c meeting there was a consensus to use the current w3c baggage definition, and avoid using a custom header name.