### PR TITLE
Add spec compliance matrix entry for StatusCode

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -41,8 +41,7 @@ status of the feature is not known.
 |End with timestamp                            | + | +  | + | +    | +  | +    | + | -  | + | +  |
 |IsRecording                                   | + | +  | + | +    | +  | +    | + |    | + | +  |
 |IsRecording becomes false after End           |   |    |   |      |    |      |   |    |   |    |
-|Set status                                    | + | +  | + | +    | +  | +    | + | +  | + | +  |
-|Set status takes StatusCode (Unset, Ok, Error)|   |    |   |      |    |      |   |    |   |    |
+|Set status with StatusCode (Unset, Ok, Error) |   |    |   |      |    |      |   |    |   |    |
 |Safe for concurrent calls                     | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1157)    | +  | +    | + | +  | + | +  |
 |events collection size limit                  |   |    |   |      |    |      |   |    |   |    |
 |attribute collection size limit               |   |    |   |      |    |      |   |    |   |    |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -42,6 +42,7 @@ status of the feature is not known.
 |IsRecording                                   | + | +  | + | +    | +  | +    | + |    | + | +  |
 |IsRecording becomes false after End           |   |    |   |      |    |      |   |    |   |    |
 |Set status                                    | + | +  | + | +    | +  | +    | + | +  | + | +  |
+|Set status takes StatusCode (Unset, Ok, Error)|   |    |   |      |    |      |   |    |   |    |
 |Safe for concurrent calls                     | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1157)    | +  | +    | + | +  | + | +  |
 |events collection size limit                  |   |    |   |      |    |      |   |    |   |    |
 |attribute collection size limit               |   |    |   |      |    |      |   |    |   |    |


### PR DESCRIPTION
The current `+` refer to the old Status API taking `StatusCanonicalCode`. This entry is for tracking the new API as per #966 and #1081.

Follow-up of #1107.