### PR TITLE
Clarify that link and event don't need to be objects in the API

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -379,7 +379,8 @@ Span creation.
 A `Link` is semantically defined by the following properties:
 
 - `SpanContext` of the `Span` to link to.
-- Zero or more `Attribute`s as defined [here](../common/common.md#attributes).
+- Zero or more [`Attributes`](../common/common.md#attributes) further describing
+  the link.
 
 The Span creation API MUST provide:
 
@@ -458,8 +459,9 @@ An `Event` is semantically defined by the following properties:
 
 - Name of the event.
 - A timestamp for the event. Either the time at which the event was
-added or a custom timestamp provided by the user.
-- [`Attributes`](../common/common.md#attributes) further describing the event.
+  added or a custom timestamp provided by the user.
+- Zero or more [`Attributes`](../common/common.md#attributes) further describing
+  the event.
 
 The Span interface MUST provide:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -495,7 +495,7 @@ Note that [`RecordException`](#record-exception) is a specialized variant of
 Sets the `Status` of the `Span`. If used, this will override the default `Span`
 status, which is `Unset`.
 
-`Status` is semantically defined by the following properties:
+`Status` is structurally defined by the following properties:
 
 - `StatusCanonicalCode` that represents the canonical set of `Status` codes.
 - Optional `Description` that provides a descriptive message of the `Status`.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -385,12 +385,11 @@ The Span creation API MUST provide:
 
 - An API to record a single `Link` where the `Link` properties are passed as
   arguments. This MAY be called `AddLink`. This API takes the `SpanContext` of
-  the `Span` to link to and optional `Attributes`.
+  the `Span` to link to and optional `Attributes`, either as individual
+  parameters or as an immutable object encapsulating them, whichever is most
+  appropriate for the language.
 
 Links SHOULD preserve the order in which they're set.
-
-Note that there are multiple ways to implement this API, such as: overloading,
-variadic arguments, or define an immutable object to be passed to the API calls.
 
 ### Span operations
 
@@ -467,9 +466,11 @@ The Span interface MUST provide:
 - An API to record a single `Event` where the `Event` properties are passed as
   arguments. This MAY be called `AddEvent`.
   This API takes the name of the event, optional `Attributes` and an optional
-  `Timestamp` which can be used to specify the time at which the event occurred.
-  If no custom timestamp is provided by the user, the implementation automatically
-  sets the time at which this API is called on the event.
+  `Timestamp` which can be used to specify the time at which the event occurred,
+  either as individual parameters or as an immutable object encapsulating them,
+  whichever is most appropriate for the language. If no custom timestamp is
+  provided by the user, the implementation automatically sets the time at which
+  this API is called on the event.
 
 Events SHOULD preserve the order in which they are recorded.
 This will typically match the ordering of the events' timestamps,
@@ -486,9 +487,6 @@ keys"](semantic_conventions/README.md) which have prescribed semantic meanings.
 
 Note that [`RecordException`](#record-exception) is a specialized variant of
 `AddEvent` for recording exception events.
-
-Note that there are multiple ways to implement this API, such as: overloading,
-variadic arguments, or define an immutable object to be passed to the API calls.
 
 #### Set Status
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -376,7 +376,7 @@ During the `Span` creation user MUST have the ability to record links to other
 description](../overview.md#links-between-spans). `Link`s cannot be added after
 Span creation.
 
-A `Link` is semantically defined by the following properties:
+A `Link` is structurally defined by the following properties:
 
 - `SpanContext` of the `Span` to link to.
 - Zero or more [`Attributes`](../common/common.md#attributes) further describing
@@ -455,7 +455,7 @@ attributes, cannot change their decisions.
 A `Span` MUST have the ability to add events. Events have a time associated
 with the moment when they are added to the `Span`.
 
-An `Event` is semantically defined by the following properties:
+An `Event` is structurally defined by the following properties:
 
 - Name of the event.
 - A timestamp for the event. Either the time at which the event was

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -373,16 +373,13 @@ For example, a `Propagator` performing context extraction may need this.
 
 During the `Span` creation user MUST have the ability to record links to other
 `Span`s. Linked `Span`s can be from the same or a different trace. See [Links
-description](../overview.md#links-between-spans).
+description](../overview.md#links-between-spans). `Link`s cannot be added after
+Span creation.
 
-`Link`s cannot be added after Span creation.
-
-A `Link` is defined by the following properties:
+A `Link` is semantically defined by the following properties:
 
 - `SpanContext` of the `Span` to link to.
 - Zero or more `Attribute`s as defined [here](../common/common.md#attributes).
-
-The `Link` SHOULD be an immutable type.
 
 The Span creation API MUST provide:
 
@@ -391,6 +388,9 @@ The Span creation API MUST provide:
   the `Span` to link to and optional `Attributes`.
 
 Links SHOULD preserve the order in which they're set.
+
+Note that there are multiple ways to implement this API, such as: overloading,
+variadic arguments, or define an immutable object to be passed to the API calls.
 
 ### Span operations
 
@@ -455,14 +455,12 @@ attributes, cannot change their decisions.
 A `Span` MUST have the ability to add events. Events have a time associated
 with the moment when they are added to the `Span`.
 
-An `Event` is defined by the following properties:
+An `Event` is semantically defined by the following properties:
 
 - Name of the event.
 - A timestamp for the event. Either the time at which the event was
 added or a custom timestamp provided by the user.
 - [`Attributes`](../common/common.md#attributes) further describing the event.
-
-The `Event` SHOULD be an immutable type.
 
 The Span interface MUST provide:
 
@@ -488,6 +486,9 @@ keys"](semantic_conventions/README.md) which have prescribed semantic meanings.
 
 Note that [`RecordException`](#record-exception) is a specialized variant of
 `AddEvent` for recording exception events.
+
+Note that there are multiple ways to implement this API, such as: overloading,
+variadic arguments, or define an immutable object to be passed to the API calls.
 
 #### Set Status
 


### PR DESCRIPTION
Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>

Related issues #1037
