### PR TITLE
Update the baggage spec to include opaque metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release.
 
 ## Unreleased
 
+New:
+
 - Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation
   ([#1066](https://github.com/open-telemetry/opentelemetry-specification/pull/1066))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ release.
 
 ## Unreleased
 
+- Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation
+  ([#1066](https://github.com/open-telemetry/opentelemetry-specification/pull/1066))
+
 New:
 
 - Change Status to be consistent with Link and Event
@@ -43,8 +46,6 @@ New:
   ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 - Add Metric SDK specification (partial): covering terminology and Accumulator component
   ([#626](https://github.com/open-telemetry/opentelemetry-specification/pull/626))
-- Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation
-  ([TODO](https://gitnub.com/todo))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ New:
   ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 - Add Metric SDK specification (partial): covering terminology and Accumulator component
   ([#626](https://github.com/open-telemetry/opentelemetry-specification/pull/626))
+- Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation
+  ([TODO](https://gitnub.com/todo))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ New:
 
 - Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation
   ([#1066](https://github.com/open-telemetry/opentelemetry-specification/pull/1066))
-
-New:
-
 - Change Status to be consistent with Link and Event
   ([#1067](https://github.com/open-telemetry/opentelemetry-specification/pull/1067))
 - Clarify env variables in otlp exporter

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -64,13 +64,16 @@ contains a `Baggage` with the new value.
 
 REQUIRED parameters:
 
-`Name` the name for which to set the value.
+`Name` The name for which to set the value. This is string-valued.
 
-`Value` the value to set.
+`Value` The value to set. This is string-valued.
 
 OPTIONAL parameters:
 
-`Context` the context containing the `Baggage` in which to set the baggage entry.
+`Metadata` Optional metadata associated with the name-value pair. An opaque string with no
+semantic meaning.
+
+`Context` The context containing the `Baggage` in which to set the baggage entry.
 
 ### Remove baggage
 
@@ -103,6 +106,10 @@ OPTIONAL parameters:
 The API layer MAY include the following `Propagator`s:
 
 * A `TextMapPropagator` implementing the [W3C Baggage Specification](https://w3c.github.io/baggage).
+
+Note: The W3C baggage specification does not currently assign semantic meaning to the optional metadata.
+On `extract`, the propagator should store all metadata per entry as a single opaque string. On `inject`,
+the propagator should append the metadata per the W3C specification format.
 
 ## Conflict Resolution
 

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -108,8 +108,16 @@ The API layer MAY include the following `Propagator`s:
 * A `TextMapPropagator` implementing the [W3C Baggage Specification](https://w3c.github.io/baggage).
 
 Note: The W3C baggage specification does not currently assign semantic meaning to the optional metadata.
+
 On `extract`, the propagator should store all metadata as a single metadata instance per entry.
 On `inject`, the propagator should append the metadata per the W3C specification format.
+
+Notes:
+
+If the propagator is unable to parse the `baggage` header, `extract` MUST return a Context with no baggage entries in it.
+
+If the `baggage` header is present, but contains no entries, `extract` MUST return a Context with
+no baggage entries in it.
 
 ## Conflict Resolution
 

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -70,8 +70,8 @@ REQUIRED parameters:
 
 OPTIONAL parameters:
 
-`Metadata` Optional metadata associated with the name-value pair. An opaque string with no
-semantic meaning.
+`Metadata` Optional metadata associated with the name-value pair. This should be an opaque wrapper
+for a string with no semantic meaning. Left opaque to allow for future functionality.
 
 `Context` The context containing the `Baggage` in which to set the baggage entry.
 
@@ -108,8 +108,8 @@ The API layer MAY include the following `Propagator`s:
 * A `TextMapPropagator` implementing the [W3C Baggage Specification](https://w3c.github.io/baggage).
 
 Note: The W3C baggage specification does not currently assign semantic meaning to the optional metadata.
-On `extract`, the propagator should store all metadata per entry as a single opaque string. On `inject`,
-the propagator should append the metadata per the W3C specification format.
+On `extract`, the propagator should store all metadata as a single metadata instance per entry.
+On `inject`, the propagator should append the metadata per the W3C specification format.
 
 ## Conflict Resolution
 

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -64,9 +64,9 @@ contains a `Baggage` with the new value.
 
 REQUIRED parameters:
 
-`Name` The name for which to set the value. This is string-valued.
+`Name` The name for which to set the value, of type string.
 
-`Value` The value to set. This is string-valued.
+`Value` The value to set, of type string.
 
 OPTIONAL parameters:
 


### PR DESCRIPTION
Also update the description of the propagator to clarify metadata propagation.

Fixes #1050 

## Changes

Adds the concept of baggage entry metadata, and explains how to propagate the W3C baggage.
