### PR TITLE
Clarify b3 debug flag and parent span id handling

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -348,7 +348,7 @@ When extracting B3, propagators:
 * MUST preserve a debug trace flag, if received, and propagate
   it with subsequent requests. Internally, an OpenTelemetry implementation
   MUST convert this to a sampled trace flag.
-* MUST not reuse `X-B3-SpanId` as the id for the server-side span.
+* MUST NOT reuse `X-B3-SpanId` as the id for the server-side span.
 
 #### Inject
 
@@ -357,5 +357,5 @@ When injecting B3, propagators:
 * MUST default to injecting B3 using the single-header format
 * MUST provide configuration to change the default injection format to B3
   multi-header
-* MUST omit propagating `X-B3-ParentSpanId` as OpenTelemetry does not support
+* MUST NOT propagate `X-B3-ParentSpanId` as OpenTelemetry does not support
   reusing the same id for both sides of a request.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -343,7 +343,7 @@ been established for B3 context propagation.
 When extracting B3, propagators:
 
 * MUST attempt to extract B3 encoded using single and multi-header
-  formats. When extracting, the single-header variant takes precedence over
+  formats. The single-header variant takes precedence over
   the multi-header version.
 * MUST preserve a debug trace flag, if received, and propagate
   it with subsequent requests. Internally, an OpenTelemetry implementation

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -346,8 +346,8 @@ When extracting B3, propagators:
   formats. The single-header variant takes precedence over
   the multi-header version.
 * MUST preserve a debug trace flag, if received, and propagate
-  it with subsequent requests. Internally, an OpenTelemetry implementation
-  MUST convert this to a sampled trace flag.
+  it with subsequent requests. Additionally, an OpenTelemetry implementation
+  MUST set the sampled trace flag when the debug flag is set.
 * MUST NOT reuse `X-B3-SpanId` as the id for the server-side span.
 
 #### Inject

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -332,15 +332,23 @@ a community are:
 
 ### B3 Requirements
 
-B3 has both single and multi-header encodings. To maximize compatibility between
-implementations, the following guidelines have been established for B3
-propagation in OpenTelemetry.
+B3 has both single and multi-header encodings. It also has semantics that do not
+map directly to OpenTelemetry such as a debug trace flag, and allowing spans
+from both sides of request to share the same id. To maximize compatibility
+between OpenTelemetry and Zipkin implementations, the following guidelines have
+been established for B3 context propagation.
 
 #### Extract
 
-Propagators MUST attempt to extract B3 encoded using single and multi-header
-formats. When extracting, the single-header variant takes precedence over
-the multi-header version.
+When extracting B3, propagators:
+
+* MUST attempt to extract B3 encoded using single and multi-header
+  formats. When extracting, the single-header variant takes precedence over
+  the multi-header version.
+* MUST preserve a debug trace flag, if received, and propagate
+  it with subsequent requests. Internally, an OpenTelemetry implementation
+  MUST convert this to a sampled trace flag.
+* MUST not reuse `X-B3-SpanId` as the id for the server-side span.
 
 #### Inject
 
@@ -349,3 +357,5 @@ When injecting B3, propagators:
 * MUST default to injecting B3 using the single-header format
 * MUST provide configuration to change the default injection format to B3
   multi-header
+* MUST omit propagating `X-B3-ParentSpanId` as OpenTelemetry does not support
+  reusing the same id for both sides of a request.


### PR DESCRIPTION
Fixes #1004 

## Changes

This PR clarifies how OpenTelemetry should handle the B3 debug trace flag and parent span id propagation. 

As discussed in issue #1004, OpenTelemetry does not support client and server spans sharing an id when they are part of the same request. To enable this, B3 support propagating a parent span id, in addition to the current span id. As a result, OpenTelemetry safely ignore the parent span id when propagating B3.

When receiving a B3 debug trace flag, an OpenTelemetry implementation should preserve and propagate the debug trace flag, but internally treat it as a sampled trace flag.

See https://github.com/openzipkin/b3-propagation for more details.