### PR TITLE
[Draft] Add http metrics translated from http metrics semconv table

### DIFF
--- a/semantic_conventions/metric/http.yaml
+++ b/semantic_conventions/metric/http.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: http
+  - id: metric.http
     prefix: http
     brief: 'This document defines semantic conventions for HTTP client and server Metrics.'
     note: >

--- a/semantic_conventions/metric/http.yaml
+++ b/semantic_conventions/metric/http.yaml
@@ -6,37 +6,37 @@ groups:
       These conventions can be used for http and https schemes
       and various HTTP versions like 1.1, 2 and SPDY.
     labels:
-      - id: http.method
+      - id: method
         type: string
         example: 'GET'
         brief: 'The HTTP request method'
-      - id: http.host
+      - id: host
         type: string
         example: 'www.example.com'
         brief: 'The value of the HTTP host header. When the header is empty or not present, this label should be the same.'
-      - id: http.scheme
+      - id: scheme
         type: string
         example: 'https'
         brief: 'The URI scheme identifying the used protocol in lowercase'
-      - id: http.status_code
+      - id: status_code
         type: string
         example: '200'
         brief: 'HTTP response status code'
-      - id: http.flavor
+      - id: flavor
         type: string
         example: [ '1.0', '1.1', '2', 'SPDY', 'QUIC' ]
         brief: 'Kind of HTTP protocol used'
     parameterizedLabels: # To avoid high cardinality the following labels SHOULD substitute any parameters when added as labels to http metric events
-      - id: http.url
+      - id: url
         type: string
         example: "api/users/{user_id}"
         brief: 'The originally requested URL'
-      - id: http.target
+      - id: target
         type: string
         example: "/path/{id}?q={}"
         brief: 'The full request target as passed in a HTTP request line or equivalent'
 
-  - id: http.client
+  - id: metric.http.client
     prefix: http
     extends: http
     brief: 'HTTP client metric instruments'
@@ -68,7 +68,7 @@ groups:
     brief: 'HTTP server metric instruments'
     note:
     labels:
-      - id: http.server_name
+      - id: server_name
         type: string
         example: 'localhost'
         brief: 'The primary server name of the matched virtual host'

--- a/semantic_conventions/metric/http.yaml
+++ b/semantic_conventions/metric/http.yaml
@@ -1,0 +1,92 @@
+groups:
+  - id: http
+    prefix: http
+    brief: 'This document defines semantic conventions for HTTP client and server Metrics.'
+    note: >
+      These conventions can be used for http and https schemes
+      and various HTTP versions like 1.1, 2 and SPDY.
+    labels:
+      - id: http.method
+        type: string
+        example: 'GET'
+        brief: 'The HTTP request method'
+      - id: http.host
+        type: string
+        example: 'www.example.com'
+        brief: 'The value of the HTTP host header. When the header is empty or not present, this label should be the same.'
+      - id: http.scheme
+        type: string
+        example: 'https'
+        brief: 'The URI scheme identifying the used protocol in lowercase'
+      - id: http.status_code
+        type: string
+        example: '200'
+        brief: 'HTTP response status code'
+      - id: http.flavor
+        type: string
+        example: [ '1.0', '1.1', '2', 'SPDY', 'QUIC' ]
+        brief: 'Kind of HTTP protocol used'
+    parameterizedLabels: # To avoid high cardinality the following labels SHOULD substitute any parameters when added as labels to http metric events
+      - id: http.url
+        type: string
+        example: "api/users/{user_id}"
+        brief: 'The originally requested URL'
+      - id: http.target
+        type: string
+        example: "/path/{id}?q={}"
+        brief: 'The full request target as passed in a HTTP request line or equivalent'
+
+  - id: http.client
+    prefix: http
+    extends: http
+    brief: 'HTTP client metric instruments'
+    note:
+    labels:
+      - id: net.peer.name
+        type: string
+        example: 'example.com'
+        brief: 'Remote hostname or similar'
+      - id: net.peer.port
+        type: number
+        example: 443
+        brief: 'Remote port number'
+      - id: net.peer.ip
+        type: string
+        example: '127.0.0.1'
+        brief: 'Remote address of the peer (dotted decimal for IPv4 or RFC5952 for IPv6)'
+
+  - id: http.client.duration
+    prefix: http
+    extends: http.client
+    instrument: ValueRecorder
+    units: milliseconds
+    brief: 'measure the duration of the outbound HTTP request'
+
+  - id: http.server
+    prefix: http
+    extends: http
+    brief: 'HTTP server metric instruments'
+    note:
+    labels:
+      - id: http.server_name
+        type: string
+        example: 'localhost'
+        brief: 'The primary server name of the matched virtual host'
+        note: >
+          This should be obtained via configuration. If no such configuration can be obtained,
+          this label MUST NOT be set ( net.host.name should be used instead).
+      - id: net.host.name
+        type: string
+        example: 'localhost'
+        brief: 'Local hostname or similar'
+      - id: net.host.port
+        type: number
+        example: 35555
+        brief: 'Like `net.peer.port` but for the host port'
+
+  - id: http.server.duration
+    prefix: http
+    extends: http.server
+    instrument: ValueRecorder
+    units: milliseconds
+    brief: 'measures the duration of the inbound HTTP request'


### PR DESCRIPTION
In our project we found the yaml code as configuration for semconv very useful, however, this is missing for metrics. This PR tries to add the HTTP metrics and if this structure is ok we'd like to move on to implement other types.

## Changes
Translated https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/metrics/semantic_conventions/http-metrics.md into yaml
