### PR TITLE
Updated exporter matrix for .NET library (part 2)

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -156,7 +156,7 @@ status of the feature is not known.
 |SpanKind mapping                              | + | +  | + | +    |    | +    | + | +  |   | +  |
 |InstrumentationLibrary mapping                |   | +  | - | +    |    | -    | - | +  |   | +  |
 |Boolean attributes                            | + | +  | + | +    |    | +    | + | +  |   | +  |
-|Array attributes                              | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1110)    |    | +    | + | +  |   |    |
+|Array attributes                              | + | +  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1110)    |    | +    | + | +  |   | +  |
 |Status mapping                                | + | +  | + | +    |    | +    | + | +  |   | +  |
 |Event attributes mapping to Annotations       | + | +  | + | +    |    | +    | + | +  |   | +  |
 |Integer microseconds in timestamps            |   | +  |   | +    |    |      |   |    |   | +  |


### PR DESCRIPTION
Related to #1254

## Changes

Missed one of the Zipkin items the .NET library supports.

/cc @cijothomas @reyang 