### PR TITLE
Clarify that a link is composed of trace ID / span ID / TraceState.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -382,7 +382,7 @@ description](../overview.md#links-between-spans).
 
 A `Link` is defined by the following properties:
 
-- (Required) `TraceID` and `SpanID` of the `Span` to link to. This may be in the form of a `SpanContext` of the `Span`.
+- (Required) `TraceID`, `SpanID` and `TraceState` of the `Span` to link to. This may be in the form of a `SpanContext` of the `Span`.
 - (Optional) One or more `Attribute`s as defined [here](../common/common.md#attributes).
 
 The `Link` SHOULD be an immutable type.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -382,7 +382,7 @@ description](../overview.md#links-between-spans).
 
 A `Link` is defined by the following properties:
 
-- (Required) `SpanContext` of the `Span` to link to.
+- (Required) `TraceID` and `SpanID` of the `Span` to link to. This may be in the form of a `SpanContext` of the `Span`.
 - (Optional) One or more `Attribute`s as defined [here](../common/common.md#attributes).
 
 The `Link` SHOULD be an immutable type.


### PR DESCRIPTION
OTLP `Link` only has a trace / span ID / trace state - I can't imagine traceflags to be on Links so this is probably more precise. But perhaps the intent is for Links to have those pieces too, let me know if there's any context there.
