### PR TITLE
Explicitly specify cloud.provider values for common cloud providers

### DIFF
--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -6,14 +6,14 @@
 
 | Attribute  | Description  | Example  |
 |---|---|---|
-| cloud.provider | Name of the cloud provider. See [Cloud Providers](#cloud-providers) for a list of known values. It is not guaranteed that this value will be in the set. | `gcp` |
+| cloud.provider | Name of the cloud provider. See [Cloud Providers](#cloud-providers) for a list of known values. | `gcp` |
 | cloud.account.id | The cloud account id used to identify different entities. | `opentelemetry` |
 | cloud.region | A specific geographical location where different entities can run | `us-central1` |
 | cloud.zone | Zones are a sub set of the region connected through low-latency links.<br/> In aws it is called availability-zone. | `us-central1-a` |
 
 ## Cloud Providers
 
-These are known-used values of `cloud.provider`. However, `cloud.provider` is not necessarily limited to just these in the set.
+`cloud.provider` MUST be one of the following or, if none of the listed values apply, a custom value:
 
 | cloud.provider | Description |
 |---|---|

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -6,7 +6,17 @@
 
 | Attribute  | Description  | Example  |
 |---|---|---|
-| cloud.provider | Name of the cloud provider.<br/> Example values are aws, azure, gcp. | `gcp` |
+| cloud.provider | Name of the cloud provider. See [Cloud Providers](#cloud-providers) for a list of known values. It is not guaranteed that this value will be in the set. | `gcp` |
 | cloud.account.id | The cloud account id used to identify different entities. | `opentelemetry` |
 | cloud.region | A specific geographical location where different entities can run | `us-central1` |
 | cloud.zone | Zones are a sub set of the region connected through low-latency links.<br/> In aws it is called availability-zone. | `us-central1-a` |
+
+## Cloud Providers
+
+These are known-used values of `cloud.provider`. However, `cloud.provider` is not necessarily limited to just these in the set.
+
+| cloud.provider | Description |
+|---|---|
+| aws | Amazon Web Services |
+| azure | Microsoft Azure |
+| gcp | Google Cloud Platform |


### PR DESCRIPTION
Before some cloud provider values were given as an examples but it was still
left open to interpretation about what that meant. This makes it more explicit
that these are known values for those particular cloud providers.