### PR TITLE
Clarify composite inject/extract optional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ release.
 
 ## Unreleased
 
+### Context
+
+- Clarify composite `TextMapPropagator` method required and optional arguments.
+
 ### Traces
 
 ### Metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release.
 
 ### Context
 
-- Clarify composite `TextMapPropagator` method required and optional arguments.
+- Clarify composite `TextMapPropagator` method required and optional arguments. ([#1541](https://github.com/open-telemetry/opentelemetry-specification/pull/1541))
 
 ### Traces
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -278,7 +278,7 @@ Required arguments:
 - A `Context`.
 - The carrier that holds propagation fields.
 
-If the `TextMapPropagator`'s `Inject` implementation accept the optional `Setter` argument the following arguments are REQUIRED, otherwise they are OPTIONAL:
+If the `TextMapPropagator`'s `Inject` implementation accepts the optional `Setter` argument, the following arguments are REQUIRED, otherwise they are OPTIONAL:
 
 - The `Setter` to set a propagation key/value pair. Propagators MAY invoke it multiple times in order to set multiple pairs.
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -266,6 +266,9 @@ Required arguments:
 
 - A `Context`.
 - The carrier that holds propagation fields.
+
+If the `TextMapPropagator`'s `Extract` implementation accept the optional `Getter` argument the following arguments are REQUIRED, otherwise they are OPTIONAL:
+
 - The instance of `Getter` invoked for each propagation key to get.
 
 ### Composite Inject
@@ -274,6 +277,9 @@ Required arguments:
 
 - A `Context`.
 - The carrier that holds propagation fields.
+
+If the `TextMapPropagator`'s `Inject` implementation accept the optional `Setter` argument the following arguments are REQUIRED, otherwise they are OPTIONAL:
+
 - The `Setter` to set a propagation key/value pair. Propagators MAY invoke it multiple times in order to set multiple pairs.
 
 ## Global Propagators

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -267,7 +267,7 @@ Required arguments:
 - A `Context`.
 - The carrier that holds propagation fields.
 
-If the `TextMapPropagator`'s `Extract` implementation accept the optional `Getter` argument the following arguments are REQUIRED, otherwise they are OPTIONAL:
+If the `TextMapPropagator`'s `Extract` implementation accepts the optional `Getter` argument, the following arguments are REQUIRED, otherwise they are OPTIONAL:
 
 - The instance of `Getter` invoked for each propagation key to get.
 


### PR DESCRIPTION
If the underlying `TextMapPropagator` does not accept the optional getter and setter arguments it is unreasonable that the composite needs to require these arguments. This updates the API definition to communicate this.
