### PR TITLE
Revert "Kick off the ownership clarification"

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -2,16 +2,6 @@
 
 **Status**: [Experimental](../document-status.md)
 
-**Owner:**
-
-* [Reiley Yang](https://github.com/reyang)
-
-**Domain Experts:**
-
-* [Bogdan Brutu](https://github.com/bogdandrutu)
-* [Josh Suereth](https://github.com/jsuereth)
-* [Joshua MacDonald](https://github.com/jmacd)
-
 Note: this specification is subject to major changes. To avoid thrusting
 language client maintainers, we don't recommend OpenTelemetry clients to start
 the implementation unless explicitly communicated via


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-specification#1494

Main reasons:

* Owner is a new concept undefined in otel org.
  * How do you become owner?
* Domain Expert in not defined as well, and it is not clear what are the rules to be one.

We do have concept of maintainers approvers and the right set of people are part of these groups based on clear rules. Why do we need more roles?

**Update:**
If we want to have these new roles we need to first define them then we can add it to every document/area.