### PR TITLE
Add semantic conventions spec

### DIFF
--- a/specification/semantic-conventions.md
+++ b/specification/semantic-conventions.md
@@ -1,0 +1,20 @@
+# Semantic Conventions
+
+**Status**: [Experimental](./document-status.md)
+
+This document overviews OpenTelemetry semantic conventions
+and implementation requirements from the OpenTelemetry collector
+and the libraries.
+
+Semantic conventions defined by OpenTelemetry:
+
+* [Resource](./resource/semantic_conventions)
+* [Metrics](./metrics/semantic_conventions)
+* [Trace](./trace/semantic_conventions)
+
+Both the collector and the libraries should autogenerate semantic
+convention keys into constants (or language idomatic equivalent).
+The [YAML](../semantic_conventions) files should be used as the 
+source of truth for generation. Each language implementation should 
+implement provide language-specific support to the
+[code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).

--- a/specification/semantic-conventions.md
+++ b/specification/semantic-conventions.md
@@ -12,9 +12,9 @@ Semantic conventions defined by OpenTelemetry:
 * [Metrics](./metrics/semantic_conventions)
 * [Trace](./trace/semantic_conventions)
 
-Both the collector and the libraries should autogenerate semantic
+Both the collector and the libraries SHOULD autogenerate semantic
 convention keys into constants (or language idomatic equivalent).
-The [YAML](../semantic_conventions) files should be used as the 
-source of truth for generation. Each language implementation should 
-implement provide language-specific support to the
+The [YAML](../semantic_conventions) files MUST be used as the 
+source of truth for generation. Each language implementation SHOULD 
+provide language-specific support to the
 [code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).


### PR DESCRIPTION
This is a follow up from the spec SIG model where we
discussed we should ask each langauge to autogenerate
the semantic conventions keys from the YAML files.

Adding a spec specifically for semantic conventions to
capture the implementation requirementes from the languages.
