### PR TITLE
Include k8s.pod.hostname in semantic conventions

### DIFF
--- a/specification/resource/semantic_conventions/k8s.md
+++ b/specification/resource/semantic_conventions/k8s.md
@@ -49,6 +49,7 @@ containers on your cluster.
 |---|---|---|
 | k8s.pod.uid | The uid of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` |
 | k8s.pod.name | The name of the Pod. | `opentelemetry-pod-autoconf` |
+| k8s.pod.hostname | The hostname of the Pod, if set, or [name, otherwise](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-hostname-and-subdomain-fields). | `opentelemetry-pod-autoconf` |
 
 ## Container
 
@@ -65,7 +66,9 @@ to a running container.
 
 | Attribute  | Description  | Example  |
 |---|---|---|
+| k8s.container.image | The optional Container image (when not set using higher level config)| `redis` |
 | k8s.container.name | The name of the Container in a Pod template. | `redis` |
+| k8s.container.id | The Container ID | `docker://22b7d5e3a376c22dd2f7358b2f85bd6c2432c04294cd4cbbef17b6ae1ac40603` |
 
 ## ReplicaSet
 

--- a/specification/resource/semantic_conventions/k8s.md
+++ b/specification/resource/semantic_conventions/k8s.md
@@ -66,9 +66,7 @@ to a running container.
 
 | Attribute  | Description  | Example  |
 |---|---|---|
-| k8s.container.image | The optional Container image (when not set using higher level config)| `redis` |
 | k8s.container.name | The name of the Container in a Pod template. | `redis` |
-| k8s.container.id | The Container ID | `docker://22b7d5e3a376c22dd2f7358b2f85bd6c2432c04294cd4cbbef17b6ae1ac40603` |
 
 ## ReplicaSet
 


### PR DESCRIPTION
Include `k8s.pod.hostname` in `k8s` semantic conventions.

Since this is a relatively small change (and it follows the naming scheme used right now), I didn't open a separate issue. Will be happy to update the upcoming YAML definitions if this gets accepted.

Related issues #
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/141