### PR TITLE
Remove the need to maintain third party propagators.

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -321,18 +321,7 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray (Note, AWS is used as an example, not as a requirement) trace header
-protocol can be either maintained and distributed by their respective vendors or
-as part of the OpenTelemetry organization. The reasons for maintaining those as
-a community are:
-
-- Propagators are small pieces of code and their functionality is often publicly
-  documented (unlike exporters).
-- People will often need to use propagators that are not specific to their
-  tracing or metrics vendor. For example, customers of tracing vendor may still
-  want to use an Cloud vendor-specific propagator for requests to the services
-  of this cloud vendor.
-- Only a small number of propagators will need to exist, and this number will
-  shrink as vendors and users shift to W3C TraceContext.
+protocol MUST be maintained and distributed by their respective vendors.
 
 ### B3 Requirements
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -320,8 +320,10 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 * [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format).
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
-X-Ray (Note, AWS is used as an example, not as a requirement) trace header
-protocol MUST be maintained and distributed by their respective vendors.
+X-Ray trace header protocol MUST NOT be maintained nor distributed as part of
+the core OpenTelemetry repositories.
+
+Note: AWS is used as an example, not as a requirement.
 
 ### B3 Requirements
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -323,8 +323,6 @@ Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of
 the Core OpenTelemetry repositories.
 
-Note: AWS is used as an example, not as a requirement.
-
 ### B3 Requirements
 
 B3 has both single and multi-header encodings. It also has semantics that do not

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -321,7 +321,7 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of
-the core OpenTelemetry repositories.
+the Core OpenTelemetry repositories.
 
 Note: AWS is used as an example, not as a requirement.
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -320,7 +320,7 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 * [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format).
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
-X-Ray trace header protocol MUST NOT be maintained nor distributed as part of
+X-Ray trace header protocol MUST NOT be maintained or distributed as part of
 the core OpenTelemetry repositories.
 
 Note: AWS is used as an example, not as a requirement.


### PR DESCRIPTION
Initial addressing of #1047 

## Changes

OTel repos won't initially contain any third party propagator (such as OT or AWS). @alolita will do the related follow-up, but this is a first step to put us back in the [original agreement](https://github.com/open-telemetry/opentelemetry-specification/issues/1047#issuecomment-703748553).