### PR TITLE
Allow cloud.* ad faas.* resource attributes to be set on span

### DIFF
--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -22,3 +22,7 @@
 | `azure` | Microsoft Azure |
 | `gcp` | Google Cloud Platform |
 <!-- endsemconv -->
+
+Note: When used in serverless function, all `cloud` resource attributes MAY also be used as span attributes.
+Some FaaS APIs do not provide a way to detect those attributes from the environment - they are passed as function
+parameters, available after the TracerProvider is instantiated; that makes it impossible to use them in a Resource.

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -23,6 +23,6 @@
 | `gcp` | Google Cloud Platform |
 <!-- endsemconv -->
 
-Note: When used in serverless function, all `cloud` resource attributes MAY also be used as span attributes.
+When used in serverless function, some or all `cloud` resource attributes MAY also be used as span attributes.
 Some FaaS APIs do not provide a way to detect those attributes from the environment - they are passed as function
 parameters, available after the TracerProvider is instantiated; that makes it impossible to use them in a Resource.

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -17,6 +17,6 @@
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).
 
-Note: All `faas` resource attributes MAY also be used as span attributes.
+Some or all `faas` resource attributes MAY also be used as span attributes.
 Some FaaS APIs do not provide a way to detect those attributes from the environment - they are passed as function
 parameters, available after the TracerProvider is instantiated; that makes it impossible to use them in a Resource.

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -16,3 +16,7 @@
 <!-- endsemconv -->
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).
+
+Note: All `faas` resource attributes MAY also be used as span attributes.
+Some FaaS APIs do not provide a way to detect those attributes from the environment - they are passed as function
+parameters, available after the TracerProvider is instantiated; that makes it impossible to use them in a Resource.


### PR DESCRIPTION
Fixes #1261

## Changes

Add a note to `faas` and `cloud` resource attributes that allows them to be used as span attributes in serverless functions.