### PR TITLE
small typo in the metrics API spec

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -365,7 +365,7 @@ situations, but in most cases it is the correct pattern for telemetry
 data, in order to combine telemetry data from inter-dependent
 libraries _without use of dependency injection_.  OpenTelemetry
 language APIs SHOULD offer a global instance for this reason.
-Languges that offer a global instance MUST ensure that `Meter`
+Languages that offer a global instance MUST ensure that `Meter`
 instances allocated through the global `MeterProvider` and instruments
 allocated through those `Meter` instances have their initialization
 deferred until the a global SDK is first initialized.


### PR DESCRIPTION
I found a small typo while reading through the metrics api specification 😄  
* `Languages` was misspelt as `Languges`. 