### PR TITLE
Revert: Define Propagation-only Span to simplify active Span logic in Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,6 @@ New:
   ([#988](https://github.com/open-telemetry/opentelemetry-specification/pull/988/))
 - Update the header name for otel baggage, and version date
   ([#981](https://github.com/open-telemetry/opentelemetry-specification/pull/981))
-- Define PropagationOnly Span to simplify active Span logic in Context
-  ([#994](https://github.com/open-telemetry/opentelemetry-specification/pull/994))
 - Add limits to the number of attributes, events, and links in SDK Spans
   ([#942](https://github.com/open-telemetry/opentelemetry-specification/pull/942))
 - Add Metric SDK specification (partial): covering terminology and Accumulator component


### PR DESCRIPTION
This reverts commit d14c9b7a74328c22e5d2223c4ddcaca5630aceae.

Fixes #1124 