### PR TITLE
Resolve semantic inconsistencies for non traditional messaging

### DIFF
--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -135,7 +135,7 @@ groups:
             If the key is `null`, the attribute MUST NOT be set.
           note: >
             If the key type is not string, it's string representation has to be supplied for the attribute.
-            If the key can not be represented in string form, don't include its value.
+            If the key has no unambiguous, canonical string form, don't include its value.
           examples: 'myKey'
         - id: consumer_group
           type: string

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -68,6 +68,8 @@ groups:
           brief: 'The compressed size of the message payload in bytes.'
           examples: 2048
         - ref: net.peer.name
+          note: >
+            This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
           required:
             conditional: If available.
         - ref: net.peer.ip
@@ -133,6 +135,7 @@ groups:
             If the key is `null`, the attribute MUST NOT be set.
           note: >
             If the key type is not string, it's string representation has to be supplied for the attribute.
+            If the key can not be represented in string form, don't include its value.
           examples: 'myKey'
         - id: consumer_group
           type: string
@@ -144,9 +147,9 @@ groups:
           type: string
           brief: >
             Client Id for the Consumer or Producer that is handling the message.
-          examples: '5'
+          examples: 'client-5'
         - id: partition
-          type: string
+          type: number
           brief: >
             Partition the message is sent to.
-          examples: '2'
+          examples: 2

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -47,10 +47,6 @@ groups:
           type: string
           brief: 'Connection string.'
           examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
-        - id: service
-          type: string
-          brief: 'Name of the external broker, or name of the service being interacted with. See note below for a definition.'
-          examples: ['kafkaService']
         - id: message_id
           type: string
           brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -26,7 +26,7 @@ groups:
                 brief: "A message sent to a queue"
               - id: topic
                 value: "topic"
-                brief: "A message broadcasted to the subscribers of the topic"
+                brief: "A message sent to a topic"
           required:
             conditional: 'Required only if the message destination is either a `queue` or `topic`.'
           brief: 'The kind of message destination'

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -68,9 +68,13 @@ groups:
           brief: 'The compressed size of the message payload in bytes.'
           examples: 2048
       constraints:
-        - any_of:
-          - 'net.peer.name'
-          - 'net.peer.ip'
+        - ref: net.peer.name
+          required:
+            conditional: If available.
+        - ref: net.peer.ip
+          tag: connection-level
+          required:
+            conditional: If available.
         - include: network
 
     - id: messaging.producer
@@ -114,3 +118,35 @@ groups:
       brief: >
         Semantic convention for servers that consume messages received from messaging systems
         and always send back replies directed to the producers of these messages.
+
+    - id: messaging.kafka
+      prefix: messaging.kafka
+      extends: messaging
+      brief: >
+        Attributes for Apache Kafka
+      attributes:
+        - id: message_key
+          type: string
+          brief: >
+            Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
+            They differ from `messaging.message_id` in that they're not unique.
+            If the key is `null`, the attribute MUST NOT be set.
+          note: >
+            If the key type is not string, it's string representation has to be supplied for the attribute.
+          examples: 'myKey'
+        - id: consumer_group
+          type: string
+          brief: >
+            Name of the Kafka Consumer Group that is handling the message.
+            Only applies to consumers, not producers.
+          examples: 'my-group'
+        - id: client_id
+          type: string
+          brief: >
+            Client Id for the Consumer or Producer that is handling the message.
+          examples: '5'
+        - id: partition
+          type: string
+          brief: >
+            Partition the message is sent to.
+          examples: '2'

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -67,7 +67,6 @@ groups:
           type: number
           brief: 'The compressed size of the message payload in bytes.'
           examples: 2048
-      constraints:
         - ref: net.peer.name
           required:
             conditional: If available.
@@ -75,6 +74,7 @@ groups:
           tag: connection-level
           required:
             conditional: If available.
+      constraints:
         - include: network
 
     - id: messaging.producer

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -153,3 +153,8 @@ groups:
           brief: >
             Partition the message is sent to.
           examples: 2
+        - id: tombstone
+          type: boolean
+          required:
+            conditional: 'If missing, it is assumed to be false.'
+          brief: 'A boolean that is true if the message is a tombstone.'

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -47,6 +47,10 @@ groups:
           type: string
           brief: 'Connection string.'
           examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
+        - id: service
+          type: string
+          brief: 'Name of the external broker, or name of the service being interacted with. See note below for a definition.'
+          examples: ['kafkaService']
         - id: message_id
           type: string
           brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -192,9 +192,9 @@ For Apache Kafka, the following additional attributes are defined:
 **[1]:** If the key type is not string, it's string representation has to be supplied for the attribute.
 <!-- endsemconv -->
 
