### PR TITLE
Suffix OTLP TIMEOUT variable with MILLIS

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -123,7 +123,7 @@ status of the feature is not known.
 |OTEL_LOG_LEVEL                                |   | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1059)    | +  | -    | - |    | - | -  | -   |
 |OTEL_PROPAGATORS                              |   | -  |   | +    |    | -    | - |    | - | -  | -   |
 |OTEL_BSP_*                                    |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
-|OTEL_EXPORTER_OTLP_*                          |   | +  |   | +    | +  | -    | - |    | - | -  | -   |
+|OTEL_EXPORTER_OTLP_*                          |   | -  |   | -    | -  | -    | - |    | - | -  | -   |
 |OTEL_EXPORTER_JAEGER_*                        |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_ZIPKIN_*                        |   | +  |   | +    |    | -    | - |    | - | -  | -   |
 |OTEL_EXPORTER                                 |   | -  |   | +    |    |      |   |    |   |  - | -   |

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -14,7 +14,7 @@ The following configuration options MUST be available to configure the OTLP expo
 | Certificate File     | Path to certificate file for TLS credentials of gRPC client. Should only be used if `insecure` is set to `false`. | n/a               | `OTEL_EXPORTER_OTLP_CERTIFICATE` `OTEL_EXPORTER_OTLP_SPAN_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRIC_CERTIFICATE` |
 | Headers              | Key-value pairs to be used as headers associated with gRPC or HTTP requests. See [Specifying headers](./exporter.md#specifying-headers-via-environment-variables) for more details.                   | n/a               | `OTEL_EXPORTER_OTLP_HEADERS` `OTEL_EXPORTER_OTLP_SPAN_HEADERS` `OTEL_EXPORTER_OTLP_METRIC_HEADERS` |
 | Compression          | Compression key for supported compression types. Supported compression: `gzip`| No value              | `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_SPAN_COMPRESSION` `OTEL_EXPORTER_OTLP_METRIC_COMPRESSION` |
-| Timeout              | Max waiting time for the backend to process each spans or metrics batch. | 10s               | `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT` |
+| Timeout              | Max waiting time for the backend to process each spans or metrics batch, in milliseconds. | 10s               | `OTEL_EXPORTER_OTLP_TIMEOUT_MILLIS` `OTEL_EXPORTER_OTLP_SPAN_TIMEOUT_MILLIS` `OTEL_EXPORTER_OTLP_METRIC_TIMEOUT_MILLIS` |
 
 Supported values for `OTEL_EXPORTER_OTLP_*COMPRESSION` options:
 


### PR DESCRIPTION
Fixes #1312

## Changes

Suffixes OTLP timeout variables with millis for consistency with BSP variables and to allow the variable to be self-documenting in terms of what the unit of the value is.
