### PR TITLE
Clarify IdsGenerator, same requirement for vendor specific code like Propagators

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -321,7 +321,7 @@ public interface IdGenerator {
 }
 ```
 
-Additional `IdsGenerator` implementing vendor-specific protocols such as AWS
+Additional `IdGenerator` implementing vendor-specific protocols such as AWS
 X-Ray trace id generator MUST NOT be maintained or distributed as part of the
 Core OpenTelemetry repositories.
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -301,7 +301,7 @@ There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log
 should not be emitted once per span, or per discarded attribute, event, or links.
 
-## Ids Generator
+## Id Generators
 
 The SDK MUST by default randomly generate both the `TraceId` and the `SpanId`.
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -310,7 +310,7 @@ both the `TraceId` and the `SpanId`.
 
 The SDK MAY provide this functionality by allowing custom implementations of
 an interface like the java example below (name of the interface MAY be
-`IdsGenerator`, name of the methods MUST be consistent with
+`IdGenerator`, name of the methods MUST be consistent with
 [SpanContext](./api.md#retrieving-the-traceid-and-spanid)), which provides
 extension points for two methods, one to generate a `SpanID` and one for `TraceId`.
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -10,7 +10,7 @@
 * [Tracer Provider](#tracer-provider)
 * [Additional Span Interfaces](#additional-span-interfaces)
 * [Limits on Span Collections](#limits-on-span-collections)
-* [Ids Generator](#ids-generator)
+* [Id Generator](#id-generators)
 * [Span Processor](#span-processor)
 * [Span Exporter](#span-exporter)
 
@@ -212,7 +212,7 @@ supplied to the `TracerProvider` must be used to create an
 [`InstrumentationLibrary`][otep-83] instance which is stored on the created
 `Tracer`.
 
-Configuration (i.e., [Span processors](#span-processor), [IdsGenerator](#ids-generator),
+Configuration (i.e., [Span processors](#span-processor), [IdGenerator](#id-generators),
 and [`Sampler`](#sampling)) MUST be managed solely by the `TracerProvider` and it
 MUST provide some way to configure them, at least when creating or initializing it.
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -315,7 +315,7 @@ an interface like the java example below (name of the interface MAY be
 extension points for two methods, one to generate a `SpanID` and one for `TraceId`.
 
 ```java
-public interface IdsGenerator {
+public interface IdGenerator {
   byte[] generateSpanIdBytes();
   byte[] generateTraceIdBytes();
 }

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -10,6 +10,7 @@
 * [Tracer Provider](#tracer-provider)
 * [Additional Span Interfaces](#additional-span-interfaces)
 * [Limits on Span Collections](#limits-on-span-collections)
+* [Ids Generator](#ids-generator)
 * [Span Processor](#span-processor)
 * [Span Exporter](#span-exporter)
 
@@ -211,9 +212,9 @@ supplied to the `TracerProvider` must be used to create an
 [`InstrumentationLibrary`][otep-83] instance which is stored on the created
 `Tracer`.
 
-Configuration (i.e., [Span processors](#span-processor) and [`Sampler`](#sampling))
-MUST be managed solely by the `TracerProvider` and it MUST provide some way to
-configure them, at least when creating or initializing it.
+Configuration (i.e., [Span processors](#span-processor), [IdsGenerator](#ids-generator),
+and [`Sampler`](#sampling)) MUST be managed solely by the `TracerProvider` and it
+MUST provide some way to configure them, at least when creating or initializing it.
 
 The TracerProvider MAY provide methods to update the configuration. If
 configuration is updated (e.g., adding a `SpanProcessor`),
@@ -223,23 +224,6 @@ the updated configuration MUST also apply to all already returned `Tracers`
 Note: Implementation-wise, this could mean that `Tracer` instances have a
 reference to their `TracerProvider` and access configuration only via this
 reference.
-
-The SDK MUST by default randomly generate the bytes for both the `TraceId` and
-the `SpanId`.
-
-The SDK MUST provide a mechanism for customizing the way IDs are generated for
-both the `TraceId` and the `SpanId`.
-
-The SDK MAY provide this functionality by allowing custom implementations of
-an interface like `IdsGenerator` below, which provides extension points for two
-methods, one to generate a `SpanID` and one to generate a `TraceId`.
-
-```
-IdsGenerator {
-  String generateSpanId()
-  String generateTraceId()
-}
-```
 
 ### Shutdown
 
@@ -316,6 +300,30 @@ specified in [SDK environment variables](../sdk-environment-variables.md#span-co
 There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log
 should not be emitted once per span, or per discarded attribute, event, or links.
+
+## Ids Generator
+
+The SDK MUST by default randomly generate both the `TraceId` and the `SpanId`.
+
+The SDK MUST provide a mechanism for customizing the way IDs are generated for
+both the `TraceId` and the `SpanId`.
+
+The SDK MAY provide this functionality by allowing custom implementations of
+an interface like the java example below (name of the interface MAY be
+`IdsGenerator`, name of the methods MUST be consistent with
+[SpanContext](./api.md#retrieving-the-traceid-and-spanid)), which provides
+extension points for two methods, one to generate a `SpanID` and one for `TraceId`.
+
+```java
+public interface IdsGenerator {
+  byte[] generateSpanIdBytes();
+  byte[] generateTraceIdBytes();
+}
+```
+
+Additional `IdsGenerator` implementing vendor-specific protocols such as AWS
+X-Ray trace id generator MUST NOT be maintained or distributed as part of the
+Core OpenTelemetry repositories.
 
 ## Span processor
 


### PR DESCRIPTION
In the context propagators we explicitly forbid vendor specific propagators in the core distributions, apply the same logic for IdsGenerator.