### PR TITLE
Update semantic conventions to distinguish between int and double

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -61,4 +61,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: verify semantic convention tables
-      run: docker run --rm -v $(pwd)/semantic_conventions:/source -v $(pwd)/specification:/spec otel/semconvgen:0.2.1 -f /source markdown -md /spec --md-check
+      run: docker run --rm -v $(pwd)/semantic_conventions:/source -v $(pwd)/specification:/spec otel/semconvgen:0.3.0 -f /source markdown -md /spec --md-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ release.
 
 ### Semantic Conventions
 
+- Update semantic conventions to distinguish between int and double ([#1550](https://github.com/open-telemetry/opentelemetry-specification/pull/1550))
+
 ## v1.1.0 (2021-03-11)
 
 ### Traces

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -35,7 +35,7 @@ groups:
           The execution environment ID as a string.
         examples: ['my-function:instance-0001']
       - id: max_memory
-        type: number
+        type: int
         brief: >
           The amount of memory available to the serverless function in MiB.
         note: >

--- a/semantic_conventions/resource/process.yaml
+++ b/semantic_conventions/resource/process.yaml
@@ -5,7 +5,7 @@ groups:
         An operating system process.
     attributes:
       - id: pid
-        type: number
+        type: int
         brief: >
           Process identifier (PID).
         examples: [1234]

--- a/semantic_conventions/syntax.md
+++ b/semantic_conventions/syntax.md
@@ -34,10 +34,12 @@ attributes ::= (id type brief examples | ref [brief] [examples]) [required] [not
 ref ::= id
 
 type ::= "string"
-     |   "number"
+     |   "int"
+     |   "double"
      |   "boolean"
      |   "string[]"
-     |   "number[]"
+     |   "int[]"
+     |   "double[]"
      |   "boolean[]"
      |   enum
 
@@ -95,10 +97,12 @@ An attribute is defined by:
 - `type`, either a string literal denoting the type or an enum definition (See later).
    The accepted strings literals are:
   * "string": String attributes.
-  * "number": Numeric attributes.
+  * "int": Integer attributes.
+  * "double": Double attributes.
   * "boolean": Boolean attributes.
   * "string[]": Array of strings attributes.
-  * "number[]": Array of numbers attributes.
+  * "int[]": Array of integer attributes.
+  * "double[]": Array of double attributes.
   * "boolean[]": Array of booleans attributes.
 - `ref`, optional string, reference an existing attribute, see later.
 - `required`, optional, specifies if the attribute is mandatory.
@@ -198,7 +202,7 @@ fields are present in the current attribute definition, they override the inheri
 
 ### Type
 
-An attribute type can either be a string, number, boolean, array of strings, array of numbers,
+An attribute type can either be a string, int, double, boolean, array of strings, array of int, array of double,
 array of booleans, or an enumeration. If it is an enumeration, additional fields are required:
 
 - `allow_custom_values`, optional boolean, set to false to not accept values
@@ -208,7 +212,7 @@ array of booleans, or an enumeration. If it is an enumeration, additional fields
 An enum entry has the following fields:
 
 - `id`, string that uniquely identifies the enum entry.
-- `value`, string, number, or boolean, value of the enum entry.
+- `value`, string, int, double, or boolean; value of the enum entry.
 - `brief`, optional string, brief description of the enum entry value. It defaults to the value of `id`.
 - `note`, optional string, longer description. It defaults to an empty string.
 

--- a/semantic_conventions/syntax.md
+++ b/semantic_conventions/syntax.md
@@ -95,7 +95,8 @@ An attribute is defined by:
 
 - `id`, string that uniquely identifies the attribute.
 - `type`, either a string literal denoting the type or an enum definition (See later).
-   The accepted strings literals are:
+   The accepted string literals are:
+
   * "string": String attributes.
   * "int": Integer attributes.
   * "double": Double attributes.
@@ -104,6 +105,8 @@ An attribute is defined by:
   * "int[]": Array of integer attributes.
   * "double[]": Array of double attributes.
   * "boolean[]": Array of booleans attributes.
+
+  See the [specification of Attributes](../specification/common/common.md#attributes) for the definition of the value types.
 - `ref`, optional string, reference an existing attribute, see later.
 - `required`, optional, specifies if the attribute is mandatory.
     Can be "always", or "conditional". When omitted, the attribute is not required.

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -258,7 +258,7 @@ groups:
             The name of the keyspace being accessed. To be used instead of the generic `db.name` attribute.
           examples: 'mykeyspace'
         - id: page_size
-          type: number
+          type: int
           tag: call-level-tech-specific-cassandra
           brief: >
             The fetch size used for paging, i.e. how many rows will be returned at once.
@@ -311,7 +311,7 @@ groups:
           brief: >
             Whether or not the query is idempotent.
         - id: speculative_execution_count
-          type: number
+          type: int
           tag: call-level-tech-specific-cassandra
           brief: >
             The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively.
@@ -351,7 +351,7 @@ groups:
         Call-level attributes for Redis
       attributes:
         - id: database_index
-          type: number
+          type: int
           required:
             conditional: Required, if other than the default database (`0`).
           tag: call-level-tech-specific

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -41,7 +41,7 @@ groups:
           [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6)
         examples: '127.0.0.1'
       - id: peer.port
-        type: number
+        type: int
         brief: 'Remote port number.'
         examples: [80, 8080, 443]
       - id: peer.name
@@ -53,7 +53,7 @@ groups:
         brief: 'Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host.'
         examples: '192.168.0.1'
       - id: host.port
-        type: number
+        type: int
         brief: 'Like `net.peer.port` but for the host port.'
         examples: 35555
       - id: host.name
@@ -101,7 +101,7 @@ groups:
       These attributes may be used for any operation to store information about a thread that started a span.
     attributes:
       - id: id
-        type: number
+        type: int
         brief: >
           Current "managed" thread ID (as opposed to OS thread ID).
         examples: 42
@@ -132,7 +132,7 @@ groups:
           The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path).
         examples: /usr/local/MyApplication/content_root/app/index.php
       - id: lineno
-        type: number
+        type: int
         brief: >
           The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
         examples: 42

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -35,7 +35,7 @@ groups:
         brief: 'The URI scheme identifying the used protocol.'
         examples: ["http", "https"]
       - id: status_code
-        type: number
+        type: int
         required:
           conditional: If and only if one was received/sent.
         brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
@@ -71,26 +71,26 @@ groups:
         brief: 'Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.'
         examples: ['CERN-LineMode/2.15 libwww/2.17b3']
       - id: request_content_length
-        type: number
+        type: int
         brief: >
           The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and
           is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2)
           header. For requests using transport encoding, this should be the compressed size.
         examples: 3495
       - id: request_content_length_uncompressed
-        type: number
+        type: int
         brief: >
           The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used.
         examples: 5493
       - id: response_content_length
-        type: number
+        type: int
         brief: >
           The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and
           is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2)
           header. For requests using transport encoding, this should be the compressed size.
         examples: 3495
       - id: response_content_length_uncompressed
-        type: number
+        type: int
         brief: >
           The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used.
         examples: 5493

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -58,13 +58,13 @@ groups:
             represented as a string. Sometimes called "Correlation ID".
           examples: 'MyConversationId'
         - id: message_payload_size_bytes
-          type: number
+          type: int
           brief: >
             The (uncompressed) size of the message payload in bytes.
             Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
           examples: 2738
         - id: message_payload_compressed_size_bytes
-          type: number
+          type: int
           brief: 'The compressed size of the message payload in bytes.'
           examples: 2048
         - ref: net.peer.name
@@ -149,7 +149,7 @@ groups:
             Client Id for the Consumer or Producer that is handling the message.
           examples: 'client-5'
         - id: partition
-          type: number
+          type: int
           brief: >
             Partition the message is sent to.
           examples: 2

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -65,7 +65,7 @@ or not they should be on the server, client or both.
 | [`rpc.method`](../../trace/semantic_conventions/rpc.md) | string | The name of the method being called, must be equal to the $method part in the span name. | `exampleMethod` | No, but recommended |
 | [`net.peer.ip`](../../trace/semantic_conventions/span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below |
 | [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Remote hostname or similar, see note below. | `example.com` | See below |
-| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | number | Remote port number. | `80`; `8080`; `443` | See below |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Remote port number. | `80`; `8080`; `443` | See below |
 | [`net.transport`](../../trace/semantic_conventions/span-general.md) | string | Transport protocol used. See note below. | `IP.TCP` | See below |
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -13,7 +13,7 @@
 | `faas.id` | string | The unique ID of the function being executed. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Yes |
 | `faas.version` | string | The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes). | `2.0.0` | No |
 | `faas.instance` | string | The execution environment ID as a string. | `my-function:instance-0001` | No |
-| `faas.max_memory` | number | The amount of memory available to the serverless function in MiB. [2] | `128` | No |
+| `faas.max_memory` | int | The amount of memory available to the serverless function in MiB. [2] | `128` | No |
 
 **[1]:** For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field.
 

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -27,7 +27,7 @@
 <!-- semconv process -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `process.pid` | number | Process identifier (PID). | `1234` | No |
+| `process.pid` | int | Process identifier (PID). | `1234` | No |
 | `process.executable.name` | string | The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` | See below |
 | `process.executable.path` | string | The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` | See below |
 | `process.command` | string | The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`. | `cmd/otelcol` | See below |

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -45,7 +45,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `db.user` | string | Username for accessing the database. | `readonly_user`; `reporting_user` | No |
 | [`net.peer.ip`](span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below. |
 | [`net.peer.name`](span-general.md) | string | Remote hostname or similar, see note below. | `example.com` | See below. |
-| [`net.peer.port`](span-general.md) | number | Remote port number. | `80`; `8080`; `443` | Conditional [1] |
+| [`net.peer.port`](span-general.md) | int | Remote port number. | `80`; `8080`; `443` | Conditional [1] |
 | [`net.transport`](span-general.md) | string | Transport protocol used. See note below. | `IP.TCP` | Conditional [2] |
 
 **[1]:** Required if using a port other than the default port for this DBMS.
@@ -174,7 +174,7 @@ For example, when retrieving a document, `db.operation` would be set to (literal
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `db.hbase.namespace` | string | The [HBase namespace](https://hbase.apache.org/book.html#_namespace) being accessed. To be used instead of the generic `db.name` attribute. | `default` | Yes |
-| `db.redis.database_index` | number | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute. | `0`; `1`; `15` | Conditional [1] |
+| `db.redis.database_index` | int | The index of the database being accessed as used in the [`SELECT` command](https://redis.io/commands/select), provided as an integer. To be used instead of the generic `db.name` attribute. | `0`; `1`; `15` | Conditional [1] |
 | `db.mongodb.collection` | string | The collection being accessed within the database stated in `db.name`. | `customers`; `products` | Yes |
 | `db.sql.table` | string | The name of the primary table that the operation is acting upon, including the schema name (if applicable). [2] | `public.users`; `customers` | Recommended if available. |
 
@@ -191,11 +191,11 @@ Separated for clarity.
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `db.cassandra.keyspace` | string | The name of the keyspace being accessed. To be used instead of the generic `db.name` attribute. | `mykeyspace` | Yes |
-| `db.cassandra.page_size` | number | The fetch size used for paging, i.e. how many rows will be returned at once. | `5000` | No |
+| `db.cassandra.page_size` | int | The fetch size used for paging, i.e. how many rows will be returned at once. | `5000` | No |
 | `db.cassandra.consistency_level` | string | The consistency level of the query. Based on consistency values from [CQL](https://docs.datastax.com/en/cassandra-oss/3.0/cassandra/dml/dmlConfigConsistency.html). | `ALL` | No |
 | `db.cassandra.table` | string | The name of the primary table that the operation is acting upon, including the schema name (if applicable). [1] | `mytable` | Recommended if available. |
 | `db.cassandra.idempotence` | boolean | Whether or not the query is idempotent. |  | No |
-| `db.cassandra.speculative_execution_count` | number | The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively. | `0`; `2` | No |
+| `db.cassandra.speculative_execution_count` | int | The number of times a query was speculatively executed. Not set or `0` if the query was not executed speculatively. | `0`; `2` | No |
 | `db.cassandra.coordinator.id` | string | The ID of the coordinating node for a query. | `be13faa2-8574-4d71-926d-27f16cf8a7af` | No |
 | `db.cassandra.coordinator.dc` | string | The data center of the coordinating node for a query. | `us-west-2` | No |
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -60,13 +60,13 @@ Don't set the span status description if the reason can be inferred from `http.s
 | `http.target` | string | The full request target as passed in a HTTP request line or equivalent. | `/path/12314/?q=ddds#123` | No |
 | `http.host` | string | The value of the [HTTP host header](https://tools.ietf.org/html/rfc7230#section-5.4). When the header is empty or not present, this attribute should be the same. | `www.example.org` | No |
 | `http.scheme` | string | The URI scheme identifying the used protocol. | `http`; `https` | No |
-| `http.status_code` | number | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If and only if one was received/sent. |
+| `http.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If and only if one was received/sent. |
 | `http.flavor` | string | Kind of HTTP protocol used. [2] | `1.0` | No |
 | `http.user_agent` | string | Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | No |
-| `http.request_content_length` | number | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
-| `http.request_content_length_uncompressed` | number | The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
-| `http.response_content_length` | number | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
-| `http.response_content_length_uncompressed` | number | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
+| `http.request_content_length` | int | The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
+| `http.request_content_length_uncompressed` | int | The size of the uncompressed request payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
+| `http.response_content_length` | int | The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the [Content-Length](https://tools.ietf.org/html/rfc7230#section-3.3.2) header. For requests using transport encoding, this should be the compressed size. | `3495` | No |
+| `http.response_content_length_uncompressed` | int | The size of the uncompressed response payload body after transport decoding. Not set if transport encoding not used. | `5493` | No |
 
 **[1]:** `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -136,8 +136,8 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.url` | string | Connection string. | `tibjmsnaming://localhost:7222`; `https://queue.amazonaws.com/80398EXAMPLE/MyQueue` | No |
 | `messaging.message_id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | No |
 | `messaging.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | No |
-| `messaging.message_payload_size_bytes` | number | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | No |
-| `messaging.message_payload_compressed_size_bytes` | number | The compressed size of the message payload in bytes. | `2048` | No |
+| `messaging.message_payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | No |
+| `messaging.message_payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | No |
 | [`net.peer.ip`](span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | If available. |
 | [`net.peer.name`](span-general.md) | string | Remote hostname or similar, see note below. [2] | `example.com` | If available. |
 
@@ -201,7 +201,7 @@ For Apache Kafka, the following additional attributes are defined:
 | `messaging.kafka.message_key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message_id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | No |
 | `messaging.kafka.consumer_group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | No |
 | `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `client-5` | No |
-| `messaging.kafka.partition` | number | Partition the message is sent to. | `2` | No |
+| `messaging.kafka.partition` | int | Partition the message is sent to. | `2` | No |
 | `messaging.kafka.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | If missing, it is assumed to be false. |
 
 **[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -59,7 +59,7 @@ Examples of span names:
 | `rpc.method` | string | The name of the method being called, must be equal to the $method part in the span name. | `exampleMethod` | No, but recommended |
 | [`net.peer.ip`](span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below |
 | [`net.peer.name`](span-general.md) | string | Remote hostname or similar, see note below. | `example.com` | See below |
-| [`net.peer.port`](span-general.md) | number | Remote port number. | `80`; `8080`; `443` | See below |
+| [`net.peer.port`](span-general.md) | int | Remote port number. | `80`; `8080`; `443` | See below |
 | [`net.transport`](span-general.md) | string | Transport protocol used. See note below. | `IP.TCP` | See below |
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -36,10 +36,10 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 |---|---|---|---|---|
 | `net.transport` | string | Transport protocol used. See note below. | `IP.TCP` | No |
 | `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
-| `net.peer.port` | number | Remote port number. | `80`; `8080`; `443` | No |
+| `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | No |
 | `net.peer.name` | string | Remote hostname or similar, see note below. | `example.com` | No |
 | `net.host.ip` | string | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host. | `192.168.0.1` | No |
-| `net.host.port` | number | Like `net.peer.port` but for the host port. | `35555` | No |
+| `net.host.port` | int | Like `net.peer.port` but for the host port. | `35555` | No |
 | `net.host.name` | string | Local hostname or similar, see note below. | `localhost` | No |
 
 `net.transport` MUST be one of the following:
@@ -149,7 +149,7 @@ a thread that started a span.
 <!-- semconv thread -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `thread.id` | number | Current "managed" thread ID (as opposed to OS thread ID). | `42` | No |
+| `thread.id` | int | Current "managed" thread ID (as opposed to OS thread ID). | `42` | No |
 | `thread.name` | string | Current thread name. | `main` | No |
 <!-- endsemconv -->
 
@@ -178,5 +178,5 @@ about the span.
 | `code.function` | string | The method or function name, or equivalent (usually rightmost part of the code unit's name). | `serveRequest` | No |
 | `code.namespace` | string | The "namespace" within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit. | `com.example.MyHttpService` | No |
 | `code.filepath` | string | The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path). | `/usr/local/MyApplication/content_root/app/index.php` | No |
-| `code.lineno` | number | The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`. | `42` | No |
+| `code.lineno` | int | The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`. | `42` | No |
 <!-- endsemconv -->


### PR DESCRIPTION
This distinction was recently introduced in https://github.com/open-telemetry/build-tools/releases/tag/v0.3.0.
Note that the generic `number` type was dropped.

Fixes #1096.