### PR TITLE
Release review for java tracing v1

### DIFF
--- a/release_reviews/release-review-java-tracing-v1.md
+++ b/release_reviews/release-review-java-tracing-v1.md
@@ -1,55 +1,17 @@
-# Technical Review and Specification Conformance for ${LANGUAGE}/${SIGNAL}/${MAJOR_VERSION} library
+# Technical Review and Specification Conformance for Java/Tracing/v1 library
 
-Technical Committee Sponsor(s): []
+Technical Committee Sponsor(s): @bogdandrutu
 
-Expected Release Date: []
+Expected Release Date: February 26, 2021
 
-Expected Version Number: []
+Expected Version Number: v1.0.0
 
-Spec Compliance Matrix is up to date: [Permanent link to the matrix]
+Spec Compliance Matrix is up to date: (https://github.com/open-telemetry/opentelemetry-specification/pull/1464)
 
-Versioning And Stability Document: [Link to version document]
+Versioning And Stability Document: (https://github.com/open-telemetry/opentelemetry-java/blob/main/VERSIONING.md)
 
-Public Code Documentation: [Link to godoc, javadoc, etc.]
+Public Code Documentation: (https://javadoc.io/doc/io.opentelemetry)
 
-Public Examples: [Link to couple of official usage examples]
+Public Examples: (https://github.com/open-telemetry/opentelemetry-java/tree/main/examples)
 
 Discovered Issues: [List of filed issues by the TC members during the review process]
-
-## TODOs
-
-This section must be deleted when the PR for starting the review is opened,
-but it contains a list of important TODOs that maintainers MUST do before starting the process.
-
-The Language Maintainers MUST:
-
-* Prior to starting the review, update the
-  [compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md)
-  for that language/signal.
-* Each language implementation MUST follow
-  [the versioning and stability requirements](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/versioning-and-stability.md)
-  and prepare the public documentation about the versioning and stability guarantees.
-* Work with a Technical Committee Sponsor(s) during review. The Technical
-  Committee members are not language experts, and are expected to work with the
-  language maintainers and/or invited language experts to perform this review
-  process. Language maintainers SHOULD respond to any question/issue
-  (github issues, github discussions, gitter, or comments in the review PR)
-  during the review time in a reasonable amount of time to not delay the review
-  process (ideally 1 business day).
-
-It is highly recommended to have at least 2 members of the Technical Committee
-as sponsors. Any Technical Committee member can be a sponsor, and any Technical
-Committee member can provide feedback during the review process.
-
-Technical Committee Sponsor(s) MUST:
-
-* Do the due diligence and review the public documentation and examples, and
-  ensure specification conformance.
-* Ensure conformance with the versioning and stability document.
-* Ensure consistent names across implementations (e.g. TraceId vs GlobalId)
-* Avoid confusions across implementation (e.g. same public API has different behaviors)
-* Ensure no experimental features (signals) are part of the released packages (e.g. api, sdk, etc.).
-
-The OpenTelemetry Technical Committee MUST attend one of the language SIG
-meetings and have a public discussion with the language maintainers to discuss
-any issues found during the review process.

--- a/release_reviews/release-review-java-tracing-v1.md
+++ b/release_reviews/release-review-java-tracing-v1.md
@@ -1,0 +1,55 @@
+# Technical Review and Specification Conformance for ${LANGUAGE}/${SIGNAL}/${MAJOR_VERSION} library
+
+Technical Committee Sponsor(s): []
+
+Expected Release Date: []
+
+Expected Version Number: []
+
+Spec Compliance Matrix is up to date: [Permanent link to the matrix]
+
+Versioning And Stability Document: [Link to version document]
+
+Public Code Documentation: [Link to godoc, javadoc, etc.]
+
+Public Examples: [Link to couple of official usage examples]
+
+Discovered Issues: [List of filed issues by the TC members during the review process]
+
+## TODOs
+
+This section must be deleted when the PR for starting the review is opened,
+but it contains a list of important TODOs that maintainers MUST do before starting the process.
+
+The Language Maintainers MUST:
+
+* Prior to starting the review, update the
+  [compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md)
+  for that language/signal.
+* Each language implementation MUST follow
+  [the versioning and stability requirements](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/versioning-and-stability.md)
+  and prepare the public documentation about the versioning and stability guarantees.
+* Work with a Technical Committee Sponsor(s) during review. The Technical
+  Committee members are not language experts, and are expected to work with the
+  language maintainers and/or invited language experts to perform this review
+  process. Language maintainers SHOULD respond to any question/issue
+  (github issues, github discussions, gitter, or comments in the review PR)
+  during the review time in a reasonable amount of time to not delay the review
+  process (ideally 1 business day).
+
+It is highly recommended to have at least 2 members of the Technical Committee
+as sponsors. Any Technical Committee member can be a sponsor, and any Technical
+Committee member can provide feedback during the review process.
+
+Technical Committee Sponsor(s) MUST:
+
+* Do the due diligence and review the public documentation and examples, and
+  ensure specification conformance.
+* Ensure conformance with the versioning and stability document.
+* Ensure consistent names across implementations (e.g. TraceId vs GlobalId)
+* Avoid confusions across implementation (e.g. same public API has different behaviors)
+* Ensure no experimental features (signals) are part of the released packages (e.g. api, sdk, etc.).
+
+The OpenTelemetry Technical Committee MUST attend one of the language SIG
+meetings and have a public discussion with the language maintainers to discuss
+any issues found during the review process.

--- a/release_reviews/release-review-java-tracing-v1.md
+++ b/release_reviews/release-review-java-tracing-v1.md
@@ -6,12 +6,12 @@ Expected Release Date: February 26, 2021
 
 Expected Version Number: v1.0.0
 
-Spec Compliance Matrix is up to date: (https://github.com/open-telemetry/opentelemetry-specification/pull/1464)
+Spec Compliance Matrix is up to date: [PR](https://github.com/open-telemetry/opentelemetry-specification/pull/1464)
 
-Versioning And Stability Document: (https://github.com/open-telemetry/opentelemetry-java/blob/main/VERSIONING.md)
+Versioning And Stability Document: [Versioning doc](https://github.com/open-telemetry/opentelemetry-java/blob/main/VERSIONING.md)
 
-Public Code Documentation: (https://javadoc.io/doc/io.opentelemetry)
+Public Code Documentation: [Javadoc.io](https://javadoc.io/doc/io.opentelemetry)
 
-Public Examples: (https://github.com/open-telemetry/opentelemetry-java/tree/main/examples)
+Public Examples: [Examples](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples)
 
 Discovered Issues: [List of filed issues by the TC members during the review process]

--- a/release_reviews/release-review-java-tracing-v1.md
+++ b/release_reviews/release-review-java-tracing-v1.md
@@ -14,4 +14,14 @@ Public Code Documentation: [Javadoc.io](https://javadoc.io/doc/io.opentelemetry)
 
 Public Examples: [Examples](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples)
 
-Discovered Issues: [List of filed issues by the TC members during the review process]
+Discovered Issues:
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2913
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2894
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2786
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2784
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2724
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2664
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2658
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2629
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2626
+  - https://github.com/open-telemetry/opentelemetry-java/issues/2746

--- a/release_reviews/release-review-java-tracing-v1.md
+++ b/release_reviews/release-review-java-tracing-v1.md
@@ -15,13 +15,14 @@ Public Code Documentation: [Javadoc.io](https://javadoc.io/doc/io.opentelemetry)
 Public Examples: [Examples](https://github.com/open-telemetry/opentelemetry-java/tree/main/examples)
 
 Discovered Issues:
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2913
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2894
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2786
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2784
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2724
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2664
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2658
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2629
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2626
-  - https://github.com/open-telemetry/opentelemetry-java/issues/2746
+
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2913]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2894]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2786]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2784]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2724]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2664]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2658]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2629]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2626]
+- [https://github.com/open-telemetry/opentelemetry-java/issues/2746]


### PR DESCRIPTION
This is a draft of the release review template proposed in #1418  for the proposed release of the Java Tracing API and SDK for version 1.0.0.