### PR TITLE
Remove opaque when referring to baggage metadata

### DIFF
--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -85,8 +85,8 @@ REQUIRED parameters:
 
 OPTIONAL parameters:
 
-`Metadata` Optional metadata associated with the name-value pair. This should be an opaque wrapper
-for a string with no semantic meaning. Left opaque to allow for future functionality.
+`Metadata` Optional metadata associated with the name-value pair. This should be a wrapper
+for a string with no semantic meaning. We use a wrapper to allow for future functionality.
 
 `Context` The context containing the `Baggage` in which to set the baggage entry.
 


### PR DESCRIPTION
## Changes

I don't know if this is correct, but something probably is. In Java, we currently expose the String for a baggage metadata

https://github.com/open-telemetry/opentelemetry-java/blob/master/api/src/main/java/io/opentelemetry/api/baggage/EntryMetadata.java#L40

My understanding of opaque is to not expose internal details, for example the String. So I'd generally not use opaque for this - does it make sense without the word opaque? I guess the key point here is we use a wrapper, not a String directly, to allow for more functionality in the future.
