### PR TITLE
Clarify the location of tracing's Context interaction.

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -149,9 +149,8 @@ the following functionality:
 - Set the currently active span to the implicit context. This is equivalent to getting the implicit context, then inserting the `Span` to the context.
 
 All the above functionalities operate solely on the context API, and they MAY be
-exposed as either static methods on the trace module or as static methods on a class
-inside the trace module. This functionality
-SHOULD be fully implemented in the API when possible.
+exposed as either static methods on the trace module, or as static methods on a class
+inside the trace module. This functionality SHOULD be fully implemented in the API when possible.
 
 ## Tracer
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -149,7 +149,7 @@ the following functionality:
 - Set the currently active span to the implicit context. This is equivalent to getting the implicit context, then inserting the `Span` to the context.
 
 All the above functionalities operate solely on the context API, and they MAY be
-exposed as either static methods on the trace module, as static methods on a class
+exposed as either static methods on the trace module or as static methods on a class
 inside the trace module. This functionality
 SHOULD be fully implemented in the API when possible.
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -150,7 +150,7 @@ the following functionality:
 
 All the above functionalities operate solely on the context API, and they MAY be
 exposed as either static methods on the trace module, as static methods on a class
-inside the trace module, or on the [`Tracer`](#tracer) class. This functionality
+inside the trace module. This functionality
 SHOULD be fully implemented in the API when possible.
 
 ## Tracer

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -149,10 +149,9 @@ the following functionality:
 - Set the currently active span to the implicit context. This is equivalent to getting the implicit context, then inserting the `Span` to the context.
 
 All the above functionalities operate solely on the context API, and they MAY be
-exposed as static methods on the trace module, as static methods on a class
-inside the trace module (it MAY be named `TracingContextUtilities`), or on the
-[`Tracer`](#tracer) class. This functionality SHOULD be fully implemented in the
-API when possible.
+exposed as either static methods on the trace module, as static methods on a class
+inside the trace module, or on the [`Tracer`](#tracer) class. This functionality
+SHOULD be fully implemented in the API when possible.
 
 ## Tracer
 


### PR DESCRIPTION
Clarifies the location of the tracing interaction with `Context`, i.e. we want to say that this logic can exist **anywhere** in the API, as long as it exists in a single place.

The mention of a `TracingContextUtils` class seemed like a *too-specific* suggestion, hence the removal (in Java we had this class, but ended up putting the `Context` interaction as static/instance `Span` directly).