### PR TITLE
vendors: add details about vendors offering instrumented services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Updates:
   ([#1219](https://github.com/open-telemetry/opentelemetry-specification/pull/1219))
 - Add RPC semantic conventions for metrics
   ([#1162](https://github.com/open-telemetry/opentelemetry-specification/pull/1162))
+- Clarify what it will mean for a vendor of instrumented services to "support
+  OpenTelemetry" ([#1277](https://github.com/open-telemetry/opentelemetry-specification/pull/1277)).
 
 ## v0.7.0 (11-18-2020)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Technical committee holds regular meetings, notes are held
   - [Acronym](#acronym)
   - [Contributions](#contributions)
   - [License](#license)
+- [Vendor Guidelines](specification/vendors.md)
 
 ## Project Timeline
 

--- a/specification/vendors.md
+++ b/specification/vendors.md
@@ -27,16 +27,30 @@ The goal is for users to be able to easily switch between vendors while also
 ensuring that any language with an OpenTelemetry SDK implementation is able to
 work with any vendor who claims support for OpenTelemetry.
 
+Vendor means both services and applications which provide observability related
+functionality, like accepting and analyzing traces, as well as services and
+applications that are instrumented and propagate context, like an HTTP load
+balancer.
+
 This document will explain what is required of a vendor to be considered to
 "Support OpenTelemetry" or "Implements OpenTelemetry".
 
 ## Supports OpenTelemetry
+
+### Observability Services and Applications
 
 "Supports OpenTelemetry" means the vendor must accept the output of the default
 SDK through one of two mechanisms:
 
 - By providing an exporter for the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/) and / or the OpenTelemetry SDKs
 - By building a receiver for the [OpenTelemetry protocol](https://github.com/open-telemetry/opentelemetry-proto)
+
+### Instrumented Services and Applications
+
+A service or application can be said to "Support OpenTelemetry" if its
+instrumentation supports the W3C Trace Context propagation. The propagation used
+can be configurable, but when text based propagation is used then at least the
+W3C Trace Context must be offered.
 
 ## Implements OpenTelemetry
 


### PR DESCRIPTION
## Changes

This patch expands the spec related to vendors to include vendors providing non-observability services, but instead provde services or applications that are instrumented, like a proxy or a database.

This change was motivated by the AWS announcments and distros which seem to still require their custom trace propagators: https://aws.amazon.com/blogs/opensource/distributed-tracing-with-opentelemetry/