### PR TITLE
Change default OTLP port number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,10 @@ release.
 
 New:
 
-<<<<<<< HEAD
 - Document service name mapping for Jaeger exporters
   ([1222](https://github.com/open-telemetry/opentelemetry-specification/pull/1222))
-=======
 - Change default OTLP port number
   ([#1221](https://github.com/open-telemetry/opentelemetry-specification/pull/1221))
->>>>>>> Change default OTLP port number
 - Add performance benchmark specification
   ([#748](https://github.com/open-telemetry/opentelemetry-specification/pull/748))
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,13 @@ release.
 
 New:
 
+<<<<<<< HEAD
 - Document service name mapping for Jaeger exporters
   ([1222](https://github.com/open-telemetry/opentelemetry-specification/pull/1222))
+=======
+- Change default OTLP port number
+  ([#1221](https://github.com/open-telemetry/opentelemetry-specification/pull/1221))
+>>>>>>> Change default OTLP port number
 - Add performance benchmark specification
   ([#748](https://github.com/open-telemetry/opentelemetry-specification/pull/748))
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -8,7 +8,7 @@ The following configuration options MUST be available to configure the OTLP expo
 
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
-| Endpoint             | Target to which the exporter is going to send spans or metrics. This MAY be configured to include a path (e.g. `example.com/v1/traces`). | `localhost:55680` | `OTEL_EXPORTER_OTLP_ENDPOINT` `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
+| Endpoint             | Target to which the exporter is going to send spans or metrics. This MAY be configured to include a path (e.g. `example.com/v1/traces`). | `localhost:4317` | `OTEL_EXPORTER_OTLP_ENDPOINT` `OTEL_EXPORTER_OTLP_SPAN_ENDPOINT` `OTEL_EXPORTER_OTLP_METRIC_ENDPOINT` |
 | Protocol             | The protocol used to transmit the data. One of `grpc`,`http/json`,`http/protobuf`. | `grpc`               | `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL` `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL` |
 | Insecure             | Whether to enable client transport security for the exporter's `grpc` or `http` connection. | `false`           | `OTEL_EXPORTER_OTLP_INSECURE` `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | Path to certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_CERTIFICATE` `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
@@ -26,7 +26,7 @@ Example 1
 The following configuration sends all signals to the same collector:
 
 ```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT=collector:55680
+export OTEL_EXPORTER_OTLP_ENDPOINT=collector:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ```
 
@@ -35,7 +35,7 @@ Example 2
 Traces and metrics are sent to different collectors using different protocols:
 
 ```bash
-export OTEL_EXPORTER_OTLP_SPAN_ENDPOINT=collector:55680
+export OTEL_EXPORTER_OTLP_SPAN_ENDPOINT=collector:4317
 export OTEL_EXPORTER_OTLP_SPAN_PROTOCOL=grpc
 export OTEL_EXPORTER_OTLP_SPAN_INSECURE=true
 
@@ -48,7 +48,7 @@ Example 3
 Traces are configured using the generic configuration, metrics are configured using specific configuration:
 
 ```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT=collector:55680
+export OTEL_EXPORTER_OTLP_ENDPOINT=collector:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=collector.example.com/v1/metrics

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -289,7 +289,7 @@ some in beta.
 
 #### Default Port
 
-The default network port for OTLP/gRPC is 55680.
+The default network port for OTLP/gRPC is 4317.
 
 ### OTLP/HTTP
 
@@ -445,7 +445,7 @@ connections SHOULD be configurable.
 
 #### Default Port
 
-The default network port for OTLP/HTTP is 55681. There is currently an [open
+The default network port for OTLP/HTTP is 4318. There is currently an [open
 issue](https://github.com/open-telemetry/opentelemetry-collector/issues/1256) to
 use the same port for OTLP/gRPC and OTLP/HTTP. In that case this spec will be
 updated to use the same default port for OTLP/gRPC and OTLP/HTTP.

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -445,10 +445,7 @@ connections SHOULD be configurable.
 
 #### Default Port
 
-The default network port for OTLP/HTTP is 4318. There is currently an [open
-issue](https://github.com/open-telemetry/opentelemetry-collector/issues/1256) to
-use the same port for OTLP/gRPC and OTLP/HTTP. In that case this spec will be
-updated to use the same default port for OTLP/gRPC and OTLP/HTTP.
+The default network port for OTLP/HTTP is 4317.
 
 ## Implementation Recommendations
 


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-specification/issues/1148

Note that a separate port is used for OTLP/HTTP for now. There is currently work
in progress to confirm that we can use the same port. Once we have the confirmation
I will update the spec again to use one port.
