### PR TITLE
Add jaeger option to split oversized batches

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -98,6 +98,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                   | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication | -                                                                                                |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication | -                                                                                                |
+| OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES  | Split jaeger exporter UDP batches if they exceed the UDP packet limit | false                                                                                                |
 
 ## Zipkin Exporter
 


### PR DESCRIPTION
This adds OTEL_EXPORTER_JAEGER_AGENT_SPLIT_OVERSIZED_BATCHES to 
the Jaeger exporter as porposed in 
https://github.com/open-telemetry/opentelemetry-python/pull/1500

Fixes #

## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
