### PR TITLE
Broaden criteria for populating Zipkin `remoteEndpoint`

### DIFF
--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -90,7 +90,7 @@ OpenTelemetry Span's `InstrumentationLibrary` MUST be reported as `tags` to Zipk
 
 ### Remote endpoint
 
-#### OTLP -> Zipkin
+#### OpenTelemetry -> Zipkin
 
 Zipkin's `remoteEndpoint` SHOULD be populated to allow Zipkin to
 correctly treat the Span as a dependency regardless of `SpanKind`.
@@ -113,9 +113,9 @@ attributes for `remoteEndpoint` by preferred ranking:
 * `net.peer.ip` can be used by itself as `remoteEndpoint` but should be combined
   with `net.peer.port` if it is also present.
 
-#### Zipkin -> OTLP
+#### Zipkin -> OpenTelemetry
 
-When mapping from Zipkin to OTLP set `peer.service` tag from `remoteEndpoint`
+When mapping from Zipkin to OpenTelemetry set `peer.service` tag from `remoteEndpoint`
 unless there is a `peer.service` tag defined explicitly.
 
 ### Attribute

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -92,11 +92,11 @@ OpenTelemetry Span's `InstrumentationLibrary` MUST be reported as `tags` to Zipk
 
 #### OTLP -> Zipkin
 
-If Zipkin `SpanKind` resolves to either `SpanKind.CLIENT` or `SpanKind.PRODUCER`
-then the service SHOULD specify remote endpoint otherwise Zipkin won't treat the
-Span as a dependency. `peer.service` is the preferred attribute but is not
-always available. The following table lists the possible attributes for
-`remoteEndpoint` by preferred ranking:
+Zipkin's `remoteEndpoint` SHOULD be populated to allow Zipkin to
+correctly treat the Span as a dependency regardless of `SpanKind`.
+`peer.service` is the preferred OpenTelemetry attribute to use, but is
+not always available. The following table lists the possible
+attributes for `remoteEndpoint` by preferred ranking:
 
 |Rank|Attribute Name|Reason|
 |---|---|---|


### PR DESCRIPTION
Fixes #1560

## Changes

Broadens the criteria for when to populate Zipkin's `remoteEndpoint` when converting from an `OpenTelemetry` span.