### PR TITLE
Add OT Trace Propagator.

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -330,6 +330,12 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 * [B3](https://github.com/openzipkin/b3-propagation).
 * [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format).
 
+This a list of additional propagators that MAY be maintained and distributed
+as OpenTelemetry extension packages:
+
+* [OT Trace](https://github.com/opentracing?q=basic&type=&language=). Propagation format
+  specifically used by the OpenTracing Basic Tracers.
+
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of
 the Core OpenTelemetry repositories.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -334,7 +334,7 @@ This is a list of additional propagators that MAY be maintained and distributed
 as OpenTelemetry extension packages:
 
 * [OT Trace](https://github.com/opentracing?q=basic&type=&language=). Propagation format
-  used by the OpenTracing Basic Tracers. It MUST not use `OpenTracing` in the resulting
+  used by the OpenTracing Basic Tracers. It MUST NOT use `OpenTracing` in the resulting
   propagator name as it is not widely adopted format in the OpenTracing ecosystem.
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -334,7 +334,8 @@ This a list of additional propagators that MAY be maintained and distributed
 as OpenTelemetry extension packages:
 
 * [OT Trace](https://github.com/opentracing?q=basic&type=&language=). Propagation format
-  specifically used by the OpenTracing Basic Tracers.
+  used by the OpenTracing Basic Tracers. It MUST not use `OpenTracing` in the resulting
+  propagator name as it is not wide adopted format in the OpenTracing ecosystem.
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -335,7 +335,7 @@ as OpenTelemetry extension packages:
 
 * [OT Trace](https://github.com/opentracing?q=basic&type=&language=). Propagation format
   used by the OpenTracing Basic Tracers. It MUST not use `OpenTracing` in the resulting
-  propagator name as it is not wide adopted format in the OpenTracing ecosystem.
+  propagator name as it is not widely adopted format in the OpenTracing ecosystem.
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -330,7 +330,7 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 * [B3](https://github.com/openzipkin/b3-propagation).
 * [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format).
 
-This a list of additional propagators that MAY be maintained and distributed
+This is a list of additional propagators that MAY be maintained and distributed
 as OpenTelemetry extension packages:
 
 * [OT Trace](https://github.com/opentracing?q=basic&type=&language=). Propagation format


### PR DESCRIPTION
Fixes #1391 

Adds  `OT Trace` propagator as a (very) optional extension component.

cc @yurishkuro 