### PR TITLE
Remove contradictory and confusing statement from Resource Attributes

### DIFF
--- a/specification/resource/sdk.md
+++ b/specification/resource/sdk.md
@@ -121,8 +121,7 @@ only the following operations should be provided:
 ### Retrieve attributes
 
 The SDK should provide a way to retrieve a read only collection of attributes
-associated with a resource. The attributes should consist of the name and values,
-both of which should be strings.
+associated with a resource.
 
 There is no need to guarantee the order of the attributes.
 


### PR DESCRIPTION
Fixes some portion of #1184 

## Changes
Spec says Resource attribute can be any type (string, int, bool etc.) allowed in common attribute (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/common.md#attributes). Yet the Retrieve Attribute section hints that name/value should be strings. Its best to remove this sentence to avoid any confusion. 

This is just editorial change, not changing actual spec.

