### PR TITLE
Unify the terminology for OpenTelemetry libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Technical committee holds regular meetings, notes are held
 
 - [Overview](specification/overview.md)
 - [Glossary](specification/glossary.md)
-- [Versioning and stability for OpenTelemetry clients](specification/versioning-and-stability.md)
+- [Versioning and stability for OpenTelemetry Libraries](specification/versioning-and-stability.md)
 - [Library Guidelines](specification/library-guidelines.md)
   - [Package/Library Layout](specification/library-layout.md)
   - [General error handling guidelines](specification/error-handling.md)

--- a/specification/error-handling.md
+++ b/specification/error-handling.md
@@ -62,7 +62,7 @@ The mechanism by which end users set or register a custom error handler should f
 ### Examples
 
 These are examples of how end users might register custom error handlers.
-Examples are for illustration purposes only. OpenTelemetry client authors
+Examples are for illustration purposes only. OpenTelemetry library authors
 are free to deviate from these provided that their design matches the requirements outlined above.
 
 #### Go

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -1,20 +1,20 @@
-# OpenTelemetry Client Design Principles
+# OpenTelemetry Library Guidelines
 
-This document defines common principles that will help designers create OpenTelemetry clients that are easy to use, are uniform across all supported languages, yet allow enough flexibility for language-specific expressiveness.
+This document defines common principles that will help developers create OpenTelemetry libraries that are easy to use, are uniform across all supported languages, yet allow enough flexibility for language-specific expressiveness.
 
-OpenTelemetry clients are expected to provide full features out of the box and allow for innovation and experimentation through extensibility.
+OpenTelemetry libraries are expected to provide full features out of the box and allow for innovation and experimentation through extensibility.
 
 Please read the [overview](overview.md) first, to understand the fundamental architecture of OpenTelemetry.
 
-This document does not attempt to describe the details or functionality of the OpenTelemetry client API. For API specs see the [API specifications](../README.md).
+This document does not attempt to describe the details or functionality of the OpenTelemetry library APIs. For API specs see the [API specifications](../README.md).
 
