### PR TITLE
OTLP stability clarifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Updates:
 - Modify OTLP/Zipkin Exporter format variables for 1.0 (allowing further specification post 1.0)
   ([#1358](https://github.com/open-telemetry/opentelemetry-specification/pull/1358))
 - Add `k8s.node` semantic conventions ([#1390](https://github.com/open-telemetry/opentelemetry-specification/pull/1390))
+- Clarify stability for both OTLP/HTTP and signals in OTLP.
+  ([#1400](https://github.com/open-telemetry/opentelemetry-specification/pull/1400/files))
 
 ## v0.7.0 (11-18-2020)
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -301,7 +301,8 @@ The default network port for OTLP/gRPC is 4317.
 
 ### OTLP/HTTP
 
-**Status**: [Experimental](../document-status.md)
+**Binary Format Status**: [Stable](../document-status.md)
+**JSON Format Status**: [Experimental]((../document-status.md))
 
 OTLP/HTTP uses Protobuf payloads encoded either in binary format or in JSON
 format. The Protobuf schema of the messages is the same for OTLP/HTTP and

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -48,8 +48,7 @@ of OpenTelemetry project.
 ## Signals Maturity Level
 
 Each signal has different support and stability in OTLP, described through its
-own maturity level, which in turn applies to **all** the OTLP Transports listed below,
-e.g. OTLP/gRPC.
+own maturity level, which in turn applies to **all** the OTLP Transports listed below.
 
 * Tracing: **Stable**
 * Metrics: **Beta**

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -11,6 +11,7 @@ nodes such as collectors and telemetry backends.
 Table of Contents
 </summary>
 
+- [Signal Status](#signal-status)
 - [Protocol Details](#protocol-details)
   * [OTLP/gRPC](#otlpgrpc)
     + [OTLP/gRPC Concurrent Requests](#otlpgrpc-concurrent-requests)
@@ -43,6 +44,16 @@ Table of Contents
 
 OTLP is a general-purpose telemetry data delivery protocol designed in the scope
 of OpenTelemetry project.
+
+## Signal Status
+
+Each signal has different support and stability in OTLP, described through its
+own status, which in turn applies to **all** the OTLP Transports listed below,
+e.g. OTLP/gRPC.
+
+* Tracing: [Stable](../document-status.md)
+* Metrics: [Experimental](../document-status.md)
+* Logs: [Experimental](../document-status.md)
 
 ## Protocol Details
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -11,7 +11,7 @@ nodes such as collectors and telemetry backends.
 Table of Contents
 </summary>
 
-- [Signal Status](#signal-status)
+- [Signals Maturity Level](#signals-maturity-level)
 - [Protocol Details](#protocol-details)
   * [OTLP/gRPC](#otlpgrpc)
     + [OTLP/gRPC Concurrent Requests](#otlpgrpc-concurrent-requests)
@@ -45,15 +45,17 @@ Table of Contents
 OTLP is a general-purpose telemetry data delivery protocol designed in the scope
 of OpenTelemetry project.
 
-## Signal Status
+## Signals Maturity Level
 
 Each signal has different support and stability in OTLP, described through its
-own status, which in turn applies to **all** the OTLP Transports listed below,
+own maturity level, which in turn applies to **all** the OTLP Transports listed below,
 e.g. OTLP/gRPC.
 
-* Tracing: [Stable](../document-status.md)
-* Metrics: [Experimental](../document-status.md)
-* Logs: [Experimental](../document-status.md)
+* Tracing: **Stable**
+* Metrics: **Beta**
+* Logs: **Alpha**
+
+See [OTLP Maturity Level](https://github.com/open-telemetry/opentelemetry-proto#maturity-level).
 
 ## Protocol Details
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -313,7 +313,7 @@ The default network port for OTLP/gRPC is 4317.
 ### OTLP/HTTP
 
 **Binary Format Status**: [Stable](../document-status.md)
-**JSON Format Status**: [Experimental]((../document-status.md))
+**JSON Format Status**: [Experimental](../document-status.md)
 
 OTLP/HTTP uses Protobuf payloads encoded either in binary format or in JSON
 format. The Protobuf schema of the messages is the same for OTLP/HTTP and


### PR DESCRIPTION
Fixes #1397 

Adds minimal clarifications.

Specifically, for OTLP/HTTP it simply mentions that we are stable for the Binary part, while being experimental for the JSON one. I'm also open to rewrite these sections to have them clearly separated, although that would probably be an overkill, given that they both share **a lot**.