### PR TITLE
[For 1.0] Mark TraceIdRatioBased experimental.

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -1,6 +1,8 @@
 # Tracing SDK
 
-**Status**: [Stable](../document-status.md)
+**Status**: [Mixed](../document-status.md)
+
+**Status of everything not marked otherwise**: [Stable](../document-status.md)
 
 <details>
 
@@ -151,6 +153,8 @@ The default sampler is `ParentBased(root=AlwaysOn)`.
 * Description MUST be `AlwaysOffSampler`.
 
 #### TraceIdRatioBased
+
+**Status**: [Experimental](../document-status.md)
 
 * The `TraceIdRatioBased` MUST ignore the parent `SampledFlag`. To respect the
 parent `SampledFlag`, the `TraceIdRatioBased` should be used as a delegate of


### PR DESCRIPTION
Required for #1373.

See https://github.com/open-telemetry/opentelemetry-specification/pull/1372#issuecomment-775934345

TraceIdRatioBased is only vaguely specified and has a TODO in it. We should not mark it stable now.

Alternative temporary solutions:

0. Declare it experimental (this PR)
1. Completely remove that sampler for now (from spec)
2. Document that only the algorithm is unspecified and may break for language SDKs, but the interface for configuration/creation is stable --> #1414
3. Do nothing -- the TODO might already be clear enough

Alternative permanent solution:

4. (@jkwatson) Quickly specify it before 1.0 https://github.com/open-telemetry/opentelemetry-specification/pull/1412#issuecomment-776056730,
5. Just remove the TODO, leave algorithm unspecified forever https://github.com/open-telemetry/opentelemetry-specification/pull/1412#issuecomment-776059858

Follow-up to find *some* proper solution is in #1413.