### PR TITLE
[jaeger exporter] Document mapping of service name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 New:
 
+- Document service name mapping for Jaeger exporters
+  ([1222](https://github.com/open-telemetry/opentelemetry-specification/pull/1222))
 - Add performance benchmark specification
   ([#748](https://github.com/open-telemetry/opentelemetry-specification/pull/748))
 - Enforce that the Baggage API must be fully functional, even without an installed SDK.

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -18,8 +18,12 @@ and Jaeger.
 
 ### Resource
 
-OpenTelemetry resources MUST be mapped to Jaeger process tags. Multiple resources can exist for a
+OpenTelemetry resources MUST be mapped to Jaeger's `Span.Process` tags. Multiple resources can exist for a
 single process and exporters need to handle this case accordingly.
+
+Critically, Jaeger backend depends on `Span.Process.ServiceName` to identify the service
+that produced the spans. That field MUST be populated from the `service.name` attribute
+of the [`service` resource](../../../resource/semantic_conventions#service).
 
 ### InstrumentationLibrary
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -23,7 +23,7 @@ single process and exporters need to handle this case accordingly.
 
 Critically, Jaeger backend depends on `Span.Process.ServiceName` to identify the service
 that produced the spans. That field MUST be populated from the `service.name` attribute
-of the [`service` resource](../../resource/semantic_conventions.md#service).
+of the [`service` resource](../../resource/semantic_conventions/README.md#service).
 
 ### InstrumentationLibrary
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -23,7 +23,7 @@ single process and exporters need to handle this case accordingly.
 
 Critically, Jaeger backend depends on `Span.Process.ServiceName` to identify the service
 that produced the spans. That field MUST be populated from the `service.name` attribute
-of the [`service` resource](../../resource/semantic_conventions#service).
+of the [`service` resource](../../resource/semantic_conventions.md#service).
 
 ### InstrumentationLibrary
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -23,7 +23,7 @@ single process and exporters need to handle this case accordingly.
 
 Critically, Jaeger backend depends on `Span.Process.ServiceName` to identify the service
 that produced the spans. That field MUST be populated from the `service.name` attribute
-of the [`service` resource](../../../resource/semantic_conventions#service).
+of the [`service` resource](../../resource/semantic_conventions#service).
 
 ### InstrumentationLibrary
 


### PR DESCRIPTION
## Changes

Documents how service name must be mapped to Jaeger spans.