### PR TITLE
Nulls SHOULD NOT be allowed in arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ New:
 
 Updates:
 
-- Clarify null SHOULD NOT be allowed even in arrays.
+- Clarify null SHOULD NOT be allowed even in arrays
+  ([#1214](https://github.com/open-telemetry/opentelemetry-specification/pull/1214))
 - Make `process.pid` optional, split `process.command_args` from `command_line`
   ([#1137](https://github.com/open-telemetry/opentelemetry-specification/pull/1137))
 - Renamed `CorrelationContext` to `Baggage`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ New:
 
 Updates:
 
+- Clarify null SHOULD NOT be allowed even in arrays.
 - Make `process.pid` optional, split `process.command_args` from `command_line`
   ([#1137](https://github.com/open-telemetry/opentelemetry-specification/pull/1137))
 - Renamed `CorrelationContext` to `Baggage`:

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -30,6 +30,9 @@ processors / exporters.
 Attribute values of `null` are not valid and attempting to set a `null` value is
 undefined behavior.
 
+`null` values SHOULD NOT be allowed in arrays. However, if it is impossible to
+make sure that no `null` values are accepted
+(e.g. in languages that do not have appropriate compile-time type checking),
 `null` values within arrays MUST be preserved as-is (i.e., passed on to span
 processors / exporters as `null`). If exporters do not support exporting `null`
 values, they MAY replace those values by 0, `false`, or empty strings.


### PR DESCRIPTION
Fixes #1213, closes #1155.

## Changes

Clarify null SHOULD NOT be allowed even in arrays.

CC @anuraaga 