### PR TITLE
Clarify how Otel Events should map to Jaeger Logs

### DIFF
--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -40,4 +40,12 @@ TBD
 
 ### Events
 
-TBD
+Events MUST be converted to Jaeger Logs. OpenTelemetry Event's `time_unix_nano` and `attributes` fields map directly to Jaeger Log's `timestamp` and `fields` fields. Jaeger Log has no direct equivalent for OpenTelemetry Event's `name` and `dropped_attributes_count` fields but OpenTracing semantic conventions specify some special attribute names [here](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table). OpenTelemetry Event's `name` and `dropped_attributes_count` fields should be added to Jaeger Log's `fields` map as follows:
+
+| OpenTelemetry Event Field | Jaeger Attribute |
+| -------------------------- | ----------------- |
+| `name`|`event`|
+| `dropped_attributes_count`|`otel.event.dropped_attributes_count`|
+
+* `dropped_attributes_count` should only be recorded when it contains a non-zero value.
+* If OpenTelemetry Event contains an attributes with the key `event`, it should take precedence over Event's `name` field.


### PR DESCRIPTION
Currently the spec does not clarify this as far as I can tell. Today, multiple implementations map Otel Event's `name` field to a Jaeger Log attribute with `message` as the key while `dropped_attributes_count` is completely dropped. I propose we use different names for attributes keys for Event fields that don't have a direct Jaeger Log counter-part as,

1. It's more in-line with the rest of the spec where we use `otel.*` attribute keys to map similar fields to attributes.
2. `message` is a very generic event/log attribute that users or instrumentation might actually try to set and this translation would overwrite it.
