### PR TITLE
Include attribute name pluralization guidelines (#1115)

### DIFF
--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -80,14 +80,14 @@ Names SHOULD follow these rules:
   
 ### Name Pluralization guidelines
 
-- When attribute represents a single entity, the attribute name SHOULD BE singular.
+- When an attribute represents a single entity, the attribute name SHOULD be singular.
 
-- When attribute can represent multiple entities, the attribute name SHOULD BE pluralized
-  and the value type SHOULD BE an array.
+- When attribute can represent multiple entities, the attribute name SHOULD be pluralized
+  and the value type SHOULD be an array.
 
-- When attribute represents a measurement,
+- When an attribute represents a measurement,
   [Metric Name Pluralization Guidelines](https://github.com/pmm-sumo/opentelemetry-specification/blob/master/specification/metrics/semantic_conventions/README.md#pluralization)
-  SHOULD BE followed for the attribute name.
+  SHOULD be followed for the attribute name.
 
 ### Recommendations for OpenTelemetry Authors
 

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -7,6 +7,9 @@ Table of Contents
 
 - [Attributes](#attributes)
   - [Attribute and Label Naming](#attribute-and-label-naming)
+    - [Name Pluralization Guidelines](#name-pluralization-guidelines)
+    - [Recommendations for OpenTelemetry Authors](#recommendations-for-opentelemetry-authors)
+    - [Recommendations for Application Developers](#recommendations-for-application-developers)
 
 </details>
 
@@ -74,6 +77,17 @@ Names SHOULD follow these rules:
   name prohibits existence of an equally named namespace in the future, and vice
   versa: any existing namespace prohibits existence of an equally named
   attribute or label key in the future.
+  
+### Name Pluralization guidelines
+
+- When attribute represents a single entity, the attribute name SHOULD BE singular.
+
+- When attribute can represent multiple entities, the attribute name SHOULD BE pluralized
+  and the value type SHOULD BE an array.
+
+- When attribute represents a measurement,
+  [Metric Name Pluralization Guidelines](https://github.com/pmm-sumo/opentelemetry-specification/blob/master/specification/metrics/semantic_conventions/README.md#pluralization)
+  SHOULD BE followed for the attribute name.
 
 ### Recommendations for OpenTelemetry Authors
 

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -81,9 +81,11 @@ Names SHOULD follow these rules:
 ### Name Pluralization guidelines
 
 - When an attribute represents a single entity, the attribute name SHOULD be singular.
+  Examples: `host.name`, `db.user`, `container.id`.
 
 - When attribute can represent multiple entities, the attribute name SHOULD be pluralized
-  and the value type SHOULD be an array.
+  and the value type SHOULD be an array. E.g. `process.command_args` might include multiple
+  values: the executable name and command arguments.
 
 - When an attribute represents a measurement,
   [Metric Name Pluralization Guidelines](../metrics/semantic_conventions/README.md#pluralization)

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -86,7 +86,7 @@ Names SHOULD follow these rules:
   and the value type SHOULD be an array.
 
 - When an attribute represents a measurement,
-  [Metric Name Pluralization Guidelines](https://github.com/pmm-sumo/opentelemetry-specification/blob/master/specification/metrics/semantic_conventions/README.md#pluralization)
+  [Metric Name Pluralization Guidelines](../metrics/semantic_conventions/README.md#pluralization)
   SHOULD be followed for the attribute name.
 
 ### Recommendations for OpenTelemetry Authors


### PR DESCRIPTION
Fixes #1115 

## Changes

Provides proposal for attribute name pluralization guidelines

Depends on https://github.com/open-telemetry/opentelemetry-specification/pull/1109/files

Related issues #

* [Trace payload/message size in semantic convention is inconsistent #1053
](https://github.com/open-telemetry/opentelemetry-specification/issues/1053)
* [Add metric name pluralization guidelines #1109](https://github.com/open-telemetry/opentelemetry-specification/pull/1109)
* [process.command_line accepts multiple value types #831](https://github.com/open-telemetry/opentelemetry-specification/issues/831)