### PR TITLE
Allow SpanContext to be exposed directly on Span.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -195,6 +195,8 @@ The API MUST implement methods to create a `SpanContext`. These methods SHOULD b
 create a `SpanContext`. This functionality MUST be fully implemented in the API, and SHOULD NOT be
 overridable.
 
+The API MAY expose the functionality of `SpanContext` directly on the `Span` without a separate type.
+
 ### Retrieving the TraceId and SpanId
 
 The API MUST allow retrieving the `TraceId` and `SpanId` in the following forms:


### PR DESCRIPTION
Fixes #999 

This is a relaxing of the spec to give SDKs more options in presenting the API for `SpanContext`. See attached issue for why they may decide to do this. It's post-freeze, but the hope is that since this doesn't provide any additional requirement it could still be considered.
