### PR TITLE
http.url MUST NOT contain credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ release.
 - Add `runtime` to `container` semantic conventions ([#1482](https://github.com/open-telemetry/opentelemetry-specification/pull/1482))
 - Rename `gcp_gke` to `gcp_kubernetes_engine` to have consistency with other
 Google products under `cloud.infrastructure_service` ([#1496](https://github.com/open-telemetry/opentelemetry-specification/pull/1496))
-- `http.url` MUST NOT contain password ([#1502](https://github.com/open-telemetry/opentelemetry-specification/pull/1502))
+- `http.url` MUST NOT contain credentials ([#1502](https://github.com/open-telemetry/opentelemetry-specification/pull/1502))
 
 ## v1.0.1 (2021-02-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ release.
 - Add `runtime` to `container` semantic conventions ([#1482](https://github.com/open-telemetry/opentelemetry-specification/pull/1482))
 - Rename `gcp_gke` to `gcp_kubernetes_engine` to have consistency with other
 Google products under `cloud.infrastructure_service` ([#1496](https://github.com/open-telemetry/opentelemetry-specification/pull/1496))
+- `http.url` MUST NOT contain password ([#1502](https://github.com/open-telemetry/opentelemetry-specification/pull/1502))
 
 ## v1.0.1 (2021-02-11)
 

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -17,8 +17,8 @@ groups:
             Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`.
             Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
         note: >
-          `http.url` MUST NOT contain the password if it is passed via URL in form of `https://username:password@www.example.com/`.
-          In such case the attribute's value can be set as `https://username:@www.example.com/` or `https://www.example.com/`.
+          `http.url` MUST NOT contain any credentials passed via URL in form of `https://username:password@www.example.com/`.
+          In such case the attribute's value should be `https://www.example.com/`.
         examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
       - id: target
         type: string

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -17,7 +17,7 @@ groups:
             Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`.
             Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
         note: >
-          `http.url` MUST NOT contain any credentials passed via URL in form of `https://username:password@www.example.com/`.
+          `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`.
           In such case the attribute's value should be `https://www.example.com/`.
         examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
       - id: target

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -16,6 +16,9 @@ groups:
         brief: >
             Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`.
             Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless.
+        note: >
+          `http.url` MUST NOT contain the password if it is passed via URL in form of `https://username:password@www.example.com/`.
+          In such case the attribute's value can be set as `https://username:@www.example.com/` or `https://www.example.com/`.
         examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
       - id: target
         type: string
@@ -58,7 +61,7 @@ groups:
             - id: QUIC
               value: 'QUIC'
               brief: 'QUIC protocol.'
-        brief: 'Kind of HTTP protocol used'
+        brief: 'Kind of HTTP protocol used.'
         note: >
           If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor`
           is `QUIC`, in which case `IP.UDP` is assumed.

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -68,7 +68,7 @@ Don't set the span status description if the reason can be inferred from `http.s
 | `http.response_content_length` | number | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
 | `http.response_content_length_uncompressed` | number | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
 
-**[1]:** `http.url` MUST NOT contain any credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
+**[1]:** `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
 
 **[2]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -10,14 +10,15 @@ and various HTTP versions like 1.1, 2 and SPDY.
 
 <!-- toc -->
 
-- [Name](#name)
-- [Status](#status)
-- [Common Attributes](#common-attributes)
-- [HTTP client](#http-client)
-- [HTTP server](#http-server)
-  * [HTTP server definitions](#http-server-definitions)
-  * [HTTP Server semantic conventions](#http-server-semantic-conventions)
-- [HTTP client-server example](#http-client-server-example)
+- [Semantic conventions for HTTP spans](#semantic-conventions-for-http-spans)
+  - [Name](#name)
+  - [Status](#status)
+  - [Common Attributes](#common-attributes)
+  - [HTTP client](#http-client)
+  - [HTTP server](#http-server)
+    - [HTTP server definitions](#http-server-definitions)
+    - [HTTP Server semantic conventions](#http-server-semantic-conventions)
+  - [HTTP client-server example](#http-client-server-example)
 
 <!-- tocstop -->
 
@@ -67,7 +68,7 @@ Don't set the span status description if the reason can be inferred from `http.s
 | `http.response_content_length` | number | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
 | `http.response_content_length_uncompressed` | number | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
 
-**[1]:** `http.url` MUST NOT contain the password if it is passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value can be set as `https://username:@www.example.com/` or `https://www.example.com/`.
+**[1]:** `http.url` MUST NOT contain any credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
 
 **[2]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -55,19 +55,21 @@ Don't set the span status description if the reason can be inferred from `http.s
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `http.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Yes |
-| `http.url` | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` | No |
+| `http.url` | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. [1] | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` | No |
 | `http.target` | string | The full request target as passed in a HTTP request line or equivalent. | `/path/12314/?q=ddds#123` | No |
 | `http.host` | string | The value of the [HTTP host header](https://tools.ietf.org/html/rfc7230#section-5.4). When the header is empty or not present, this attribute should be the same. | `www.example.org` | No |
 | `http.scheme` | string | The URI scheme identifying the used protocol. | `http`; `https` | No |
 | `http.status_code` | number | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If and only if one was received/sent. |
-| `http.flavor` | string | Kind of HTTP protocol used [1] | `1.0` | No |
+| `http.flavor` | string | Kind of HTTP protocol used. [2] | `1.0` | No |
 | `http.user_agent` | string | Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | No |
 | `http.request_content_length` | number | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
 | `http.request_content_length_uncompressed` | number | The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
 | `http.response_content_length` | number | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
 | `http.response_content_length_uncompressed` | number | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
 
-**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+**[1]:** `http.url` MUST NOT contain the password if it is passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value can be set as `https://username:@www.example.com/` or `https://www.example.com/`.
+
+**[2]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 `http.flavor` MUST be one of the following or, if none of the listed values apply, a custom value:
 


### PR DESCRIPTION
## Why

Example request's URL: `https://username:password@example.com:8080/path/to/file.aspx?query=1#fragment`

What is the expected attribute's value in such a case? For sure we should not pass the password. The username should not there as well per https://github.com/open-telemetry/opentelemetry-specification/pull/1502#discussion_r587860542.

Why do I think it is important? Because I saw this in OTel .NET SDK: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Instrumentation.Http/Implementation/HttpHandlerDiagnosticListener.cs#L115

Reference:
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#common-attributes
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/span-general.md#general-identity-attributes

## What 

Mandate to get rid of username (thanks to @yurishkuro) and password if it is present in the URL.
