### PR TITLE
Add none for exporter selection enums.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release.
 
 ## Unreleased
 
+- Adds `none` as a possible value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER to disable export([#1439](https://github.com/open-telemetry/opentelemetry-specification/pull/1439))
+
 ## v1.0.1 (2021-02-11)
 
 - Fix rebase issue for span limit default values ([#1429](https://github.com/open-telemetry/opentelemetry-specification/pull/1429))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ release.
 
 ## Unreleased
 
-- Adds `none` as a possible value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER to disable export([#1439](https://github.com/open-telemetry/opentelemetry-specification/pull/1439))
+- Adds `none` as a possible value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER to disable export
+  ([#1439](https://github.com/open-telemetry/opentelemetry-specification/pull/1439))
 
 ## v1.0.1 (2021-02-11)
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -141,13 +141,13 @@ Known values for OTEL_TRACES_EXPORTER are:
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"jaeger"`: [Jaeger gRPC](https://www.jaegertracing.io/docs/1.21/apis/#protobuf-via-grpc-stable)
 - `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
-- `"none"`: Disables export of traces.
+- `"none"`: No automatically configured exporter for traces.
 
 Known values for OTEL_METRICS_EXPORTER are:
 
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
-- `"none"`: Disables export of metrics.
+- `"none"`: No automatically configured exporter for metrics.
 
 ## Language Specific Environment Variables
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -141,11 +141,13 @@ Known values for OTEL_TRACES_EXPORTER are:
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"jaeger"`: [Jaeger gRPC](https://www.jaegertracing.io/docs/1.21/apis/#protobuf-via-grpc-stable)
 - `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
+- `"none"`: Disables export of traces.
 
 Known values for OTEL_METRICS_EXPORTER are:
 
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
+- `"none"`: Disables export of metrics.
 
 ## Language Specific Environment Variables
 


### PR DESCRIPTION
## Changes

Adds `none` as an option for exporter selection. Because the default is `otlp`, there is no way to disable signal export via env vars.