### PR TITLE
Split OTEL_EXPORTER to OTEL_TRACE_EXPORTER and OTEL_METRICS_EXPORTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Updates:
 
 - Additional Cassandra semantic attributes
   ([#1217](https://github.com/open-telemetry/opentelemetry-specification/pull/1217))
+- OTEL_EXPORTER environment variable replaced with OTEL_TRACE_EXPORTER and
+  OTEL_METRICS_EXPORTER which each accept only a single value, not a list.
+  ([#1318](https://github.com/open-telemetry/opentelemetry-specification/pull/1318))
 - `process.runtime.description` resource convention: Add `java.vm.name`
   ([#1242](https://github.com/open-telemetry/opentelemetry-specification/pull/1242))
 - Refine span name guideline for SQL database spans

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -126,7 +126,7 @@ status of the feature is not known.
 |OTEL_EXPORTER_OTLP_*                          |   | +  |   | +    | +  | -    | - |    | - | -  | -   |
 |OTEL_EXPORTER_JAEGER_*                        |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_ZIPKIN_*                        |   | +  |   | +    |    | -    | - |    | - | -  | -   |
-|OTEL_EXPORTER                                 |   | -  |   | +    |    |      |   |    |   |  - | -   |
+|OTEL_EXPORTERS                                |   | -  |   | -    |    |      |   |    |   | -  | -   |
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   | +  |   | +    | +  |      |   |    |   | -  | -   |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   | +  |   | +    | +  |      |   |    |   | -  | -   |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   | +  |   | +    | +  |      |   |    |   | -  | -   |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -126,7 +126,8 @@ status of the feature is not known.
 |OTEL_EXPORTER_OTLP_*                          |   | +  |   | +    | +  | -    | - |    | - | -  | -   |
 |OTEL_EXPORTER_JAEGER_*                        |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_ZIPKIN_*                        |   | +  |   | +    |    | -    | - |    | - | -  | -   |
-|OTEL_EXPORTERS                                |   | -  |   | -    |    |      |   |    |   | -  | -   |
+|OTEL_TRACE_EXPORTER                           |   | -  |   | -    |    |      |   |    |   | -  | -   |
+|OTEL_METRICS_EXPORTERS                        |   | -  |   | -    |    |      |   |    |   | -  | -   |
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   | +  |   | +    | +  |      |   |    |   | -  | -   |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   | +  |   | +    | +  |      |   |    |   | -  | -   |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   | +  |   | +    | +  |      |   |    |   | -  | -   |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -127,7 +127,7 @@ status of the feature is not known.
 |OTEL_EXPORTER_JAEGER_*                        |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_ZIPKIN_*                        |   | +  |   | +    |    | -    | - |    | - | -  | -   |
 |OTEL_TRACE_EXPORTER                           |   | -  |   | -    |    |      |   |    |   | -  | -   |
-|OTEL_METRICS_EXPORTERS                        |   | -  |   | -    |    |      |   |    |   | -  | -   |
+|OTEL_METRICS_EXPORTER                        |   | -  |   | -    |    |      |   |    |   | -  | -   |
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   | +  |   | +    | +  |      |   |    |   | -  | -   |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   |   | +  |   | +    | +  |      |   |    |   | -  | -   |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    |   | +  |   | +    | +  |      |   |    |   | -  | -   |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -75,13 +75,24 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 ## Exporter Selection
 
+We define environment variables for setting a single exporter per signal. SDKs SHOULD provide a means to
+set multiple exporters for a signal programmatically.
+
 | Name          | Description                                                                  | Default |
 | ------------- | ---------------------------------------------------------------------------- | ------- |
-| OTEL_EXPORTERS | Exporters to be used as a comma separated list | "otlp"  |
+| OTEL_TRACE_EXPORTER | Trace exporter to be used | "otlp"  |
+| OTEL_METRICS_EXPORTER | Metrics exporter to be used | "otlp"  |
 
-Known values for OTEL_EXPORTERS are: "otlp", "jaeger", "zipkin", "prometheus", "otlp_span", "otlp_metric".
+Known values for OTEL_TRACE_EXPORTER are:
 
-Note: "otlp" is equivalent to "otlp_span,otlp_metric".
+- `"otlp"`: [OTLP](./protocol/otlp.md)
+- `"jaeger"`: [Jaeger gRPC](https://www.jaegertracing.io/docs/1.21/apis/#protobuf-via-grpc-stable)
+- `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
+
+Known values for OTEL_METRICS_EXPORTER are:
+
+- `"otlp"`: [OTLP](./protocol/otlp.md)
+- `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
 
 ## Language Specific Environment Variables
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -77,9 +77,9 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 | Name          | Description                                                                  | Default |
 | ------------- | ---------------------------------------------------------------------------- | ------- |
-| OTEL_EXPORTER | Exporter to be used, can be a comma-separated list to use multiple exporters | "otlp"  |
+| OTEL_EXPORTERS | Exporters to be used as a comma separated list | "otlp"  |
 
-Known values for OTEL_EXPORTER are: "otlp", "jaeger", "zipkin", "prometheus", "otlp_span", "otlp_metric".
+Known values for OTEL_EXPORTERS are: "otlp", "jaeger", "zipkin", "prometheus", "otlp_span", "otlp_metric".
 
 Note: "otlp" is equivalent to "otlp_span,otlp_metric".
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -75,8 +75,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 ## Exporter Selection
 
-We define environment variables for setting a single exporter per signal. SDKs SHOULD provide a means to
-set multiple exporters for a signal programmatically.
+We define environment variables for setting a single exporter per signal.
 
 | Name          | Description                                                                  | Default |
 | ------------- | ---------------------------------------------------------------------------- | ------- |


### PR DESCRIPTION
Fixes #1309
Fixes #1313

## Changes

Splits `OTEL_EXPORTER` into two variables that only accept a single value. This makes the syntax of the variable consistent with others (singular name, singular value) and removes some corner cases in configuration caused by the previous list (multiple jaeger exporters accept different format for endpoint, push / pull metrics exporters can't be enabled at the same time, inconsistency in not having a way of enabling multiple exporters of a same type).
