### PR TITLE
Remove ordering reqirement for attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ New:
 
 Updates:
 
-- Remove ordering SHOULD-requirement for attributes.
+- Remove ordering SHOULD-requirement for attributes
+  ([#1212](https://github.com/open-telemetry/opentelemetry-specification/pull/1212))
 - Make `process.pid` optional, split `process.command_args` from `command_line`
   ([#1137](https://github.com/open-telemetry/opentelemetry-specification/pull/1137))
 - Renamed `CorrelationContext` to `Baggage`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ New:
 
 Updates:
 
+- Remove ordering SHOULD-requirement for attributes.
 - Make `process.pid` optional, split `process.command_args` from `command_line`
   ([#1137](https://github.com/open-telemetry/opentelemetry-specification/pull/1137))
 - Renamed `CorrelationContext` to `Baggage`:

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -21,8 +21,6 @@ Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have 
     i.e. it MUST NOT contain values of different types. For protocols that do
     not natively support array values such values SHOULD be represented as JSON strings.
 
-Attributes SHOULD preserve the order in which they're set.
-
 Attribute values expressing a numerical value of zero, an empty string, or an
 empty array are considered meaningful and MUST be stored and passed on to
 processors / exporters.


### PR DESCRIPTION
Fixes #1203

## Changes

Removes ordering requirement for attributes for now.

## Motivation

If we decide this is helpful, we can add it back after GA. But if we have it in GA and decide it is not worth it (e.g. for performance reasons), removing this would be a potentially breaking change for users.

CC @jkwatson 