### PR TITLE
Update spec compliance matrix for Ruby

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -69,7 +69,7 @@ status of the feature is not known.
 |Allow samplers to modify tracestate           |   | +  |   | +    | +  | +    |   | +  |   |    |  +  |
 |ShouldSample gets full parent Context         |   | +  | + | +    | +  | +    |   |    |   |    |  +  |
 |[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |   |    |   | +    | +  |      |   |    |   |    | +   |
-|SDK Trace & Span ID generation is customizable| + | +  | + |  +   |    |      |   |    |   | +  |     |
+|SDK Trace & Span ID generation is customizable| + | +  | + |  +   | +  |      |   |    |   | +  |     |
 
 ## Baggage
 


### PR DESCRIPTION
Added customizable SDK Trace and Span ID generation: https://github.com/open-telemetry/opentelemetry-ruby/pull/529