### PR TITLE
Add a directive that the Baggage API must function, even without an SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ release.
 ## Unreleased
 
 New:
-
+- Enforce that the Baggage API must be fully functional, even without an installed SDK.
+  ([#1103](https://github.com/open-telemetry/opentelemetry-specification/pull/1103))
 - Rename "Canonical status code" to "Status code"
   ([#1081](https://github.com/open-telemetry/opentelemetry-specification/pull/1081))
 - Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ release.
 ## Unreleased
 
 New:
+
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.
   ([#1103](https://github.com/open-telemetry/opentelemetry-specification/pull/1103))
 - Rename "Canonical status code" to "Status code"

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -33,6 +33,10 @@ into the context. The [Get all](#get-all) function could be implemented by retur
 object as a whole from the function call. If an idiom like this is implemented, the Baggage object/struct
 MUST be immutable, so that the containing Context also remains immutable.
 
+The Baggage API MUST be fully functional in the absence of an installed SDK. This is required in
+order to enable transparent cross-process Baggage propagation. If a Baggage propagator is installed
+into the API, it will work with or without an installed SDK.
+
 ### Baggage
 
 `Baggage` is used to annotate telemetry, adding context and information to metrics, traces, and logs.


### PR DESCRIPTION
Fixes #1070

## Changes

Clarifies that the Baggage API MUST be functional with only the OpenTelemetry API, without an installed SDK.

