### PR TITLE
Messaging-System Metric semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 New:
 
+- Add semantic conventions for messaging system metrics.
+  ([#1077](https://github.com/open-telemetry/opentelemetry-specification/pull/1077))
 - Add performance benchmark specification
   ([#748](https://github.com/open-telemetry/opentelemetry-specification/pull/748))
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.

--- a/semantic_conventions/metrics/messaging.yaml
+++ b/semantic_conventions/metrics/messaging.yaml
@@ -1,66 +1,21 @@
 groups:
-    - id: messaging
+    - id: metrics-messaging
       prefix: messaging
       brief: >
-          This document defines the lables used in
-          messaging systems.
+          This document defines the attributes used in
+          messaging system metrics.
       attributes:
-        - id: system
-          type: string
+        - ref: messaging.system
           required: always
-          brief: 'A string identifying the messaging system.'
-          examples: ['kafka', 'rabbitmq', 'activemq']
-        - id: destination
-          type: string
+        - ref: messaging.destination
           required: always
-          brief: >
-            The message destination name.
-          examples: ['MyQueue', 'MyTopic']
-        - id: destination_kind
-          type:
-            allow_custom_values: false
-            members:
-              - id: queue
-                value: "queue"
-                brief: "A message sent to a queue"
-              - id: topic
-                value: "topic"
-                brief: "A message broadcast to the subscribers of the topic"
-          required:
-            conditional: 'Required only if the message destination is either a `queue` or `topic`.'
-          brief: 'The kind of message destination'
-        - id: temp_destination
-          type: boolean
-          required:
-            conditional: 'If missing, it is assumed to be false.'
-          brief: 'A boolean that is true if the message destination is temporary.'
-        - id: protocol
-          type: string
-          brief: 'The name of the transport protocol.'
-          examples: ['AMQP', 'MQTT']
-        - id: protocol_version
-          type: string
-          brief: 'The version of the transport protocol.'
-          examples: '0.9.1'
-        - id: url
-          type: string
-          brief: 'Connection string.'
-          examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
+        - ref: messaging.destination_kind
+          required: always
+        - ref: messaging.temp_destination
+        - ref: messaging.protocol
+        - ref: messaging.protocol_version
+        - ref: messaging.url
         - ref: net.peer.name
-          note: >
-            This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
-          required:
-            conditional: If available.
         - ref: net.peer.ip
-          tag: connection-level
-          required:
-            conditional: If available.
         - ref: net.peer.port
-          tag: connection-level
-          required:
-            conditional: If available.
         - ref: net.transport
-          tag: connection-level
-          brief: 'Transport protocol used.'
-          required:
-            conditional: If available.

--- a/semantic_conventions/metrics/messaging.yaml
+++ b/semantic_conventions/metrics/messaging.yaml
@@ -1,0 +1,55 @@
+groups:
+    - id: messaging
+      prefix: messaging
+      brief: >
+          This document defines the lables used in
+          messaging systems.
+      attributes:
+        - id: system
+          type: string
+          required: always
+          brief: 'A string identifying the messaging system.'
+          examples: ['kafka', 'rabbitmq', 'activemq']
+        - id: destination
+          type: string
+          required: always
+          brief: >
+            The message destination name.
+          examples: ['MyQueue', 'MyTopic']
+        - id: destination_kind
+          type:
+            allow_custom_values: false
+            members:
+              - id: queue
+                value: "queue"
+                brief: "A message sent to a queue"
+              - id: topic
+                value: "topic"
+                brief: "A message broadcast to the subscribers of the topic"
+          required:
+            conditional: 'Required only if the message destination is either a `queue` or `topic`.'
+          brief: 'The kind of message destination'
+        - id: temp_destination
+          type: boolean
+          required:
+            conditional: 'If missing, it is assumed to be false.'
+          brief: 'A boolean that is true if the message destination is temporary.'
+        - id: protocol
+          type: string
+          brief: 'The name of the transport protocol.'
+          examples: ['AMQP', 'MQTT']
+        - id: protocol_version
+          type: string
+          brief: 'The version of the transport protocol.'
+          examples: '0.9.1'
+        - id: url
+          type: string
+          brief: 'Connection string.'
+          examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
+      constraints:
+        - any_of:
+          - 'net.peer.name'
+          - 'net.peer.ip'
+          - 'net.peer.port'
+          - 'net.transport'
+        - include: network

--- a/semantic_conventions/metrics/messaging.yaml
+++ b/semantic_conventions/metrics/messaging.yaml
@@ -3,7 +3,7 @@ groups:
       prefix: messaging
       brief: >
           This document defines the attributes used in
-          messaging system metrics.
+          messaging system metric instruments.
       attributes:
         - ref: messaging.system
           required: always

--- a/semantic_conventions/metrics/messaging.yaml
+++ b/semantic_conventions/metrics/messaging.yaml
@@ -46,10 +46,21 @@ groups:
           type: string
           brief: 'Connection string.'
           examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
-      constraints:
-        - any_of:
-          - 'net.peer.name'
-          - 'net.peer.ip'
-          - 'net.peer.port'
-          - 'net.transport'
-        - include: network
+        - ref: net.peer.name
+          note: >
+            This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+          required:
+            conditional: If available.
+        - ref: net.peer.ip
+          tag: connection-level
+          required:
+            conditional: If available.
+        - ref: net.peer.port
+          tag: connection-level
+          required:
+            conditional: If available.
+        - ref: net.transport
+          tag: connection-level
+          brief: 'Transport protocol used.'
+          required:
+            conditional: If available.

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -1,4 +1,4 @@
-# Semantic conventions for messaging system metrics
+# Semantic conventions for messaging systems
 
 The conventions described in this section are specific to messaging systems. When interactions with messaging systems occur,
 metric events about those operations will be generated and reported, providing insight into those
@@ -13,7 +13,7 @@ The [Trace Messaging Semantic Conventions Definitions](../../trace/semantic_conv
 
 ## Common Labels
 
-The following labels **SHOULD** be applied to all messaging metric instruments.
+The following labels SHOULD be applied to all messaging metric instruments.
 
 <!-- semconv metrics-messaging -->
 | Attribute  | Type | Description  | Example  | Required |
@@ -31,62 +31,61 @@ The following labels **SHOULD** be applied to all messaging metric instruments.
 | [`net.transport`](../../trace/semantic_conventions/span-general.md) | string enum | Transport protocol used. See note below. | `IP.TCP` | No |
 <!-- endsemconv -->
 
-For messaging metric labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):
+For messaging system metric event labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):
 
 * `messaging.url`
 * `net.peer.name`, `net.peer.port`, `net.peer.ip`, `net.transport`
 
 ## Send Message Metric Instruments
 
-The following metric instruments SHOULD be captured for every message send operation
- unless the producer is batching. If the producer is batching some metrics may be
- omitted (e.g. `messaging.producer.duration` and `messaging.producer.compressed.bytes`).
+The following metric instruments SHOULD be used to capture metric events for every message send operation
+ unless the producer is batching. If the producer is batching any metric instruments
+within this section MAY be omitted.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.producer.duration` | ValueRecorder | milliseconds | Time spent producing a message to a queue/topic. |
-| `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric instrument if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.producer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
 ### Send Batch Metric Instruments
 
 When a message system uses batching the following metric instruments SHOULD
-be captured for every batch send operation.
+be used to capture metric events for every batch send operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent prodcing a batch of messages to a queue/topic. |
+| `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent producing a batch of messages to a queue/topic. |
 | `messaging.producer.batch.size` | ValueRecorder | messages | The number of messages in each batch if this producer/client is batching messages. |
-| `messaging.producer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
+| `messaging.producer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch sent in bytes. Also use this metric instrument if it is unknown whether the compressed or uncompressed batch size is reported. |
 | `messaging.producer.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch sent in bytes. |
 
 ## Receive Message Metric Instruments
 
-The following metric instruments SHOULD be captured for every message receive operation
- unless the consumer is receiving batches. If the consumer is receiving batches some metrics
- may be omitted (e.g. `messaging.consumer.duration` and `messaging.consumer.compressed.bytes`).
+The following metric instruments SHOULD be used to capture metric events for every message receive operation
+ unless the consumer is receiving batches. If the consumer is receiving batches any metric instruments within this section MAY be omitted.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.consumer.received.duration` | ValueRecorder | milliseconds | Time spent receiving a message from a queue/topic. |
-| `messaging.consumer.received.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.consumer.received.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric instrument if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.consumer.received.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
 ### Receive Batch Metric Instruments
 
 When a message system uses batching the following metric instruments SHOULD
-be captured for every batch receive operation.
+be used to capture metric events for every batch receive operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.consumer.received.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch of messages from a queue/topic. |
 | `messaging.consumer.received.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
-| `messaging.consumer.received.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
+| `messaging.consumer.received.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric instrument if it is unknown whether the compressed or uncompressed batch size is reported. |
 | `messaging.consumer.received.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch received in bytes. |
 
 ## Process Message Metric Instruments
 
-The following metric instruments SHOULD be captured for every message process operation.
+The following metric instruments SHOULD be used to capture metric events for every message processing operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -57,10 +57,10 @@ The following metric instruments SHOULD be captured for every message receive op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.messages` | Counter | messages | Total number of messages received. |
-| `messaging.consumer.duration` | ValueRecorder | milliseconds | Time spent receiving a message from a queue/topic. |
-| `messaging.consumer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
-| `messaging.consumer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
+| `messaging.consumer.received.messages` | Counter | messages | Total number of messages received. |
+| `messaging.consumer.received.duration` | ValueRecorder | milliseconds | Time spent receiving a message from a queue/topic. |
+| `messaging.consumer.received.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.consumer.received.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
 ### Receive Batch Metric Instruments
 
@@ -69,11 +69,11 @@ be captured for every batch receive operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.batches` | Counter | batches | Total number of batches received. |
-| `messaging.consumer.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch of messages from a queue/topic. |
-| `messaging.consumer.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
-| `messaging.consumer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
-| `messaging.consumer.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch received in bytes. |
+| `messaging.consumer.received.batches` | Counter | batches | Total number of batches received. |
+| `messaging.consumer.received.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch of messages from a queue/topic. |
+| `messaging.consumer.received.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
+| `messaging.consumer.received.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
+| `messaging.consumer.received.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch received in bytes. |
 
 ## Process Message Metric Instruments
 

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -18,17 +18,17 @@ The following labels **SHOULD** be applied to all messaging metric instruments.
 <!-- semconv metrics-messaging -->
 | Attribute  | Type | Description  | Example  | Required |
 |---|---|---|---|---|
-| `messaging.destination` | string | The message destination name. This might be equal to the span name but is required nevertheless. | `MyQueue`<br>`MyTopic` | Yes |
-| `messaging.destination_kind` | string enum | The kind of message destination | `queue` | Yes |
-| `messaging.protocol` | string | The name of the transport protocol. | `AMQP`<br>`MQTT` | No |
-| `messaging.protocol_version` | string | The version of the transport protocol. | `0.9.1` | No |
-| `messaging.system` | string | A string identifying the messaging system. | `kafka`<br>`rabbitmq`<br>`activemq` | Yes |
-| `messaging.temp_destination` | boolean | A boolean that is true if the message destination is temporary. |  | No |
-| `messaging.url` | string | Connection string. | `tibjmsnaming://localhost:7222`<br>`https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No |
-| `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
-| `net.peer.name` | string | Remote hostname or similar, see note below. | `example.com` | No |
-| `net.peer.port` | number | Remote port number. | `80`<br>`8080`<br>`443` | No |
-| `net.transport` | string enum | Transport protocol used. See note below. | `IP.TCP` | No |
+| [`messaging.destination`](../../trace/semantic_conventions/messaging.md) | string | The message destination name. This might be equal to the span name but is required nevertheless. | `MyQueue`<br>`MyTopic` | Yes |
+| [`messaging.destination_kind`](../../trace/semantic_conventions/messaging.md) | string enum | The kind of message destination | `queue` | Yes |
+| [`messaging.protocol`](../../trace/semantic_conventions/messaging.md) | string | The name of the transport protocol. | `AMQP`<br>`MQTT` | No |
+| [`messaging.protocol_version`](../../trace/semantic_conventions/messaging.md) | string | The version of the transport protocol. | `0.9.1` | No |
+| [`messaging.system`](../../trace/semantic_conventions/messaging.md) | string | A string identifying the messaging system. | `kafka`<br>`rabbitmq`<br>`activemq` | Yes |
+| [`messaging.temp_destination`](../../trace/semantic_conventions/messaging.md) | boolean | A boolean that is true if the message destination is temporary. |  | No |
+| [`messaging.url`](../../trace/semantic_conventions/messaging.md) | string | Connection string. | `tibjmsnaming://localhost:7222`<br>`https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No |
+| [`net.peer.ip`](../../trace/semantic_conventions/span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Remote hostname or similar, see note below. | `example.com` | No |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | number | Remote port number. | `80`<br>`8080`<br>`443` | No |
+| [`net.transport`](../../trace/semantic_conventions/span-general.md) | string enum | Transport protocol used. See note below. | `IP.TCP` | No |
 <!-- endsemconv -->
 
 For messaging metric labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -42,10 +42,10 @@ The following metric instruments SHOULD be captured for every message send opera
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.sent.messages` | Counter | messages | Sum of messages sent. |
-| `messaging.sent.duration` | ValueRecorder | milliseconds | Time spent sending a message. |
-| `messaging.sent.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
-| `messaging.sent.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
+| `messaging.producer.messages` | Counter | messages | Sum of messages sent. |
+| `messaging.producer.duration` | ValueRecorder | milliseconds | Time spent sending a message. |
+| `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.producer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
 ## Receive Message Metric Instruments
 
@@ -53,10 +53,10 @@ The following metric instruments SHOULD be captured for every message receive op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.received.messages` | Counter | messages | Sum of messages received. |
-| `messaging.received.duration` | ValueRecorder | milliseconds | Time spent receiving a message or batch if batching messages. |
-| `messaging.received.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
-| `messaging.received.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
+| `messaging.consumer.messages` | Counter | messages | Sum of messages received. |
+| `messaging.consumer.duration` | ValueRecorder | milliseconds | Time spent receiving a message or batch if batching messages. |
+| `messaging.consumer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.consumer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
 ## Process Message Metric Instruments
 
@@ -64,5 +64,5 @@ The following metric instruments SHOULD be captured for every message process op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.processed.messages` | Counter | messages | Sum of messages processed. |
-| `messaging.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |
+| `messaging.consumer.processed.messages` | Counter | messages | Sum of messages processed. |
+| `messaging.consumer.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -1,12 +1,12 @@
 # Semantic conventions for messaging system metrics
 
 The conventions described in this section are specific to messaging systems. When interactions with messaging systems occur,
-metric events about those operations will be generated and reported, providing insight into those 
+metric events about those operations will be generated and reported, providing insight into those
 operations.
 
 **Disclaimer:** These are initial messaging system metric instruments and labels, more may be added
  in the future.
- 
+
 ## Definitions
 
 The [Trace Messaging Semantic Conventions Definitions](../../trace/semantic_conventions/messaging.md#definitions) is a resource for the messaging system terminology used in this document.
@@ -91,5 +91,3 @@ The following metric instruments SHOULD be captured for every message process op
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.consumer.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |
-
-Test

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -32,7 +32,7 @@ The following metric instruments SHOULD be captured for every message send opera
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.producer.messages` | Counter | messages | Sum of messages sent. |
-| `messaging.producer.duration` | ValueRecorder | milliseconds | Time spent sending a message. |
+| `messaging.producer.duration` | ValueRecorder | milliseconds | Time spent producing a message to a queue/topic. |
 | `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.producer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
@@ -44,7 +44,7 @@ be captured for every batch send operation.
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.producer.batches` | Counter | batches | Sum of batches sent. |
-| `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent sending a batch. |
+| `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent prodcing a batch of messages to a queue/topic. |
 | `messaging.producer.batch.size` | ValueRecorder | messages | The number of messages in each batch if this producer/client is batching messages. |
 | `messaging.producer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
 | `messaging.producer.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch sent in bytes. |
@@ -58,7 +58,7 @@ The following metric instruments SHOULD be captured for every message receive op
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.consumer.messages` | Counter | messages | Sum of messages received. |
-| `messaging.consumer.duration` | ValueRecorder | milliseconds | Time spent receiving a message or batch if batching messages. |
+| `messaging.consumer.duration` | ValueRecorder | milliseconds | Time spent receiving a message from a queue/topic. |
 | `messaging.consumer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.consumer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
@@ -70,7 +70,7 @@ be captured for every batch receive operation.
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `messaging.consumer.batches` | Counter | batches | Sum of batches received. |
-| `messaging.consumer.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch. |
+| `messaging.consumer.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch of messages from a queue/topic. |
 | `messaging.consumer.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
 | `messaging.consumer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
 | `messaging.consumer.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch received in bytes. |

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -44,7 +44,6 @@ The following metric instruments SHOULD be captured for every message send opera
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.producer.messages` | Counter | messages | Total number of messages sent. |
 | `messaging.producer.duration` | ValueRecorder | milliseconds | Time spent producing a message to a queue/topic. |
 | `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.producer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
@@ -56,7 +55,6 @@ be captured for every batch send operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.producer.batches` | Counter | batches | Total number of batches sent. |
 | `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent prodcing a batch of messages to a queue/topic. |
 | `messaging.producer.batch.size` | ValueRecorder | messages | The number of messages in each batch if this producer/client is batching messages. |
 | `messaging.producer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
@@ -70,7 +68,6 @@ The following metric instruments SHOULD be captured for every message receive op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.received.messages` | Counter | messages | Total number of messages received. |
 | `messaging.consumer.received.duration` | ValueRecorder | milliseconds | Time spent receiving a message from a queue/topic. |
 | `messaging.consumer.received.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.consumer.received.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
@@ -82,7 +79,6 @@ be captured for every batch receive operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.received.batches` | Counter | batches | Total number of batches received. |
 | `messaging.consumer.received.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch of messages from a queue/topic. |
 | `messaging.consumer.received.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
 | `messaging.consumer.received.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
@@ -94,7 +90,6 @@ The following metric instruments SHOULD be captured for every message process op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.processed.messages` | Counter | messages | Total number of messages processed. |
 | `messaging.consumer.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |
 
 Test

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -1,0 +1,68 @@
+# Semantic conventions for messaging system metrics
+
+The conventions described in this section are specific to messaging systems. When interactions with messaging systems occur,
+metric events about those operations will be generated and reported, providing insight into those 
+operations.
+
+**Disclaimer:** These are initial messaging system metric instruments and labels, more may be added
+ in the future.
+ 
+## Definitions
+
+The [Trace Messaging Semantic Conventions Definitions](../../trace/semantic_conventions/messaging.md#definitions) is a resource for the messaging system terminology used in this document.
+
+## Common Labels
+
+The following labels **SHOULD** be applied to all messaging metric instruments.
+
+| Label | Description  | Example  | Required |
+|---|---|---|---|
+| `messaging.system` | A string identifying the messaging system. | `kafka`<br>`rabbitmq`<br>`activemq` | Yes |
+| `messaging.destination` | The message destination name. | `MyQueue`<br>`MyTopic` | Yes |
+| `messaging.destination_kind` | The kind of message destination | `queue` | Conditional [1] |
+| `messaging.temp_destination` | A boolean that is true if the message destination is temporary. | true | Conditional<br>If missing, it is assumed to be false. |
+| `messaging.protocol` | The name of the transport protocol. | `AMQP`<br>`MQTT` | No |
+| `messaging.protocol_version` | The version of the transport protocol. | `0.9.1` | No |
+| `messaging.url` | Connection string. | `tibjmsnaming://localhost:7222`<br>`https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No [2] |
+| `net.peer.name`    | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | kafka-pool-us-east | No [2] |
+| `net.peer.port`    | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | 9092 | No [2] |
+| `net.peer.ip`      | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | 127.0.0.1 | No [2] |
+| `net.transport`      | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | IP.TCP | No [2] |
+
+**[1]:** Required only if the message destination is either a `queue` or `topic`.
+
+**[2]** For messaging metric labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):
+
+* `messaging.url`
+* `net.peer.name`, `net.peer.port`, `net.peer.ip`, `net.transport`
+
+## Send Message Metric Instruments
+
+The following metric instruments SHOULD be captured for every message send operation.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `messaging.sent.messages` | Counter | messages | Sum of messages sent. |
+| `messaging.sent.duration` | ValueRecorder | milliseconds | Time spent sending a message. |
+| `messaging.sent.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.sent.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
+
+## Receive Message Metric Instruments
+
+The following metric instruments SHOULD be captured for every message receive operation.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `messaging.received.messages` | Counter | messages | Sum of messages received. |
+| `messaging.received.duration` | ValueRecorder | milliseconds | Time spent receiving a message or batch if batching messages. |
+| `messaging.received.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
+| `messaging.received.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
+
+## Process Message Metric Instruments
+
+The following metric instruments SHOULD be captured for every message process operation.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `messaging.processed.messages` | Counter | messages | Sum of messages processed. |
+| `messaging.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -15,23 +15,10 @@ The [Trace Messaging Semantic Conventions Definitions](../../trace/semantic_conv
 
 The following labels **SHOULD** be applied to all messaging metric instruments.
 
-| Label | Description  | Example  | Required |
-|---|---|---|---|
-| `messaging.system` | A string identifying the messaging system. | `kafka`<br>`rabbitmq`<br>`activemq` | Yes |
-| `messaging.destination` | The message destination name. | `MyQueue`<br>`MyTopic` | Yes |
-| `messaging.destination_kind` | The kind of message destination | `queue` | Conditional [1] |
-| `messaging.temp_destination` | A boolean that is true if the message destination is temporary. | true | Conditional<br>If missing, it is assumed to be false. |
-| `messaging.protocol` | The name of the transport protocol. | `AMQP`<br>`MQTT` | No |
-| `messaging.protocol_version` | The version of the transport protocol. | `0.9.1` | No |
-| `messaging.url` | Connection string. | `tibjmsnaming://localhost:7222`<br>`https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No [2] |
-| `net.peer.name`    | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | kafka-pool-us-east | No [2] |
-| `net.peer.port`    | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | 9092 | No [2] |
-| `net.peer.ip`      | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | 127.0.0.1 | No [2] |
-| `net.transport`      | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes) | IP.TCP | No [2] |
+<!-- semconv messaging -->
+<!-- endsemconv -->
 
-**[1]:** Required only if the message destination is either a `queue` or `topic`.
-
-**[2]** For messaging metric labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):
+For messaging metric labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):
 
 * `messaging.url`
 * `net.peer.name`, `net.peer.port`, `net.peer.ip`, `net.transport`

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -25,7 +25,9 @@ For messaging metric labels, one of the following sets of labels is RECOMMENDED 
 
 ## Send Message Metric Instruments
 
-The following metric instruments SHOULD be captured for every message send operation.
+The following metric instruments SHOULD be captured for every message send operation
+ unless the producer is batching. If the producer is batching some metrics may be
+ omitted (e.g. `messaging.producer.duration` and `messaging.producer.compressed.bytes`).
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
@@ -34,9 +36,24 @@ The following metric instruments SHOULD be captured for every message send opera
 | `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.producer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
 
+### Send Batch Metric Instruments
+
+When a message system uses batching the following metric instruments SHOULD
+be captured for every batch send operation.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `messaging.producer.batches` | Counter | batches | Sum of batches sent. |
+| `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent sending a batch. |
+| `messaging.producer.batch.size` | ValueRecorder | messages | The number of messages in each batch if this producer/client is batching messages. |
+| `messaging.producer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
+| `messaging.producer.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch sent in bytes. |
+
 ## Receive Message Metric Instruments
 
-The following metric instruments SHOULD be captured for every message receive operation.
+The following metric instruments SHOULD be captured for every message receive operation
+ unless the consumer is receiving batches. If the consumer is receiving batches some metrics
+ may be omitted (e.g. `messaging.consumer.duration` and `messaging.consumer.compressed.bytes`).
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
@@ -44,6 +61,19 @@ The following metric instruments SHOULD be captured for every message receive op
 | `messaging.consumer.duration` | ValueRecorder | milliseconds | Time spent receiving a message or batch if batching messages. |
 | `messaging.consumer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.consumer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
+
+### Receive Batch Metric Instruments
+
+When a message system uses batching the following metric instruments SHOULD
+be captured for every batch receive operation.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `messaging.consumer.batches` | Counter | batches | Sum of batches received. |
+| `messaging.consumer.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch. |
+| `messaging.consumer.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
+| `messaging.consumer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
+| `messaging.consumer.batch.compressed.bytes` | ValueRecorder | bytes | The compressed size of the batch received in bytes. |
 
 ## Process Message Metric Instruments
 
@@ -53,3 +83,5 @@ The following metric instruments SHOULD be captured for every message process op
 |----------------------|---------------|--------------|-------------|
 | `messaging.consumer.processed.messages` | Counter | messages | Sum of messages processed. |
 | `messaging.consumer.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |
+
+Test

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -31,7 +31,7 @@ The following metric instruments SHOULD be captured for every message send opera
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.producer.messages` | Counter | messages | Sum of messages sent. |
+| `messaging.producer.messages` | Counter | messages | Total number of messages sent. |
 | `messaging.producer.duration` | ValueRecorder | milliseconds | Time spent producing a message to a queue/topic. |
 | `messaging.producer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the payload sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.producer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
@@ -43,7 +43,7 @@ be captured for every batch send operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.producer.batches` | Counter | batches | Sum of batches sent. |
+| `messaging.producer.batches` | Counter | batches | Total number of batches sent. |
 | `messaging.producer.batch.duration` | ValueRecorder | milliseconds | Time spent prodcing a batch of messages to a queue/topic. |
 | `messaging.producer.batch.size` | ValueRecorder | messages | The number of messages in each batch if this producer/client is batching messages. |
 | `messaging.producer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch sent in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
@@ -57,7 +57,7 @@ The following metric instruments SHOULD be captured for every message receive op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.messages` | Counter | messages | Sum of messages received. |
+| `messaging.consumer.messages` | Counter | messages | Total number of messages received. |
 | `messaging.consumer.duration` | ValueRecorder | milliseconds | Time spent receiving a message from a queue/topic. |
 | `messaging.consumer.bytes` | ValueRecorder | bytes | The (uncompressed) size of the message received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed payload size is reported. |
 | `messaging.consumer.compressed.bytes` | ValueRecorder | bytes | The compressed size of the payload sent in bytes. |
@@ -69,7 +69,7 @@ be captured for every batch receive operation.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.batches` | Counter | batches | Sum of batches received. |
+| `messaging.consumer.batches` | Counter | batches | Total number of batches received. |
 | `messaging.consumer.batch.duration` | ValueRecorder | milliseconds | Time spent receiving a batch of messages from a queue/topic. |
 | `messaging.consumer.batch.size` | ValueRecorder | messages | The number of messages in each batch if messages are consumed in batches. |
 | `messaging.consumer.batch.bytes` | ValueRecorder | bytes | The (uncompressed) size of the batch received in bytes. Also use this metric if it is unknown whether the compressed or uncompressed batch size is reported. |
@@ -81,7 +81,7 @@ The following metric instruments SHOULD be captured for every message process op
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `messaging.consumer.processed.messages` | Counter | messages | Sum of messages processed. |
+| `messaging.consumer.processed.messages` | Counter | messages | Total number of messages processed. |
 | `messaging.consumer.processed.duration` | ValueRecorder | milliseconds | Time spent processing a message. |
 
 Test

--- a/specification/metrics/semantic_conventions/messaging.md
+++ b/specification/metrics/semantic_conventions/messaging.md
@@ -15,7 +15,20 @@ The [Trace Messaging Semantic Conventions Definitions](../../trace/semantic_conv
 
 The following labels **SHOULD** be applied to all messaging metric instruments.
 
-<!-- semconv messaging -->
+<!-- semconv metrics-messaging -->
+| Attribute  | Type | Description  | Example  | Required |
+|---|---|---|---|---|
+| `messaging.destination` | string | The message destination name. This might be equal to the span name but is required nevertheless. | `MyQueue`<br>`MyTopic` | Yes |
+| `messaging.destination_kind` | string enum | The kind of message destination | `queue` | Yes |
+| `messaging.protocol` | string | The name of the transport protocol. | `AMQP`<br>`MQTT` | No |
+| `messaging.protocol_version` | string | The version of the transport protocol. | `0.9.1` | No |
+| `messaging.system` | string | A string identifying the messaging system. | `kafka`<br>`rabbitmq`<br>`activemq` | Yes |
+| `messaging.temp_destination` | boolean | A boolean that is true if the message destination is temporary. |  | No |
+| `messaging.url` | string | Connection string. | `tibjmsnaming://localhost:7222`<br>`https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No |
+| `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
+| `net.peer.name` | string | Remote hostname or similar, see note below. | `example.com` | No |
+| `net.peer.port` | number | Remote port number. | `80`<br>`8080`<br>`443` | No |
+| `net.transport` | string enum | Transport protocol used. See note below. | `IP.TCP` | No |
 <!-- endsemconv -->
 
 For messaging metric labels, one of the following sets of labels is RECOMMENDED (in order of usual preference unless for a particular messaging system it is known that some other set is preferable for some reason; all strings must be non-empty):


### PR DESCRIPTION
## Changes

Add semantic conventions for messaging system metrics.

Related issues:
Fixes #1014

## PR Details

The general approach I took here was to take the messaging operations referenced in the tracing semantic conventions (sending, receiving, processing) and break them into 3 distinct metric groups. I created metrics for monitoring throughput and latency within these operations.

I've left individual commits to highlight some open questions/points of interest that I will elaborate on here.

### Metric naming with Span Kind
@justinfoote mentioned that the preference is that when name spacing labels and metrics the second field should be the "span kind". The second commit attempts to follow this convention. However the span kind [as defined in the tracing semantic conventions of messaging](https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/trace/semantic_conventions/messaging.md#span-kind) suggest producer/consumer should be used for async message processing, and server/client should be used for synchronous message processing. Should we change the metric names based on whether the application is sync or async? I assumed no. Also there's a bit of ambiguity here because the [tracing semantic conventions yaml refers to](https://github.com/open-telemetry/opentelemetry-specification/blob/master/semantic_conventions/trace/messaging.yaml#L110) things like `messaging.consumer.synchronous` instead of `messaging.client`.

### Superfluous Counters vs. ease of use
I created a specific Counter to track the messages sent, received and processed. This information is already captured in the
count of the `duration` metric ValueRecorder. Personally I feel like the extra metric is worth the ease of use but I don't know where the OTEL community stands on this.

### Semconv format and generator
I went ahead and attempted to use the semconv yaml format and generator. Many of these labels are identical to tracing messaging attributes but I went ahead and copied them into a separate yaml for messaging metrics. I could not get the generator to actually work though. Here's an example: `docker run --rm otel/semconvgen --yaml-root ../../opentelemetry-specification/semantic_conventions markdown --markdown-root ../../opentelemetry-specification/specification`

### Batch metrics
The last commit adds metrics around batching because I see that as a common feature that needs to be monitored. Introducing metrics around batching does create confusion around whether some of the non-batch metrics still exist or what they mean. I'm interested to hear if others feel the behavior is sufficiently explained or if batch metrics should be dropped entirely.

### Other metrics
Here's a list of other potential metric categories that I omitted. I'm assuming these are too specific to only a subset of messaging systems to be included here:
1. Lag
1. I/O time
1. Connection pooling
1. Errors
1. Retries

@jmacd @bogdandrutu mentioning you as potential reviewers.