### PR TITLE
Finalize SpanLimits definition, add option to configure it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New:
 
 - Add `cloud.infrastructure_service` resource attribute
   ([#1112](https://github.com/open-telemetry/opentelemetry-specification/pull/1112))
+- Add `SpanLimits` as a configuration for the TracerProvider([#1416](https://github.com/open-telemetry/opentelemetry-specification/pull/1416))
 
 Updates:
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -70,6 +70,7 @@ status of the feature is not known.
 | ShouldSample gets full parent Context                                                            |          |    | +    | +  | +      | +    | +      |     |      | +   | -    | +     |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          |    |      |    | +      | +    |        |     |      |     | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators) ]                                       |          |    |      |    |        |      |        |     |      |     |      |       |
+| [SpanLimits](specification/trace/sdk.md#span-limits) ]                                           |          |    |      |    |        |      |        |     |      |     |      |       |
 
 ## Baggage
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -70,7 +70,7 @@ status of the feature is not known.
 | ShouldSample gets full parent Context                                                            |          |    | +    | +  | +      | +    | +      |     |      | +   | -    | +     |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          |    |      |    | +      | +    |        |     |      |     | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators) ]                                       |          |    |      |    |        |      |        |     |      |     |      |       |
-| [SpanLimits](specification/trace/sdk.md#span-limits) ]                                           |          |    |      |    |        |      |        |     |      |     |      |       |
+| [SpanLimits](specification/trace/sdk.md#span-limits) ]                                           | X        |    |      |    |        |      |        |     |      |     |      |       |
 
 ## Baggage
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -73,7 +73,9 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 ## Span Collection Limits
 
-**Status**: [Experimental](document-status.md)
+**Status**: [Stable](document-status.md)
+
+See the SDK [Span Limits](trace/sdk.md#span-limits) section for the definition of the limits.
 
 | Name                            | Description                          | Default | Notes |
 | ------------------------------- | ------------------------------------ | ------- | ----- |

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -303,9 +303,11 @@ To protect against such errors, SDK Spans MAY discard attributes, links, and
 events that would increase the number of elements of each collection beyond
 the configured limit.
 
-It the SDK implements the limits above it MUST provide a way to change these limits, via a configuration to the
-TracerProvider, by allowing users to configure individual limits like in the Java
-example bellow. The name of the configuration class MAY be `SpanLimits`, and the
+It the SDK implements the limits above it MUST provide a way to change these
+limits, via a configuration to the TracerProvider, by allowing users to
+configure individual limits like in the Java example bellow.
+
+The name of the configuration class MAY be `SpanLimits`, and the
 name of the properties SHOULD be `AttributeCountLimit`, `EventCountLimit` and
 `LinkCountLimit`. Implementations MAY provide additional configuration such as
 `AttributePerEventCountLimit` and `AttributePerLinkCountLimit`.
@@ -324,13 +326,13 @@ public final class SpanLimits {
 
 **Configurable parameters:**
 
-* `AttributeCountLimit` - Maximum allowed span attribute count;
-* `EventCountLimit` - Maximum allowed span event count;
-* `LinkCountLimit` - Maximum allowed span link count;
-* `AttributePerEventCountLimit` - Maximum allowed attribute per span event count;
-* `AttributePerLinkCountLimit` - Maximum allowed attribute per span link count;
+* `AttributeCountLimit` (Default=1000) - Maximum allowed span attribute count;
+* `EventCountLimit` (Default=1000) - Maximum allowed span event count;
+* `LinkCountLimit` (Default=1000) - Maximum allowed span link count;
+* `AttributePerEventCountLimit` (Default=128) - Maximum allowed attribute per span event count;
+* `AttributePerLinkCountLimit` (Default=128) - Maximum allowed attribute per span link count;
 
-If there is a configurable provided, the SDK SHOULD honor the environment variables
+If there is a configuration provided, the SDK SHOULD honor the environment variables
 specified in [SDK environment variables](../sdk-environment-variables.md#span-collection-limits).
 
 There SHOULD be a log emitted to indicate to the user that an attribute, event,

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -307,10 +307,10 @@ It the SDK implements the limits above it MUST provide a way to change these
 limits, via a configuration to the TracerProvider, by allowing users to
 configure individual limits like in the Java example bellow.
 
-The name of the configuration class MAY be `SpanLimits`, and the
-name of the properties SHOULD be `AttributeCountLimit`, `EventCountLimit` and
-`LinkCountLimit`. Implementations MAY provide additional configuration such as
-`AttributePerEventCountLimit` and `AttributePerLinkCountLimit`.
+The name of the configuration options SHOULD be `AttributeCountLimit`,
+`EventCountLimit` and `LinkCountLimit`. The options MAY be bundled in a class,
+which then SHOULD be called `SpanLimits`. Implementations MAY provide additional
+configuration such as `AttributePerEventCountLimit` and `AttributePerLinkCountLimit`.
 
 ```java
 public final class SpanLimits {
@@ -331,9 +331,6 @@ public final class SpanLimits {
 * `LinkCountLimit` (Default=1000) - Maximum allowed span link count;
 * `AttributePerEventCountLimit` (Default=128) - Maximum allowed attribute per span event count;
 * `AttributePerLinkCountLimit` (Default=128) - Maximum allowed attribute per span link count;
-
-If there is a configuration provided, the SDK SHOULD honor the environment variables
-specified in [SDK environment variables](../sdk-environment-variables.md#span-collection-limits).
 
 There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -303,12 +303,12 @@ To protect against such errors, SDK Spans MAY discard attributes, links, and
 events that would increase the number of elements of each collection beyond
 the configured limit.
 
-The SDKs MUST provide a way to change these limits, via a configuration to the
-TracerProvider, by allowing users to configure individual limits like the java
-example bellow. The name of the cofiguration class MAY be `SpanLimits`, and the
-name of the properties SHOULD be `AttributeCountLimit`, `EventCountLimit`,
-`LinkCountLimit`. Implementation MAY provide additional configuration such as
-`AttributePerEventCountLimit`, `AttributePerLinkCountLimit`.
+It the SDK implements the limits above it MUST provide a way to change these limits, via a configuration to the
+TracerProvider, by allowing users to configure individual limits like in the Java
+example bellow. The name of the configuration class MAY be `SpanLimits`, and the
+name of the properties SHOULD be `AttributeCountLimit`, `EventCountLimit` and
+`LinkCountLimit`. Implementations MAY provide additional configuration such as
+`AttributePerEventCountLimit` and `AttributePerLinkCountLimit`.
 
 ```java
 public final class SpanLimits {

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -9,7 +9,7 @@
 * [Tracer Provider](#tracer-provider)
 * [Additional Span Interfaces](#additional-span-interfaces)
 * [Sampling](#sampling)
-* [Limits on Span Collections](#limits-on-span-collections)
+* [Span Limits](#span-limits)
 * [Id Generator](#id-generators)
 * [Span Processor](#span-processor)
 * [Span Exporter](#span-exporter)
@@ -26,9 +26,10 @@ supplied to the `TracerProvider` must be used to create an
 [`InstrumentationLibrary`][otep-83] instance which is stored on the created
 `Tracer`.
 
-Configuration (i.e., [Span processors](#span-processor), [IdGenerator](#id-generators),
-and [`Sampler`](#sampling)) MUST be managed solely by the `TracerProvider` and it
-MUST provide some way to configure them, at least when creating or initializing it.
+Configuration (i.e., [SpanProcessors](#span-processor), [IdGenerator](#id-generators),
+[SpanLimits](#span-limits) and [`Sampler`](#sampling)) MUST be managed solely by
+the `TracerProvider` and it MUST provide some way to configure all of them that
+are implemented in the SDK, at least when creating or initializing it.
 
 The TracerProvider MAY provide methods to update the configuration. If
 configuration is updated (e.g., adding a `SpanProcessor`),
@@ -292,7 +293,7 @@ Optional parameters:
 |present|false|true|`localParentSampled()`|
 |present|false|false|`localParentNotSampled()`|
 
-## Limits on Span Collections
+## Span Limits
 
 Erroneous code can add unintended attributes, events, and links to a span. If
 these collections are unbounded, they can quickly exhaust available memory,
@@ -300,9 +301,36 @@ resulting in crashes that are difficult to recover from safely.
 
 To protect against such errors, SDK Spans MAY discard attributes, links, and
 events that would increase the number of elements of each collection beyond
-the recommended limit of 128 elements. SDKs MAY provide a way to change this limit.
+the configured limit.
 
-If there is a configurable limit, the SDK SHOULD honor the environment variables
+The SDKs MUST provide a way to change these limits, via a configuration to the
+TracerProvider, by allowing users to configure individual limits like the java
+example bellow. The name of the cofiguration class MAY be `SpanLimits`, and the
+name of the properties SHOULD be `AttributeCountLimit`, `EventCountLimit`,
+`LinkCountLimit`. Implementation MAY provide additional configuration such as
+`AttributePerEventCountLimit`, `AttributePerLinkCountLimit`.
+
+```java
+public final class SpanLimits {
+  SpanLimits(int attributeCountLimit, int linkCountLimit, int eventCountLimit);
+
+  public int getAttributeCountLimit();
+
+  public int getEventCountLimit();
+
+  public int getLinkCountLimit();
+}
+```
+
+**Configurable parameters:**
+
+* `AttributeCountLimit` - Maximum allowed span attribute count;
+* `EventCountLimit` - Maximum allowed span event count;
+* `LinkCountLimit` - Maximum allowed span link count;
+* `AttributePerEventCountLimit` - Maximum allowed attribute per span event count;
+* `AttributePerLinkCountLimit` - Maximum allowed attribute per span link count;
+
+If there is a configurable provided, the SDK SHOULD honor the environment variables
 specified in [SDK environment variables](../sdk-environment-variables.md#span-collection-limits).
 
 There SHOULD be a log emitted to indicate to the user that an attribute, event,


### PR DESCRIPTION
Followup from https://github.com/open-telemetry/opentelemetry-specification/pull/1407 when we were asked to exclude the environment variables for the span limits.


**Update:**
Discussed with the @open-telemetry/technical-committee if we want to have this or not, and decision was to include this PR in the version 1.0 that will be released today:
* This PR does not add a new functionality, the limits were defined before and defined only as configurable via ENV variables. Having the limits was and will remain optional. 
* This PR indeed does make required to add the code configuration as well and standardize it, for languages that implement this feature, but all languages which support the ENV variables have a way to configure this via code anyway, so this PR tries only to standardize on that mechanism and will be a small rename (if any).