### PR TITLE
Span processor clarifications

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -293,11 +293,11 @@ exporters such as [z-pages](../../experimental/trace/zpages.md).
 Span processors can be registered directly on SDK `TracerProvider` and they are
 invoked in the same order as they were registered.
 
-Each processor registered on `TracerProvider` is a start of pipeline that consist
-of span processor and optional exporter. SDK MUST allow to end each pipeline with
+Each processor registered on `TracerProvider` is a start of a pipeline that consists
+of a span processor and an optional exporter. The SDK MUST allow to end each pipeline with
 individual exporter.
 
-SDK MUST allow users to implement and configure custom processors and decorate
+The SDK MUST allow users to implement and configure custom processors and decorate
 built-in processors for advanced scenarios such as tagging or filtering.
 
 The following diagram shows `SpanProcessor`'s relationship to other components
@@ -392,13 +392,13 @@ make the flush timeout configurable.
 
 The standard OpenTelemetry SDK MUST implement both simple and batch processors,
 as described below. Other common processing scenarios should be first considered
-for implementation out-of-process in [OpenTelemetry Collector](../overview.md#collector)
+for implementation out-of-process in an [OpenTelemetry Collector](../overview.md#collector).
 
 #### Simple processor
 
 This is an implementation of `SpanProcessor` which passes finished spans
-and passes the export-friendly span data representation to the configured
-`SpanExporter`, as soon as they are finished.
+and the export-friendly span data representation to the configured
+`SpanExporter` as soon as they are finished.
 
 **Configurable parameters:**
 
@@ -406,21 +406,21 @@ and passes the export-friendly span data representation to the configured
 
 #### Batching processor
 
-This is an implementation of the `SpanProcessor` which create batches of finished
+This is an implementation of `SpanProcessor` which creates batches of finished
 spans and passes the export-friendly span data representations to the
 configured `SpanExporter`.
 
 **Configurable parameters:**
 
 * `exporter` - the exporter where the spans are pushed.
-* `maxQueueSize` - the maximum queue size. After the size is reached spans are
+* `maxQueueSize` - the maximum queue size. After this limit is reached, spans are
   dropped. The default value is `2048`.
 * `scheduledDelayMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
 * `exportTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
 * `maxExportBatchSize` - the maximum batch size of every export. It must be
-  smaller or equal to `maxQueueSize`. The default value is `512`.
+  smaller than or equal to `maxQueueSize`. The default value is `512`.
 
 ## Span Exporter
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -411,9 +411,8 @@ in the background.
 
 #### Batching processor
 
-This is an implementation of `SpanProcessor` which creates batches of finished
-spans and passes the export-friendly span data representations to the
-configured `SpanExporter`.
+This is an implementation of `SpanProcessor` which collects finished spans into batches
+and passes the export-friendly span data representations to the associated `SpanExporter`.
 
 Typically, the batching processor will be more suitable for production environments
 than the simple processor.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -399,11 +399,11 @@ This is an implementation of `SpanProcessor` which passes finished spans
 and the export-friendly span data representation to the configured
 `SpanExporter` as soon as they are finished.
 
-Typically, the simple processor will be most suitable for use in testing. Exceptions to this
-include scenarios where creating multiple threads is not desirable (since batching
-span processors will typically be threaded in order to pass spans on to exporters
-in the background) and scenarios where different custom attributes should be added to individual
-spans based on code scopes.
+Typically, the simple processor will be most suitable for use in testing; it should be used with
+caution in production. It may be appropriate for production use in scenarios where creating
+multiple threads is not desirable (since batching span processors will typically be threaded
+in order to pass spans on to exporters in the background) as well as scenarios where different
+custom attributes should be added to individual spans based on code scopes.
 
 **Configurable parameters:**
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -400,10 +400,11 @@ This is an implementation of `SpanProcessor` which passes finished spans
 and the export-friendly span data representation to the configured
 `SpanExporter` as soon as they are finished.
 
-Typically, the simple processor will be most suitable for use in testing and/or
-in scenarios where creating multiple threads is not desirable, since batching
+Typically, the simple processor will be most suitable for use in testing. Exceptions to this
+include scenarios where creating multiple threads is not desirable (since batching
 span processors will typically be threaded in order to pass spans on to exporters
-in the background.
+in the background) and scenarios where different custom attributes should be added to individual
+spans based on code scopes.
 
 **Configurable parameters:**
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -399,8 +399,8 @@ This is an implementation of `SpanProcessor` which passes finished spans
 and the export-friendly span data representation to the configured
 `SpanExporter` as soon as they are finished.
 
-Typically, the simple processor will be most suitable for use in testing; it should be used with
-caution in production. It may be appropriate for production use in scenarios where creating
+The simple processor must not be used lightly in production. It runs on application thread and may
+degrade performance. It may be appropriate for production use in scenarios where creating
 multiple threads is not desirable (since batching span processors will typically be threaded
 in order to pass spans on to exporters in the background) as well as scenarios where different
 custom attributes should be added to individual spans based on code scopes.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -297,8 +297,7 @@ Each processor registered on `TracerProvider` is a start of a pipeline that cons
 of one or more span processors and, optionally, one or more exporters. The SDK MUST
 allow ending each pipeline with an individual exporter.
 
-The SDK MUST allow users to implement and configure custom processors and decorate
-built-in processors for advanced scenarios such as tagging or filtering.
+The SDK MUST allow users to implement and configure custom processors.
 
 The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -294,8 +294,8 @@ Span processors can be registered directly on SDK `TracerProvider` and they are
 invoked in the same order as they were registered.
 
 Each processor registered on `TracerProvider` is a start of a pipeline that consists
-of a span processor and an optional exporter. The SDK MUST allow to end each pipeline with
-individual exporter.
+of one or more span processors and, optionally, one or more exporters. The SDK MUST
+allow ending each pipeline with an individual exporter.
 
 The SDK MUST allow users to implement and configure custom processors and decorate
 built-in processors for advanced scenarios such as tagging or filtering.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -400,6 +400,11 @@ This is an implementation of `SpanProcessor` which passes finished spans
 and the export-friendly span data representation to the configured
 `SpanExporter` as soon as they are finished.
 
+Typically, the simple processor will be most suitable for use in testing and/or
+in scenarios where creating multiple threads is not desirable, since batching
+span processors will typically be threaded in order to pass spans on to exporters
+in the background.
+
 **Configurable parameters:**
 
 * `exporter` - the exporter where the spans are pushed.
@@ -409,6 +414,9 @@ and the export-friendly span data representation to the configured
 This is an implementation of `SpanProcessor` which creates batches of finished
 spans and passes the export-friendly span data representations to the
 configured `SpanExporter`.
+
+Typically, the batching processor will be more suitable for production environments
+than the simple processor.
 
 **Configurable parameters:**
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -287,7 +287,8 @@ invocations. The span processors are invoked only when
 [`IsRecording`](api.md#isrecording) is true.
 
 Built-in span processors are responsible for batching and conversion of spans to
-exportable representation and passing batches to exporters.
+exportable representation and passing batches to exporters or alternatives to
+exporters such as [z-pages](../../experimental/trace/zpages.md).
 
 Span processors can be registered directly on SDK `TracerProvider` and they are
 invoked in the same order as they were registered.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -421,7 +421,7 @@ than the simple processor.
 
 * `exporter` - the exporter where the spans are pushed.
 * `maxQueueSize` - the maximum queue size. After this limit is reached, spans are
-  dropped. The default value is `2048`.
+  skipped by this BatchSpanProcessor. The default value is `2048`.
 * `scheduledDelayMillis` - the delay interval in milliseconds between two
   consecutive exports. The default value is `5000`.
 * `exportTimeoutMillis` - how long the export can run before it is cancelled.


### PR DESCRIPTION
## Changes

This PR attempts to clarify information about span processors in the Trace SDK spec. It contains:
* More information about when one might want to use a simple vs. batching span processor
* More information about scenarios in which span processors may be used without exporters
* Minor grammatical fixes

### Related issues
The need for clarification in the spec came to my attention when it was mentioned in this ticket: https://github.com/open-telemetry/opentelemetry-ruby/issues/397.