### PR TITLE
Updating spec compliance for Python

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -14,7 +14,7 @@ status of the feature is not known.
 |[TracerProvider](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracerprovider-operations)|
 |Create TracerProvider                         | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |Get a Tracer                                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
-|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  | + | +  |
+|Safe for concurrent calls                     | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/392)    | +  | +    | + | +  | + | +  |
 |[Tracing Context Utilities](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#tracing-context-utilities)|
 |Get active Span                               |   |    |   | +    |    |      |   |    |   |    |
 |Set active Span                               |   |    |   | +    |    |      |   |    |   |    |
@@ -22,7 +22,7 @@ status of the feature is not known.
 |Create a new Span                             | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |Get active Span                               | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |Mark Span active                              | + | +  | + | +    | +  | +    | + | +  | - | -  |
-|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  | + | +  |
+|Safe for concurrent calls                     | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1156)    | +  | +    | + | +  | + | +  |
 |[SpanContext](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#spancontext)|
 |IsValid                                       | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |IsRemote                                      | - | +  | + | +    | +  | +    | + | +  | + | +  |
@@ -39,7 +39,7 @@ status of the feature is not known.
 |End with timestamp                            | + | +  | + | +    | +  | +    | + | -  | + | +  |
 |IsRecording                                   | + | +  | + | +    | +  | +    | + |    | + | +  |
 |Set status                                    | + | +  | + | +    | +  | +    | + | +  | + | +  |
-|Safe for concurrent calls                     | + | +  | + |      | +  | +    | + | +  | + | +  |
+|Safe for concurrent calls                     | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1157)    | +  | +    | + | +  | + | +  |
 |[Span attributes](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#set-attributes)|
 |SetAttribute                                  | + | +  | + | +    | +  | +    | + | +  | + | +  |
 |Set order preserved                           | + | -  | + | +    | +  | +    | + | +  | + | +  |
@@ -59,7 +59,7 @@ status of the feature is not known.
 |Safe for concurrent calls                     | + | +  | + | +    | +  | +    | + | +  | - | +  |
 |[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
 |RecordException                               | - | +  | + | +    | +  | -    |   | +  | - | +  |
-|RecordException with extra parameters         | - | +  | + | -    | -  | -    |   | +  | - | +  |
+|RecordException with extra parameters         | - | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1102)    | -  | -    |   | +  | - | +  |
 
 ## Baggage
 
@@ -97,12 +97,12 @@ status of the feature is not known.
 |Global Propagator                             |  | +  | + | +    | +  |      |   |    |   |    |
 |TraceContext Propagator                       |  | +  | + | +    | +  |      |   |    |   |    |
 |B3 Propagator                                 |  | +  | + | +    |    |      |   |    |   |    |
-|Jaeger Propagator                             |  | -  | + | -    |    |      |   |    |   |    |
+|Jaeger Propagator                             |  | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1103)    |    |      |   |    |   |    |
 |[TextMapPropagator](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#textmap-propagator)|
-|Fields                                        |  | +  |   | -   |    |      |   |    |   |    |
+|Fields                                        |  | +  |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1104)   |    |      |   |    |   |    |
 |Setter argument                               |  | +  | + | +   |    |      |   |    |   |    |
 |Getter argument                               |  | +  | + | +   |    |      |   |    |   |    |
-|Getter argument returning Keys                |  | -  |   | -   |    |      |   |    |   |    |
+|Getter argument returning Keys                |  | -  |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1084)   |    |      |   |    |   |    |
 
 ## Error Handling
 
@@ -115,13 +115,13 @@ status of the feature is not known.
 |Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|
 |OTEL_RESOURCE_ATTRIBUTES                      | + | +  | + | +    | +  | -    | - |    | - | -  |
-|OTEL_LOG_LEVEL                                |   | -  | + | -    | +  | -    | - |    | - | -  |
-|OTEL_PROPAGATORS                              |   |    |   | -    |    | -    | - |    | - | -  |
-|OTEL_BSP_*                                    |   | +  |   | -    | +  | -    | - |    | - | -  |
-|OTEL_EXPORTER_OTLP_*                          |   |    |   | -    | +  | -    | - |    | - | -  |
-|OTEL_EXPORTER_JAEGER_*                        |   |    |   | -    | +  | -    | - |    | - | -  |
+|OTEL_LOG_LEVEL                                |   | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1059)    | +  | -    | - |    | - | -  |
+|OTEL_PROPAGATORS                              |   |    |   | +    |    | -    | - |    | - | -  |
+|OTEL_BSP_*                                    |   | +  |   | +    | +  | -    | - |    | - | -  |
+|OTEL_EXPORTER_OTLP_*                          |   |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1004)    | +  | -    | - |    | - | -  |
+|OTEL_EXPORTER_JAEGER_*                        |   |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1056)    | +  | -    | - |    | - | -  |
 |OTEL_EXPORTER_ZIPKIN_*                        |   |    |   | +    |    | -    | - |    | - | -  |
