### PR TITLE
correct the default span limit values to 128

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -326,9 +326,9 @@ public final class SpanLimits {
 
 **Configurable parameters:**
 
-* `AttributeCountLimit` (Default=1000) - Maximum allowed span attribute count;
-* `EventCountLimit` (Default=1000) - Maximum allowed span event count;
-* `LinkCountLimit` (Default=1000) - Maximum allowed span link count;
+* `AttributeCountLimit` (Default=128) - Maximum allowed span attribute count;
+* `EventCountLimit` (Default=128) - Maximum allowed span event count;
+* `LinkCountLimit` (Default=128) - Maximum allowed span link count;
 * `AttributePerEventCountLimit` (Default=128) - Maximum allowed attribute per span event count;
 * `AttributePerLinkCountLimit` (Default=128) - Maximum allowed attribute per span link count;
 


### PR DESCRIPTION
Original PR https://github.com/open-telemetry/opentelemetry-specification/pull/1419 updated SDK values, but during rebase of https://github.com/open-telemetry/opentelemetry-specification/pull/1416 they were reverted by mistake.