### PR TITLE
erlang process.runtime attributes: remove TODO note and update descriptions

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -17,8 +17,8 @@ status of the feature is not known.
 | Safe for concurrent calls                                                                        |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Shutdown (SDK only required)                                                                     |          |    | +    | +  | +      | +    | -      |     | +    | +   | +    | +     |
 | [Trace / Context interaction](specification/trace/api.md#context-interaction)                    |          |    |      |    |        |      |        |     |      |     |      |       |
-| Get active Span                                                                                  |          |    | +    | +  | +      | +    | N/A    |     | +    | +   | +    | +     |
-| Set active Span                                                                                  |          |    | +    | +  | +      | +    | N/A    |     | +    | +   | +    | +     |
+| Get active Span                                                                                  |          |    | +    | +  | +      | +    | +    |     | +    | +   | +    | +     |
+| Set active Span                                                                                  |          |    | +    | +  | +      | +    | +    |     | +    | +   | +    | +     |
 | [Tracer](specification/trace/api.md#tracer-operations)                                           |          |    |      |    |        |      |        |     |      |     |      |       |
 | Create a new Span                                                                                |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Get active Span                                                                                  |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
@@ -68,7 +68,7 @@ status of the feature is not known.
 | [Sampling](specification/trace/sdk.md#sampling)                                                  |          |    |      |    |        |      |        |     |      |     |      |       |
 | Allow samplers to modify tracestate                                                              |          |    | +    |    | +      | +    | +      |     | +    |     | -    | +     |
 | ShouldSample gets full parent Context                                                            |          |    | +    | +  | +      | +    | +      |     |      | +   | -    | +     |
-| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          |    |      |    | +      | +    |        |     |      |     | -    | +     |
+| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          |    |      |    | +      | +    | +      |     |      |     | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          |    |      |    |        | +    |        |     |      |     |      |       |
 | [SpanLimits](specification/trace/sdk.md#span-limits)                                             | X        |    |      |    |        | +    |        |     |      |     |      |       |
 
@@ -91,9 +91,9 @@ status of the feature is not known.
 |---------------------------------------------------------------------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | Create from Attributes                                                                                                                      |          | +  | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
 | Create empty                                                                                                                                |          | +  | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
-| [Merge (v2)](specification/resource/sdk.md#merge)                                                                                           |          |    |      |    | +      | +    |        |     |      | +   | +    |       |
+| [Merge (v2)](specification/resource/sdk.md#merge)                                                                                           |          |    |      |    | +      | +    | +      |     |      | +   | +    |       |
 | Retrieve attributes                                                                                                                         |          | +  | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
-| [Default value](specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value) for service.name |          |    |      |    | +      | +    |        |     |      | +   | +    |       |
+| [Default value](specification/resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value) for service.name |          |    |      |    | +      | +    | +      |     |      | +   | +    |       |
 
 ## Context Propagation
 
@@ -122,20 +122,20 @@ Note: Support for environment variables is optional.
 
 |Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|Swift|
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|-----|
-|OTEL_RESOURCE_ATTRIBUTES                      | + | +  | + | +    | +  | -    | - | +  | - | +  | -   |
-|OTEL_LOG_LEVEL                                |   | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1059)    | +  | -    | - |    | - | -  | -   |        |
-|OTEL_PROPAGATORS                              |   | +  |   | +    | +  | -    | - |    | - | -  | -   |
-|OTEL_BSP_*                                    |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
+|OTEL_RESOURCE_ATTRIBUTES                      | + | +  | + | +    | +  | +    | - | +  | - | +  | -   |
+|OTEL_LOG_LEVEL                                |   | -  | + | [-](https://github.com/open-telemetry/opentelemetry-python/issues/1059)    | +  | +    | - |    | - | -  | -   |        |
+|OTEL_PROPAGATORS                              |   | +  |   | +    | +  | +    | - |    | - | -  | -   |
+|OTEL_BSP_*                                    |   | +  |   | +    | +  | +    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_OTLP_*                          |   | -  |   | -    | +  | -    | - |    | - | -  | -   |
 |OTEL_EXPORTER_JAEGER_*                        |   | +  |   | +    | +  | -    | - | +  | - | -  | -   |
 |OTEL_EXPORTER_ZIPKIN_*                        |   | +  |   | +    |    | -    | - |    | - | -  | -   |
-|OTEL_TRACES_EXPORTER                          |   |    |   | +    | +  |      |   |    |   |    |     |
-|OTEL_METRICS_EXPORTER                         |   | +  |   | +    |    |      |   |    |   | -  | -   |
-|OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   |    |   | +    | +  |      |   |    |   |    |     |
-|OTEL_SPAN_EVENT_COUNT_LIMIT                   |   |    |   | +    | +  |      |   |    |   |    |     |
-|OTEL_SPAN_LINK_COUNT_LIMIT                    |   |    |   | +    | +  |      |   |    |   |    |     |
-|OTEL_TRACES_SAMPLER                           |   |    |   | +    | +  |      |   |    |   |    |     |
-|OTEL_TRACES_SAMPLER_ARG                       |   |    |   | +    | +  |      |   |    |   |    |     |
+|OTEL_TRACES_EXPORTER                          |   |    |   | +    | +  | +    |   |    |   |    |     |
+|OTEL_METRICS_EXPORTER                         |   | +  |   | +    |    | -    |   |    |   | -  | -   |
+|OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               |   |    |   | +    | +  | -    |   |    |   |    |     |
+|OTEL_SPAN_EVENT_COUNT_LIMIT                   |   |    |   | +    | +  | -    |   |    |   |    |     |
+|OTEL_SPAN_LINK_COUNT_LIMIT                    |   |    |   | +    | +  | -    |   |    |   |    |     |
+|OTEL_TRACES_SAMPLER                           |   |    |   | +    | +  | +    |   |    |   |    |     |
+|OTEL_TRACES_SAMPLER_ARG                       |   |    |   | +    | +  | +    |   |    |   |    |     |
 
 ## Exporters
 

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -70,6 +70,12 @@ In addition to these attributes, [`telemetry.sdk.language`](README.md#telemetry-
 - `process.runtime.version` -  The version of the runtime (ERTS - Erlang Runtime System), i.e., `erlang:system_info(version)`.
 - `process.runtime.description` - string | An additional description about the runtime made by combining the OTP version, i.e., `erlang:system_info(otp_release)`, and ERTS version.
 
+Example:
+
+| `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |
+| --- | --- | --- |
+| BEAM | 11.1 |  Erlang/OTP 23 erts-11.1 |
+
 ### Go Runtimes
 
 TODO(<https://github.com/open-telemetry/opentelemetry-go/issues/1181>): Confirm the contents here

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -66,17 +66,9 @@ In addition to these attributes, [`telemetry.sdk.language`](README.md#telemetry-
 
 ### Erlang Runtimes
 
-TODO(<https://github.com/open-telemetry/opentelemetry-erlang/issues/96>): Confirm the contents here
-
-- `process.runtime.name` - The name of the Erlang runtime being used. Usually will be BEAM.
-- `process.runtime.version` - The ERTS (Erlang Runtime System) version. For BEAM this is found with `application:get_key(erts, vsn)`.
-- `process.runtime.description` - The OTP version `erlang:system_info(otp_release)` and ERTS version combined.
-
-Example:
-
-| Name | `process.runtime.name` | `process.runtime.version` | `process.runtime.description` |
-| --- | --- | --- | --- |
-| beam | BEAM | 11.0.3 | Erlang/OTP 24 erts-11.0.3 |
+- `process.runtime.name` - The name of the Erlang VM being used, i.e., `erlang:system_info(machine)`.
+- `process.runtime.version` -  The version of the runtime (ERTS - Erlang Runtime System), i.e., `erlang:system_info(version)`.
+- `process.runtime.description` - string | An additional description about the runtime made by combining the OTP version, i.e., `erlang:system_info(otp_release)`, and ERTS version.
 
 ### Go Runtimes
 


### PR DESCRIPTION
No real change here, simply removes the TODO since it is done and updates the attributes into a table.

Related issue: https://github.com/open-telemetry/opentelemetry-erlang/issues/96
