### PR TITLE
Clarify the TraceIdRatioBased description format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ release.
 
 ### Traces
 
+- Clarify the description for the `TraceIdRatioBased` sampler needs to include the sampler's sampling ratio. ([#1536](https://github.com/open-telemetry/opentelemetry-specification/pull/1536))
+
 ### Metrics
 
 ### Logs

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -257,7 +257,7 @@ the `ParentBased` sampler specified below.
   represented as a decimal number. The precision of the number SHOULD follow
   implementation language standards and SHOULD be high enough to identify when
   Samplers have different ratios. For example, if a TraceIdRatioBased Sampler
-  had a sampling ratio of 1 to every 10,000 spans it could return
+  had a sampling ratio of 1 to every 10,000 spans it COULD return
   `"TraceIdRatioBased{0.000100}"` as its description.
 
 TODO: Add details about how the `TraceIdRatioBased` is implemented as a function

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -252,7 +252,13 @@ The default sampler is `ParentBased(root=AlwaysOn)`.
 * The `TraceIdRatioBased` MUST ignore the parent `SampledFlag`. To respect the
 parent `SampledFlag`, the `TraceIdRatioBased` should be used as a delegate of
 the `ParentBased` sampler specified below.
-* Description MUST be `TraceIdRatioBased{0.000100}`.
+* Description MUST return a string of the form `"TraceIdRatioBased{RATIO}"`
+  with `RATIO` replaced with the Sampler instances' trace sampling ratio
+  represented as a decimal number. The precision of the number SHOULD follow
+  implementation language standards and SHOULD be high enough to identify when
+  Samplers have different ratios. For example, if a TraceIdRatioBased Sampler
+  had a sampling ratio of 1 to every 10,000 spans it could return
+  `"TraceIdRatioBased{0.000100}"` as its description.
 
 TODO: Add details about how the `TraceIdRatioBased` is implemented as a function
 of the `TraceID`. [#1413](https://github.com/open-telemetry/opentelemetry-specification/issues/1413)

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -253,7 +253,7 @@ The default sampler is `ParentBased(root=AlwaysOn)`.
 parent `SampledFlag`, the `TraceIdRatioBased` should be used as a delegate of
 the `ParentBased` sampler specified below.
 * Description MUST return a string of the form `"TraceIdRatioBased{RATIO}"`
-  with `RATIO` replaced with the Sampler instances' trace sampling ratio
+  with `RATIO` replaced with the Sampler instance's trace sampling ratio
   represented as a decimal number. The precision of the number SHOULD follow
   implementation language standards and SHOULD be high enough to identify when
   Samplers have different ratios. For example, if a TraceIdRatioBased Sampler


### PR DESCRIPTION
Samplers need to return a static string as a description. The string the TraceIdRatioBased sampler returns needs to be based on the sampling ratio that it is configured for. The current specification could be misinterpreted as requiring a static string that was not based on the samplers sampling ratio be used. This corrects that discrepancy.

Resolves #1524 