### PR TITLE
Update to latest semconv table generator to fix int enum issue

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -61,4 +61,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: verify semantic convention tables
-      run: docker run --rm -v $(pwd)/semantic_conventions:/source -v $(pwd)/specification:/spec otel/semconvgen:0.3.0 -f /source markdown -md /spec --md-check
+      run: docker run --rm -v $(pwd)/semantic_conventions:/source -v $(pwd)/specification:/spec otel/semconvgen:0.3.1 -f /source markdown -md /spec --md-check

--- a/semantic_conventions/syntax.md
+++ b/semantic_conventions/syntax.md
@@ -215,7 +215,7 @@ array of booleans, or an enumeration. If it is an enumeration, additional fields
 An enum entry has the following fields:
 
 - `id`, string that uniquely identifies the enum entry.
-- `value`, string, int, double, or boolean; value of the enum entry.
+- `value`, string, int, or boolean; value of the enum entry.
 - `brief`, optional string, brief description of the enum entry value. It defaults to the value of `id`.
 - `note`, optional string, longer description. It defaults to an empty string.
 

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -105,7 +105,7 @@ For remote procedure calls via [gRPC][], additional conventions are described in
 <!-- semconv rpc.grpc -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `rpc.grpc.status_code` | number | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `16` | Yes |
+| `rpc.grpc.status_code` | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `16` | Yes |
 
 `rpc.grpc.status_code` MUST be one of the following:
 


### PR DESCRIPTION
Also, `double`s are not supported as enum values.

See https://github.com/open-telemetry/build-tools/releases/tag/v0.3.1.