-|OTEL_EXPORTER                                 |   |    |   |      |    |      |   |    |   |    |
+|OTEL_EXPORTER                                 |   |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1155)    |    |      |   |    |   |    |
 
 ## Exporters
 
@@ -131,27 +131,27 @@ status of the feature is not known.
 |In-memory (mock exporter)                     | + | +  | + | +    | +  | +    | - | -  | - | -  |
 |[OTLP](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/protocol/otlp.md)|
 |OTLP/gRPC Exporter                            | + | +  | + | +    |    | +    |   | +  | + | +  |
-|OTLP/HTTP binary Protobuf Exporter            | - | -  | + | -    | +  | +    |   |    | + | +  |
-|OTLP/HTTP JSON Protobuf Exporter              | - | -  | + | -    |    | -    |   |    |   |    |
-|OTLP/HTTP gzip Content-Encoding support       | - | -  | + | -    |    | -    |   |    |   |    |
-|Concurrent sending                            | - |    | + | -    |    | -    |   | +  |   |    |
+|OTLP/HTTP binary Protobuf Exporter            | - | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1106)    | +  | +    |   |    | + | +  |
+|OTLP/HTTP JSON Protobuf Exporter              | - | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1003)    |    | -    |   |    |   |    |
+|OTLP/HTTP gzip Content-Encoding support       | - | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1107)    |    | -    |   |    |   |    |
+|Concurrent sending                            | - |    | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1108)    |    | -    |   | +  |   |    |
 |Honors retryable responses with backoff       | + |    | + | +    | +  | -    |   |    |   |    |
 |Honors non-retryable responses                | + |    | - | +    | +  | -    |   |    |   |    |
-|Honors throttling response                    | + |    | - | -    | +  | -    |   |    |   |    |
-|Multi-destination spec compliance             | - |    |   | -    |    | -    |   |    |   |    |
+|Honors throttling response                    | + |    | - | +    | +  | -    |   |    |   |    |
+|Multi-destination spec compliance             | - |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1109)    |    | -    |   |    |   |    |
 |[Zipkin](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk_exporters/zipkin.md)|
-|Zipkin V1 JSON                                |   |    |   | -    |    | -    | - | -  |   |    |
-|Zipkin V1 Thrift                              |   |    |   | -    |    | -    | - | -  |   |    |
+|Zipkin V1 JSON                                |   |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1173)    |    | -    | - | -  |   |    |
+|Zipkin V1 Thrift                              |   |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1174)    |    | -    | - | -  |   |    |
 |Zipkin V2 JSON                                | + |    |   | +    |    | -    | + | +  |   |    |
-|Zipkin V2 Protobuf                            |   |    |   | -    |    | +    |   | -  |   |    |
+|Zipkin V2 Protobuf                            |   |    |   | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1175)    |    | +    |   | -  |   |    |
 |Service name mapping                          | + | +  | + | +    |    | +    | + | +  |   |    |
 |SpanKind mapping                              | + | +  | + | +    |    | +    | + | +  |   |    |
-|InstrumentationLibrary mapping                |   | +  | - | -    |    | -    | - | -  |   |    |
+|InstrumentationLibrary mapping                |   | +  | - | +    |    | -    | - | -  |   |    |
 |Boolean attributes                            | + | +  | + | +    |    | +    | + | +  |   |    |
-|Array attributes                              | + | +  | + | -    |    | +    | + | +  |   |    |
-|Status mapping                                | + | -  | + | -    |    | +    | + | +  |   |    |
+|Array attributes                              | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1110)    |    | +    | + | +  |   |    |
+|Status mapping                                | + | -  | + | +    |    | +    | + | +  |   |    |
 |Event attributes mapping to Annotations       | + |    | + | +    |    | +    | + | +  |   |    |
-|Integer microseconds in timestamps            |   |    |   |      |    |      |   |    |   |    |
+|Integer microseconds in timestamps            |   |    |   | +    |    |      |   |    |   |    |
 |Jaeger|
 |TBD|
 |OpenCensus|


### PR DESCRIPTION
## Changes

Updating the spec compliance matrix, as part of this change, added links to track all the issues for items not currently supported. The idea here is to:

- help maintainers understand where the work is tracked
- give SIGs an easy way to find issues they can use as a template
- give users a way to find ways they can help the project for features they want/need

The downside of this change is the formatting on the table is uglier.
