### PR TITLE
Kick off the ownership clarification

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -2,6 +2,16 @@
 
 **Status**: [Experimental](../document-status.md)
 
+**Owner:**
+
+* [Reiley Yang](https://github.com/reyang)
+
+**Domain Experts:**
+
+* [Bogdan Brutu](https://github.com/bogdandrutu)
+* [Josh Suereth](https://github.com/jsuereth)
+* [Joshua MacDonald](https://github.com/jmacd)
+
 Note: this specification is subject to major changes. To avoid thrusting
 language client maintainers, we don't recommend OpenTelemetry clients to start
 the implementation unless explicitly communicated via


### PR DESCRIPTION
Per discussion during the [03/02/2021 Spec SIG Mtg](https://docs.google.com/document/d/1-bCYkN-DWJq4jw1ybaDZYYmx-WAe6HnwfWbkm8d57v8/edit#heading=h.qjk2i7r08k0r), I'm sending this PR in hope that all the spec docs would have owners/experts clarified. This could become very useful for semantic convention spec.

@rakyll please review.

@bogdandrutu @jmacd @jsuereth I put your names as the "domain experts" for metrics API spec, please approve if you'd like to be listed in the doc. If I haven't got your approval, I'll assume that you don't want to be listed here so I'll remove your name.

