### PR TITLE
Update ottrace environment variable to match spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ New:
 
 Updates:
 
+- Update OT Trace propagator environment variable to match latest name
 - Remove Metrics SDK specification to avoid confusion, clarify that Metrics API
   specification is not recommended for client implementation
   ([#1401](https://github.com/open-telemetry/opentelemetry-specification/pull/1401))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ New:
 
 Updates:
 
-- Update OT Trace propagator environment variable to match latest name
+- Update OT Trace propagator environment variable to match latest name([#1406](https://github.com/open-telemetry/opentelemetry-specification/pull/1406))
 - Remove Metrics SDK specification to avoid confusion, clarify that Metrics API
   specification is not recommended for client implementation
   ([#1401](https://github.com/open-telemetry/opentelemetry-specification/pull/1401))

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -39,7 +39,7 @@ Known values for OTEL_PROPAGATORS are:
 - `"b3multi"`: [B3 Multi](https://github.com/openzipkin/b3-propagation#multiple-headers)
 - `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
-- `"ottrace"`: [OT Trace]https://github.com/opentracing?q=basic&type=&language=) (_third party_)
+- `"ottrace"`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)
 
 Known values for `OTEL_TRACES_SAMPLER` are:
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -39,7 +39,7 @@ Known values for OTEL_PROPAGATORS are:
 - `"b3multi"`: [B3 Multi](https://github.com/openzipkin/b3-propagation#multiple-headers)
 - `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
-- `"ottracer"`: [Lightstep](https://github.com/lightstep/lightstep-tracer-java-common/blob/master/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java) (_third party_)
+- `"ottrace"`: [OT Trace]https://github.com/opentracing?q=basic&type=&language=) (_third party_)
 
 Known values for `OTEL_TRACES_SAMPLER` are:
 


### PR DESCRIPTION
Presuming this was just missing from #1402. Hope it can be added without much ceremony, otherwise recommend renaming OT Trace to OT Tracer for the spec entry (matches the header name)