### PR TITLE
Rename cloud.zone to cloud.availability_zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ release.
 Google products under `cloud.infrastructure_service` ([#1496](https://github.com/open-telemetry/opentelemetry-specification/pull/1496))
 - `http.url` MUST NOT contain credentials ([#1502](https://github.com/open-telemetry/opentelemetry-specification/pull/1502))
 - Add `aws.eks.cluster.arn` to EKS specific semantic conventions ([#1484](https://github.com/open-telemetry/opentelemetry-specification/pull/1484))
-- Rename `zone` to `availability_zone` in `cloud` semantic conventions
+- Rename `zone` to `availability_zone` in `cloud` semantic conventions ([#1495](https://github.com/open-telemetry/opentelemetry-specification/pull/1495))
 
 ## v1.0.1 (2021-02-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ release.
 Google products under `cloud.infrastructure_service` ([#1496](https://github.com/open-telemetry/opentelemetry-specification/pull/1496))
 - `http.url` MUST NOT contain credentials ([#1502](https://github.com/open-telemetry/opentelemetry-specification/pull/1502))
 - Add `aws.eks.cluster.arn` to EKS specific semantic conventions ([#1484](https://github.com/open-telemetry/opentelemetry-specification/pull/1484))
+- Rename `zone` to `availability_zone` in `cloud` semantic conventions
 
 ## v1.0.1 (2021-02-11)
 

--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -37,7 +37,7 @@ groups:
         type: string
         brief: >
           Cloud regions often have multiple, isolated locations known as zones
-          to increase availability. Availability zone represents the isolated
+          to increase availability. Availability zone represents the
           zone where the resource is running.
         note: >
           Google Cloud calls availability zones zones.

--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -33,15 +33,15 @@ groups:
           [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or
           [Google Cloud regions](https://cloud.google.com/about/locations).
         examples: ['us-central1', 'us-east-1']
-      - id: zone
+      - id: availability_zone
         type: string
         brief: >
           Cloud regions often have multiple, isolated locations known as zones
-          to increase availability. Zone represents the zone where the resource 
-          is running.
+          to increase availability. Availability zone represents the isolated
+          zone where the resource is running.
         note: >
-          AWS and Azure calls them availability zones or AZs.
-        examples: ['us-central1-a', 'us-east-1c']
+          Google Cloud calls availability zones zones.
+        examples: ['us-east-1c']
       - id: infrastructure_service
         type:
           allow_custom_values: true

--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -40,7 +40,7 @@ groups:
           to increase availability. Availability zone represents the
           zone where the resource is running.
         note: >
-          Google Cloud calls availability zones zones.
+          Google Cloud calls availability zones just "zones".
         examples: ['us-east-1c']
       - id: infrastructure_service
         type:

--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -40,7 +40,7 @@ groups:
           to increase availability. Availability zone represents the
           zone where the resource is running.
         note: >
-          Google Cloud calls availability zones just "zones".
+          Availability zones are called "zones" on Google Cloud.
         examples: ['us-east-1c']
       - id: infrastructure_service
         type:

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -12,10 +12,10 @@
 | `cloud.provider` | string | Name of the cloud provider. | `gcp` | No |
 | `cloud.account.id` | string | The cloud account ID the resource is assigned to. | `111111111111`; `opentelemetry` | No |
 | `cloud.region` | string | The geographical region the resource is running. Refer to your provider's docs to see the available regions, for example [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations). | `us-central1`; `us-east-1` | No |
-| `cloud.zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Zone represents the zone where the resource  is running. [1] | `us-central1-a`; `us-east-1c` | No |
+| `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the isolated zone where the resource is running. [1] | `us-east-1c` | No |
 | `cloud.infrastructure_service` | string | The cloud infrastructure resource in use. [2] | `aws_ec2`; `azure_vm`; `gcp_compute_engine` | No |
 
-**[1]:** AWS and Azure calls them availability zones or AZs.
+**[1]:** Google Cloud calls availability zones zones.
 
 **[2]:** The prefix of the service SHOULD match the one specified in `cloud.provider`.
 

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -12,10 +12,10 @@
 | `cloud.provider` | string | Name of the cloud provider. | `gcp` | No |
 | `cloud.account.id` | string | The cloud account ID the resource is assigned to. | `111111111111`; `opentelemetry` | No |
 | `cloud.region` | string | The geographical region the resource is running. Refer to your provider's docs to see the available regions, for example [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations). | `us-central1`; `us-east-1` | No |
-| `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the isolated zone where the resource is running. [1] | `us-east-1c` | No |
+| `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [1] | `us-east-1c` | No |
 | `cloud.infrastructure_service` | string | The cloud infrastructure resource in use. [2] | `aws_ec2`; `azure_vm`; `gcp_compute_engine` | No |
 
-**[1]:** Google Cloud calls availability zones zones.
+**[1]:** Google Cloud calls availability zones just "zones".
 
 **[2]:** The prefix of the service SHOULD match the one specified in `cloud.provider`.
 

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -15,7 +15,7 @@
 | `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [1] | `us-east-1c` | No |
 | `cloud.infrastructure_service` | string | The cloud infrastructure resource in use. [2] | `aws_ec2`; `azure_vm`; `gcp_compute_engine` | No |
 
-**[1]:** Google Cloud calls availability zones just "zones".
+**[1]:** Availability zones are called "zones" on Google Cloud.
 
 **[2]:** The prefix of the service SHOULD match the one specified in `cloud.provider`.
 


### PR DESCRIPTION
Only Google Cloud calls availability zones a zone. Renaming zone
to make the least common case an exception.

This change is a follow-up of https://github.com/open-telemetry/opentelemetry-specification/pull/1481.
