### PR TITLE
[jaeger] Point to Jaeger Thrift format

### DIFF
--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -2,8 +2,9 @@
 
 This document defines the transformation between OpenTelemetry and Jaeger Spans.
 Jaeger accepts spans in two formats:
-  * Thrift `Batch`, defined in [jaeger-idl/.../jaeger.thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift)
-  * Protobuf `Batch`, defined in [jaeger-idl/.../model.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/model.proto)
+
+* Thrift `Batch`, defined in [jaeger-idl/.../jaeger.thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift)
+* Protobuf `Batch`, defined in [jaeger-idl/.../model.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/model.proto)
 
 ## Summary
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -1,8 +1,9 @@
 # OpenTelemetry to Jaeger Transformation
 
 This document defines the transformation between OpenTelemetry and Jaeger Spans.
-Jaeger's v2 API is defined in the
-[jaeger model.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/model.proto)
+Jaeger accepts spans in two formats:
+  * Thrift `Batch`, defined in [jaeger-idl/.../jaeger.thrift](https://github.com/jaegertracing/jaeger-idl/blob/master/thrift/jaeger.thrift)
+  * Protobuf `Batch`, defined in [jaeger-idl/.../model.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/model.proto)
 
 ## Summary
 


### PR DESCRIPTION
## Changes

Jaeger exporters usually include Thrift-over-UDP exporter that is the default in Jaeger native SDKs, but the spec was only mentioning the Protobuf model. Added link to Thrift model.
