### PR TITLE
Update spec-compliance-matrix span ID creation for Go

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -69,7 +69,7 @@ status of the feature is not known.
 | [Sampling](specification/trace/sdk.md#sampling)                                                  |          |    |      |    |        |      |        |     |      |     |      |       |
 | Allow samplers to modify tracestate                                                              |          | +  | +    |    | +      | +    | +      |     | +    |     | -    | +     |
 | ShouldSample gets full parent Context                                                            |          | +  | +    | +  | +      | +    | +      |     |      | +   | -    | +     |
-| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          |    | +    |    | +      | +    | +      |     |      |     | -    | +     |
+| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          | +  | +    |    | +      | +    | +      |     |      |     | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          |    | +    |    |        | +    |        |     |      |     |      | +     |
 | [SpanLimits](specification/trace/sdk.md#span-limits)                                             | X        |    | +    |    |        | +    |        |     |      |     |      | +     |
 


### PR DESCRIPTION
| Feature                                                                                          | Go |
|--------------------------------------------------------------------------------------------------|----|
| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) | [+](https://github.com/open-telemetry/opentelemetry-go/blob/8b1be11a549eefb6efeda2f940cbda70b3c3d08d/sdk/trace/span.go#L526-L543)   |

New Span IDs are created for all spans. See the linked issue for more details.


Resolves https://github.com/open-telemetry/opentelemetry-go/issues/1648
