### PR TITLE
Replace CAN with MAY

### DIFF
--- a/experimental/trace/zpages.md
+++ b/experimental/trace/zpages.md
@@ -86,19 +86,19 @@ Each zPages implementation MUST create a wrapper class for zPages, since they al
 
 ### HTTP Server
 
-All zPages MUST have a HTTP Server to render information on a webpage when a host:port and endpoint is accessed. All zPages MUST be accessed from the same host:port; For example, host1 should equal host2 and port1 should equal port2 for `host1:post1/tracez` and `host2:port2/rpcz`. There SHOULD be handlers to group logic by type of zPage, and there SHOULD be a landing page. This landing page would be at the root `host:port/`, displaying links to currently implemented zPages for that repository. Similar behavior CAN be implemented for any invalid endpoints as well.
+All zPages MUST have a HTTP Server to render information on a webpage when a host:port and endpoint is accessed. All zPages MUST be accessed from the same host:port; For example, host1 should equal host2 and port1 should equal port2 for `host1:post1/tracez` and `host2:port2/rpcz`. There SHOULD be handlers to group logic by type of zPage, and there SHOULD be a landing page. This landing page would be at the root `host:port/`, displaying links to currently implemented zPages for that repository. Similar behavior MAY be implemented for any invalid endpoints as well.
 
 Traditionally, zPages have approached this by rendering web pages purely on the server-side. This means the server would only serve static resources (HTML, CSS and possibly Javascript) when the user accesses a given endpoint. Based on the type of zPage and the server language used, a pure server-side approach would generate HTML pages using hardcoded strings from scratch or using a template; this would tightly couple the data and UI layer.
 
 The following endpoints SHOULD be used for serving files (which are ideally standardized, per the [Shared Static Files](#shared-static-files) sections under future possibilities), for any HTTP server approach for any zPage:
 
 - `host:port/{zpage}` display the main page and aggregations
-- `host:port/{zpage}/style.css` SHOULD contain the styling logic. This CAN also be embedded in the HTML, but SHOULD be separated and linked in the page head using `<link rel="stylesheet" href="/{zpage}/style.css">`
+- `host:port/{zpage}/style.css` SHOULD contain the styling logic. This MAY also be embedded in the HTML, but SHOULD be separated and linked in the page head using `<link rel="stylesheet" href="/{zpage}/style.css">`
 - If server-side only:
   - `host:port/{zpage}/{...}`, and other variants SHOULD display detailed information on the data described by the {...}
     - an example of this: If a user accesses `host:port/tracez?type=error&name=span1`, that Tracez page should display all currently sampled error spans with the name `span1`
 - If adding client-side:
-  - `host:port/{zpage}/script.js` SHOULD return the frontend Javascript code if these zPages uses client-side interaction. This CAN also be embedded in the HTML, but SHOULD be separated and linked in the page head using `<script src="/{zpage}/script.js">`
+  - `host:port/{zpage}/script.js` SHOULD return the frontend Javascript code if these zPages uses client-side interaction. This MAY also be embedded in the HTML, but SHOULD be separated and linked in the page head using `<script src="/{zpage}/script.js">`
 
 All zPages need some server-side rendering, but the data and UI layer MAY be separated by adding client-side functionality. This separation has benefits including 1.) allowing users to consume zPages data without a browser, styling, or Javascript, such as when using wget on the endpoints serving JSON data and 2.) adding extensibility to zPages (e.g. the frontend can be centralized and used in multiple  OTel language repositories). This approach is detailed below.
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -67,7 +67,7 @@ Carriers used at [Inject](#inject) are expected to be mutable.
 
 `Propagator`s MUST define `Inject` and `Extract` operations, in order to write
 values to and read values from carriers respectively. Each `Propagator` type MUST define the specific carrier type
-and CAN define additional parameters.
+and MAY define additional parameters.
 
 #### Inject
 

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -19,7 +19,7 @@
 At least one of `process.executable.name`, `process.executable.path`, `process.command`, or `process.command_line` is required.
 
 `process.runtime.name` SHOULD be set to one of the values listed below, unless more detailed instructions are provided.
-If none of the listed values apply, a custom value best describing the runtime CAN be used.
+If none of the listed values apply, a custom value best describing the runtime MAY be used.
 
 ***Erlang Runtimes:***
 


### PR DESCRIPTION
## Changes

"CAN" is not a standard normative word used in specs. Replace with MAY.

"CAN" indicates the ability. "MAY" indicates permissibility, which is the concern of the spec.