### PR TITLE
Mark Versioning documents as stable

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -1,5 +1,7 @@
 # OpenTelemetry Environment Variable Specification
 
+**Status**: [Stable](document-status.md)
+
 The goal of this specification is to unify the environment variable names between different OpenTelemetry SDK implementations. SDKs MAY choose to allow configuration via the environment variables in this specification, but are not required to. If they do, they SHOULD use the names listed in this document.
 
 ## Special configuration types

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -1,7 +1,5 @@
 # OpenTelemetry Environment Variable Specification
 
-**Status**: [Stable](document-status.md)
-
 The goal of this specification is to unify the environment variable names between different OpenTelemetry SDK implementations. SDKs MAY choose to allow configuration via the environment variables in this specification, but are not required to. If they do, they SHOULD use the names listed in this document.
 
 ## Special configuration types

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -1,4 +1,7 @@
 # Versioning and stability for OpenTelemetry clients
+
+**Status**: [Stable](document-status.md)
+
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 
 <!-- toc -->


### PR DESCRIPTION
Fixes #
Resolves v1.0 blocker identified here: [](https://github.com/open-telemetry/opentelemetry-specification/pull/1372#issuecomment-775278062)

## Changes
* Marks "OpenTelemetry Environment Variable Specification" document as stable
* Marks "Versioning and stability for OpenTelemetry clients" document as stable
