### PR TITLE
Database metric semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ New:
   ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 - Add Metric SDK specification (partial): covering terminology and Accumulator component
   ([#626](https://github.com/open-telemetry/opentelemetry-specification/pull/626))
+- Add semantic conventions for Database metrics ([#1076](https://github.com/open-telemetry/opentelemetry-specification/pull/1076))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,8 @@ New:
   ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 - Add Metric SDK specification (partial): covering terminology and Accumulator component
   ([#626](https://github.com/open-telemetry/opentelemetry-specification/pull/626))
-- Add semantic conventions for Database metrics ([#1076](https://github.com/open-telemetry/opentelemetry-specification/pull/1076))
+- Add semantic conventions for Database metrics
+  ([#1076](https://github.com/open-telemetry/opentelemetry-specification/pull/1076))
 
 Updates:
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -204,7 +204,6 @@ pools. They SHOULD have all [common](#common) labels applied to them.
 | `db.connection_pool.limit` | ValueObserver | {connections} | The total number of database connections available in the connection pool. |
 | `db.connection_pool.usage` | ValueObserver | {connections} | The number of database connections _in use_. |
 
-
 If the following detailed information is available, the following metric
 instruments MAY be collected. They SHOULD have all [common](#common) labels
 applied to them.

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -34,11 +34,12 @@ databases), as well as connect operations.
 In addition to the [common](#common) labels, the following labels **SHOULD** be
 applied to all database call-level metric instruments.
 
-| Attribute  | Type | Description  | Example  | Required |
-|------------|------|--------------|----------|----------|
-| `db.name` | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
-| `db.statement` | string | The database statement being executed. [3][5] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional<br>Required if applicable. |
-| `db.operation` | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET` | Conditional<br>Required, if `db.statement` is not applicable. |
+| Attribute        | Type   | Description  | Example  | Required |
+|------------------|--------|--------------|----------|----------|
+| `db.name`        | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
+| `db.statement`   | string | The database statement being executed. [3][5] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional<br>Required if applicable. |
+| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET` | Conditional<br>Required, if `db.statement` is not applicable. |
+| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Conditional<br>Required if applicable. |
 
 **[1]:** In some SQL databases, the database name to be used is called "schema name".
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -10,16 +10,19 @@ The following labels SHOULD be applied to all database metric instruments.
 
 | Attribute              | Description  | Example  | Required |
 |------------------------|--------------|----------|----------|
-| `db.system`            | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | Yes |
+| `db.system`            | An identifier for the database management system (DBMS) product being used. [1] | `other_sql` | Yes |
 | `db.connection_string` | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` | No |
 | `db.user`              | Username for accessing the database. | `readonly_user`<br>`reporting_user` | No |
-| `net.transport`        | Transport protocol used. See note below. See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes). | `IP.TCP`<br>`Unix` | Conditional [1] |
+| `net.transport`        | Transport protocol used. See note below. See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes). | `IP.TCP`<br>`Unix` | Conditional [2] |
 | `net.peer.ip`          | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
 | `net.peer.port`        | Remote port number. | `80`<br>`8080`<br>`443` | No |
 | `net.peer.name`        | Remote hostname or similar, see note below. | `example.com` | No |
 
 
-**[1]:** Recommended in general, required for in-process databases (`"inproc"`).
+**[1]:** See the [database trace semantic conventions](../../trace/semantic_conventions/database.md#connection-level-attributes)
+for the list of well-known database system values.
+
+**[2]:** Recommended in general, required for in-process databases (`"inproc"`).
 
 ## Call-level Metric Instruments
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -68,6 +68,126 @@ a stored procedure name (without arguments), operation name, etc.
 
 **[1]:** Required, if other than the default database (`0`).
 
+### Examples
+
+#### PostgreSQL SELECT Query
+
+For a client executing a query like this:
+
+```SQL
+SELECT * FROM public.user_table WHERE user_id = 301;
+```
+
+while connected to a PostgreSQL database named "user_db" running on host 
+`postgres-server:5432`, the following instrument should result:
+
+```json
+{
+  "name": "db.client.duration",
+  "labels": {
+    "db.operation": "SELECT",
+    "db.table": "user_table",
+    "db.name": "user_db",
+    "db.system": "postgresql",
+    "db.connection_string": "postgresql://postgres-server:5432/user_db",
+    "db.user": "",
+    "net.peer.ip": "192.0.10.2",
+    "net.peer.port": 5432,
+    "net.peer.name": "postgres-server"
+  }
+}
+```
+
+#### MySQL SELECT Query
+
+For a client executing a query like this:
+
+```SQL
+SELECT * FROM orders WHERE order_id = 301;
+```
+
+while connected to a MySQL database named "ShopDb" running on host 
+`shopdb.example.com`, the following instrument should result:
+
+
+```json
+{
+  "name": "db.client.duration",
+  "labels": {
+  	"db.operation": "SELECT",
+  	"db.table": "orders",
+  	"db.name": "ShopDb",
+  	"db.system": "mysql",
+  	"db.connection_string": "Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;",
+  	"db.user": "billing_user",
+  	"net.peer.name": "shopdb.example.com",
+  	"net.peer.ip": "192.0.2.12",
+  	"net.peer.port": "3306",
+  	"net.transport": "IP.TCP"
+  }
+}
+
+```
+
+#### Redis HMSET
+
+For a client executing a Redis HMSET command like this:
+
+```redis
+HMSET myhash field1 'Hello' field2 'World
+```
+
+while connecting to a Redis instance over a Unix socket, the following instrument
+should result:
+
+```json
+{
+  "name": "db.client.duration",
+  "labels": {
+  	"db.operation": "HMSET",
+  	"db.table": "myhash",
+  	"db.system": "redis",
+  	"db.user": "the_user",
+  	"net.peer.name": "/tmp/redis.sock",
+  	"net.transport": "Unix",
+  	"db.redis.database_index": "15"
+  }
+}
+```
+
+#### MongoDB findAndModify
+
+For a mongo client executing the `findAndModify` command like this:
+
+```javascript
+{
+  findAndModify: "people",
+  query: { name: "Tom", state: "active", rating: { $gt: 10 } },
+  sort: { rating: 1 },
+  update: { $inc: { score: 1 } }
+}
+```
+
+against the database named "userdatabase" while connected to a MongoDB available
+at `mongodb.example.com`, the following instrument should result:
+
+```json
+{
+  "name": "db.client.duration",
+  "labels": {
+  	"db.operation": "findAndModify",
+  	"db.table": "people",
+  	"db.name": "userdatabase",
+  	"db.system": "mongodb",
+  	"db.user": "the_user",
+  	"net.peer.name": "mongodb.example.com",
+  	"net.peer.ip": "192.0.2.14",
+  	"net.peer.port": "27017",
+  	"net.transport": "IP.TCP"
+  }
+}
+```
+
 ## Connection Pooling Metric Instruments
 
 Otherwise, the following metric instruments SHOULD be collected. They SHOULD

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -14,6 +14,8 @@
     + [Redis HMSET](#redis-hmset)
     + [MongoDB findAndModify](#mongodb-findandmodify)
 - [Connection Pooling Metric Instruments](#connection-pooling-metric-instruments)
+- [Additional metric instruments for specific technologies](#additional-metric-instruments-for-specific-technologies)
+  * [Examples](#examples-1)
 
 <!-- tocstop -->
 
@@ -220,16 +222,25 @@ pools. They SHOULD have all [common](#common) labels applied to them.
 | `db.connection_pool.limit` | ValueObserver | {connections} | The total number of database connections available in the connection pool. |
 | `db.connection_pool.usage` | ValueObserver | {connections} | The number of database connections _in use_. |
 
-If the following detailed information is available, the following metric
-instruments MAY be collected. They SHOULD have all [common](#common) labels
-applied to them.
+## Additional metric instruments for specific technologies
 
-| Name                      | Instrument | Units         | Description |
-|---------------------------|------------|---------------|-------------|
-| `db.connections.taken`    | Counter    | {connections} | Incremented when a connection is requested and returned from the pool.  |
-| `db.connections.new`      | Counter    | {connections} | Incremented when a connection is requested and returned from the pool only if the connection pool returns a newly created connection. |
-| `db.connections.reused`   | Counter    | {connections} | Incremented when a connection is requested and returned from the pool only if the connection pool returns a previously used connection. |
-| `db.connections.returned` | Counter    | {connections} | Incremented when the application is finished using a connection and returns it to the pool. |
-| `db.connections.closed`   | Counter    | {connections} | Incremented when the pool closes a connection. [1] |
+Additional metric instruments MAY be used for technology-specific measurements. Such
+instruments SHOULD have all [common](#common) labels applied to them, and their names
+should follow the pattern (in which `{db.system}` is one of the allowed values for the
+db.system trace attribute):
 
-**[1]:** Connection pools sometimes close connections after some pre-configured time has elapsed, or when the application is shutting down. The `db.connections.closed` instrument should be incremented for each connection closed. It should _eventually_ be true that `db.connections.new - db.connections.closed = 0`.
+```
+db.{db.system}.*
+```
+
+### Examples
+
+* `db.redis.connections.taken`
+* `db.redis.connections.new`
+* `db.redis.connections.reused`
+* `db.redis.connections.returned`
+* `db.redis.connections.closed`
+* `db.mongo.average_object_size`
+* `db.mongo.write_lock_percentage`
+* `db.mongo.object_count`
+* `db.postgresql.cache_hits`

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -60,13 +60,12 @@ applied to all database call-level metric instruments.
 | Label Name       | Type   | Description  | Example  | Required |
 |------------------|--------|--------------|----------|----------|
 | `db.name`        | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Required if applicable. |
-| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET`<br>`SELECT`<br>`CONNECT` | Required if applicable. |
-| `db.table`       | string | The name of the primary table, collection, segment, etc... that the operation is acting upon. | `user_table` | Required if applicable. |
+| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword. [4][5] | `findAndModify`<br>`HMSET`<br>`SELECT`<br>`CONNECT` | Required if applicable. |
 | `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Required if applicable. |
 
 **[1]:** In some SQL databases, the database name to be used is called "schema name".
 
-**[4]:** For SQL operations, this should be set to the SQL keyword (example: `SELECT` or `INSERT`).
+**[4]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 
 **[5]:** To reduce cardinality, the value for `db.operation` should have parameters
 removed or substituted. The resulting value should be a low-cardinality value
@@ -81,8 +80,11 @@ a stored procedure name (without arguments), operation name, etc.
 | `db.hbase.namespace`      | The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute. | `default` | Yes |
 | `db.redis.database_index` | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` label. | `0`<br>`1`<br>`15` | Conditional [1] |
 | `db.mongodb.collection`   | The collection being accessed within the database stated in `db.name`. | `customers`<br>`products` | Yes |
+| `db.sql.table` | string | The name of the primary table that the operation is acting upon, including the schema name (if applicable). [2] | `public.users`<br>`customers` | Conditional<br>Recommended if available. |
 
 **[1]:** Required, if other than the default database (`0`).
+
+**[2]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
 
 ### Examples
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -43,24 +43,19 @@ applied to all database call-level metric instruments.
 
 | Attribute        | Type   | Description  | Example  | Required |
 |------------------|--------|--------------|----------|----------|
-| `db.name`        | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
-| `db.statement`   | string | The database statement being executed. [3][5] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional.<br>Required if applicable. |
-| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET` | Conditional<br>Required, if `db.statement` is not applicable. |
-| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Conditional.<br>Required if applicable. |
+| `db.name`        | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Required if applicable. |
+| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET`<br>`SELECT` | Required if applicable. |
+| `db.table`       | string | The name of the primary table, collection, segment, etc... that the operation is acting upon. | `user_table` | Required if applicable. |
+| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Required if applicable. |
 
 **[1]:** In some SQL databases, the database name to be used is called "schema name".
 
-**[2]:** Required, if applicable and no more-specific attribute is defined.
+**[4]:** For SQL operations, this should be set to the SQL keyword (example: `SELECT` or `INSERT`).
 
-**[3]:** The value may be sanitized to exclude sensitive information.
-
-**[4]:** While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT` or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property (the back end can do that if required).
-
-**[5]:** To reduce cardinality, the values for `db.statement` and `db.operation`
-should have parameters removed or substituted. The resulting value should be a
-low-cardinality value represeting the statement or operation being executed on
-the database. It may be a stored procedure name (without arguments), SQL
-statement without variable arguments, operation name, etc.
+**[5]:** To reduce cardinality, the value for `db.operation` should have parameters
+removed or substituted. The resulting value should be a low-cardinality value
+represeting the statement or operation being executed on the database. It may be
+a stored procedure name (without arguments), operation name, etc.
 
 ### Call-level labels for specific technologies
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -1,5 +1,13 @@
 # Semantic Conventions for Database Metrics
 
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+Run the tool to have the TOC generated here
+
+<!-- tocstop -->
+
 This document contains semantic conventions for database client metrics in
 OpenTelemetry. When instrumenting database clients, also consider the
 [general metric semantic conventions](README.md#general-metric-semantic-conventions).

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -6,7 +6,7 @@ OpenTelemetry. When instrumenting database clients, also consider the
 
 ## Common
 
-The following labels **SHOULD** be applied to all database metric instruments.
+The following labels SHOULD be applied to all database metric instruments.
 
 | Attribute              | Description  | Example  | Required |
 |------------------------|--------------|----------|----------|
@@ -19,27 +19,27 @@ The following labels **SHOULD** be applied to all database metric instruments.
 
 ## Call-level Metric Instruments
 
-The following metric instruments **SHOULD** be iterated for every database operation.
+The following metric instruments SHOULD be iterated for every database operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `db.client.duration` | ValueRecorder | milliseconds | measures the duration of the database operation |
+| `db.client.duration` | ValueRecorder | milliseconds | The duration of the database operation. |
 
-Database operations **SHOULD** include execution of queries, including DDL, DML,
+Database operations SHOULD include execution of queries, including DDL, DML,
 DCL, and TCL SQL statements (and the corresponding operations in non-SQL
 databases), as well as connect operations.
 
 ### Labels
 
-In addition to the [common](#common) labels, the following labels **SHOULD** be
+In addition to the [common](#common) labels, the following labels SHOULD be
 applied to all database call-level metric instruments.
 
 | Attribute        | Type   | Description  | Example  | Required |
 |------------------|--------|--------------|----------|----------|
 | `db.name`        | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
-| `db.statement`   | string | The database statement being executed. [3][5] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional<br>Required if applicable. |
+| `db.statement`   | string | The database statement being executed. [3][5] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional.<br>Required if applicable. |
 | `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET` | Conditional<br>Required, if `db.statement` is not applicable. |
-| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Conditional<br>Required if applicable. |
+| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Conditional.<br>Required if applicable. |
 
 **[1]:** In some SQL databases, the database name to be used is called "schema name".
 
@@ -68,7 +68,7 @@ statement without variable arguments, operation name, etc.
 
 ## Connection Pooling Metric Instruments
 
-If possible, instrumentation should collect the following. They should have
+If possible, instrumentation SHOULD collect the following. They SHOULD have
 all [common](#common) labels applied to them.
 
 | Name                      | Instrument | Units         | Description |
@@ -80,11 +80,11 @@ all [common](#common) labels applied to them.
 | `db.connections.closed`   | Counter    | {connections} | The number of connections closed. |
 
  
-Otherwise, the following metric instruments should be collected. They should
+Otherwise, the following metric instruments SHOULD be collected. They SHOULD
 have all [common](#common) labels applied to them.
 
 | Name                      | Instrument    | Units        | Description |
 |---------------------------|---------------|--------------|-------------|
-| `db.connectionPool.limit` | ValueObserver | {connections} | measures the total number of database connections available in the connection pool |
-| `db.connectionPool.usage` | ValueObserver | {connections} | measures the number of database connections _in use_. |
+| `db.connectionPool.limit` | ValueObserver | {connections} | The total number of database connections available in the connection pool. |
+| `db.connectionPool.usage` | ValueObserver | {connections} | The number of database connections _in use_. |
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -4,7 +4,16 @@
 
 <!-- toc -->
 
-Run the tool to have the TOC generated here
+- [Common](#common)
+- [Call-level Metric Instruments](#call-level-metric-instruments)
+  * [Labels](#labels)
+  * [Call-level labels for specific technologies](#call-level-labels-for-specific-technologies)
+  * [Examples](#examples)
+    + [PostgreSQL SELECT Query](#postgresql-select-query)
+    + [MySQL SELECT Query](#mysql-select-query)
+    + [Redis HMSET](#redis-hmset)
+    + [MongoDB findAndModify](#mongodb-findandmodify)
+- [Connection Pooling Metric Instruments](#connection-pooling-metric-instruments)
 
 <!-- tocstop -->
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -140,7 +140,7 @@ while connected to a MySQL database named "ShopDb" running on host
 For a client executing a Redis HMSET command like this:
 
 ```redis
-HMSET myhash field1 'Hello' field2 'World
+HMSET myhash field1 'Hello' field2 'World'
 ```
 
 while connecting to a Redis instance over a Unix socket, the following instrument
@@ -196,16 +196,17 @@ at `mongodb.example.com`, the following instrument should result:
 
 ## Connection Pooling Metric Instruments
 
-Otherwise, the following metric instruments SHOULD be collected. They SHOULD
-have all [common](#common) labels applied to them.
+The following metric instruments SHOULD be collected for database connection
+pools. They SHOULD have all [common](#common) labels applied to them.
 
 | Name                      | Instrument    | Units        | Description |
 |---------------------------|---------------|--------------|-------------|
 | `db.connection_pool.limit` | ValueObserver | {connections} | The total number of database connections available in the connection pool. |
 | `db.connection_pool.usage` | ValueObserver | {connections} | The number of database connections _in use_. |
 
-If the following detailed information is available, instrumentation MAY collect
-the following metric instruments. They SHOULD have all [common](#common) labels
+
+If the following detailed information is available, the following metric
+instruments MAY be collected. They SHOULD have all [common](#common) labels
 applied to them.
 
 | Name                      | Instrument | Units         | Description |

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -87,7 +87,7 @@ operation name, etc.
 | `db.hbase.namespace`      | The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute. | `default` | Yes |
 | `db.redis.database_index` | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` label. | `0`<br>`1`<br>`15` | Conditional [1] |
 | `db.mongodb.collection`   | The collection being accessed within the database stated in `db.name`. | `customers`<br>`products` | Yes |
-| `db.sql.table` | string | The name of the primary table that the operation is acting upon, including the schema name (if applicable). [2] | `public.users`<br>`customers` | Conditional<br>Recommended if available. |
+| `db.sql.table`            | The name of the primary table that the operation is acting upon, including the schema name (if applicable). [2] | `public.users`<br>`customers` | Conditional<br>Recommended if available. |
 
 **[1]:** Required, if other than the default database (`0`).
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -1,7 +1,7 @@
 # Semantic Conventions for Database Metrics
 
 This document contains semantic conventions for database client metrics in
-OpenTelemetry. When instrumenting database clients, also consider the 
+OpenTelemetry. When instrumenting database clients, also consider the
 [general metric semantic conventions](README.md#general-metric-semantic-conventions).
 
 ## Common
@@ -17,7 +17,6 @@ The following labels SHOULD be applied to all database metric instruments.
 | `net.peer.ip`          | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
 | `net.peer.port`        | Remote port number. | `80`<br>`8080`<br>`443` | No |
 | `net.peer.name`        | Remote hostname or similar, see note below. | `example.com` | No |
-
 
 **[1]:** See the [database trace semantic conventions](../../trace/semantic_conventions/database.md#connection-level-attributes)
 for the list of well-known database system values.
@@ -78,7 +77,7 @@ For a client executing a query like this:
 SELECT * FROM public.user_table WHERE user_id = 301;
 ```
 
-while connected to a PostgreSQL database named "user_db" running on host 
+while connected to a PostgreSQL database named "user_db" running on host
 `postgres-server:5432`, the following instrument should result:
 
 ```json
@@ -106,24 +105,23 @@ For a client executing a query like this:
 SELECT * FROM orders WHERE order_id = 301;
 ```
 
-while connected to a MySQL database named "ShopDb" running on host 
+while connected to a MySQL database named "ShopDb" running on host
 `shopdb.example.com`, the following instrument should result:
-
 
 ```json
 {
   "name": "db.client.duration",
   "labels": {
-  	"db.operation": "SELECT",
-  	"db.table": "orders",
-  	"db.name": "ShopDb",
-  	"db.system": "mysql",
-  	"db.connection_string": "Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;",
-  	"db.user": "billing_user",
-  	"net.peer.name": "shopdb.example.com",
-  	"net.peer.ip": "192.0.2.12",
-  	"net.peer.port": "3306",
-  	"net.transport": "IP.TCP"
+    "db.operation": "SELECT",
+    "db.table": "orders",
+    "db.name": "ShopDb",
+    "db.system": "mysql",
+    "db.connection_string": "Server=shopdb.example.com;Database=ShopDb;Uid=billing_user;TableCache=true;UseCompression=True;MinimumPoolSize=10;MaximumPoolSize=50;",
+    "db.user": "billing_user",
+    "net.peer.name": "shopdb.example.com",
+    "net.peer.ip": "192.0.2.12",
+    "net.peer.port": "3306",
+    "net.transport": "IP.TCP"
   }
 }
 
@@ -144,13 +142,13 @@ should result:
 {
   "name": "db.client.duration",
   "labels": {
-  	"db.operation": "HMSET",
-  	"db.table": "myhash",
-  	"db.system": "redis",
-  	"db.user": "the_user",
-  	"net.peer.name": "/tmp/redis.sock",
-  	"net.transport": "Unix",
-  	"db.redis.database_index": "15"
+    "db.operation": "HMSET",
+    "db.table": "myhash",
+    "db.system": "redis",
+    "db.user": "the_user",
+    "net.peer.name": "/tmp/redis.sock",
+    "net.transport": "Unix",
+    "db.redis.database_index": "15"
   }
 }
 ```
@@ -175,15 +173,15 @@ at `mongodb.example.com`, the following instrument should result:
 {
   "name": "db.client.duration",
   "labels": {
-  	"db.operation": "findAndModify",
-  	"db.table": "people",
-  	"db.name": "userdatabase",
-  	"db.system": "mongodb",
-  	"db.user": "the_user",
-  	"net.peer.name": "mongodb.example.com",
-  	"net.peer.ip": "192.0.2.14",
-  	"net.peer.port": "27017",
-  	"net.transport": "IP.TCP"
+    "db.operation": "findAndModify",
+    "db.table": "people",
+    "db.name": "userdatabase",
+    "db.system": "mongodb",
+    "db.user": "the_user",
+    "net.peer.name": "mongodb.example.com",
+    "net.peer.ip": "192.0.2.14",
+    "net.peer.port": "27017",
+    "net.transport": "IP.TCP"
   }
 }
 ```
@@ -204,8 +202,8 @@ applied to them.
 
 | Name                      | Instrument | Units         | Description |
 |---------------------------|------------|---------------|-------------|
-| `db.connections.new`      | Counter	 | {connections} | The number of new connections created. |
-| `db.connections.taken`    | Counter	 | {connections} | The number of connections taken from the connection pool. |
-| `db.connections.returned` | Counter	 | {connections} | The number of connections returned to the connection pool. |
-| `db.connections.reused`   | Counter	 | {connections} | The number of connections reused. |
+| `db.connections.new`      | Counter   | {connections} | The number of new connections created. |
+| `db.connections.taken`    | Counter   | {connections} | The number of connections taken from the connection pool. |
+| `db.connections.returned` | Counter   | {connections} | The number of connections returned to the connection pool. |
+| `db.connections.reused`   | Counter   | {connections} | The number of connections reused. |
 | `db.connections.closed`   | Counter    | {connections} | The number of connections closed. |

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -240,7 +240,7 @@ db.{db.system}.*
 * `db.redis.connections.reused`
 * `db.redis.connections.returned`
 * `db.redis.connections.closed`
-* `db.mongo.average_object_size`
-* `db.mongo.write_lock_percentage`
-* `db.mongo.object_count`
+* `db.mongodb.average_object_size`
+* `db.mongodb.write_lock_percentage`
+* `db.mongodb.object_count`
 * `db.postgresql.cache_hits`

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -8,7 +8,7 @@ OpenTelemetry. When instrumenting database clients, also consider the
 
 The following labels SHOULD be applied to all database metric instruments.
 
-| Attribute              | Description  | Example  | Required |
+| Label Name             | Description  | Example  | Required |
 |------------------------|--------------|----------|----------|
 | `db.system`            | An identifier for the database management system (DBMS) product being used. [1] | `other_sql` | Yes |
 | `db.connection_string` | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` | No |
@@ -41,10 +41,10 @@ databases), as well as connect operations.
 In addition to the [common](#common) labels, the following labels SHOULD be
 applied to all database call-level metric instruments.
 
-| Attribute        | Type   | Description  | Example  | Required |
+| Label Name       | Type   | Description  | Example  | Required |
 |------------------|--------|--------------|----------|----------|
 | `db.name`        | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Required if applicable. |
-| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET`<br>`SELECT` | Required if applicable. |
+| `db.operation`   | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET`<br>`SELECT`<br>`CONNECT` | Required if applicable. |
 | `db.table`       | string | The name of the primary table, collection, segment, etc... that the operation is acting upon. | `user_table` | Required if applicable. |
 | `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.sql.SQLException`<br/>`psycopg2.OperationalError` | Required if applicable. |
 
@@ -59,7 +59,7 @@ a stored procedure name (without arguments), operation name, etc.
 
 ### Call-level labels for specific technologies
 
-| Attribute                 | Description  | Example  | Required |
+| Label Name                | Description  | Example  | Required |
 |---------------------------|--------------|----------|----------|
 | `db.cassandra.keyspace`   | The name of the keyspace being accessed. To be used instead of the generic `db.name` attribute. | `mykeyspace` | Yes |
 | `db.hbase.namespace`      | The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute. | `default` | Yes |

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -13,7 +13,11 @@ The following labels SHOULD be applied to all database metric instruments.
 | `db.system`            | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | Yes |
 | `db.connection_string` | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` | No |
 | `db.user`              | Username for accessing the database. | `readonly_user`<br>`reporting_user` | No |
-| `net.transport`        | Transport protocol used. See note below. See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes). | `IP.TCP` | Conditional [1] |
+| `net.transport`        | Transport protocol used. See note below. See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes). | `IP.TCP`<br>`Unix` | Conditional [1] |
+| `net.peer.ip`          | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
+| `net.peer.port`        | Remote port number. | `80`<br>`8080`<br>`443` | No |
+| `net.peer.name`        | Remote hostname or similar, see note below. | `example.com` | No |
+
 
 **[1]:** Recommended in general, required for in-process databases (`"inproc"`).
 

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -70,8 +70,17 @@ a stored procedure name (without arguments), operation name, etc.
 
 ## Connection Pooling Metric Instruments
 
-If possible, instrumentation SHOULD collect the following. They SHOULD have
-all [common](#common) labels applied to them.
+Otherwise, the following metric instruments SHOULD be collected. They SHOULD
+have all [common](#common) labels applied to them.
+
+| Name                      | Instrument    | Units        | Description |
+|---------------------------|---------------|--------------|-------------|
+| `db.connection_pool.limit` | ValueObserver | {connections} | The total number of database connections available in the connection pool. |
+| `db.connection_pool.usage` | ValueObserver | {connections} | The number of database connections _in use_. |
+
+If the following detailed information is available, instrumentation MAY collect
+the following metric instruments. They SHOULD have all [common](#common) labels
+applied to them.
 
 | Name                      | Instrument | Units         | Description |
 |---------------------------|------------|---------------|-------------|
@@ -80,13 +89,3 @@ all [common](#common) labels applied to them.
 | `db.connections.returned` | Counter	 | {connections} | The number of connections returned to the connection pool. |
 | `db.connections.reused`   | Counter	 | {connections} | The number of connections reused. |
 | `db.connections.closed`   | Counter    | {connections} | The number of connections closed. |
-
- 
-Otherwise, the following metric instruments SHOULD be collected. They SHOULD
-have all [common](#common) labels applied to them.
-
-| Name                      | Instrument    | Units        | Description |
-|---------------------------|---------------|--------------|-------------|
-| `db.connectionPool.limit` | ValueObserver | {connections} | The total number of database connections available in the connection pool. |
-| `db.connectionPool.usage` | ValueObserver | {connections} | The number of database connections _in use_. |
-

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -1,0 +1,77 @@
+# Semantic Conventions for Database Metrics
+
+This document contains semantic conventions for database client metrics in
+OpenTelemetry. When instrumenting database clients, also consider the 
+[general metric semantic conventions](README.md#general-metric-semantic-conventions).
+
+## Common
+
+The following labels **SHOULD** be applied to all database metric instruments.
+
+| Attribute              | Description  | Example  | Required |
+|------------------------|--------------|----------|----------|
+| `db.system`            | An identifier for the database management system (DBMS) product being used. See below for a list of well-known identifiers. | `other_sql` | Yes |
+| `db.connection_string` | The connection string used to connect to the database. It is recommended to remove embedded credentials. | `Server=(localdb)\v11.0;Integrated Security=true;` | No |
+| `db.user`              | Username for accessing the database. | `readonly_user`<br>`reporting_user` | No |
+| `net.transport`        | Transport protocol used. See note below. See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes). | `IP.TCP` | Conditional [1] |
+
+**[1]:** Recommended in general, required for in-process databases (`"inproc"`).
+
+## Call-level Metric Instruments
+
+The following metric instruments **SHOULD** be iterated for every database operation.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `db.client.duration` | ValueRecorder | milliseconds | measures the duration of the database operation |
+
+Database operations **SHOULD** include execution of queries, including DDL, DML,
+DCL, and TCL SQL statements (and the corresponding operations in non-SQL
+databases), as well as connect operations.
+
+### Labels
+
+In addition to the [common](#common) labels, the following labels **SHOULD** be
+applied to all database call-level metric instruments.
+
+| Attribute  | Type | Description  | Example  | Required |
+|------------|------|--------------|----------|----------|
+| `db.name` | string | If no [tech-specific label](#call-level-labels-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
+| `db.statement` | string | The database statement being executed. [3][5] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional<br>Required if applicable. |
+| `db.operation` | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4][5] | `findAndModify`<br>`HMSET` | Conditional<br>Required, if `db.statement` is not applicable. |
+
+**[1]:** In some SQL databases, the database name to be used is called "schema name".
+
+**[2]:** Required, if applicable and no more-specific attribute is defined.
+
+**[3]:** The value may be sanitized to exclude sensitive information.
+
+**[4]:** While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT` or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property (the back end can do that if required).
+
+**[5]:** To reduce cardinality, the values for `db.statement` and `db.operation`
+should have parameters removed or substituted. The resulting value should be a
+low-cardinality value represeting the statement or operation being executed on
+the database. It may be a stored procedure name (without arguments), SQL
+statement without variable arguments, operation name, etc.
+
+### Call-level labels for specific technologies
+
+| Attribute                 | Description  | Example  | Required |
+|---------------------------|--------------|----------|----------|
+| `db.cassandra.keyspace`   | The name of the keyspace being accessed. To be used instead of the generic `db.name` attribute. | `mykeyspace` | Yes |
+| `db.hbase.namespace`      | The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute. | `default` | Yes |
+| `db.redis.database_index` | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` label. | `0`<br>`1`<br>`15` | Conditional [1] |
+| `db.mongodb.collection`   | The collection being accessed within the database stated in `db.name`. | `customers`<br>`products` | Yes |
+
+**[1]:** Required, if other than the default database (`0`).
+
+
+## Connection-level Metric Instruments
+
+The following metric instruments should be collected every harvest interval. They should have all [common](#common) labels applied to them.
+
+| Name                      | Instrument    | Units        | Description |
+|---------------------------|---------------|--------------|-------------|
+| `db.connectionPool.limit` | ValueObserver | {connections} | measures the total number of database connections available in the connection pool |
+| `db.connectionPool.usage` | ValueObserver | {connections} | measures the number of database connections _in use_. |
+

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -221,8 +221,10 @@ applied to them.
 
 | Name                      | Instrument | Units         | Description |
 |---------------------------|------------|---------------|-------------|
-| `db.connections.new`      | Counter   | {connections} | The number of new connections created. |
-| `db.connections.taken`    | Counter   | {connections} | The number of connections taken from the connection pool. |
-| `db.connections.returned` | Counter   | {connections} | The number of connections returned to the connection pool. |
-| `db.connections.reused`   | Counter   | {connections} | The number of connections reused. |
-| `db.connections.closed`   | Counter    | {connections} | The number of connections closed. |
+| `db.connections.taken`    | Counter    | {connections} | Incremented when a connection is requested and returned from the pool.  |
+| `db.connections.new`      | Counter    | {connections} | Incremented when a connection is requested and returned from the pool only if the connection pool returns a newly created connection. |
+| `db.connections.reused`   | Counter    | {connections} | Incremented when a connection is requested and returned from the pool only if the connection pool returns a previously used connection. |
+| `db.connections.returned` | Counter    | {connections} | Incremented when the application is finished using a connection and returns it to the pool. |
+| `db.connections.closed`   | Counter    | {connections} | Incremented when the pool closes a connection. [1] |
+
+**[1]:** Connection pools sometimes close connections after some pre-configured time has elapsed, or when the application is shutting down. The `db.connections.closed` instrument should be incremented for each connection closed. It should _eventually_ be true that `db.connections.new - db.connections.closed = 0`.

--- a/specification/metrics/semantic_conventions/database.md
+++ b/specification/metrics/semantic_conventions/database.md
@@ -65,10 +65,22 @@ statement without variable arguments, operation name, etc.
 
 **[1]:** Required, if other than the default database (`0`).
 
+## Connection Pooling Metric Instruments
 
-## Connection-level Metric Instruments
+If possible, instrumentation should collect the following. They should have
+all [common](#common) labels applied to them.
 
-The following metric instruments should be collected every harvest interval. They should have all [common](#common) labels applied to them.
+| Name                      | Instrument | Units         | Description |
+|---------------------------|------------|---------------|-------------|
+| `db.connections.new`      | Counter	 | {connections} | The number of new connections created. |
+| `db.connections.taken`    | Counter	 | {connections} | The number of connections taken from the connection pool. |
+| `db.connections.returned` | Counter	 | {connections} | The number of connections returned to the connection pool. |
+| `db.connections.reused`   | Counter	 | {connections} | The number of connections reused. |
+| `db.connections.closed`   | Counter    | {connections} | The number of connections closed. |
+
+ 
+Otherwise, the following metric instruments should be collected. They should
+have all [common](#common) labels applied to them.
 
 | Name                      | Instrument    | Units        | Description |
 |---------------------------|---------------|--------------|-------------|


### PR DESCRIPTION
Fixes #1012

This PR attempts to specify semanatic conventions for database metric instruments.  

There are a few spicy parts that I'd love feedback about:

### 1. `db.operation` and `db.table`

We'd like to correlate the golden signal metrics to the spans that represent the same 
operation. The easiest way to do that may have been to include the `db.statement` as a 
label, but this has the potential to drastically increase cardinality.
The alternative that I see is to include `db.operation` and `db.table` as labels. 

This has clearly been discussed already, and the trace semantic convention includes
this line:

> While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT` or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property (the back end can do that if required).

But in my experience, these values are frequently available from an ORM library _without_
requiring SQL string parsing, and if this instrumentation may be eventually written into
those ORM libraries, I'd like to encourage them to provide this information on the 
metric instruments.

### 2. Connection pool metrics

There is some prior art in go-redis of some very detailed metrics describing database
connection pool behavior. While this is pretty interesting, I think these values will not
be widely available to all database client libraries. So I've recommended that we record
a simpler `db.connection_pool.limit` and `db.connection_pool.usage`. 

I've also included a MAY to allow instrumentation to collect more detailed information if
it is available. I'm thinking that if these concepts will be used by more than just
go-redis, it would be ideal if they looked the same.

## Changes

This PR adds a new semantic conventions at  specification/metrics/semantic_conventions/database.md
