### PR TITLE
Revert "Fix typo in cloud resource convention. (#1097)"

### DIFF
--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -13,7 +13,7 @@ groups:
               brief: 'Amazon Web Services'
             - id: Azure
               value: 'azure'
-              brief: 'Microsoft Azure'
+              brief: 'Amazon Web Services'
             - id: GCP
               value: 'gcp'
               brief: 'Google Cloud Platform'

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -19,6 +19,6 @@
 | Value  | Description |
 |---|---|
 | `aws` | Amazon Web Services |
-| `azure` | Microsoft Azure |
+| `azure` | Amazon Web Services |
 | `gcp` | Google Cloud Platform |
 <!-- endsemconv -->


### PR DESCRIPTION
This reverts commit e4d934945f6683097d3bfd3400039010ce90a4b1.

Fixes #

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
