### PR TITLE
Zipkin exporter: Switch code / description tag values.

### DIFF
--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -144,12 +144,11 @@ The following table defines the OpenTelemetry `Status` to Zipkin `tags` mapping.
 
 | Status|Tag Key| Tag Value |
 |--|--|--|
-|Code | `otel.status_code` | Name of the code, either `OK` or `ERROR`. MUST NOT be set if the code is `UNSET`. |
-|Description| `error` | Description of the `Status`. MUST be set if the code is `ERROR`, use an empty string if Description has no value. MUST NOT be set for `OK` and `UNSET` codes. |
+|Code | `error` | `true` if the code is `ERROR`, unset otherwise. |
+|Description| `otel.status_description` | Description of the `Status`. MUST be set if the code is `ERROR`, use an empty string if Description has no value. MUST NOT be set for `OK` and `UNSET` codes. |
 
-Note: The `error` tag should only be set if `Status` is `Error`. If a boolean
-version (`{"error":false}` or `{"error":"false"}`) is present, it SHOULD be
-removed. Zipkin will treat any span with `error` sent as failed.
+Note: The `error` tag should only be set if `Status` is `Error`.
+Zipkin will treat any span with `error` sent as failed.
 
 ### Events
 


### PR DESCRIPTION
## Changes

Zipkin instrumentation sets `error` to a code type of value, for example the exception class name or the gRPC status code, and not the exception message of gRPC description. So we should avoid setting it to the status description for consistency with Zipkin instrumentation. As we only have one code corresponding with an error, I set a boolean instead but maybe it could be the word `ERROR` anyways.

Reference:
https://github.com/open-telemetry/opentelemetry-go/pull/1688#issuecomment-798968221