### PR TITLE
Add prometheus exporter env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New:
 
 - Clarify env variables in otlp exporter
   ([#975](https://github.com/open-telemetry/opentelemetry-specification/pull/975))
+- Add Prometheus exporter environment variables
+  ([#2021](https://github.com/open-telemetry/opentelemetry-specification/pull/1021)).
 - Default propagators in un-configured API must be no-op
   ([#930](https://github.com/open-telemetry/opentelemetry-specification/pull/930)).
 - Define resource mapping for Jaeger exporters

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -42,6 +42,13 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 | ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
 
+## Prometheus Exporter
+
+| Name                          | Description                     | Default                      |
+| ----------------------------- | --------------------------------| ---------------------------- |
+| OTEL_EXPORTER_PROMETHEUS_HOST | Host used by the Prometheus exporter | All addresses: "0.0.0.0"|
+| OTEL_EXPORTER_PROMETHEUS_PORT | Port used by the Prometheus exporter | 9464                    |
+
 ## Exporter Selection
 
 | Name          | Description                                                                  | Default |


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

## Changes

Add prometheus exporter env vars.


## Related issues

https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/385

