### PR TITLE
Update spec-compliance-matrix context propagators for Go

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -106,16 +106,16 @@ status of the feature is not known.
 | Attach Context                                                                   |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
 | Detach Context                                                                   |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
 | Get current Context                                                              |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Composite Propagator                                                             |          |    | +    | +  | +      | +    | N/A    |     | +    |     | +    | +     |
-| Global Propagator                                                                |          |    | +    | +  | +      | +    | +      |     | +    |     | +    | +     |
-| TraceContext Propagator                                                          |          |    | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
-| B3 Propagator                                                                    |          |    | +    | +  | +      | +    | +      |     | +    |     | +    | +     |
-| Jaeger Propagator                                                                |          |    | +    | +  | +      |      | +      |     | +    |     | -    | -     |
-| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          |    |      |    |        |      |        |     |      |     |      |       |
-| Fields                                                                           |          |    | +    | +  | +      |      | +      |     | +    |     | +    | +     |
-| Setter argument                                                                  |          |    | +    | +  | +      | +    | +      |     |      |     | +    | +     |
-| Getter argument                                                                  |          |    | +    | +  | +      | +    | +      |     |      |     | +    | +     |
-| Getter argument returning Keys                                                   |          |    | +    | +  | +      | +    | +      |     |      |     | -    | +     |
+| Composite Propagator                                                             |          | +  | +    | +  | +      | +    | N/A    |     | +    |     | +    | +     |
+| Global Propagator                                                                |          | +  | +    | +  | +      | +    | +      |     | +    |     | +    | +     |
+| TraceContext Propagator                                                          |          | +  | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
+| B3 Propagator                                                                    |          | +  | +    | +  | +      | +    | +      |     | +    |     | +    | +     |
+| Jaeger Propagator                                                                |          | +  | +    | +  | +      |      | +      |     | +    |     | -    | -     |
+| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          | +  |      |    |        |      |        |     |      |     |      |       |
+| Fields                                                                           |          | +  | +    | +  | +      |      | +      |     | +    |     | +    | +     |
+| Setter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      |     |      |     | +    | +     |
+| Getter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      |     |      |     | +    | +     |
+| Getter argument returning Keys                                                   | X        | N/A| +    | +  | +      | +    | +      |     |      |     | -    | +     |
 
 ## Environment Variables
 


### PR DESCRIPTION
Additionally, mark the optional [getter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#textmap-extract)/[setter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#textmap-inject) arguments as such.

For more information see the linked issue this resolves, but for a quick overview:

| Feature                                                                          | Go |
|----------------------------------------------------------------------------------|----|
| Composite Propagator                                                             | [+](https://pkg.go.dev/go.opentelemetry.io/otel@v0.18.0/propagation#NewCompositeTextMapPropagator) |
| Global Propagator                                                                | + [1](https://pkg.go.dev/go.opentelemetry.io/otel@v0.18.0/#GetTextMapPropagator), [2](https://pkg.go.dev/go.opentelemetry.io/otel/@v0.18.0/#SetTextMapPropagator) |
| TraceContext Propagator                                                          | [+](https://pkg.go.dev/go.opentelemetry.io/otel@v0.18.0/propagation#TraceContext)   |
| B3 Propagator                                                                    | [+](https://pkg.go.dev/go.opentelemetry.io/contrib/propagators@v0.18.0/b3)   |
| Jaeger Propagator                                                                | [+](https://pkg.go.dev/go.opentelemetry.io/contrib/propagators@v0.18.0/jaeger)   |
| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) | [+](https://pkg.go.dev/go.opentelemetry.io/otel@v0.18.0/propagation#TextMapPropagator)   |
| Fields                                                                           | + [TextMapPropagator.Fields](https://pkg.go.dev/go.opentelemetry.io/otel@v0.18.0/propagation#TextMapPropagator)   |
| Setter argument                                                                  | N/A OPTIONAL not impmetented  |
| Getter argument                                                                  | N/A OPTIONAL not impmetented  |
| Getter argument returning Keys                                                   | N/A OPTIONAL not impmetented  |

Resolves https://github.com/open-telemetry/opentelemetry-go/issues/1601