### PR TITLE
Mention that semantic conventions should be autogenerated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Google products under `cloud.infrastructure_service` ([#1496](https://github.com
 - `http.url` MUST NOT contain credentials ([#1502](https://github.com/open-telemetry/opentelemetry-specification/pull/1502))
 - Add `aws.eks.cluster.arn` to EKS specific semantic conventions ([#1484](https://github.com/open-telemetry/opentelemetry-specification/pull/1484))
 - Rename `zone` to `availability_zone` in `cloud` semantic conventions ([#1495](https://github.com/open-telemetry/opentelemetry-specification/pull/1495))
+- Add section describing that libraries and the collector should autogenerate
+the semantic convention keys.
 
 ## v1.0.1 (2021-02-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ Google products under `cloud.infrastructure_service` ([#1496](https://github.com
 - Add `aws.eks.cluster.arn` to EKS specific semantic conventions ([#1484](https://github.com/open-telemetry/opentelemetry-specification/pull/1484))
 - Rename `zone` to `availability_zone` in `cloud` semantic conventions ([#1495](https://github.com/open-telemetry/opentelemetry-specification/pull/1495))
 - Add section describing that libraries and the collector should autogenerate
-the semantic convention keys.
+the semantic convention keys. ([#1515](https://github.com/open-telemetry/opentelemetry-specification/pull/1515))
 
 ## v1.0.1 (2021-02-11)
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -188,9 +188,3 @@ Note: Support for environment variables is optional.
 
 `*` For each type of exporter, OTLP, Zipkin, and Jaeger, implementing at least one of the supported formats is required.
 Implementing more than one formats is optional.
-
-## Semantic Conventions
-
-|Feature                                       |Java|Go|JS|Python|Ruby|Erlang|PHP|Rust|C++|.Net|Swift|
-|----------------------------------------------|----|--|--|------|----|------|---|----|---|----|-----|
-|Auto-generate semantic convention key/enums   |  + |  |  |      |    |      |   |    |   |    |     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -188,3 +188,9 @@ Note: Support for environment variables is optional.
 
 `*` For each type of exporter, OTLP, Zipkin, and Jaeger, implementing at least one of the supported formats is required.
 Implementing more than one formats is optional.
+
+## Semantic Conventions
+
+|Feature                                       |Java|Go|JS|Python|Ruby|Erlang|PHP|Rust|C++|.Net|Swift|
+|----------------------------------------------|----|--|--|------|----|------|---|----|---|----|-----|
+|Auto-generate semantic convention key/enums   |  + |  |  |      |    |      |   |    |   |    |     |

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -77,7 +77,7 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 
 Both the collector and the libraries SHOULD autogenerate semantic
 convention keys into constants (or language idomatic equivalent).
-The [YAML](../semantic_conventions) files MUST be used as the 
+The [YAML](../semantic_conventions/README.md) files MUST be used as the 
 source of truth for generation. Each language implementation SHOULD 
 provide language-specific support to the
 [code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -75,6 +75,13 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 * [Span Conventions](trace/semantic_conventions/README.md)
 * [Metrics Conventions](metrics/semantic_conventions/README.md)
 
+Both the collector and the libraries SHOULD autogenerate semantic
+convention keys into constants (or language idomatic equivalent).
+The [YAML](../semantic_conventions) files MUST be used as the 
+source of truth for generation. Each language implementation SHOULD 
+provide language-specific support to the
+[code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).
+
 ### Contrib Packages
 
 The OpenTelemetry project maintains integrations with popular OSS projects which have been identified as important for observing modern web services.

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -77,7 +77,7 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 
 Both the collector and the client libraries SHOULD autogenerate semantic
 convention keys and enum values into constants (or language idomatic
-equivalent). Generated values shouldn't be distrubuted in stable packages
+equivalent). Generated values shouldn't be distributed in stable packages
 until semantic conventions are stable.
 The [YAML](../semantic_conventions) files MUST be used as the
 source of truth for generation. Each language implementation SHOULD

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -75,9 +75,9 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 * [Span Conventions](trace/semantic_conventions/README.md)
 * [Metrics Conventions](metrics/semantic_conventions/README.md)
 
-Both the collector and the libraries SHOULD autogenerate semantic
+Both the collector and the client libraries SHOULD autogenerate semantic
 convention keys into constants (or language idomatic equivalent).
-The [YAML](../semantic_conventions/README.md) files MUST be used as the
+The [YAML](../semantic_conventions) files MUST be used as the
 source of truth for generation. Each language implementation SHOULD
 provide language-specific support to the
 [code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -77,8 +77,8 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 
 Both the collector and the libraries SHOULD autogenerate semantic
 convention keys into constants (or language idomatic equivalent).
-The [YAML](../semantic_conventions/README.md) files MUST be used as the 
-source of truth for generation. Each language implementation SHOULD 
+The [YAML](../semantic_conventions/README.md) files MUST be used as the
+source of truth for generation. Each language implementation SHOULD
 provide language-specific support to the
 [code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -76,7 +76,9 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 * [Metrics Conventions](metrics/semantic_conventions/README.md)
 
 Both the collector and the client libraries SHOULD autogenerate semantic
-convention keys into constants (or language idomatic equivalent).
+convention keys and enum values into constants (or language idomatic
+equivalent). Generated values shouldn't be distrubuted in stable packages
+until semantic conventions are stable.
 The [YAML](../semantic_conventions) files MUST be used as the
 source of truth for generation. Each language implementation SHOULD
 provide language-specific support to the

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -79,7 +79,7 @@ Both the collector and the client libraries SHOULD autogenerate semantic
 convention keys and enum values into constants (or language idomatic
 equivalent). Generated values shouldn't be distributed in stable packages
 until semantic conventions are stable.
-The [YAML](../semantic_conventions) files MUST be used as the
+The [YAML](../semantic_conventions/README.md) files MUST be used as the
 source of truth for generation. Each language implementation SHOULD
 provide language-specific support to the
 [code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).


### PR DESCRIPTION
Adding a section to semantic conventions to capture the implementation
requirements from the languages.

This is a follow up from the spec SIG model where we
discussed we should ask each language to autogenerate
the semantic conventions keys from the YAML files.