### PR TITLE
Update spec-compliance-matrix context section for Go

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -100,12 +100,12 @@ status of the feature is not known.
 
 | Feature                                                                          | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .Net | Swift |
 |----------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
-| Create Context Key                                                               |          |    | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Get value from Context                                                           |          |    | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Set value for Context                                                            |          |    | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Attach Context                                                                   |          |    | +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
-| Detach Context                                                                   |          |    | +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
-| Get current Context                                                              |          |    | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
+| Create Context Key                                                               |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
+| Get value from Context                                                           |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
+| Set value for Context                                                            |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
+| Attach Context                                                                   |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
+| Detach Context                                                                   |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
+| Get current Context                                                              |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Composite Propagator                                                             |          |    | +    | +  | +      | +    | N/A    |     | +    |     | +    | +     |
 | Global Propagator                                                                |          |    | +    | +  | +      | +    | +      |     | +    |     | +    | +     |
 | TraceContext Propagator                                                          |          |    | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |


### PR DESCRIPTION
The [Golang context.Context](https://golang.org/pkg/context/) is used as the OTel-Go context implementation.

| Feature                | Go  |
|------------------------|-----|
| Create Context Key     | + keys are Go interfaces; e.g. `interface{}(name)` satisfies the API |
| Get value from Context | + [Context.Value](https://pkg.go.dev/context#Context)  |
| Set value for Context  | + [context.WithValue](https://pkg.go.dev/context#WithValue) |
| Attach Context         | N/A (no implicit context) |
| Detach Context         | N/A (no implicit context) |
| Get current Context    | N/A (no implicit context) |


Resolves https://github.com/open-telemetry/opentelemetry-go/issues/1600
