### PR TITLE
Overhaul process command-line resource conventions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ New:
 
 Updates:
 
+- Make `process.pid` optional, split `process.command_args` from `command_line`
+  ([#1137](https://github.com/open-telemetry/opentelemetry-specification/pull/1137))
 - Renamed `CorrelationContext` to `Baggage`:
   ([#857](https://github.com/open-telemetry/opentelemetry-specification/pull/857))
 - Add semantic convention for NGINX custom HTTP 499 status code.
@@ -91,7 +93,8 @@ Updates:
 - Version attributes no longer have a prefix such as semver:
   ([#873](https://github.com/open-telemetry/opentelemetry-specification/pull/873))
 - Add semantic conventions for process runtime
-  ([#882](https://github.com/open-telemetry/opentelemetry-specification/pull/882))
+  ([#882](https://github.com/open-telemetry/opentelemetry-specification/pull/882),
+   [#1137](https://github.com/open-telemetry/opentelemetry-specification/pull/1137))
 - Use hex encoding for trace id and span id fields in OTLP JSON encoding:
   ([#911](https://github.com/open-telemetry/opentelemetry-specification/pull/911))
 - Explicitly specify the SpanContext APIs IsValid and IsRemote as required

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -6,17 +6,34 @@
 
 | Attribute  | Description  | Example  | Required |
 |---|---|---|--|
-| process.pid | Process identifier (PID). | `1234` | Yes |
+| process.pid | Process identifier (PID). | `1234` | No |
 | process.executable.name | The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` | See below |
 | process.executable.path | The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` | See below |
 | process.command | The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`. | `cmd/otelcol` | See below |
-| process.command_line | The full command used to launch the process. The value can be either a list of strings representing the ordered list of arguments, or a single string representing the full command. On Linux based systems, can be set to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. On Windows, can be set to the result of `GetCommandLineW`. | Linux: `[ cmd/otecol, --config=config.yaml ]`, Windows: `cmd/otecol --config=config.yaml` | See below |
+| process.command_line | The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead. | `C:\cmd\otecol --config="my directory\config.yaml"` | See below |
+| process.command_args | All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`. | `[ cmd/otecol, --config=config.yaml ]` | See below |
 | process.owner | The username of the user that owns the process. | `root` | No |
 | process.runtime.name | The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler. | `OpenJDK Runtime Environment` | No |
 | process.runtime.version | The version of the runtime of this process, as returned by the runtime without modification. | `14.0.2` | No |
 | process.runtime.description | An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. | `Eclipse OpenJ9 openj9-0.21.0` | No |
 
-At least one of `process.executable.name`, `process.executable.path`, `process.command`, or `process.command_line` is required.
+Between `process.command_args` and `process.command_line`, usually `process.command_args` should be preferred.
+On Windows and other systems where the native format of process commands is a single string,
+`process.command_args` can additionally (or instead) be used.
+
+At least one of `process.executable.name`, `process.executable.path`, `process.command`, `process.command_line` or `process.command_args` is required.
+
+## Process runtimes
+
+**type:** `process.runtime`
+
+**Description:** The single (language) runtime instance which is monitored.
+
+| Attribute  | Description  | Example  | Required |
+|---|---|---|--|
+| process.runtime.name | The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler. | `OpenJDK Runtime Environment` | No |
+| process.runtime.version | The version of the runtime of this process, as returned by the runtime without modification. | `14.0.2` | No |
+| process.runtime.description | An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. | `Eclipse OpenJ9 openj9-0.21.0` | No |
 
 `process.runtime.name` SHOULD be set to one of the values listed below, unless more detailed instructions are provided.
 If none of the listed values apply, a custom value best describing the runtime CAN be used.

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -13,9 +13,6 @@
 | process.command_line | The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead. | `C:\cmd\otecol --config="my directory\config.yaml"` | See below |
 | process.command_args | All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`. | `[ cmd/otecol, --config=config.yaml ]` | See below |
 | process.owner | The username of the user that owns the process. | `root` | No |
-| process.runtime.name | The name of the runtime of this process. For compiled native binaries, this SHOULD be the name of the compiler. | `OpenJDK Runtime Environment` | No |
-| process.runtime.version | The version of the runtime of this process, as returned by the runtime without modification. | `14.0.2` | No |
-| process.runtime.description | An additional description about the runtime of the process, for example a specific vendor customization of the runtime environment. | `Eclipse OpenJ9 openj9-0.21.0` | No |
 
 Between `process.command_args` and `process.command_line`, usually `process.command_args` should be preferred.
 On Windows and other systems where the native format of process commands is a single string,

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -16,7 +16,7 @@
 
 Between `process.command_args` and `process.command_line`, usually `process.command_args` should be preferred.
 On Windows and other systems where the native format of process commands is a single string,
-`process.command_args` can additionally (or instead) be used.
+`process.command_line` can additionally (or instead) be used.
 
 For backwards compatibility with older versions of this semantic convention,
 it is possible but deprecated to use an array as type for `process.command_line`.

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -21,6 +21,10 @@ Between `process.command_args` and `process.command_line`, usually `process.comm
 On Windows and other systems where the native format of process commands is a single string,
 `process.command_args` can additionally (or instead) be used.
 
+For backwards compatibility with older versions of this semantic convention,
+it is possible but deprecated to use an array as type for `process.command_line`.
+In that case it MUST be interpreted as if it was `process.command_args`.
+
 At least one of `process.executable.name`, `process.executable.path`, `process.command`, `process.command_line` or `process.command_args` is required.
 
 ## Process runtimes

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -25,7 +25,7 @@ For backwards compatibility with older versions of this semantic convention,
 it is possible but deprecated to use an array as type for `process.command_line`.
 In that case it MUST be interpreted as if it was `process.command_args`.
 
-At least one of `process.executable.name`, `process.executable.path`, `process.command`, `process.command_line` or `process.command_args` is required.
+At least one of `process.executable.name`, `process.executable.path`, `process.command`, `process.command_line` or `process.command_args` is required to allow back ends to identify the executable.
 
 ## Process runtimes
 


### PR DESCRIPTION
Fixes #831, fixes #997

## Changes

* Splits process.runtime as a separate semantic convention from process (fixes #997)
* No longer require PID in any case (would also fix #997, but this is mainly for languages where the pid is not available)
* Split process.command_args from process.command_line (fixes #831).
