### PR TITLE
Database semantic conventions: Add db.table, allow SQL keyword as db.operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ New:
   ([#1074](https://github.com/open-telemetry/opentelemetry-specification/pull/1074))
 - Add semantic conventions for system metrics
   ([#937](https://github.com/open-telemetry/opentelemetry-specification/pull/937))
+- Add `db.table` and `db.operation` to semantic conventions ([#1141](https://github.com/open-telemetry/opentelemetry-specification/pull/1141))
 
 Updates:
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -191,12 +191,27 @@ groups:
             conditional: Required, if `db.statement` is not applicable.
           brief: >
             The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations)
-            such as `findAndModify`.
+            such as `findAndModify`, or the SQL keyword.
           note: >
-            While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT` or `INSERT`,
-            it is not recommended to attempt any client-side parsing of `db.statement` just to get this property
-            (the back end can do that if required).
-          examples: ['findAndModify', 'HMSET']
+            It is not recommended to attempt any client-side parsing of
+            `db.statement` just to get this property, but it should be set if 
+            the operation name is provided by the library being instrumented.
+            If the statement has an ambiguous operation, or performs more than
+            one operation, this value may be omitted.
+          examples: ['findAndModify', 'HMSET', 'SELECT']
+        - id: table
+          tag: call-level
+          type: string
+          required:
+            conditional: Recommended if available.
+          brief: The name of the primary table, collection, segment, etc... that the operation is acting upon, including the schema name (if applicable).
+          note: >
+            It is not recommended to attempt any  client-side parsing of
+            `db.statement` just to get this property, but it should be set if
+            it is provided by the library being instrumented.
+            If the operation is acting upon an anonymous table, or more than one
+            table, this value may be omitted.
+          examples: ['public.users', 'customers']
         - ref: net.peer.name
           tag: connection-level
           required:

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -193,11 +193,12 @@ groups:
             The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations)
             such as `findAndModify`, or the SQL keyword.
           note: >
-            It is not recommended to attempt any client-side parsing of
-            `db.statement` just to get this property, but it should be set if
-            the operation name is provided by the library being instrumented.
-            If the statement has an ambiguous operation, or performs more than
-            one operation, this value may be omitted.
+            When setting this to an SQL keyword, it is not recommended to
+            attempt any client-side parsing of `db.statement` just to get this
+            property, but it should be set if the operation name is provided by
+            the library being instrumented.
+            If the SQL statement has an ambiguous operation, or performs more
+            than one operation, this value may be omitted.
           examples: ['findAndModify', 'HMSET', 'SELECT']
         - ref: net.peer.name
           tag: connection-level

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -199,19 +199,6 @@ groups:
             If the statement has an ambiguous operation, or performs more than
             one operation, this value may be omitted.
           examples: ['findAndModify', 'HMSET', 'SELECT']
-        - id: table
-          tag: call-level
-          type: string
-          required:
-            conditional: Recommended if available.
-          brief: The name of the primary table, collection, segment, etc... that the operation is acting upon, including the schema name (if applicable).
-          note: >
-            It is not recommended to attempt any client-side parsing of
-            `db.statement` just to get this property, but it should be set if
-            it is provided by the library being instrumented.
-            If the operation is acting upon an anonymous table, or more than one table, this
-            value may be omitted.
-          examples: ['public.users', 'customers']
         - ref: net.peer.name
           tag: connection-level
           required:
@@ -309,6 +296,27 @@ groups:
             The collection being accessed within the database stated in `db.name`.
           examples: [ 'customers', 'products' ]
 
+    - id: db.sql
+      prefix: 'db.sql'
+      extends: 'db'
+      brief: >
+        Call-level attrbiutes for SQL databases
+      attributes:
+        - id: table
+          tag: call-level-tech-specific
+          type: string
+          required:
+            conditional: Recommended if available.
+          brief: The name of the primary table that the operation is acting upon, including the schema name (if applicable).
+          note: >
+            It is not recommended to attempt any client-side parsing of
+            `db.statement` just to get this property, but it should be set if
+            it is provided by the library being instrumented.
+            If the operation is acting upon an anonymous table, or more than one table, this
+            value may be omitted.
+          examples: ['public.users', 'customers']
+
+
     - id: db.tech
       brief: "Semantic convention group for specific technologies"
       constraints:
@@ -316,3 +324,4 @@ groups:
         - include: 'db.hbase'
         - include: 'db.redis'
         - include: 'db.mongodb'
+        - include: 'db.sql'

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -314,7 +314,7 @@ groups:
             `db.statement` just to get this property, but it should be set if
             it is provided by the library being instrumented.
             If the operation is acting upon an anonymous table, or more than one table, this
-            value may be omitted.
+            value MUST NOT be set.
           examples: ['public.users', 'customers']
 
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -194,7 +194,7 @@ groups:
             such as `findAndModify`, or the SQL keyword.
           note: >
             It is not recommended to attempt any client-side parsing of
-            `db.statement` just to get this property, but it should be set if 
+            `db.statement` just to get this property, but it should be set if
             the operation name is provided by the library being instrumented.
             If the statement has an ambiguous operation, or performs more than
             one operation, this value may be omitted.
@@ -206,11 +206,11 @@ groups:
             conditional: Recommended if available.
           brief: The name of the primary table, collection, segment, etc... that the operation is acting upon, including the schema name (if applicable).
           note: >
-            It is not recommended to attempt any  client-side parsing of
+            It is not recommended to attempt any client-side parsing of
             `db.statement` just to get this property, but it should be set if
             it is provided by the library being instrumented.
-            If the operation is acting upon an anonymous table, or more than one
-            table, this value may be omitted.
+            If the operation is acting upon an anonymous table, or more than one table, this
+            value may be omitted.
           examples: ['public.users', 'customers']
         - ref: net.peer.name
           tag: connection-level

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -136,7 +136,6 @@ Usually only one `db.name` will be used per connection though.
 | `db.name` | string | If no [tech-specific attribute](#call-level-attributes-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
 | `db.statement` | string | The database statement being executed. [3] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional<br>Required if applicable. |
 | `db.operation` | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword. [4] | `findAndModify`<br>`HMSET`<br>`SELECT` | Conditional<br>Required, if `db.statement` is not applicable. |
-| `db.table` | string | The name of the primary table, collection, segment, etc... that the operation is acting upon, including the schema name (if applicable). [5] | `public.users`<br>`customers` | Conditional<br>Recommended if available. |
 
 **[1]:** In some SQL databases, the database name to be used is called "schema name".
 
@@ -145,8 +144,6 @@ Usually only one `db.name` will be used per connection though.
 **[3]:** The value may be sanitized to exclude sensitive information.
 
 **[4]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
-
-**[5]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
 <!-- endsemconv -->
 
 For **Redis**, the value provided for `db.statement` SHOULD correspond to the syntax of the Redis CLI.
@@ -168,8 +165,11 @@ For example, when retrieving a document, `db.operation` would be set to (literal
 | `db.hbase.namespace` | string | The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute. | `default` | Yes |
 | `db.redis.database_index` | number | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute. | `0`<br>`1`<br>`15` | Conditional [1] |
 | `db.mongodb.collection` | string | The collection being accessed within the database stated in `db.name`. | `customers`<br>`products` | Yes |
+| `db.sql.table` | string | The name of the primary table that the operation is acting upon, including the schema name (if applicable). [2] | `public.users`<br>`customers` | Conditional<br>Recommended if available. |
 
 **[1]:** Required, if other than the default database (`0`).
+
+**[2]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
 <!-- endsemconv -->
 
 ## Examples

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -144,9 +144,9 @@ Usually only one `db.name` will be used per connection though.
 
 **[3]:** The value may be sanitized to exclude sensitive information.
 
-**[4]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if  the operation name is provided by the library being instrumented. If the statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+**[4]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 
-**[5]:** It is not recommended to attempt any  client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
+**[5]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
 <!-- endsemconv -->
 
 For **Redis**, the value provided for `db.statement` SHOULD correspond to the syntax of the Redis CLI.

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -135,7 +135,8 @@ Usually only one `db.name` will be used per connection though.
 |---|---|---|---|---|
 | `db.name` | string | If no [tech-specific attribute](#call-level-attributes-for-specific-technologies) is defined, this attribute is used to report the name of the database being accessed. For commands that switch the database, this should be set to the target database (even if the command fails). [1] | `customers`<br>`main` | Conditional [2] |
 | `db.statement` | string | The database statement being executed. [3] | `SELECT * FROM wuser_table`<br>`SET mykey "WuValue"` | Conditional<br>Required if applicable. |
-| `db.operation` | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`. [4] | `findAndModify`<br>`HMSET` | Conditional<br>Required, if `db.statement` is not applicable. |
+| `db.operation` | string | The name of the operation being executed, e.g. the [MongoDB command name](https://docs.mongodb.com/manual/reference/command/#database-operations) such as `findAndModify`, or the SQL keyword. [4] | `findAndModify`<br>`HMSET`<br>`SELECT` | Conditional<br>Required, if `db.statement` is not applicable. |
+| `db.table` | string | The name of the primary table, collection, segment, etc... that the operation is acting upon, including the schema name (if applicable). [5] | `public.users`<br>`customers` | Conditional<br>Recommended if available. |
 
 **[1]:** In some SQL databases, the database name to be used is called "schema name".
 
@@ -143,7 +144,9 @@ Usually only one `db.name` will be used per connection though.
 
 **[3]:** The value may be sanitized to exclude sensitive information.
 
-**[4]:** While it would semantically make sense to set this, e.g., to a SQL keyword like `SELECT` or `INSERT`, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property (the back end can do that if required).
+**[4]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if  the operation name is provided by the library being instrumented. If the statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+
+**[5]:** It is not recommended to attempt any  client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
 <!-- endsemconv -->
 
 For **Redis**, the value provided for `db.statement` SHOULD correspond to the syntax of the Redis CLI.

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -143,7 +143,7 @@ Usually only one `db.name` will be used per connection though.
 
 **[3]:** The value may be sanitized to exclude sensitive information.
 
-**[4]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
+**[4]:** When setting this to an SQL keyword, it is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if the operation name is provided by the library being instrumented. If the SQL statement has an ambiguous operation, or performs more than one operation, this value may be omitted.
 <!-- endsemconv -->
 
 For **Redis**, the value provided for `db.statement` SHOULD correspond to the syntax of the Redis CLI.

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -169,7 +169,7 @@ For example, when retrieving a document, `db.operation` would be set to (literal
 
 **[1]:** Required, if other than the default database (`0`).
 
-**[2]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value may be omitted.
+**[2]:** It is not recommended to attempt any client-side parsing of `db.statement` just to get this property, but it should be set if it is provided by the library being instrumented. If the operation is acting upon an anonymous table, or more than one table, this value MUST NOT be set.
 <!-- endsemconv -->
 
 ## Examples


### PR DESCRIPTION
Fixes #1104

## Changes

This PR adds a new attribute to the trace semantic conventions for database operations: `db.table`, and adds guidance that this attribute should be set only if the value is readily available from the library being instrumented. 
It also changes the guidance around `db.operation` to indicate that it should be set to the SQL keyword, but also only if the value is readily available from the library being instrumented.

