### PR TITLE
Scope baggage/context interaction functionality

### DIFF
--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -35,7 +35,7 @@ The Baggage API consists of:
 The functions described here are one way to approach interacting with the
 `Baggage` via having struct/object that represents the entire Baggage content.
 Depending on language idioms, a language API MAY implement these functions by
-interacting with the `Baggage` via the `Context` directly.
+interacting with the baggage via the `Context` directly.
 
 The Baggage API MUST be fully functional in the absence of an installed SDK.
 This is required in order to enable transparent cross-process Baggage

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -101,8 +101,8 @@ REQUIRED parameters:
 This section defines all operations within the Baggage API that interact with
 the [`Context`](../context/context.md).
 
-The API MUST provide the following functionality to interact with a `Context`
-instance:
+If an implementation of this API does not interact purely via the `Context`, it
+MUST provide the following functionality to interact with a `Context` instance:
 
 - Extract the `Baggage` from a `Context` instance
 - Insert the `Baggage` to a `Context` instance

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -35,7 +35,7 @@ The Baggage API consists of:
 The functions described here are one way to approach interacting with the
 `Baggage` via having struct/object that represents the entire Baggage content.
 Depending on language idioms, a language API MAY implement these functions by
-providing the defined functionality interacting purely via the `Context`.
+interacting with the `Baggage` via the `Context` directly.
 
 The Baggage API MUST be fully functional in the absence of an installed SDK.
 This is required in order to enable transparent cross-process Baggage
@@ -101,7 +101,7 @@ REQUIRED parameters:
 This section defines all operations within the Baggage API that interact with
 the [`Context`](../context/context.md).
 
-If an implementation of this API does not interact purely via the `Context`, it
+If an implementation of this API does not operate directly on the `Context`, it
 MUST provide the following functionality to interact with a `Context` instance:
 
 - Extract the `Baggage` from a `Context` instance


### PR DESCRIPTION
[The Baggage API states](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.0.1/specification/baggage/api.md#overview) that it can be implemented by providing functionality interacting solely with the `Context`. If an implementation chooses this option it follows that it should not be required to provide access to a Baggage object. This updates the Context Interaction section of the Baggage API to clarify this caveat and makes the caveat meaning clearer in the Overview section.
