### PR TITLE
Fix capitalization of MUST NOT/SHOULD NOT

### DIFF
--- a/semantic_conventions/syntax.md
+++ b/semantic_conventions/syntax.md
@@ -191,7 +191,7 @@ examples:
 
 ### Ref
 
-`ref` MUST have an id of an existing attribute. When it is set, `id` and `type` MUST not be present.
+`ref` MUST have an id of an existing attribute. When it is set, `id` and `type` MUST NOT be present.
 `ref` is useful for specifying that an existing attribute of another semantic convention is part of
 the current semantic convention and inherit its `brief`, `note`, and `example` values. However, if these
 fields are present in the current attribute definition, they override the inherited values.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -211,7 +211,7 @@ The API MUST allow retrieving the `TraceId` and `SpanId` in the following forms:
 * Binary - returns the binary representation of the `TraceId` (result MUST be a
 16-byte array) or `SpanId` (result MUST be an 8-byte array).
 
-The API should not expose details about how they are internally stored.
+The API SHOULD NOT expose details about how they are internally stored.
 
 ### IsValid
 
@@ -241,7 +241,7 @@ All mutating operations MUST return a new `TraceState` with the modifications ap
 `TraceState` MUST at all times be valid according to rules specified in [W3C Trace Context specification](https://www.w3.org/TR/trace-context/#tracestate-header-field-values).
 Every mutating operations MUST validate input parameters.
 If invalid value is passed the operation MUST NOT return `TraceState` containing invalid data
-and MUST follow the [general error handling guidelines](../error-handling.md) (e.g. it usually must not return null or throw an exception).
+and MUST follow the [general error handling guidelines](../error-handling.md) (e.g. it usually should not return null or throw an exception).
 
 Please note, since `SpanContext` is immutable, it is not possible to update `SpanContext` with a new `TraceState`.
 Such changes then make sense only right before
@@ -354,7 +354,7 @@ The API MUST accept the following parameters:
 - `Link`s - an ordered sequence of Links, see API definition [here](#specifying-links).
 - `Start timestamp`, default to current time. This argument SHOULD only be set
   when span creation time has already passed. If API is called at a moment of
-  a Span logical start, API user MUST not explicitly set this argument.
+  a Span logical start, API user MUST NOT explicitly set this argument.
 
 Each span has zero or one parent span and zero or more child spans, which
 represent causally related operations. A tree of related spans comprises a
@@ -650,7 +650,7 @@ The API MUST provide an operation for wrapping a `SpanContext` with an object
 implementing the `Span` interface. This is done in order to expose a `SpanContext`
 as a `Span` in operations such as in-process `Span` propagation.
 
-If a new type is required for supporting this operation, it SHOULD not be exposed
+If a new type is required for supporting this operation, it SHOULD NOT be exposed
 publicly if possible (e.g. by only exposing a function that returns something
 with the Span interface type). If a new type is required to be publicly exposed,
 it SHOULD be named `NonRecordingSpan`.
@@ -686,9 +686,9 @@ circumstances.  It can be useful for tracing systems to know this
 property, since synchronous Spans may contribute to the overall trace
 latency. Asynchronous scenarios can be remote or local.
 
-In order for `SpanKind` to be meaningful, callers should arrange that
+In order for `SpanKind` to be meaningful, callers SHOULD arrange that
 a single Span does not serve more than one purpose.  For example, a
-server-side span should not be used directly as the parent of another
+server-side span SHOULD NOT be used directly as the parent of another
 remote span.  As a simple guideline, instrumentation should create a
 new Span prior to extracting and serializing the SpanContext for a
 remote call.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -241,7 +241,7 @@ All mutating operations MUST return a new `TraceState` with the modifications ap
 `TraceState` MUST at all times be valid according to rules specified in [W3C Trace Context specification](https://www.w3.org/TR/trace-context/#tracestate-header-field-values).
 Every mutating operations MUST validate input parameters.
 If invalid value is passed the operation MUST NOT return `TraceState` containing invalid data
-and MUST follow the [general error handling guidelines](../error-handling.md) (e.g. it usually should not return null or throw an exception).
+and MUST follow the [general error handling guidelines](../error-handling.md).
 
 Please note, since `SpanContext` is immutable, it is not possible to update `SpanContext` with a new `TraceState`.
 Such changes then make sense only right before

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -485,7 +485,7 @@ destination.
 Export() will never be called concurrently for the same exporter instance.
 Export() can be called again only after the current call returns.
 
-Export() must not block indefinitely, there must be a reasonable upper limit
+Export() MUST NOT block indefinitely, there MUST be a reasonable upper limit
 after which the call must time out with an error result (`Failure`).
 
 Any retry logic that is required by the exporter is the responsibility

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -63,7 +63,7 @@ not work properly. OpenTelemetry doesn't provide this consistency guarantee.
 Exporter may chose to override the value for service name based on a local root
 span to improve Zipkin user experience.
 
-*Note*, the attribute `service.namespace` must not be used for the Zipkin
+*Note*, the attribute `service.namespace` MUST NOT be used for the Zipkin
 service name and should be sent as a Zipkin tag.
 
 ### SpanKind

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -37,7 +37,7 @@ The _span name_ MUST be the full RPC method name formatted as:
 $package.$service/$method
 ```
 
-(where $service must not contain dots and $method must not contain slashes)
+(where $service MUST NOT contain dots and $method MUST NOT contain slashes)
 
 If there is no package name or if it is unknown, the `$package.` part (including the period) is omitted.
 


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc2119, the work "NOT" must also be capitalized.

Skipping changelog since this is a stylistic change.