### PR TITLE
Update stale-pr.yaml

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -12,5 +12,6 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
         close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
+        exempt-pr-labels: 'release:after-ga'
         days-before-stale: 7
         days-before-close: 7


### PR DESCRIPTION
Stale bot will ignore PRs with 'release:after-ga' label