### PR TITLE
Make Resource.Merge consistent with Span.SetAttribute.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Updates:
   ([1234](https://github.com/open-telemetry/opentelemetry-specification/pull/1234))
 - Resource SDK: Reverse (suggested) order of Resource.Merge parameters, remove
   special case for empty strings
-  ([#????](https://github.com/open-telemetry/opentelemetry-specification/pull/????))
+  ([#1345](https://github.com/open-telemetry/opentelemetry-specification/pull/1345))
 
 ## v0.7.0 (11-18-2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Updates:
   ([#1322](https://github.com/open-telemetry/opentelemetry-specification/pull/1322))
 - Require schemed endpoints for OTLP exporters
   ([1234](https://github.com/open-telemetry/opentelemetry-specification/pull/1234))
+- Resource SDK: Reverse (suggested) order of Resource.Merge parameters, remove
+  special case for empty strings
+  ([#????](https://github.com/open-telemetry/opentelemetry-specification/pull/????))
 
 ## v0.7.0 (11-18-2020)
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -90,7 +90,7 @@ status of the feature is not known.
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|-----|
 |Create from Attributes                        | + | +  | + | +    | +  | +    |   | +  |   | +  | +   |
 |Create empty                                  | + | +  | + | +    | +  | +    |   | +  |   | +  | +   |
-|Merge                                         | + | +  | + | +    | +  | +    |   | +  |   | +  | +   |
+|[Merge (v2)](specification/resource/sdk.md#merge) |   |    |   |      |    |      |   |    |   |    |     |
 |Retrieve attributes                           | + | +  | + | +    | +  | +    |   | +  |   | +  | +   |
 |[Default value](specification/resource/semantic_conventions/README.md#attributes-with-default-value) for service.name |   |    |   |      |    |      |   |    |   |    |     |
 

--- a/specification/resource/sdk.md
+++ b/specification/resource/sdk.md
@@ -43,7 +43,7 @@ Required parameters:
 
 ### Merge
 
-The interface MUST provide a way for a old resource and a
+The interface MUST provide a way for an old resource and an
 updating resource to be merged into a new resource.
 
 Note: This is intended to be utilized for merging of resources whose attributes

--- a/specification/resource/sdk.md
+++ b/specification/resource/sdk.md
@@ -43,27 +43,21 @@ Required parameters:
 
 ### Merge
 
-The interface MUST provide a way for a primary resource and a
-secondary resource to be merged into a new resource.
+The interface MUST provide a way for a old resource and a
+updating resource to be merged into a new resource.
 
 Note: This is intended to be utilized for merging of resources whose attributes
 come from different sources,
 such as environment variables, or metadata extracted from the host or container.
 
 The resulting resource MUST have all attributes that are on any of the two input resources.
-Conflicts (i.e. a key for which attributes exist on both the primary and secondary resource)
-MUST be handled as follows:
-
-* If the value on the primary resource is an empty string, the result has the value of the secondary resource.
-* Otherwise, the value of the primary resource is used.
-
-Attribute key namespacing SHOULD be used to prevent collisions across different
-resource detection steps.
+If a key exists on both the old and updating resource, the value of the updating
+resource MUST be picked (even if the updated value is empty).
 
 Required parameters:
 
-- the primary resource whose attributes take precedence.
-- the secondary resource whose attributes will be merged in.
+- the old resource
+- the updating resource whose attributes take precedence
 
 ### The empty resource
 


### PR DESCRIPTION
Required for #1346.
Resolves parts of #1184.

As agreed (except for the empty-string change) in the spec meeting, this is a pre-requesite for the updated default resource wording of #1294.

## Changes

- Remove special case for empty string when merging resources.
- Let the second argument take precedence, i.e. x.Merge(y) will have values from y on conflict.