### PR TITLE
Introduce resource attribute `faas.max_memory`

### DIFF
--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -39,10 +39,8 @@ groups:
         brief: >
           The amount of memory available to the serverless function in MiB.
         note: >
+          It's recommended to set this attribute in since e.g. too little memory can easily
+          stop a Java AWS Lambda function from working correctly.
           On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`
           provides this information.
-        required:
-          conditional: >
-            Required for executions on serverless environments given that the
-            respective environment provides this information.
         examples: 128

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -37,7 +37,7 @@ groups:
       - id: max_memory
         type: number
         brief: >
-          The amount of memory available to the serverless function in MB.
+          The amount of memory available to the serverless function in MiB.
         note: >
           On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`
           provides this information.

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -34,3 +34,15 @@ groups:
         brief: >
           The execution environment ID as a string.
         examples: ['my-function:instance-0001']
+      - id: max_memory
+        type: number
+        brief: >
+          The amount of memory available to the serverless function in MB.
+        note: >
+          On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE`
+          provides this information.
+        required:
+          conditional: >
+            Required for executions on serverless environments given that the
+            respective environment provides this information.
+        examples: 128

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -11,13 +11,11 @@
 | `faas.id` | string | The unique ID of the function being executed. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Yes |
 | `faas.version` | string | The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes). | `2.0.0` | No |
 | `faas.instance` | string | The execution environment ID as a string. | `my-function:instance-0001` | No |
-| `faas.max_memory` | number | The amount of memory available to the serverless function in MiB. [2] | `128` | Conditional [3] |
+| `faas.max_memory` | number | The amount of memory available to the serverless function in MiB. [2] | `128` | No |
 
 **[1]:** For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field.
 
-**[2]:** On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
-
-**[3]:** Required for executions on serverless environments given that the respective environment provides this information.
+**[2]:** It's recommended to set this attribute in since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
 <!-- endsemconv -->
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -11,7 +11,7 @@
 | `faas.id` | string | The unique ID of the function being executed. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Yes |
 | `faas.version` | string | The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes). | `2.0.0` | No |
 | `faas.instance` | string | The execution environment ID as a string. | `my-function:instance-0001` | No |
-| `faas.max_memory` | number | The amount of memory available to the serverless function in MB. [2] | `128` | Conditional [3] |
+| `faas.max_memory` | number | The amount of memory available to the serverless function in MiB. [2] | `128` | Conditional [3] |
 
 **[1]:** For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field.
 

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -11,8 +11,13 @@
 | `faas.id` | string | The unique ID of the function being executed. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Yes |
 | `faas.version` | string | The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes). | `2.0.0` | No |
 | `faas.instance` | string | The execution environment ID as a string. | `my-function:instance-0001` | No |
+| `faas.max_memory` | number | The amount of memory available to the serverless function in MB. [2] | `128` | Conditional [3] |
 
 **[1]:** For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field.
+
+**[2]:** On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
+
+**[3]:** Required for executions on serverless environments given that the respective environment provides this information.
 <!-- endsemconv -->
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).


### PR DESCRIPTION
Fixes #

## Changes

This PR introduces the new attribute `max_memory` to the `faas` resource attributes. Maximum memory allocated to a serverless function is a useful metric since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly.