### PR TITLE
Define the fallback tracer name for invalid values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ release.
 
 - Add `ForceFlush` to `Span Exporter` interface ([#1467](https://github.com/open-telemetry/opentelemetry-specification/pull/1467))
 - Clarify the description for the `TraceIdRatioBased` sampler needs to include the sampler's sampling ratio. ([#1536](https://github.com/open-telemetry/opentelemetry-specification/pull/1536))
+- Define the fallback tracer name for invalid values.
+  ([#1534](https://github.com/open-telemetry/opentelemetry-specification/pull/1534))
 
 ### Metrics
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -109,7 +109,7 @@ This API MUST accept the following parameters:
   In that scenario, the `name` denotes a module name or component name within that library
   or application.
   In case an invalid name (null or empty string) is specified, a working
-  default Tracer implementation MUST be returned as a fallback rather than returning
+  Tracer implementation MUST be returned as a fallback rather than returning
   null or throwing an exception, its `name` property SHOULD keep the original invalid value,
   and a message reporting that the specified value is invalid SHOULD be logged.
   A library, implementing the OpenTelemetry API *may* also ignore this name and

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -109,8 +109,10 @@ This API MUST accept the following parameters:
   In that scenario, the `name` denotes a module name or component name within that library
   or application.
   In case an invalid name (null or empty string) is specified, a working
-  default Tracer implementation as a fallback is returned rather than returning
-  null or throwing an exception.
+  default Tracer implementation as a fallback MUST be returned rather than returning
+  null or throwing an exception, and `name` SHOULD be the set to the
+  `<INVALID INSTRUMENTATION NAME PROVIDED>` literal, in order to signal the
+  specified value is invalid.
   A library, implementing the OpenTelemetry API *may* also ignore this name and
   return a default instance for all calls, if it does not support "named"
   functionality (e.g. an implementation which is not even observability-related).

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -111,7 +111,7 @@ This API MUST accept the following parameters:
   In case an invalid name (null or empty string) is specified, a working
   default Tracer implementation MUST be returned as a fallback rather than returning
   null or throwing an exception, and `name` SHOULD be the set to the
-  `<INVALID INSTRUMENTATION NAME PROVIDED>` literal, in order to signal the
+  "`<INVALID INSTRUMENTATION NAME PROVIDED>`" literal, in order to signal that the
   specified value is invalid.
   A library, implementing the OpenTelemetry API *may* also ignore this name and
   return a default instance for all calls, if it does not support "named"

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -110,8 +110,8 @@ This API MUST accept the following parameters:
   or application.
   In case an invalid name (null or empty string) is specified, a working
   default Tracer implementation MUST be returned as a fallback rather than returning
-  null or throwing an exception, and `name` SHOULD keep the original invalid value,
-  with a log message reporting that the specified value is invalid.
+  null or throwing an exception, its `name` property SHOULD keep the original invalid value,
+  and a message reporting that the specified value is invalid SHOULD be logged.
   A library, implementing the OpenTelemetry API *may* also ignore this name and
   return a default instance for all calls, if it does not support "named"
   functionality (e.g. an implementation which is not even observability-related).

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -110,9 +110,8 @@ This API MUST accept the following parameters:
   or application.
   In case an invalid name (null or empty string) is specified, a working
   default Tracer implementation MUST be returned as a fallback rather than returning
-  null or throwing an exception, and `name` SHOULD be the set to the
-  "`<INVALID INSTRUMENTATION NAME PROVIDED>`" literal, in order to signal that the
-  specified value is invalid.
+  null or throwing an exception, and `name` SHOULD keep the original invalid value,
+  with a log message reporting that the specified value is invalid.
   A library, implementing the OpenTelemetry API *may* also ignore this name and
   return a default instance for all calls, if it does not support "named"
   functionality (e.g. an implementation which is not even observability-related).

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -109,7 +109,7 @@ This API MUST accept the following parameters:
   In that scenario, the `name` denotes a module name or component name within that library
   or application.
   In case an invalid name (null or empty string) is specified, a working
-  default Tracer implementation as a fallback MUST be returned rather than returning
+  default Tracer implementation MUST be returned as a fallback rather than returning
   null or throwing an exception, and `name` SHOULD be the set to the
   `<INVALID INSTRUMENTATION NAME PROVIDED>` literal, in order to signal the
   specified value is invalid.


### PR DESCRIPTION
Fixes #1472 

Keeps the original invalid value (to be handled by the backends instead), while asking implementations to log this as an error.