### PR TITLE
Update default for span limits to 128, 1000 seems off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ New:
 
 Updates:
 
+- Update default limit for span attributes, events, links to 128([#1419](https://github.com/open-telemetry/opentelemetry-specification/pull/1419))
 - Update OT Trace propagator environment variable to match latest name([#1406](https://github.com/open-telemetry/opentelemetry-specification/pull/1406))
 - Remove Metrics SDK specification to avoid confusion, clarify that Metrics API
   specification is not recommended for client implementation

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -77,9 +77,9 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 | Name                            | Description                          | Default | Notes |
 | ------------------------------- | ------------------------------------ | ------- | ----- |
-| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | Maximum allowed span attribute count | 1000    |       |
-| OTEL_SPAN_EVENT_COUNT_LIMIT     | Maximum allowed span event count     | 1000    |       |
-| OTEL_SPAN_LINK_COUNT_LIMIT      | Maximum allowed span link count      | 1000    |       |
+| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | Maximum allowed span attribute count | 128     |       |
+| OTEL_SPAN_EVENT_COUNT_LIMIT     | Maximum allowed span event count     | 128     |       |
+| OTEL_SPAN_LINK_COUNT_LIMIT      | Maximum allowed span link count      | 128     |       |
 
 ## OTLP Exporter
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -300,7 +300,7 @@ resulting in crashes that are difficult to recover from safely.
 
 To protect against such errors, SDK Spans MAY discard attributes, links, and
 events that would increase the number of elements of each collection beyond
-the recommended limit of 1000 elements. SDKs MAY provide a way to change this limit.
+the recommended limit of 128 elements. SDKs MAY provide a way to change this limit.
 
 If there is a configurable limit, the SDK SHOULD honor the environment variables
 specified in [SDK environment variables](../sdk-environment-variables.md#span-collection-limits).


### PR DESCRIPTION
128 is based on the value used in OpenCensus and it was not a problem there. See https://github.com/census-instrumentation/opencensus-java/blob/3d7f0b511dea392bbf68ee5268dd95857552dd87/api/src/main/java/io/opencensus/trace/config/TraceParams.java#L36

The limits for attributes and links were smaller, but I applied a max(of_all) function.