### PR TITLE
Follow up for #988.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ New:
     ([#784](https://github.com/open-telemetry/opentelemetry-specification/pull/784),
     [#946](https://github.com/open-telemetry/opentelemetry-specification/pull/946))
 - Allow samplers to modify tracestate
-  ([#856](https://github.com/open-telemetry/opentelemetry-specification/pull/988/))
+  ([#988](https://github.com/open-telemetry/opentelemetry-specification/pull/988/))
 - Update the header name for otel baggage, and version date
   ([#981](https://github.com/open-telemetry/opentelemetry-specification/pull/981))
 - Define PropagationOnly Span to simplify active Span logic in Context

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -60,7 +60,7 @@ status of the feature is not known.
 |[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
 |RecordException                               | - | +  | + | +    | +  | -    |   | +  | - | +  |
 |RecordException with extra parameters         | - | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1102)    | -  | -    |   | +  | - | +  |
-|[Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampler)|
+|[Sampling](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampling)|
 |Allow samplers to modify tracestate           |  |    |   |      |    |      |   |    |   |    |
 
 ## Baggage

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -60,6 +60,8 @@ status of the feature is not known.
 |[Span exceptions](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/api.md#record-exception)|
 |RecordException                               | - | +  | + | +    | +  | -    |   | +  | - | +  |
 |RecordException with extra parameters         | - | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1102)    | -  | -    |   | +  | - | +  |
+|[Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/sdk.md#sampler)|
+|Allow samplers to modify tracestate           |  |    |   |      |    |      |   |    |   |    |
 
 ## Baggage
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -101,8 +101,8 @@ It produces an output called `SamplingResult` which contains:
 object must be immutable (multiple calls may return different immutable objects).
 * A `Tracestate` that will be associated with the `Span` through the new
   `SpanContext`.
-  Note: If the sampler returns an empty `Tracestate` here, the `Tracestate` will be cleared,
-  so samplers should normally return the passed-in `Tracestate` if they do not intend
+  If the sampler returns an empty `Tracestate` here, the `Tracestate` will be cleared,
+  so samplers SHOULD normally return the passed-in `Tracestate` if they do not intend
   to change it.
 
 #### GetDescription


### PR DESCRIPTION
- Fix CHANGELOG entry.
- Use SHOULD for the tracestate change.
- Add it to the compliance matrix.

Related to #988 

Note: Realized we need to add the list of the built-in samplers to the compliance matrix, but will do that in another PR.