### PR TITLE
sdk env: change OTEL_PROPAGATORS to OTEL_TEXT_MAP_PROPAGATORS to be explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Updates:
 - Resource SDK: Reverse (suggested) order of Resource.Merge parameters, remove
   special case for empty strings
   ([#1345](https://github.com/open-telemetry/opentelemetry-specification/pull/1345))
+- Change environment variable `OTEL_PROPAGATORS` to `OTEL_TEXT_MAP_PROPAGATORS`
+  ([#1365](https://github.com/open-telemetry/opentelemetry-specification/pull/1365))
 
 ## v0.7.0 (11-18-2020)
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -121,7 +121,7 @@ status of the feature is not known.
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|-----|
 |OTEL_RESOURCE_ATTRIBUTES                      | + | +  | + | +    | +  | -    | - | +  | - | +  | -   |
 |OTEL_LOG_LEVEL                                |   | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1059)    | +  | -    | - |    | - | -  | -   |
-|OTEL_PROPAGATORS                              |   | +  |   | +    |    | -    | - |    | - | -  | -   |
+|OTEL_TEXT_MAP_PROPAGATORS                     |   | +  |   | +    |    | -    | - |    | - | -  | -   |
 |OTEL_BSP_*                                    |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_OTLP_*                          |   | +  |   | +    | +  | -    | - |    | - | -  | -   |
 |OTEL_EXPORTER_JAEGER_*                        |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -27,7 +27,7 @@ For example, the value `12000` indicates 12000 milliseconds, i.e., 12 seconds.
 | ------------------------ | ------------------------------------------------- | --------------------------------- | ----------------------------------- |
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes |                                   | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
-| OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. |
+| OTEL_TEXT_MAP_PROPAGATORS | Text map propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. |
 | OTEL_TRACE_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
 | OTEL_TRACE_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACE_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST be otherwise ignored, i.e. the SDK MUST behave as if OTEL_TRACE_SAMPLER_ARG is not set.  |
 


### PR DESCRIPTION
## Changes

This changes the name of the propagators OS environment variable to `OTEL_TEXT_MAP_PROPAGATORS ` to match with what it is actually setting up, https://github.com/open-telemetry/opentelemetry-specification/blob/master/specification/context/api-propagators.md#textmap-propagator