### PR TITLE
Modify Exporter format variables for 1.0 (allowing further specification post 1.0)

### DIFF
--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -64,7 +64,7 @@ the future:
 - `OTEL_EXPORTER_OTLP_TRACE_PROTOCOL`
 - `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL`
 
-SDKs are free to choose a default, if no configuration is provided.
+SDKs have an unspecified default, if no configuration is provided.
 
 ### Specifying headers via environment variables
 

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -9,7 +9,6 @@ The following configuration options MUST be available to configure the OTLP expo
 | Configuration Option | Description                                                  | Default           | Env variable                                                 |
 | -------------------- | ------------------------------------------------------------ | ----------------- | ------------------------------------------------------------ |
 | Endpoint             | Target to which the exporter is going to send spans or metrics. The endpoint MUST be a valid URL with scheme (http or https) and host, and MAY contain a port and path. A scheme of https indicates a secure connection. When using `OTEL_EXPORTER_ENDPOINT` with OTLP/HTTP, exporters SHOULD follow the collector convention of appending the version and signal to the path (e.g. `v1/traces` or `v1/metrics`). The per-signal endpoint configuration options take precedence and can be used to override this behavior. See the [OTLP Specification][otlphttp-req] for more details. | `https://localhost:4317` | `OTEL_EXPORTER_OTLP_ENDPOINT` `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` |
-| Protocol             | The protocol used to transmit the data. One of `grpc`,`http/json`,`http/protobuf`. | `grpc`               | `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` |
 | Certificate File     | Path to certificate file for TLS credentials of gRPC client. Should only be used for a secure connection. | n/a               | `OTEL_EXPORTER_OTLP_CERTIFICATE` `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE` |
 | Headers              | Key-value pairs to be used as headers associated with gRPC or HTTP requests. See [Specifying headers](./exporter.md#specifying-headers-via-environment-variables) for more details.                   | n/a               | `OTEL_EXPORTER_OTLP_HEADERS` `OTEL_EXPORTER_OTLP_TRACES_HEADERS` `OTEL_EXPORTER_OTLP_METRICS_HEADERS` |
 | Compression          | Compression key for supported compression types. Supported compression: `gzip`| No value              | `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION` |
@@ -52,6 +51,20 @@ export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://collector.example.com/v1/metrics
 export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/json
 ```
+
+### Specify Protocol
+
+Currently, OTLP haas more than one transport protocol it can support, e.g. 
+`grpc`,  `http/json`, `http/protobuf`.   As of 1.0 of the specification, there 
+*is no specified default, or configuration via environment variables*.  We
+reserve the following environment variables for configuration of protocols in
+the future:
+
+- `OTEL_EXPORTER_OTLP_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL`
+
+SDKs are free to choose a default, if no configuration is provided.
 
 ### Specifying headers via environment variables
 

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -61,7 +61,7 @@ reserve the following environment variables for configuration of protocols in
 the future:
 
 - `OTEL_EXPORTER_OTLP_PROTOCOL`
-- `OTEL_EXPORTER_OTLP_SPAN_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_TRACE_PROTOCOL`
 - `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL`
 
 SDKs are free to choose a default, if no configuration is provided.

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -54,7 +54,7 @@ export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/json
 
 ### Specify Protocol
 
-Currently, OTLP haas more than one transport protocol it can support, e.g.
+Currently, OTLP has more than one transport protocol it can support, e.g.
 `grpc`,  `http/json`, `http/protobuf`.   As of 1.0 of the specification, there
 *is no specified default, or configuration via environment variables*.  We
 reserve the following environment variables for configuration of protocols in

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -54,8 +54,8 @@ export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/json
 
 ### Specify Protocol
 
-Currently, OTLP haas more than one transport protocol it can support, e.g. 
-`grpc`,  `http/json`, `http/protobuf`.   As of 1.0 of the specification, there 
+Currently, OTLP haas more than one transport protocol it can support, e.g.
+`grpc`,  `http/json`, `http/protobuf`.   As of 1.0 of the specification, there
 *is no specified default, or configuration via environment variables*.  We
 reserve the following environment variables for configuration of protocols in
 the future:

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -91,6 +91,17 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 | ----------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | OTEL_EXPORTER_ZIPKIN_ENDPOINT | Endpoint for Zipkin traces | <!-- markdown-link-check-disable --> "http://localhost:9411/api/v2/spans"<!-- markdown-link-check-enable --> |
 
+Addtionally, the following environment variables are reserved for future
+usage in Zipkin Exporter configuration:
+
+- `OTEL_EXPORTER_ZIPKIN_PROTOCOL`
+
+This will be used to specify whether or not the exporter uses v1 or v2, json,
+thrift or protobuf.  As of 1.0 of the specification, there 
+*is no specified default, or configuration via environment variables*.
+
+
+
 ## Prometheus Exporter
 
 | Name                          | Description                     | Default                      |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -97,10 +97,8 @@ usage in Zipkin Exporter configuration:
 - `OTEL_EXPORTER_ZIPKIN_PROTOCOL`
 
 This will be used to specify whether or not the exporter uses v1 or v2, json,
-thrift or protobuf.  As of 1.0 of the specification, there 
+thrift or protobuf.  As of 1.0 of the specification, there
 *is no specified default, or configuration via environment variables*.
-
-
 
 ## Prometheus Exporter
 


### PR DESCRIPTION
Adapts #1340

## Changes
- Reserve ZIPKIN format environment variable for post 1.0 implementation.
- Update specification to keep OTLP protocol + ZIPKIN protocol story consistent for 1.0 (request from @bogdandrutu, note: seeing this, I'm not sure I agree, looking for feedback)

Related issues #1336
