### PR TITLE
Add metric name pluralization guidelines

### DIFF
--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -77,7 +77,7 @@ Metric names SHOULD NOT be pluralized, unless the value being recorded
 represents discrete instances of a
 [countable quantity](https://en.wikipedia.org/wiki/Count_noun).
 Generally, the name SHOULD be pluralized only if the unit of the metric in
-question is a pseudo-unit (like `{faults}` or `{operations}`).
+question is a non-unit (like `{faults}` or `{operations}`).
 
 Examples:
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -1,5 +1,18 @@
 # Metrics Semantic Conventions
 
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [General Guidelines](#general-guidelines)
+  * [Units](#units)
+  * [Pluralization](#pluralization)
+- [General Metric Semantic Conventions](#general-metric-semantic-conventions)
+  * [Instrument Naming](#instrument-naming)
+  * [Units](#units-1)
+
+<!-- tocstop -->
+
 The following semantic conventions surrounding metrics are defined:
 
 * [HTTP Metrics](http-metrics.md): Semantic conventions and instruments for HTTP metrics.

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -50,11 +50,28 @@ and confusion for end users. (For example, prefer `runtime.java.gc*` over
 `runtime.gc.*`.) Measures of many operating system metrics are similarly
 ambiguous.
 
+### Units
+
 Conventional metrics or metrics that have their units included in
 OpenTelemetry metadata (e.g. `metric.WithUnit` in Go) SHOULD NOT include the
 units in the metric name. Units may be included when it provides additional
 meaning to the metric name. Metrics MUST, above all, be understandable and
 usable.
+
+### Pluralization
+
+Metric names SHOULD NOT be pluralized, unless the value being recorded
+represents discrete instances of a
+[countable quantity](https://en.wikipedia.org/wiki/Count_noun).
+Generally, the name SHOULD be pluralized only if the unit of the metric in
+question is a pseudo-unit (like `{faults}` or `{operations}`).
+
+Examples:
+
+* `system.filesystem.utilization`, `http.server.duration`, and `system.cpu.time`
+should not be pluralized, even if many data points are recorded.
+* `system.paging.faults`, `system.disk.operations`, and `system.network.packets`
+should be pluralized, even if only a single data point is recorded.
 
 ## General Metric Semantic Conventions
 


### PR DESCRIPTION
This PR is part of the solution to issue #600.

## Changes

This PR is a clarification in the general metrics semantic conventions guidelines. It adds some guidelines about when to use a pluralized metric name (like `system.paging.faults`) and when to use a singular name (like `http.server.duration`).

Related issues #600 and #705

Related oteps: [#108](https://github.com/open-telemetry/oteps/pull/108)
