### PR TITLE
Add ForceFlush to Tracing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ release.
 
 - Adds `none` as a possible value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER to disable export
   ([#1439](https://github.com/open-telemetry/opentelemetry-specification/pull/1439))
+- Add `ForceFlush` to [Tracing SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown) ([#1452](https://github.com/open-telemetry/opentelemetry-specification/pull/1452))
 
 ## v1.0.1 (2021-02-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release.
 
 - Adds `none` as a possible value for OTEL_TRACES_EXPORTER and OTEL_METRICS_EXPORTER to disable export
   ([#1439](https://github.com/open-telemetry/opentelemetry-specification/pull/1439))
-- Add `ForceFlush` to [Tracing SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown) ([#1452](https://github.com/open-telemetry/opentelemetry-specification/pull/1452))
+- Add [`ForceFlush`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#forceflush) to SDK's `TracerProvider` ([#1452](https://github.com/open-telemetry/opentelemetry-specification/pull/1452))
 
 ## v1.0.1 (2021-02-11)
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -16,6 +16,7 @@ status of the feature is not known.
 | Get a Tracer                                                                                     |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Safe for concurrent calls                                                                        |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Shutdown (SDK only required)                                                                     |          |    | +    | +  | +      | +    | -      |     | +    | +   | +    | +     |
+| ForceFlush (SDK only required)                                                                   |          |    | +    | -  | -      | -    | -      |     | -    | -   | +    | -     |
 | [Trace / Context interaction](specification/trace/api.md#context-interaction)                    |          |    |      |    |        |      |        |     |      |     |      |       |
 | Get active Span                                                                                  |          |    | +    | +  | +      | +    | N/A    |     | +    | +   | +    | +     |
 | Set active Span                                                                                  |          |    | +    | +  | +      | +    | N/A    |     | +    | +   | +    | +     |

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -70,7 +70,7 @@ implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. OpenTelemetry client authors can decide if they want to
 make the flush timeout configurable.
 
-`ForceFlush` MUST invoke `ForceFlush` on all `SpanProcessors` of the `TracerProvider`.
+`ForceFlush` MUST invoke `ForceFlush` on all registered `SpanProcessors`.
 
 ## Additional Span Interfaces
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -70,7 +70,7 @@ implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. OpenTelemetry client authors can decide if they want to
 make the flush timeout configurable.
 
-`ForceFlush` MUST be implemented at least by invoking `ForceFlush` within all internal processors.
+`ForceFlush` MUST invoke `ForceFlush` on all `SpanProcessors` of the `TracerProvider`.
 
 ## Additional Span Interfaces
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -58,6 +58,20 @@ make the shutdown timeout configurable.
 
 `Shutdown` MUST be implemented at least by invoking `Shutdown` within all internal processors.
 
+### ForceFlush
+
+This method provides a way for provider to immediately export all spans that have not yet been exported for all the internal processors.
+
+`ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
+failed or timed out.
+
+`ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
+implemented as a blocking API or an asynchronous API which notifies the caller
+via a callback or an event. OpenTelemetry client authors can decide if they want to
+make the flush timeout configurable.
+
+`ForceFlush` MUST be implemented at least by invoking `ForceFlush` within all internal processors.
+
 ## Additional Span Interfaces
 
 The [API-level definition for Span's interface](api.md#span-operations)


### PR DESCRIPTION
Fixes #1451

## Changes

Added `ForceFlush` to [Tracing SDK](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#shutdown) like it was done for the `Shutdown` method.
