### PR TITLE
Give guideline of not using unit names in attributes (#1053)

### DIFF
--- a/specification/common/attribute-and-label-naming.md
+++ b/specification/common/attribute-and-label-naming.md
@@ -49,6 +49,10 @@ Names SHOULD follow these rules:
   name prohibits existence of an equally named namespace in the future, and vice
   versa: any existing namespace prohibits existence of an equally named
   attribute or label key in the future.
+
+- Names should not contain unit names; neither should it contain a fraction of
+  the name's unit. For example, `http.request_content_length` does not have
+  bytes in its name.
   
 ## Name Pluralization guidelines
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -181,6 +181,8 @@ For batch receiving and processing (see the [Batch receiving](#batch-receiving) 
 Even though in that case one might think that the processing span's kind should be `INTERNAL`, that kind MUST NOT be used.
 Instead span kind should be set to either `CONSUMER` or `SERVER` according to the rules defined above.
 
+**Note:** The payload size names (`message_payload_compressed_size_bytes` and `message_payload_size_bytes`) don't comply with the [Attribute and Label Naming](../../common/attribute-and-label-naming.md), it should not contain `bytes`. This is due to historical reasons.
+
 ### Attributes specific to certain messaging systems
 
 #### RabbitMQ


### PR DESCRIPTION
Add a paragraph in the attribute name guidelines that discourage the use
of unit names and prefixes.

Add note about historical naming violation in messaging.md, the attribute names
message_payload_size_bytes and message_payload_compressed_size_bytes about the
incorrect use of bytes in the name.

Fixes #1053

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
