### PR TITLE
Use MUST consistently instead of shall.

### DIFF
--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -57,7 +57,7 @@ OPTIONAL parameters:
 ### Get baggage
 
 To access the value for a name/value pair by a prior event, the Baggage API
-SHALL provide a function that takes a context and a name as input, and returns a
+MUST provide a function that takes a context and a name as input, and returns a
 value. Returns the value associated with the given name, or null
 if the given name is not present.
 
@@ -71,7 +71,7 @@ OPTIONAL parameters:
 
 ### Set baggage
 
-To record the value for a name/value pair, the Baggage API SHALL provide a function which
+To record the value for a name/value pair, the Baggage API MUST provide a function which
 takes a context, a name, and a value as input. Returns a new `Context` which
 contains a `Baggage` with the new value.
 
@@ -90,7 +90,7 @@ for a string with no semantic meaning. Left opaque to allow for future functiona
 
 ### Remove baggage
 
-To delete a name/value pair, the Baggage API SHALL provide a function which takes a context
+To delete a name/value pair, the Baggage API MUST provide a function which takes a context
 and a name as input. Returns a new `Context` which no longer contains the selected name.
 
 REQUIRED parameters:
@@ -103,7 +103,7 @@ OPTIONAL parameters:
 
 ### Clear
 
-To avoid sending any name/value pairs to an untrusted process, the Baggage API SHALL provide
+To avoid sending any name/value pairs to an untrusted process, the Baggage API MUST provide
 a function to remove all baggage entries from a context. Returns a new `Context`
 with no `Baggage`.
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -75,7 +75,7 @@ Often such destinations are unnamed or have an auto-generated name.
 
 ## Conventions
 
-Given these definitions, the remainder of this section describes the semantic conventions that shall be followed for Spans describing interactions with messaging systems.
+Given these definitions, the remainder of this section describes the semantic conventions that MUST be followed for Spans describing interactions with messaging systems.
 
 ### Span name
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -75,7 +75,7 @@ Often such destinations are unnamed or have an auto-generated name.
 
 ## Conventions
 
-Given these definitions, the remainder of this section describes the semantic conventions that MUST be followed for Spans describing interactions with messaging systems.
+Given these definitions, the remainder of this section describes the semantic conventions for Spans describing interactions with messaging systems.
 
 ### Span name
 


### PR DESCRIPTION
Randomly noticed this - removes usage of SHALL for MUST which is much more common in our spec, and means the same. Consistency can reduce some cognitive load.