-_Note to OpenTelemetry client Authors:_ OpenTelemetry specification, API and SDK implementation guidelines are work in progress. If you notice incomplete or missing information, contradictions, inconsistent styling and other defects please let specification writers know by creating an issue in this repository or posting in [Gitter](https://gitter.im/open-telemetry/opentelemetry-specification). As implementors of the specification you will often have valuable insights into how the specification can be improved. The Specification SIG and members of Technical Committee highly value your opinion and welcome your feedback.
+_Note to OpenTelemetry Library Authors:_ OpenTelemetry specification, API and SDK implementation guidelines are work in progress. If you notice incomplete or missing information, contradictions, inconsistent styling and other defects please let specification writers know by creating an issue in this repository or posting in [Gitter](https://gitter.im/open-telemetry/opentelemetry-specification). As implementors of the specification you will often have valuable insights into how the specification can be improved. The Specification SIG and members of Technical Committee highly value your opinion and welcome your feedback.
 
 ## Requirements
 
-1. The OpenTelemetry API must be well-defined and clearly decoupled from the implementation. This allows end users to consume API only without also consuming the implementation (see points 2 and 3 for why it is important).
+1. The OpenTelemetry APIs must be well-defined and clearly decoupled from the implementation. This allows end users to consume the APIs only without also consuming the implementation (see points 2 and 3 for why it is important).
 
-2. Third party libraries and frameworks that add instrumentation to their code will have a dependency only on the API of OpenTelemetry client. The developers of third party libraries and frameworks do not care (and cannot know) what specific implementation of OpenTelemetry is used in the final application.
+2. Third party libraries and frameworks that add instrumentation to their code will have a dependency only on the API of OpenTelemetry library. The developers of third party libraries and frameworks do not care (and cannot know) what specific implementation of OpenTelemetry is used in the final application.
 
 3. The developers of the final application normally decide how to configure OpenTelemetry SDK and what extensions to use. They should be also free to choose to not use any OpenTelemetry implementation at all, even though the application and/or its libraries are already instrumented.  The rationale is that third-party libraries and frameworks which are instrumented with OpenTelemetry must still be fully usable in the applications which do not want to use OpenTelemetry (so this removes the need for framework developers to have "instrumented" and "non-instrumented" versions of their framework).
 
@@ -26,21 +26,21 @@ _Note to OpenTelemetry client Authors:_ OpenTelemetry specification, API and SDK
     - Zipkin.
     - Prometheus.
     - Standard output (or logging) to use for debugging and testing as well as an input for the various log proxy tools.
-    - In-memory (mock) exporter that accumulates telemetry data in the local memory and allows to inspect it (useful for e.g. unit tests).
+    - In-memory (mock) exporter that accumulates telemetry data in the local memory and allows to inspect it for unit testing.
 
     Note: some of these support multiple protocols (e.g. gRPC, Thrift, etc). The exact list of protocols to implement in the exporters is TBD.
 
-    Other vendor-specific exporters (exporters that implement vendor protocols) should not be included in OpenTelemetry clients and should be placed elsewhere (the exact approach for storing and maintaining vendor-specific exporters will be defined in the future).
+    Other vendor-specific exporters (exporters that implement vendor protocols) should not be included in OpenTelemetry libraries and should be placed elsewhere (the exact approach for storing and maintaining vendor-specific exporters will be defined in the future).
 
-## OpenTelemetry Client Generic Design
+## OpenTelemetry Library Design
 
-Here is a generic design for an OpenTelemetry client (arrows indicate calls):
+Here is a generic design for an OpenTelemetry library (arrows indicate calls):
 
-![OpenTelemetry client Design Diagram](../internal/img/library-design.png)
+![OpenTelemetry Library Design Diagram](../internal/img/library-design.png)
 
 ### Expected Usage
 
-The OpenTelemetry client is composed of 4 types of [packages](glossary.md#packages): API packages, SDK packages, a Semantic Conventions package, and plugin packages.
+The OpenTelemetry libraries are composed of 4 types of [packages](glossary.md#packages): API packages, SDK packages, a Semantic Conventions package, and plugin packages.
 The API and the SDK are split into multiple packages, based on signal type (e.g. one for api-trace, one for api-metric, one for sdk-trace, one for sdk-metric) is considered an implementation detail as long as the API artifact(s) stay separate from the SDK artifact(s).
 
 Libraries, frameworks, and applications that want to be instrumented with OpenTelemetry take a dependency only on the API packages. The developers of these third-party libraries will make calls to the API to produce telemetry data.
@@ -103,7 +103,7 @@ The end-user application may decide to take a dependency on alternative implemen
 
 SDK provides flexibility and extensibility that may be used by many implementations. Before developing an alternative implementation, please, review extensibility points provided by OpenTelemetry.
 
-An example use-case for alternate implementations is automated testing. A mock implementation can be plugged in during automated tests. For example, it can store all generated telemetry data in memory and provide a capability to inspect this stored data. This will allow the tests to verify that the telemetry is generated correctly. OpenTelemetry client authors are encouraged to provide such a mock implementation.
+An example use-case for alternate implementations is automated testing. A mock implementation can be plugged in during automated tests. For example, it can store all generated telemetry data in memory and provide a capability to inspect this stored data. This will allow the tests to verify that the telemetry is generated correctly. OpenTelemetry library authors are encouraged to provide such a mock implementation.
 
 Note that mocking is also possible by using SDK and a Mock `Exporter` without needing to swap out the entire SDK.
 
@@ -113,9 +113,9 @@ The mocking approach chosen will depend on the testing goals and at which point 
 
 API and SDK packages must use semantic version numbering. API package version number and SDK package version number are decoupled and can be different (and they both can be also different from the Specification version number that they implement). API and SDK packages MUST be labeled with their own version number.
 
-This decoupling of version numbers allows OpenTelemetry client authors to make API and SDK package releases independently without the need to coordinate and match version numbers with the Specification.
+This decoupling of version numbers allows OpenTelemetry library authors to make API and SDK package releases independently without the need to coordinate and match version numbers with the Specification.
 
-Because API and SDK package version numbers are not coupled, every API and SDK package release MUST clearly mention the Specification version number that they implement. In addition, if a particular version of SDK package is only compatible with a specific version of API package, then this compatibility information must be also published by OpenTelemetry client authors. OpenTelemetry client authors MUST include this information in the release notes. For example, the SDK package release notes may say: "SDK 0.3.4, use with API 0.1.0, implements OpenTelemetry Specification 0.1.0".
+Because API and SDK package version numbers are not coupled, every API and SDK package release MUST clearly mention the Specification version number that they implement. In addition, if a particular version of SDK package is only compatible with a specific version of API package, then this compatibility information must be also published by OpenTelemetry library authors. OpenTelemetry library authors MUST include this information in the release notes. For example, the SDK package release notes may say: "SDK 0.3.4, use with API 0.1.0, implements OpenTelemetry Specification 0.1.0".
 
 _TODO: How should third-party library authors who use OpenTelemetry for instrumentation guide their end users to find the correct SDK package?_
 

--- a/specification/library-layout.md
+++ b/specification/library-layout.md
@@ -1,12 +1,12 @@
-# OpenTelemetry Project Package Layout
+# OpenTelemetry Library Package Layout
 
-This documentation serves to document the "look and feel" of a basic layout for OpenTelemetry
-projects. This package layout is intentionally generic and it doesn't try to impose a language
-specific package structure.
+This documentation serves to document the "look and feel" of the basic layout of
+OpenTelemetry libraries. This layout is intentionally generic and it doesn't
+try to impose a language specific package structure.
 
 ## API Package
 
-Here is a proposed generic package structure for OpenTelemetry API package.
+Here is a proposed generic package structure for OpenTelemetry library API packages.
 
 A typical top-level directory layout:
 
@@ -56,7 +56,7 @@ Private application and library code.
 
 ## SDK Package
 
-Here is a proposed generic package structure for OpenTelemetry SDK package.
+Here is a proposed generic package structure for OpenTelemetry library SDK package.
 
 A typical top-level directory layout:
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -8,7 +8,7 @@ Table of Contents
 
 <!-- toc -->
 
-- [OpenTelemetry Client Architecture](#opentelemetry-client-architecture)
+- [OpenTelemetry Library Architecture](#opentelemetry-library-architecture)
   * [API](#api)
   * [SDK](#sdk)
   * [Semantic Conventions](#semantic-conventions)
@@ -42,23 +42,23 @@ This document provides an overview of the OpenTelemetry project and defines impo
 
 Additional term definitions can be found in the [glossary](glossary.md).
 
-## OpenTelemetry Client Architecture
+## OpenTelemetry Library Architecture
 
 ![Cross cutting concerns](../internal/img/architecture.png)
 
-At the highest architectural level, OpenTelemetry clients are organized into [**signals**](glossary.md#signals).
+At the highest architectural level, OpenTelemetry libraries are organized into [**signals**](glossary.md#signals).
 Each signal provides a specialized form of observability. For example, tracing, metrics, and baggage are three separate signals.
 Signals share a common subsystem – **context propagation** – but they function independently from each other.
 
 Each signal provides a mechanism for software to describe itself. A codebase, such as web framework or a database client, takes a dependency on various signals in order to describe itself. OpenTelemetry instrumentation code can then be mixed into the other code within that codebase.
-This makes OpenTelemetry a **cross-cutting concern** - a piece of software which is mixed into many other pieces of software in order to provide value. Cross-cutting concerns, by their very nature, violate a core design principle – separation of concerns. As a result, OpenTelemetry client design requires extra care and attention to avoid creating issues for the codebases which depend upon these cross-cutting APIs.
+This makes OpenTelemetry a **cross-cutting concern** - a piece of software which is mixed into many other pieces of software in order to provide value. Cross-cutting concerns, by their very nature, violate a core design principle – separation of concerns. As a result, OpenTelemetry library design requires extra care and attention to avoid creating issues for the codebases which depend upon these cross-cutting APIs.
 
-OpenTelemetry clients are designed to separate the portion of each signal which must be imported as cross-cutting concerns from the portions which can be managed independently. OpenTelemetry clients are also designed to be an extensible framework.
+OpenTelemetry libraries are designed to separate the portion of each signal which must be imported as cross-cutting concerns from the portions which can be managed independently. OpenTelemetry libraries are also designed to be an extensible framework.
 To accomplish these goals, each signal consists of four types of packages: API, SDK, Semantic Conventions, and Contrib.
 
 ### API
 
-API packages consist of the cross-cutting public interfaces used for instrumentation. Any portion of an OpenTelemetry client which is imported into third-party libraries and application code is considered part of the API.
+API packages consist of the cross-cutting public interfaces used for instrumentation. Any portion of an OpenTelemetry libraries which is imported into third-party libraries and application code is considered part of the API.
 
 ### SDK
 

--- a/specification/performance.md
+++ b/specification/performance.md
@@ -1,6 +1,6 @@
 # Performance and Blocking of OpenTelemetry API
 
-This document defines common principles that will help designers create OpenTelemetry clients that are safe to use.
+This document defines common principles that will help designers create OpenTelemetry libraries that are safe to use.
 
 ## Key principles
 
@@ -17,27 +17,27 @@ See also [Concurrency and Thread-Safety](library-guidelines.md#concurrency-and-t
 
 Incomplete asynchronous I/O tasks or background tasks may consume memory to preserve their state. In such a case, there is a tradeoff between dropping some tasks to prevent memory starvation and keeping all tasks to prevent information loss.
 
-If there is such tradeoff in OpenTelemetry client, it should provide the following options to end-user:
+If there is such tradeoff in OpenTelemetry library, it should provide the following options to end-user:
 
 - **Prevent information loss**: Preserve all information but possible to consume many resources
 - **Prevent blocking**: Dropping some information under overwhelming load and show warning log to inform when information loss starts and when recovered
   - Should provide option to change threshold of the dropping
   - Better to provide metric that represents effective sampling ratio
-  - OpenTelemetry client might provide this option for Logging
+  - OpenTelemetry library might provide this option for Logging
 
 ### End-user application should be aware of the size of logs
 
 Logging could consume much memory by default if the end-user application emits too many logs. This default behavior is intended to preserve logs rather than dropping it. To make resource usage bounded, the end-user should consider reducing logs that are passed to the exporters.
 
-Therefore, the OpenTelemetry client should provide a way to filter logs to capture by OpenTelemetry. End-user applications may want to log so much into log file or stdout (or somewhere else) but not want to send all of the logs to OpenTelemetry exporters.
+Therefore, the OpenTelemetry library should provide a way to filter logs to capture by OpenTelemetry. End-user applications may want to log so much into log file or stdout (or somewhere else) but not want to send all of the logs to OpenTelemetry exporters.
 
-In a documentation of the OpenTelemetry client, it is a good idea to point out that too many logs consume many resources by default then guide how to filter logs.
+In a documentation of the OpenTelemetry library, it is a good idea to point out that too many logs consume many resources by default then guide how to filter logs.
 
 ### Shutdown and explicit flushing could block
 
-The OpenTelemetry client could block the end-user application when it shut down. On shutdown, it has to flush data to prevent information loss. The OpenTelemetry client should support user-configurable timeout if it blocks on shut down.
+The OpenTelemetry library could block the end-user application when it shut down. On shutdown, it has to flush data to prevent information loss. The OpenTelemetry library should support user-configurable timeout if it blocks on shut down.
 
-If the OpenTelemetry client supports an explicit flush operation, it could block also. But should support a configurable timeout.
+If the OpenTelemetry library supports an explicit flush operation, it could block also. But should support a configurable timeout.
 
 ## Documentation
 

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -1,4 +1,4 @@
-# Versioning and stability for OpenTelemetry clients
+# Versioning and stability for OpenTelemetry Libraries
 
 **Status**: [Stable](document-status.md)
 
@@ -30,9 +30,9 @@
 
 <!-- tocstop -->
 
-This document defines the stability guarantees offered by the OpenTelemetry clients, along with the rules and procedures for meeting those guarantees.
+This document defines the stability guarantees offered by the OpenTelemetry libraries, along with the rules and procedures for meeting those guarantees.
 
-In this document, the terms "OpenTelemetry" and "language implementations" both specifically refer to the OpenTelemetry clients.
+In this document, the terms "OpenTelemetry" and "language implementations" both specifically refer to the OpenTelemetry libraries.
 These terms do not refer to the specification or the Collector in this document.
 
 Each language implementation MUST take these versioning and stability requirements, and produce a language-specific document which details how these requirements will be met.
@@ -76,9 +76,9 @@ Components SHOULD NOT be expected to be feature-complete.
 In some cases, the experiment MAY be discarded and removed entirely.
 Long-term dependencies SHOULD NOT be taken against experimental signals.
 
-OpenTelemetry clients MUST be designed in a manner that allows experimental signals to be created without breaking the stability guarantees of existing signals.
+OpenTelemetry libraries MUST be designed in a manner that allows experimental signals to be created without breaking the stability guarantees of existing signals.
 
-OpenTelemetry clients MUST NOT be designed in a manner that breaks existing users when a signal transitions from experimental to stable. This would punish users of the release candidate, and hinder adoption.
+OpenTelemetry libraries MUST NOT be designed in a manner that breaks existing users when a signal transitions from experimental to stable. This would punish users of the release candidate, and hinder adoption.
 
 Terms which denote stability, such as "experimental," MUST NOT be used as part of a directory or import name.
 Package **version numbers** MAY include a suffix, such as -alpha, -beta, -rc, or -experimental, to differentiate stable and experimental packages.
@@ -171,9 +171,9 @@ We invented a new tracing API, but continue to support the old one.
 
 ## Version numbers
 
-OpenTelemetry clients follow [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html), with the following clarifications.
+OpenTelemetry libraries follow [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html), with the following clarifications.
 
-OpenTelemetry clients have four components: API, SDK, Semantic Conventions, and Contrib.
+OpenTelemetry libraries have four components: API, SDK, Semantic Conventions, and Contrib.
 
 For the purposes of versioning, all code within a component MUST treated as if it were part of a single package, and versioned with the same version number,
 except for Contrib, which may be a collection of packages versioned separately.
@@ -204,7 +204,7 @@ Major version bumps SHOULD NOT occur for changes which do not result in a drop i
 
 ### Minor version bump
 
-Most changes to OpenTelemetry clients result in a minor version bump.
+Most changes to OpenTelemetry libraries result in a minor version bump.
 
 * New backward-compatible functionality added to any component.
 * Breaking changes to internal SDK components.


### PR DESCRIPTION
Spec names the libraries either clients or libraries. Unifying the
terminology to use "library" because specs must be very consistent
about naming the same concept similarly to avoid confusion.
