### PR TITLE
Add OTEL_TRACE_SAMPLER.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ New:
   ([#1074](https://github.com/open-telemetry/opentelemetry-specification/pull/1074))
 - Add semantic conventions for system metrics
   ([#937](https://github.com/open-telemetry/opentelemetry-specification/pull/937))
+- Add OTEL_TRACE_SAMPLER env variable definition
+  ([#1136](https://github.com/open-telemetry/opentelemetry-specification/pull/1136/))
 
 Updates:
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -128,6 +128,7 @@ status of the feature is not known.
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   |    |   |      |    |      |   |    |   |    |
+|OTEL_TRACE_SAMPLER                            |   |    |   |      |    |      |   |    |   |    |
 
 ## Exporters
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -23,7 +23,6 @@ Known values for `OTEL_TRACE_SAMPLER` are:
 - `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
 - `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
 
-
 ## Batch Span Processor
 
 | Name                           | Description                                    | Default | Notes                                                 |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -9,7 +9,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes |                                   | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
-| OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
+| OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -9,9 +9,12 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes |                                   | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
+| OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".
+
+Known values for OTEL_TRACE_SAMPLER are: "always_on", "always_off", "traceidratio", "parentbased_traceidratio".
 
 ## Batch Span Processor
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -14,7 +14,15 @@ The goal of this specification is to unify the environment variable names betwee
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".
 
-Known values for OTEL_TRACE_SAMPLER are: "always_on", "always_off", "traceidratio", "parentbased_traceidratio".
+Known values for `OTEL_TRACE_SAMPLER` are:
+
+- `"always_on"`: `AlwaysOnSampler`
+- `"always_off"`: `AlwaysOffSampler`
+- `"traceidratio"`: `TraceIdRatioBased`
+- `"parentbased_always_on"`: `ParentBased(root=AlwaysOnSampler)`
+- `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
+- `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
+
 
 ## Batch Span Processor
 


### PR DESCRIPTION
Adds `OTEL_TRACE_SAMPLER`, required for properly resolving #1105 .

This is a super minimalistic, but hopefully correct approach. Following @jmacd's comment about the possibility of adding sampling for metrics in the future, I added `TRACE` in it.
