### PR TITLE
Define Propagation-only Span to simplify active Span logic in Context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ New:
     [#946](https://github.com/open-telemetry/opentelemetry-specification/pull/946))
 - Update the header name for otel baggage, and version date
   ([#981](https://github.com/open-telemetry/opentelemetry-specification/pull/981))
-- Define DefaultSpan to simplify active Span logic in Context
+- Define PropagationOnly Span to simplify active Span logic in Context
   ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 
 Updates:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ New:
     [#946](https://github.com/open-telemetry/opentelemetry-specification/pull/946))
 - Update the header name for otel baggage, and version date
   ([#981](https://github.com/open-telemetry/opentelemetry-specification/pull/981))
+- Define DefaultSpan to simplify active Span logic in Context
+  ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 
 Updates:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -31,6 +31,7 @@ Table of Contents
     * [End](#end)
     * [Record Exception](#record-exception)
   * [Span lifetime](#span-lifetime)
+  * [DefaultSpan creation](#defaultspan-creation)
 * [Status](#status)
   * [StatusCanonicalCode](#statuscanonicalcode)
   * [Status creation](#status-creation)
@@ -352,18 +353,13 @@ parent is remote.
 
 #### Determining the Parent Span from a Context
 
-When a new `Span` is created from a `Context`, the `Context` may contain:
+When a new `Span` is created from a `Context`, the `Context` may contain a `Span`
+representing the currently active instance, and will be used as parent.
+If there is no `Span` in the `Context`, the newly created `Span` will be a root instance.
 
-- A current `Span`
-- An extracted `SpanContext`
-- A current `Span` and an extracted `SpanContext`
-- Neither a current `Span` nor an extracted `Span` context
-
-The parent should be selected in the following order of precedence:
-
-- Use the current `Span`, if available.
-- Use the extracted `SpanContext`, if available.
-- There is no parent. Create a root `Span`.
+A `SpanContext` may set as the active instance in a `Context` (for example, by a `Propagator`
+performing context extraction) through the use of a [DefaultSpan](#defaultspan-creation)
+wrapping it.
 
 #### Add Links
 
@@ -565,6 +561,18 @@ timestamps to the Span object:
 
 Start and end time as well as Event's timestamps MUST be recorded at a time of a
 calling of corresponding API.
+
+### DefaultSpan creation
+
+The API MUST provide an operation for wrapping a `SpanContext` with an object
+implementing the `Span` interface, known as `DefaultSpan`. This is done in order to expose
+a `SpanContext` as a `Span` in operations such as in-process `Span` propagation.
+
+- `GetContext()` MUST return the wrapped `SpanContext`.
+- `IsRecording` MUST return `false` to signal that events, attributes and other elements
+  are not being recorded, i.e. they are being dropped.
+
+The remaining functionality of `Span` must be defined as no-op operations.
 
 ## Status
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -355,7 +355,7 @@ parent is remote.
 
 When a new `Span` is created from a `Context`, the `Context` may contain a `Span`
 representing the currently active instance, and will be used as parent.
-If there is no `Span` in the `Context`, the newly created `Span` will be a root instance.
+If there is no `Span` in the `Context`, the newly created `Span` will be a root span.
 
 A `SpanContext` may set as the active instance in a `Context` (for example, by a `Propagator`
 performing context extraction) through the use of a [DefaultSpan](#defaultspan-creation)

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -578,8 +578,7 @@ The behavior is defined as follows:
 
 The remaining functionality of `Span` MUST be defined as no-op operations.
 
-Note: This is expected to be fully implemented in the API, and MUST NOT be overridable
-by the SDK.
+This functionality MUST be fully implemented in the API, and SHOULD NOT be overridable.
 
 ## Status
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -31,7 +31,7 @@ Table of Contents
     * [End](#end)
     * [Record Exception](#record-exception)
   * [Span lifetime](#span-lifetime)
-  * [PropagationOnly Span creation](#propagationonly-span-creation)
+  * [Propagated Span creation](#propagated-span-creation)
 * [Status](#status)
   * [StatusCanonicalCode](#statuscanonicalcode)
   * [Status creation](#status-creation)
@@ -358,7 +358,7 @@ representing the currently active instance, and will be used as parent.
 If there is no `Span` in the `Context`, the newly created `Span` will be a root span.
 
 A `SpanContext` cannot be set as active in a `Context` directly, but through the use
-of a [PropagationOnly Span](#propagationonly-span-creation) wrapping it.
+of a [Propagated Span](#propagated-span-creation) wrapping it.
 For example, a `Propagator` performing context extraction may need this.
 
 #### Add Links
@@ -562,13 +562,13 @@ timestamps to the Span object:
 Start and end time as well as Event's timestamps MUST be recorded at a time of a
 calling of corresponding API.
 
-### PropagationOnly Span creation
+### Propagated Span creation
 
 The API MUST provide an operation for wrapping a `SpanContext` with an object
 implementing the `Span` interface. This is done in order to expose a `SpanContext`
 as a `Span` in operations such as in-process `Span` propagation.
 
-If a new type is required for supporting this operation, it SHOULD be named `PropagatorOnlySpan`.
+If a new type is required for supporting this operation, it SHOULD be named `PropagatedSpan`.
 
 The behavior is defined as follows:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -357,9 +357,9 @@ When a new `Span` is created from a `Context`, the `Context` may contain a `Span
 representing the currently active instance, and will be used as parent.
 If there is no `Span` in the `Context`, the newly created `Span` will be a root span.
 
-A `SpanContext` may set as the active instance in a `Context` (for example, by a `Propagator`
-performing context extraction) through the use of a [DefaultSpan](#defaultspan-creation)
-wrapping it.
+A `SpanContext` cannot be set as active in a `Context` directly,
+but through the use of a [DefaultSpan](#defaultspan-creation) wrapping it.
+For example, a `Propagator` performing context extraction, may need this.
 
 #### Add Links
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -578,6 +578,9 @@ The behavior is defined as follows:
 
 The remaining functionality of `Span` MUST be defined as no-op operations.
 
+Note: This is expected to be fully implemented in the API, and MUST NOT be overridable
+by the SDK.
+
 ## Status
 
 `Status` interface represents the status of a finished `Span`. It's composed of

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -31,7 +31,7 @@ Table of Contents
     * [End](#end)
     * [Record Exception](#record-exception)
   * [Span lifetime](#span-lifetime)
-  * [DefaultSpan creation](#defaultspan-creation)
+  * [PropagationOnly Span creation](#propagationonly-span-creation)
 * [Status](#status)
   * [StatusCanonicalCode](#statuscanonicalcode)
   * [Status creation](#status-creation)
@@ -357,9 +357,9 @@ When a new `Span` is created from a `Context`, the `Context` may contain a `Span
 representing the currently active instance, and will be used as parent.
 If there is no `Span` in the `Context`, the newly created `Span` will be a root span.
 
-A `SpanContext` cannot be set as active in a `Context` directly,
-but through the use of a [DefaultSpan](#defaultspan-creation) wrapping it.
-For example, a `Propagator` performing context extraction, may need this.
+A `SpanContext` cannot be set as active in a `Context` directly, but through the use
+of a [PropagationOnly Span](#propagationonly-span-creation) wrapping it.
+For example, a `Propagator` performing context extraction may need this.
 
 #### Add Links
 
@@ -562,17 +562,21 @@ timestamps to the Span object:
 Start and end time as well as Event's timestamps MUST be recorded at a time of a
 calling of corresponding API.
 
-### DefaultSpan creation
+### PropagationOnly Span creation
 
 The API MUST provide an operation for wrapping a `SpanContext` with an object
-implementing the `Span` interface, known as `DefaultSpan`. This is done in order to expose
-a `SpanContext` as a `Span` in operations such as in-process `Span` propagation.
+implementing the `Span` interface. This is done in order to expose a `SpanContext`
+as a `Span` in operations such as in-process `Span` propagation.
+
+If a new type is required for supporting this operation, it SHOULD be named `PropagatorOnlySpan`.
+
+The behavior is defined as follows:
 
 - `GetContext()` MUST return the wrapped `SpanContext`.
 - `IsRecording` MUST return `false` to signal that events, attributes and other elements
   are not being recorded, i.e. they are being dropped.
 
-The remaining functionality of `Span` must be defined as no-op operations.
+The remaining functionality of `Span` MUST be defined as no-op operations.
 
 ## Status
 


### PR DESCRIPTION
Fixes #949 

## Changes

Define the notion of a `PropagatedSpan`, which wraps a `SpanContext`, and can be leveraged to simplify the active `Span` logic when detecting the parent `Span` in a given `Context` (so we don't have to store a `Span` **and** a `SpanContext` in `Context`).

(Observe I tried to keep it as simple as possible in order to expedite this PR as much as possible ;) )