### PR TITLE
Clarify the requirement about newly created Span

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -329,8 +329,8 @@ directly. All `Span`s MUST be created via a `Tracer`.
 There MUST NOT be any API for creating a `Span` other than with a [`Tracer`](#tracer).
 
 `Span` creation MUST NOT set the newly created `Span` as the
-active `Span` in the implicit `Context` by default, but this functionality MAY be offered additionally
-as a separate operation. Languages that use explicit `Context` are not suitable for this requirement.
+active `Span` in the [implicit `Context`](#context-interaction) by default, but this functionality MAY be offered additionally
+as a separate operation in languages with implicit context propagation.
 
 The API MUST accept the following parameters:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -328,9 +328,9 @@ directly. All `Span`s MUST be created via a `Tracer`.
 
 There MUST NOT be any API for creating a `Span` other than with a [`Tracer`](#tracer).
 
-`Span` creation MUST NOT set the newly created `Span` as the currently
-active `Span` by default, but this functionality MAY be offered additionally
-as a separate operation.
+`Span` creation MUST NOT set the newly created `Span` as the
+active `Span` in the implicit `Context` by default, but this functionality MAY be offered additionally
+as a separate operation. Languages that use explicit `Context` are not suitable for this requirement.
 
 The API MUST accept the following parameters:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -328,9 +328,10 @@ directly. All `Span`s MUST be created via a `Tracer`.
 
 There MUST NOT be any API for creating a `Span` other than with a [`Tracer`](#tracer).
 
-`Span` creation MUST NOT set the newly created `Span` as the
-active `Span` in the [implicit `Context`](#context-interaction) by default, but this functionality MAY be offered additionally
-as a separate operation in languages with implicit context propagation.
+In languages with implicit `Context` propagation, `Span` creation MUST NOT
+set the newly created `Span` as the active `Span` in the
+[current `Context`](#context-interaction) by default, but this functionality
+MAY be offered additionally as a separate operation.
 
 The API MUST accept the following parameters:
 


### PR DESCRIPTION
The requirement that `Span` creation can't set the newly created `Span` in `Context` is not suitable for languages that use explicit `Context`, such as Go.

This corrects that ambiguity.

Resolves #1508