### PR TITLE
Add missing details closing tag

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -37,6 +37,8 @@ Table of Contents
 - [Glossary](#glossary)
 - [References](#references)
 
+</details>
+
 OTLP is a general-purpose telemetry data delivery protocol designed in the scope
 of OpenTelemetry project.
 


### PR DESCRIPTION
## Changes

It seems wired that the closing tag of `<details>` is missing. As a result, most of the content has been folded. 
Added a closing `</details>` tags to only fold the table of contents.

Before the change:
![image](https://user-images.githubusercontent.com/12531298/101312037-ccbd5080-3820-11eb-89d0-e153de96dacd.png)

After the change:
![image](https://user-images.githubusercontent.com/12531298/101312107-ef4f6980-3820-11eb-86c9-f8a35627dc9b.png)
