### PR TITLE
Clarify that we are not referring to the Span's SpanContext itself, j…

### DIFF
--- a/specification/performance-benchmark.md
+++ b/specification/performance-benchmark.md
@@ -11,7 +11,7 @@ platform.
 
 ### Span Configuration
 
-- No parent `Span` and `SpanContext`.
+- No parent `Span` or parent `SpanContext`.
 - Default Span [Kind](./trace/api.md#spankind) and
   [Status](./trace/api.md#set-status).
 - Associated to a [resource](overview.md#resources) with attributes


### PR DESCRIPTION
…ust parent.

A teammate had a hard time understanding this bullet point since they thought `SpanContext` was referring to the `Span` itself, not parent (the `Span` will always have its `SpanContext`). This makes sure it's clear.
