### PR TITLE
Update CHANGELOG and OTLP env vars with the latest names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ Updates:
 - Clarify that Jaeger/Zipkin exporters must rely on the default Resource to
   get service.name if none was specified.
   ([#1386](https://github.com/open-telemetry/opentelemetry-specification/pull/1386))
+- Modify OTLP/Zipkin Exporter format variables for 1.0 (allowing further specification post 1.0)
+  ([#1358](https://github.com/open-telemetry/opentelemetry-specification/pull/1358))
 
 ## v0.7.0 (11-18-2020)
 

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -25,31 +25,16 @@ The following configuration sends all signals to the same collector:
 
 ```bash
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ```
 
 Example 2
 
-Traces and metrics are sent to different collectors using different protocols:
+Traces and metrics are sent to different collectors:
 
 ```bash
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://collector:4317
-export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc
 
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://collector.example.com/v1/metrics
-export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/protobuf
-```
-
-Example 3
-
-Traces are configured using the generic configuration, metrics are configured using specific configuration:
-
-```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
-export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-
-export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://collector.example.com/v1/metrics
-export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL=http/json
 ```
 
 ### Specify Protocol
@@ -61,8 +46,8 @@ reserve the following environment variables for configuration of protocols in
 the future:
 
 - `OTEL_EXPORTER_OTLP_PROTOCOL`
-- `OTEL_EXPORTER_OTLP_TRACE_PROTOCOL`
-- `OTEL_EXPORTER_OTLP_METRIC_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL`
+- `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`
 
 SDKs have an unspecified default, if no configuration is provided.
 


### PR DESCRIPTION
Follow up to #1358 

- Adds a CHANGELOG entry
- Updates the OTLP environment variables with the actual latest names.

Removed an example that is not valid anymore as well.