### PR TITLE
Clarify primitive values in an array are nullable

### DIFF
--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -17,7 +17,7 @@ Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have 
 - The attribute key, which MUST be a non-`null` and non-empty string.
 - The attribute value, which is either:
   - A primitive type: string, boolean, double precision floating point (IEEE 754-1985) or signed 64 bit integer.
-  - An array of primitive type values. The array MUST be homogeneous,
+  - An array of nullable primitive type values. The array MUST be homogeneous,
     i.e. it MUST NOT contain values of different types. For protocols that do
     not natively support array values such values SHOULD be represented as JSON strings.
 


### PR DESCRIPTION
This is just an idea - it may just be me but I generally feel a primitive type isn't nullable. Does anyone else think that? Having the word nullable here makes me less confused, "why does it talk about null below even though we're talking about primitive types". 