### PR TITLE
Fix .NET spec matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -69,7 +69,7 @@ status of the feature is not known.
 |Allow samplers to modify tracestate           |   | +  |   | +    | +  | +    |   | +  |   |    |  +  |
 |ShouldSample gets full parent Context         |   | +  | + | +    | +  | +    |   |    |   |    |  +  |
 |[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |   |    |   | +    | +  |      |   |    |   |    | +   |
-|SDK Trace & Span ID generation is customizable| + | +  | + |  +   | +  |      |   |    |   | +  |     |
+|SDK Trace & Span ID generation is customizable| + | +  | + |  +   | +  |      |   |    |   | -  |     |
 
 ## Baggage
 


### PR DESCRIPTION
SDK Trace & Span ID generation is customizable - this row was marked as done for .NET. This is not fully true.
1. For spanid, there is no customization allowed now.
2. For traceid, there is no proper support for this now. The id generation is part of the .NET runtime itself. Currently a workaround (https://github.com/open-telemetry/opentelemetry-dotnet-contrib/blob/master/src/OpenTelemetry.Contrib.Extensions.AWSXRay/AWSXRayIdGenerator.cs#L60) is used by AWSXRay generator, to somewhat achieve custom traceid generation.

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
