### PR TITLE
Add Post GA Workflow document.

### DIFF
--- a/post-ga-workflow.md
+++ b/post-ga-workflow.md
@@ -24,7 +24,8 @@ OTEPs are used as a mean to add entirely new components (such as logging) or to 
 
 ## Releases
 
-Minor releases are expected to approximately happen every 6 months, containing additive, non-breaking changes in the API, as mentioned above.
+Minor releases are expected to happen ad-hoc, containing additive, non-breaking changes in the API, as mentioned above.
+Releases with regular cadence will be considered in the future.
 
 Major releases are allowed to contain breaking changes in the API.
 

--- a/post-ga-workflow.md
+++ b/post-ga-workflow.md
@@ -4,12 +4,12 @@
 
 The following changes to the Specification v1.x will be allowed after GA:
 
-- Editorial changes.
-- API: additive, non-breaking changes. This is done in order to stay
+- API **additive** changes. This is done in order to stay
   compatible with previous versions. Adding entirely new API components,
   such as logging, is thus allowed.
 - SDK changes.
-- Semantic conventions for new libraries.
+- Editorial changes.
+- Semantic conventions additions.
 
 The `main` branch will always contain the latest changes, and branches will be used to track published releases.
 

--- a/post-ga-workflow.md
+++ b/post-ga-workflow.md
@@ -1,0 +1,31 @@
+# Post-GA Workflow
+
+## Specification Changes
+
+The following changes to the Specification v1.x will be allowed after GA:
+
+- Editorial changes.
+- API: additive, non-breaking changes. This is done in order to stay
+  compatible with previous versions. Adding entirely new API components,
+  such as logging, is thus allowed.
+- SDK changes.
+- Semantic conventions for new libraries.
+
+The `master` branch will always contain the latest changes, and branches will be used to track published releases.
+
+API-breaking changes can be accepted under `experimental` subdirectories.
+
+## OTEPS
+
+OTEPs are used as a mean to add entirely new components (such as logging) or to introduce API-breaking changes. They will have similar rules as Specification PRs regarding their lifetime:
+
+- OTEP PRs will be automatically marked stale after 14 days without activity.
+- OTEP PRs will be automatically closed 14 days after being marked stale.
+
+## Releases
+
+Minor releases are expected to approximately happen every 6 months, containing additive, non-breaking changes in the API, as mentioned above.
+
+Major releases are allowed to contain breaking changes in the API.
+
+Language SIGs releases MUST point to what Specification Tag/Version are they complying to.

--- a/post-ga-workflow.md
+++ b/post-ga-workflow.md
@@ -11,7 +11,7 @@ The following changes to the Specification v1.x will be allowed after GA:
 - SDK changes.
 - Semantic conventions for new libraries.
 
-The `master` branch will always contain the latest changes, and branches will be used to track published releases.
+The `main` branch will always contain the latest changes, and branches will be used to track published releases.
 
 API-breaking changes can be accepted under `experimental` subdirectories.
 

--- a/post-ga-workflow.md
+++ b/post-ga-workflow.md
@@ -15,7 +15,7 @@ The `main` branch will always contain the latest changes, and branches will be u
 
 API-breaking changes can be accepted under `experimental` subdirectories.
 
-## OTEPS
+## OTEPs
 
 OTEPs are used as a mean to add entirely new components (such as logging) or to introduce API-breaking changes. They will have similar rules as Specification PRs regarding their lifetime:
 


### PR DESCRIPTION
It was discussed in the @open-telemetry/technical-committee  that a document briefly describing the after-GA workflow would be great to add clarity - the contents of this document reflect the related discussion.