### PR TITLE
Add OTEL_TRACE_SAMPLER_ARG env variable definition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ New:
   ([#937](https://github.com/open-telemetry/opentelemetry-specification/pull/937))
 - Add OTEL_TRACE_SAMPLER env variable definition
   ([#1136](https://github.com/open-telemetry/opentelemetry-specification/pull/1136/))
+- Add OTEL_TRACE_SAMPLER_ARG env variable definition
+  ([#1202](https://github.com/open-telemetry/opentelemetry-specification/pull/1202))
 
 Updates:
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -128,6 +128,7 @@ status of the feature is not known.
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   | +  |   |      |    |      |   |    |   |    |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   | +  |   |      |    |      |   |    |   |    |
 |OTEL_TRACE_SAMPLER                            |   | -  |   |      |    |      |   |    |   |    |
+|OTEL_TRACE_SAMPLER_ARG                        |   |    |   |      |    |      |   |    |   |    |
 
 ## Exporters
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -24,9 +24,9 @@ Known values for `OTEL_TRACE_SAMPLER` are:
 - `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
 - `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
 
-Known values for `OTEL_TRACE_SAMPLER_ARG` are:
+Depending on the value of `OTEL_TRACE_SAMPLER`, `OTEL_TRACE_SAMPLER_ARG` may be set as follows:
 
-- `traceidratio` and `parentbased_traceidratio`: Sampling probability, a number in the [0..1] range, e.g. "0.25".
+- For `traceidratio` and `parentbased_traceidratio` samplers: Sampling probability, a number in the [0..1] range, e.g. "0.25".
 
 ## Batch Span Processor
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -10,7 +10,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
-| OTEL_TRACE_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACE_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST NOT result in an error.  |
+| OTEL_TRACE_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACE_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST be otherwise ignored, i.e. the SDK MUST behave as if OTEL_TRACE_SAMPLER_ARG is not set.  |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -10,6 +10,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
 | OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. Unrecognized values MUST generate a warning and be gracefully ignored. |
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
+| OTEL_TRACE_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACE_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST NOT result in an error.  |
 
 Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "jaeger".
 Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".
@@ -22,6 +23,10 @@ Known values for `OTEL_TRACE_SAMPLER` are:
 - `"parentbased_always_on"`: `ParentBased(root=AlwaysOnSampler)`
 - `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
 - `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
+
+Known values for `OTEL_TRACE_SAMPLER_ARG` are:
+
+- `traceidratio` and `parentbased_traceidratio`: A number in the [0..1] range, e.g. 0.25.
 
 ## Batch Span Processor
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -26,7 +26,7 @@ Known values for `OTEL_TRACE_SAMPLER` are:
 
 Known values for `OTEL_TRACE_SAMPLER_ARG` are:
 
-- `traceidratio` and `parentbased_traceidratio`: A number in the [0..1] range, e.g. 0.25.
+- `traceidratio` and `parentbased_traceidratio`: Sampling probability, a number in the [0..1] range, e.g. "0.25".
 
 ## Batch Span Processor
 


### PR DESCRIPTION
Fixes #1105 
Closes #1190 (alternative solution)

## Changes

It was discussed in the latest TC meeting trying out the approach taken by [Jaeger](https://github.com/jaegertracing/jaeger-client-java/blob/master/jaeger-core/src/main/java/io/jaegertracing/Configuration.java#L122), which uses two environment variables to configure samplers:

1) JAEGER_SAMPLER_TYPE
2) JAEGER_SAMPLER_PARAM: the Sampler-specific parameters (as defined by each specific type).

This way, each `Sampler` will use the same environment variable, and we could even extend the future expected input, i.e. accept json.