### PR TITLE
Require the SDK to provide custom ID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Updates:
 - Resource's service.name MUST have a default value, service.instance.id is not
   required.
   ([#1269](https://github.com/open-telemetry/opentelemetry-specification/pull/1269))
+- Add requirement that the SDK allow custom generation of Trace IDs and Span IDs
+  ([#1006](https://github.com/open-telemetry/opentelemetry-specification/pull/1006))
 
 ## v0.7.0 (11-18-2020)
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -69,6 +69,7 @@ status of the feature is not known.
 |Allow samplers to modify tracestate           |   | +  |   | +    |    | +    |   | +  |   |    |  +  |
 |ShouldSample gets full parent Context         |   | +  | + | +    |    | +    |   |    |   |    |  +  |
 |[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |   |    |   | +    |    |      |   |    |   |    | +   |
+|SDK Trace & Span ID generation is customizable| + | +  | + |  +   |    |      |   |    |   | +  |     |
 
 ## Baggage
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -222,6 +222,23 @@ Note: Implementation-wise, this could mean that `Tracer` instances have a
 reference to their `TracerProvider` and access configuration only via this
 reference.
 
+The SDK MUST by default randomly generate the bytes for both the `TraceId` and
+the `SpanId`.
+
+The SDK MUST provide a mechanism for customizing the way IDs are generated for
+both the `TraceId` and the `SpanId`.
+
+The SDK MAY provide this functionality by allowing custom implementations of
+an interface like `IdsGenerator` below, which provides extension points for two
+methods, one to generate a `SpanID` and one to generate a `TraceId`.
+
+```
+IdsGenerator {
+  String generateSpanId()
+  String generateTraceId()
+}
+```
+
 ### Shutdown
 
 This method provides a way for provider to do any cleanup required.


### PR DESCRIPTION
Fixes #896

## Changes

Make the SDKs commit to providing a way for IDs to be customizable by including it in the specifications.

How they do so is up to the SDKs individually.

Providing this will solve the problem of **having traces incompatible with some backends** as discussed in the linked issue.