### PR TITLE
Add OTEL_TRACE_SAMPLER_TRACEIDRATIO_RATIO env variable definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ New:
 
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.
   ([#1103](https://github.com/open-telemetry/opentelemetry-specification/pull/1103))
-- Add OTEL_TRACE_SAMPLING_PROBABILITY env variable definition
-  ([#1117](https://github.com/open-telemetry/opentelemetry-specification/pull/1117))
 - Rename "Canonical status code" to "Status code"
   ([#1081](https://github.com/open-telemetry/opentelemetry-specification/pull/1081))
 - Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation
@@ -63,6 +61,8 @@ New:
   ([#937](https://github.com/open-telemetry/opentelemetry-specification/pull/937))
 - Add OTEL_TRACE_SAMPLER env variable definition
   ([#1136](https://github.com/open-telemetry/opentelemetry-specification/pull/1136/))
+- Add OTEL_TRACE_SAMPLER_TRACEIDRATIO_RATIO env variable definition
+  ([#1190](https://github.com/open-telemetry/opentelemetry-specification/pull/1190))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ New:
 
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.
   ([#1103](https://github.com/open-telemetry/opentelemetry-specification/pull/1103))
+- Add OTEL_SAMPLING_PROBABILITY env variable definition
+  ([#1117](https://github.com/open-telemetry/opentelemetry-specification/pull/1117))
 - Rename "Canonical status code" to "Status code"
   ([#1081](https://github.com/open-telemetry/opentelemetry-specification/pull/1081))
 - Add Metadata for Baggage entries, and clarify W3C Baggage Propagator implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ New:
 
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.
   ([#1103](https://github.com/open-telemetry/opentelemetry-specification/pull/1103))
-- Add OTEL_SAMPLING_PROBABILITY env variable definition
+- Add OTEL_TRACE_SAMPLING_PROBABILITY env variable definition
   ([#1117](https://github.com/open-telemetry/opentelemetry-specification/pull/1117))
 - Rename "Canonical status code" to "Status code"
   ([#1081](https://github.com/open-telemetry/opentelemetry-specification/pull/1081))

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -127,7 +127,11 @@ status of the feature is not known.
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   |    |   |      |    |      |   |    |   |    |
+<<<<<<< HEAD
 |OTEL_TRACE_SAMPLER                            |   |    |   |      |    |      |   |    |   |    |
+=======
+|OTEL_SAMPLING_PROBABILITY                     |   |    |   |      |    |      |   |    |   |    |
+>>>>>>> Add OTEL_SAMPLING_PROBABILITY env variable definition
 
 ## Exporters
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -127,11 +127,8 @@ status of the feature is not known.
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   |    |   |      |    |      |   |    |   |    |
-<<<<<<< HEAD
 |OTEL_TRACE_SAMPLER                            |   |    |   |      |    |      |   |    |   |    |
-=======
-|OTEL_SAMPLING_PROBABILITY                     |   |    |   |      |    |      |   |    |   |    |
->>>>>>> Add OTEL_SAMPLING_PROBABILITY env variable definition
+|OTEL_TRACE_SAMPLING_PROBABILITY               |   |    |   |      |    |      |   |    |   |    |
 
 ## Exporters
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -128,7 +128,7 @@ status of the feature is not known.
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   |    |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   |    |   |      |    |      |   |    |   |    |
 |OTEL_TRACE_SAMPLER                            |   |    |   |      |    |      |   |    |   |    |
-|OTEL_TRACE_SAMPLING_PROBABILITY               |   |    |   |      |    |      |   |    |   |    |
+|OTEL_TRACE_SAMPLER_TRACEIDRATIO_RATIO         |   |    |   |      |    |      |   |    |   |    |
 
 ## Exporters
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -10,7 +10,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"           | See [Sampling](./trace/sdk.md#sampling) |
-| OTEL_TRACE_SAMPLING_PROBABILITY| Sampling probability, a number in the [0..1] range, e.g. 0.25| 1                |                                     |
+| OTEL_TRACE_SAMPLER_TRACEIDRATIO_RATIO | Sampling probability, a number in the [0..1] range, e.g. 0.25 | 1        | The specified value will only be used if OTEL_TRACER_SAMPLER is set to "traceidratio" |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -9,11 +9,8 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes |                                   | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
-<<<<<<< HEAD
-| OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
-=======
-| OTEL_SAMPLING_PROBABILITY| Sampling probability, a number in the [0..1] range| 1                                 |                                     |
->>>>>>> Add OTEL_SAMPLING_PROBABILITY env variable definition
+| OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"           | See [Sampling](./trace/sdk.md#sampling) |
+| OTEL_TRACE_SAMPLING_PROBABILITY| Sampling probability, a number in the [0..1] range, e.g. 0.25| 1                |                                     |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -10,7 +10,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"           | See [Sampling](./trace/sdk.md#sampling) |
-| OTEL_TRACE_SAMPLER_TRACEIDRATIO_RATIO | Sampling probability, a number in the [0..1] range, e.g. 0.25 | 1        | The specified value will only be used if OTEL_TRACER_SAMPLER is set to "traceidratio" |
+| OTEL_TRACE_SAMPLER_TRACEIDRATIO_RATIO | Sampling probability, a number in the [0..1] range, e.g. 0.25 | 0.01        | The specified value will only be used if OTEL_TRACER_SAMPLER is set to "traceidratio" or "parentbased_traceidratio" |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -9,7 +9,11 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes |                                   | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
+<<<<<<< HEAD
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
+=======
+| OTEL_SAMPLING_PROBABILITY| Sampling probability, a number in the [0..1] range| 1                                 |                                     |
+>>>>>>> Add OTEL_SAMPLING_PROBABILITY env variable definition
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".


### PR DESCRIPTION
Fixes #1105 

Opened on behalf of #1117 - a few of the pending issues to discuss/address:

* Any additional instructions on how this should work?
* Is it enough to have a simple clarification on this env var used only in conjunction with the TraceIdRatio Sampler?
* A follow-up should come, mentioning how this and other env-vars (such as `OTEL_PROPAGATORS`) are meant to be primarily used by Auto-Instrumentation, and not by SDKs yet.

cc @jkwatson @cijothomas @Oberon00 