### PR TITLE
Simplify wording for 3rd party propagators to ensure consistency acro…

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -12,8 +12,7 @@ The goal of this specification is to unify the environment variable names betwee
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
 | OTEL_TRACE_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACE_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST be otherwise ignored, i.e. the SDK MUST behave as if OTEL_TRACE_SAMPLER_ARG is not set.  |
 
-Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "b3multi", "jaeger".
-Additional values can be specified in the respective SDK's documentation, in case third party `Propagator`s are supported, such as "xray" or "ottracer".
+Known values for OTEL_PROPAGATORS are: "tracecontext", "baggage", "b3", "b3multi", "jaeger", "xray", "ottracer".
 See [B3 propagation](./context/api-propagators.md#b3-requirements) for details regarding single and multi encoding.
 
 Known values for `OTEL_TRACE_SAMPLER` are:


### PR DESCRIPTION
…ss SDKs.

I suspect the current wording is out of an abundance of caution of leaving 3rd party stuff out of the spec as much as possible. But it seems to provide no real benefit - an SDK will naturally have configurations specific to that language or implementation and this does not need a special callout. On the flip side, the main reason to have the spec is to ensure configuration consistency among different languages. If we have values we recognize specifically, even if they're 3rd party, it seems to help everyone to make sure the values are consistent rather than leaving it to respective SDKs?