-For Apache Kafka producers, [`peer.service`](./span-general.md#general-remote-service-attributes) SHOULD be set to the name of the broker or external service the message will be sent to.
-Consumers SHOULD identify the [Resource](../../resource/semantic_conventions/README.md#service) that received the message.
-The `service.name` of a Consumer's Resource SHOULD match the `peer.service` of the Producer.
+For Apache Kafka producers, [`peer.service`](./span-general.md#general-remote-service-attributes) SHOULD be set to the name of the broker or service the message will be sent to.
+The `service.name` of a Consumer's Resource SHOULD match the `peer.service` of the Producer, when the message is directly passed to another service.
+If an intermediary broker is present, `service.name` and `peer.service` will not be the same.
 
 ## Examples
 
@@ -222,8 +222,8 @@ Process CB:                 | Span CB1 |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
 | `messaging.destination` | `"T"` | `"T"` | `"T"` |
 | `messaging.destination_kind` | `"topic"` | `"topic"` | `"topic"` |
-| `messaging.service` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` |
 | `messaging.operation` |  | `"process"` | `"process"` |
+| `messaging.message_id` | `"a1"` | `"a1"`| `"a1"` |
 
 ### Apache Kafka Example
 
@@ -248,7 +248,7 @@ Process CB:                           | Span Rcv2 |
 | SpanKind | `PRODUCER` | `CONSUMER` | `CONSUMER` | `PRODUCER` | `CONSUMER` |
 | Status | `Ok` | `Ok` | `Ok` | `Ok` | `Ok` |
 | `peer.service` | `"myKafka"` |  |  | `"myKafka"` |  |
-| `service.name` |  | `"myKafka"` | `"myKafka"` |  | `"myKafka"` |
+| `service.name` |  | `"myConsumer1"` | `"myConsumer1"` |  | `"myConsumer2"` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination` | `"T1"` | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
 | `messaging.destination_kind` | `"topic"` | `"topic"` | `"topic"` | `"topic"` | `"topic"` |
@@ -284,7 +284,6 @@ Process C:                      | Span Recv1 |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
 | `messaging.destination` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
 | `messaging.destination_kind` | `"queue"` | `"queue"` | `"queue"` | `"queue"` | `"queue"` |
-| `messaging.service` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` |
 | `messaging.operation` |  |  | `"receive"` | `"process"` | `"process"` |
 | `messaging.message_id` | `"a1"` | `"a2"` | | `"a1"` | `"a2"` |
 
@@ -318,6 +317,5 @@ Process C:                              | Span Recv1 | Span Recv2 |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
 | `messaging.destination` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
 | `messaging.destination_kind` | `"queue"` | `"queue"` | `"queue"` | `"queue"` | `"queue"` |
-| `messaging.service` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` | `"myRabbitMQ"` |
 | `messaging.operation` |  |  | `"receive"` | `"receive"` | `"process"` |
 | `messaging.message_id` | `"a1"` | `"a2"` | `"a1"` | `"a2"` | |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -184,15 +184,18 @@ The routing key MUST be provided to the attribute `messaging.rabbitmq.routing_ke
 
 For Apache Kafka, the following additional attributes are defined:
 
+<!-- semconv messaging.kafka -->
 | Attribute name |                          Notes and examples                            |
 | -------------- | ---------------------------------------------------------------------- |
 | `messaging.kafka.message_key` | Differs from `messaging.message_id` in that it's not unique, and can be `null`. The type is a String representation of the type of the actual value. |
 | `messaging.kafka.consumer_group` | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. |
 | `messaging.kafka.client_id` | Client Id for the Consumer or Producer that is handling the message. |
 | `messaging.kafka.partition` | Partition the message is sent to. |
+<!-- endsemconv -->
 
-For Apache Kafka producers, `peer.service` should be set to the name of the broker or external service the message will be sent to.
-Consumers should set `service.name` as the Resource receiving the message. The value should match `peer.service` set by a Producer.
+For Apache Kafka producers, [`peer.service`](./span-general.md#general-remote-service-attributes) SHOULD be set to the name of the broker or external service the message will be sent to.
+Consumers SHOULD identify the [Resource](../../resource/semantic_conventions/README.md#service) that received the message.
+The `service.name` of a Consumer's Resource SHOULD match the `peer.service` of the Producer.
 
 ## Examples
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -226,7 +226,7 @@ Process CB:                 | Span CB1 |
 ### Apache Kafka Example
 
 Given is a process P, that publishes a message to a topic T1 on Apache Kafka.
-One process, CA, receives the message and publishes a new message to a topic T2 that is then received and processed by CB. 
+One process, CA, receives the message and publishes a new message to a topic T2 that is then received and processed by CB.
 
 ```
 Process P:  | Span Prod1 |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -120,7 +120,7 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.protocol` | string | The name of the transport protocol. | `AMQP`<br>`MQTT` | No |
 | `messaging.protocol_version` | string | The version of the transport protocol. | `0.9.1` | No |
 | `messaging.url` | string | Connection string. | `tibjmsnaming://localhost:7222`<br>`https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No |
-| `messaging.service` | string | Name of the external broker, or name of the service being interacted with. See note below for a definition. | No |
+| `messaging.service` | string | Name of the external broker, or name of the service being interacted with. See note below for a definition. | `myKey` | No |
 | `messaging.message_id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | No |
 | `messaging.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | No |
 | `messaging.message_payload_size_bytes` | number | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | No |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -201,7 +201,7 @@ For Apache Kafka, the following additional attributes are defined:
 | `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `client-5` | No |
 | `messaging.kafka.partition` | number | Partition the message is sent to. | `2` | No |
 
-**[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key can not be represented in string form, don't include its value.
+**[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
 <!-- endsemconv -->
 
 For Apache Kafka producers, [`peer.service`](./span-general.md#general-remote-service-attributes) SHOULD be set to the name of the broker or service the message will be sent to.

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -126,13 +126,10 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | No |
 | `messaging.message_payload_size_bytes` | number | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | No |
 | `messaging.message_payload_compressed_size_bytes` | number | The compressed size of the message payload in bytes. | `2048` | No |
+| [`net.peer.ip`](span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | Conditional<br>If available. |
+| [`net.peer.name`](span-general.md) | string | Remote hostname or similar, see note below. | `example.com` | Conditional<br>If available. |
 
 **[1]:** Required only if the message destination is either a `queue` or `topic`.
-
-**Additional attribute recommendations:** At least one of the following sets of attributes is recommended:
-
-* [`net.peer.name`](span-general.md)
-* [`net.peer.ip`](span-general.md)
 
 `messaging.destination_kind` MUST be one of the following:
 
@@ -185,12 +182,14 @@ The routing key MUST be provided to the attribute `messaging.rabbitmq.routing_ke
 For Apache Kafka, the following additional attributes are defined:
 
 <!-- semconv messaging.kafka -->
-| Attribute name |                          Notes and examples                            |
-| -------------- | ---------------------------------------------------------------------- |
-| `messaging.kafka.message_key` | Differs from `messaging.message_id` in that it's not unique, and can be `null`. The type is a String representation of the type of the actual value. |
-| `messaging.kafka.consumer_group` | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. |
-| `messaging.kafka.client_id` | Client Id for the Consumer or Producer that is handling the message. |
-| `messaging.kafka.partition` | Partition the message is sent to. |
+| Attribute  | Type | Description  | Example  | Required |
+|---|---|---|---|---|
+| `messaging.kafka.message_key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | No |
+| `messaging.kafka.consumer_group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | No |
+| `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `5` | No |
+| `messaging.kafka.partition` | string | Partition the message is sent to. | `2` | No |
+
+**[1]:** If the key type is not string, it's string representation has to be supplied for the attribute.
 <!-- endsemconv -->
 
 For Apache Kafka producers, [`peer.service`](./span-general.md#general-remote-service-attributes) SHOULD be set to the name of the broker or external service the message will be sent to.

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -200,6 +200,7 @@ For Apache Kafka, the following additional attributes are defined:
 | `messaging.kafka.consumer_group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | No |
 | `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `client-5` | No |
 | `messaging.kafka.partition` | number | Partition the message is sent to. | `2` | No |
+| `messaging.kafka.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | Conditional<br>If missing, it is assumed to be false. |
 
 **[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -137,9 +137,11 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.message_payload_size_bytes` | number | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | No |
 | `messaging.message_payload_compressed_size_bytes` | number | The compressed size of the message payload in bytes. | `2048` | No |
 | [`net.peer.ip`](span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | Conditional<br>If available. |
-| [`net.peer.name`](span-general.md) | string | Remote hostname or similar, see note below. | `example.com` | Conditional<br>If available. |
+| [`net.peer.name`](span-general.md) | string | Remote hostname or similar, see note below. [2] | `example.com` | Conditional<br>If available. |
 
 **[1]:** Required only if the message destination is either a `queue` or `topic`.
+
+**[2]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
 
 `messaging.destination_kind` MUST be one of the following:
 
@@ -196,10 +198,10 @@ For Apache Kafka, the following additional attributes are defined:
 |---|---|---|---|---|
 | `messaging.kafka.message_key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | No |
 | `messaging.kafka.consumer_group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | No |
-| `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `5` | No |
-| `messaging.kafka.partition` | string | Partition the message is sent to. | `2` | No |
+| `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `client-5` | No |
+| `messaging.kafka.partition` | number | Partition the message is sent to. | `2` | No |
 
-**[1]:** If the key type is not string, it's string representation has to be supplied for the attribute.
+**[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key can not be represented in string form, don't include its value.
 <!-- endsemconv -->
 
 For Apache Kafka producers, [`peer.service`](./span-general.md#general-remote-service-attributes) SHOULD be set to the name of the broker or service the message will be sent to.

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -148,7 +148,7 @@ The following operations related to messages are defined for these semantic conv
 | Value  | Description |
 |---|---|
 | `queue` | A message sent to a queue |
-| `topic` | A message broadcasted to the subscribers of the topic |
+| `topic` | A message sent to a topic |
 <!-- endsemconv -->
 
 Additionally `net.peer.port` from the [network attributes][] is recommended.


### PR DESCRIPTION
Fixes #977

## Changes

Update tracing semantic conventions for messaging systems to better reflect "non-traditional" approaches such as Apache Kafka.

Include recommended semantic attributes for Apache Kafka