### PR TITLE
Pin Semantic Convention tool to v0.2.1

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -61,4 +61,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: verify semantic convention tables
-      run: docker run --rm -v $(pwd)/semantic_conventions:/source -v $(pwd)/specification:/spec otel/semconvgen -f /source markdown -md /spec --md-check
+      run: docker run --rm -v $(pwd)/semantic_conventions:/source -v $(pwd)/specification:/spec otel/semconvgen:0.2.1 -f /source markdown -md /spec --md-check


### PR DESCRIPTION
## Changes

Use a fixed version for the semantic convention tool. 
This way, we will not block other spec PRs if we update the tool. 

Examples of this problem: 
- https://github.com/open-telemetry/opentelemetry-specification/pull/1342#event-4204907874
- https://github.com/open-telemetry/opentelemetry-specification/pull/1339#issuecomment-768226487