### PR TITLE
Add OTEL_EXPORTER_ZIPKIN_TRANSPORT_FORMAT to sdk-environment-variables

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -72,9 +72,17 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 ## Zipkin Exporter
 
-| Name                          | Description                | Default                                                                                                      |
-| ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
+| Name                                      | Description                           | Default                                                                                                       |
+| -----------------------------             | --------------------------            | ------------------------------------------------------------------------------------------------------------  |
+| OTEL_EXPORTER_ZIPKIN_ENDPOINT             | Endpoint for Zipkin traces            | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable -->  |
+| OTEL_EXPORTER_ZIPKIN_TRANSPORT_FORMAT     | Transport format for Zipkin traces    | V2_JSON                                                                                                       |
+
+Known values for OTEL_EXPORTER_ZIPKIN_TRANSPORT_FORMAT are:
+
+- `"V1_JSON"`
+- `"V1_THRIFT"`
+- `"V2_JSON"`
+- `"V2_PROTOBUF"`
 
 ## Prometheus Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -75,7 +75,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 | Name                                      | Description                           | Default                                                                                                       |
 | -----------------------------             | --------------------------            | ------------------------------------------------------------------------------------------------------------  |
 | OTEL_EXPORTER_ZIPKIN_ENDPOINT             | Endpoint for Zipkin traces            | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable -->  |
-| OTEL_EXPORTER_ZIPKIN_TRANSPORT_FORMAT     | Transport format for Zipkin traces    | V2_JSON                                                                                                       |
+| OTEL_EXPORTER_ZIPKIN_TRANSPORT_FORMAT     | Transport format for Zipkin traces    | V2_PROTOBUF                                                                                                   |
 
 Known values for OTEL_EXPORTER_ZIPKIN_TRANSPORT_FORMAT are:
 


### PR DESCRIPTION
Fixes #1336 

## Changes

This change adds environment variable to specify transport format for Zipkin exporter with default value `V2_PROTOBUF`. 
