### PR TITLE
Semantic conventions for `up` metric on Resources. #1078

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 New:
 
+- Semantic conventions for `up` metric on Resources.
+  ([#1102](https://github.com/open-telemetry/opentelemetry-specification/pull/1102))
 - Add performance benchmark specification
   ([#748](https://github.com/open-telemetry/opentelemetry-specification/pull/748))
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.

--- a/specification/metrics/semantic_conventions/resource-metrics.md
+++ b/specification/metrics/semantic_conventions/resource-metrics.md
@@ -16,4 +16,3 @@ telemetry.
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
 | `resource.up` | ValueRecorder | 1 | A value of `1` indicates the Resource is healthy, `0` if the Resource is unhealthy. |
-

--- a/specification/metrics/semantic_conventions/resource-metrics.md
+++ b/specification/metrics/semantic_conventions/resource-metrics.md
@@ -15,4 +15,4 @@ telemetry.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `resource.up` | ValueRecorder | 1 | A value of `1` indicates the Resource is healthy, `0` if the Resource is unhealthy. |
+| `resource.up` | UpDownSumObserver | 1 | A value of `1` indicates the Resource is healthy, `0` if the Resource is unhealthy. |

--- a/specification/metrics/semantic_conventions/resource-metrics.md
+++ b/specification/metrics/semantic_conventions/resource-metrics.md
@@ -1,10 +1,7 @@
 # Semantic conventions for Resource metrics
 
 This document describes metrics created about [Resources](../../resource/sdk.md), the entities
-producing telemetry in a system. 
-
-**Disclaimer:** These are initial Resource metric instruments and labels, more may be added
- in the future.
+producing telemetry in a system.
 
 ## Labels
 
@@ -18,5 +15,5 @@ telemetry.
 
 | Name                 | Instrument    | Units        | Description |
 |----------------------|---------------|--------------|-------------|
-| `resource.up` | ValueRecorder | yes/no | A value of `1` indicates the Resource is healthy, `0` if the Resource is unhealthy. |
+| `resource.up` | ValueRecorder | 1 | A value of `1` indicates the Resource is healthy, `0` if the Resource is unhealthy. |
 

--- a/specification/metrics/semantic_conventions/resource-metrics.md
+++ b/specification/metrics/semantic_conventions/resource-metrics.md
@@ -1,0 +1,22 @@
+# Semantic conventions for Resource metrics
+
+This document describes metrics created about [Resources](../../resource/sdk.md), the entities
+producing telemetry in a system. 
+
+**Disclaimer:** These are initial Resource metric instruments and labels, more may be added
+ in the future.
+
+## Labels
+
+The current Resource metrics do not have any explicit labels. They SHOULD inherit the [attributes
+of the encapsulating](../../resource/semantic_conventions/README.md) Resource when being exported.
+
+## Metric Instruments
+
+The following metric instruments SHOULD be synthesized every time a Resource produces some
+telemetry.
+
+| Name                 | Instrument    | Units        | Description |
+|----------------------|---------------|--------------|-------------|
+| `resource.up` | ValueRecorder | yes/no | A value of `1` indicates the Resource is healthy, `0` if the Resource is unhealthy. |
+


### PR DESCRIPTION
Fixes #1078 

## Changes

Describe the `up` metric on Resources.

## PR Description & Discussion

This PR lays the groundwork for an `up` metric to identify Resources that are healthy or unhealthy. There are a few open questions on where this metric should be generated and if it should have any labels. I'll mention those questions here but for now I tried to leave the semantic convention fairly open-ended.

1. Where in a metric pipeline should this metric be synthesized?

The `up` metric makes sense in a telemetry system using a pull model. This is because the component doing the pulling already has to keep state about which targets it is pulling metrics from and when. If a pull from a specific target ever fails, this component can synthesize the `up` metric with a value of 0 indicating it is unhealthy.

In a telemetry system using a push model, it's less clear how beneficial the `up` metric is. If the server side was to synthesize the `up` metric in a push system, there are a few problems: 1. the server would be forced to keep state about the Resources that have reported so that it can generate the "unhealthy" `up` metric when they stop reporting, 2. is a Resource that stops reporting always unhealthy? Or perhaps it simply no longer exists. If the client side was to synthesize the `up` metric in a push system can it ever really report unhealthy? If the process pushing these metrics has died then it can't report as unhealthy. Then the indication that this Resource is unhealthy becomes anytime this metric is not present. That seems superfluous since you could use any metric from this Resource to try to determine that.

In summary I think it would be useful to generate the `up` metric in receivers that are using a pull model. I am less convinced it makes sense to synthesize the `up` metric in all exporters, where unhealthy just becomes the lack of presence of a metric. I could see generating the `up` metric in prometheus exporters that push data (prometheus remote write) for backwards compatibility. A prometheus exporter that simply acts as a scrape target shouldn't need to synthesize up since the prometheus server will do it automatically.

2. This metric should be label free

I agree that this metric doesn't have any explicit labels but, we at least want some attributes from the Resource this metric is reported for added to the metric when it is exported. Without those labels the metric is useless. Maybe that is obvious and doesn't need to be called out in the semantic convention.

Related issues #1078 

Mentioning @jmacd and @bogdandrutu for reviews.