### PR TITLE
Small clarification for default's service.name for exporters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Updates:
   ([#1339](https://github.com/open-telemetry/opentelemetry-specification/pull/1339))
 - Trace Exporters: Fix TODOs in Jaeger exporter spec
   ([#1374](https://github.com/open-telemetry/opentelemetry-specification/pull/1374))
-- Clarify that Jaeger/Zipkin exporters must to rely on the default Resource to
+- Clarify that Jaeger/Zipkin exporters must rely on the default Resource to
   get service.name if none was specified.
   ([#1386](https://github.com/open-telemetry/opentelemetry-specification/pull/1386))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ Updates:
   ([#1339](https://github.com/open-telemetry/opentelemetry-specification/pull/1339))
 - Trace Exporters: Fix TODOs in Jaeger exporter spec
   ([#1374](https://github.com/open-telemetry/opentelemetry-specification/pull/1374))
+- Clarify that Jaeger/Zipkin exporters must to rely on the default Resource to
+  get service.name if none was specified.
+  ([#1386](https://github.com/open-telemetry/opentelemetry-specification/pull/1386))
 
 ## v0.7.0 (11-18-2020)
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -43,6 +43,8 @@ single process and exporters need to handle this case accordingly.
 Critically, Jaeger backend depends on `Span.Process.ServiceName` to identify the service
 that produced the spans. That field MUST be populated from the `service.name` attribute
 of the [`service` resource](../../resource/semantic_conventions/README.md#service).
+If no `service.name` was specified, that field MUST be populated from the
+[default](../../resource/sdk.md#sdk-provided-resource-attributes) `Resource`.
 
 ### InstrumentationLibrary
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -43,7 +43,7 @@ single process and exporters need to handle this case accordingly.
 Critically, Jaeger backend depends on `Span.Process.ServiceName` to identify the service
 that produced the spans. That field MUST be populated from the `service.name` attribute
 of the [`service` resource](../../resource/semantic_conventions/README.md#service).
-If no `service.name` was specified, that field MUST be populated from the
+If no `service.name` is contained in a Span's Resource, that field MUST be populated from the
 [default](../../resource/sdk.md#sdk-provided-resource-attributes) `Resource`.
 
 ### InstrumentationLibrary

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -53,7 +53,7 @@ and Zipkin.
 
 Zipkin service name MUST be set to the value of the
 [resource attribute](../../resource/semantic_conventions/README.md):
-`service.name`. If no `service.name` was specified, it MUST be populated from the
+`service.name`. If no `service.name` is contained in a Span's Resource, it MUST be populated from the
 [default](../../resource/sdk.md#sdk-provided-resource-attributes) `Resource`.
 In Zipkin it is important that the service name is consistent
 for all spans in a local root. Otherwise service graph and aggregations would

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -64,9 +64,6 @@ span to improve Zipkin user experience.
 *Note*, the attribute `service.namespace` must not be used for the Zipkin
 service name and should be sent as a Zipkin tag.
 
-*Note*, exporter to Zipkin MUST allow to configure the default "fall back" name
-to use as a Zipkin service name.
-
 ### SpanKind
 
 The following table lists all the `SpanKind` mappings between OpenTelemetry and

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -53,7 +53,9 @@ and Zipkin.
 
 Zipkin service name MUST be set to the value of the
 [resource attribute](../../resource/semantic_conventions/README.md):
-`service.name`. In Zipkin it is important that the service name is consistent
+`service.name`. If no `service.name` was specified, it MUST be populated from the
+[default](../../resource/sdk.md#sdk-provided-resource-attributes) `Resource`.
+In Zipkin it is important that the service name is consistent
 for all spans in a local root. Otherwise service graph and aggregations would
 not work properly. OpenTelemetry doesn't provide this consistency guarantee.
 Exporter may chose to override the value for service name based on a local root


### PR DESCRIPTION
Fixes #1237 
Fixes #1380 

Small clarification on using the default `Resource` is no `service.name` was used.

PS - Don't think we need a CHANGELOG entry for this, but happy to add one if needed.