### PR TITLE
Add outcome label for http conventions for metrics (only)

### DIFF
--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -38,7 +38,7 @@ and whether they should be on server, client, or both types of HTTP metric event
 | `http.host`        | `client` & `server` | see [label alternatives](#label-alternatives) | The value of the [HTTP host header][]. When the header is empty or not present, this label should be the same. |
 | `http.scheme`      | `client` & `server` | see [label alternatives](#label-alternatives) | The URI scheme identifying the used protocol in lowercase: `"http"` or `"https"` |
 | `http.status_code` | `client` & `server` | Optional          | [HTTP response status code][]. E.g. `200` (String) |
-| `http.outcome`     | `client` & `server` | Optional          | Outcome, e.g. 'success', see [3] |
+| `http.status_class`| `client` & `server` | Optional          | Class of status code, e.g. 'success', see [3] |
 | `http.flavor`      | `client` & `server` | Optional          | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |
 | `net.peer.name`    | `client`            | see [1] in [label alternatives](#label-alternatives) | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) |
 | `net.peer.port`    | `client`            | see [1] in [label alternatives](#label-alternatives) | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) |
@@ -92,12 +92,14 @@ Namely, one of the following sets is RECOMMENDED (in order of usual preference u
 * `http.scheme`, `net.host.name`, `net.host.port`, `http.target`
 * `http.url`
 
-**[3]** Represent the `outcome` of the request using a grouping/categorization of status codes:
+**[3]** The class of the http status code, as represented by its first digit.
 
-| status code range | outcome value   |
+| status code class | outcome value   |
 |-------------------|-----------------|
-| `[100-200)`       | `informational` |
-| `[200-300)`       | `success`       |
-| `[300-400)`       | `redirection`   |
-| `[400-500)`       | `client_error`  |
-| `[500-600)`       | `server_error`  |
+| `1`               | `informational` |
+| `2`               | `success`       |
+| `3`               | `redirection`   |
+| `4`               | `client_error`  |
+| `5`               | `server_error`  |
+
+[HTTP status code and reason phrase]: https://tools.ietf.org/html/rfc2616#section-6.1.1

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -38,6 +38,7 @@ and whether they should be on server, client, or both types of HTTP metric event
 | `http.host`        | `client` & `server` | see [label alternatives](#label-alternatives) | The value of the [HTTP host header][]. When the header is empty or not present, this label should be the same. |
 | `http.scheme`      | `client` & `server` | see [label alternatives](#label-alternatives) | The URI scheme identifying the used protocol in lowercase: `"http"` or `"https"` |
 | `http.status_code` | `client` & `server` | Optional          | [HTTP response status code][]. E.g. `200` (String) |
+| `http.outcome`     | `client` & `server` | Optional          | Outcome, e.g. 'success', see [3] |
 | `http.flavor`      | `client` & `server` | Optional          | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`. |
 | `net.peer.name`    | `client`            | see [1] in [label alternatives](#label-alternatives) | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) |
 | `net.peer.port`    | `client`            | see [1] in [label alternatives](#label-alternatives) | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) |
@@ -90,3 +91,13 @@ Namely, one of the following sets is RECOMMENDED (in order of usual preference u
 * `http.scheme`, `http.server_name`, `net.host.port`, `http.target`
 * `http.scheme`, `net.host.name`, `net.host.port`, `http.target`
 * `http.url`
+
+**[3]** Represent the `outcome` of the request using a grouping/categorization of status codes:
+
+| status code range | outcome value   |
+|-------------------|-----------------|
+| `[100-200)`       | `informational` |
+| `[200-300)`       | `success`       |
+| `[300-400)`       | `redirection`   |
+| `[400-500)`       | `client_error`  |
+| `[500-600)`       | `server_error`  |


### PR DESCRIPTION
Add `outcome` as a label for http metrics that makes it easier to create queries for successful vs. unsuccessful requests (e.g.) without having to deal with querying/grouping multiple status codes. 

## Changes

Add an optional `outcome` label to the semantic conventions for metrics.

Related issues #

From https://github.com/open-telemetry/opentelemetry-specification/pull/739#issuecomment-669609233
