### PR TITLE
Clarify B3 requirements and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ release.
 ### Context
 
 - Clarify composite `TextMapPropagator` method required and optional arguments. ([#1541](https://github.com/open-telemetry/opentelemetry-specification/pull/1541))
+- Clarify B3 requirements and configuration. ([#1570](https://github.com/open-telemetry/opentelemetry-specification/pull/1570))
 
 ### Traces
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -360,8 +360,9 @@ been established for B3 context propagation.
 When extracting B3, propagators:
 
 * MUST attempt to extract B3 encoded using single and multi-header
-  formats. The single-header variant takes precedence over
-  the multi-header version.
+  formats. When configured for B3 single, the single-header format will take
+  precendence, when configured for B3 multi, the multi-header will take
+  precendence.
 * MUST preserve a debug trace flag, if received, and propagate
   it with subsequent requests. Additionally, an OpenTelemetry implementation
   MUST set the sampled trace flag when the debug flag is set.
@@ -376,3 +377,13 @@ When injecting B3, propagators:
   multi-header
 * MUST NOT propagate `X-B3-ParentSpanId` as OpenTelemetry does not support
   reusing the same id for both sides of a request.
+
+#### Configuration
+
+| Option    | Extract Order | Inject Format | Specification     |
+|-----------|---------------|---------------| ------------------|
+| B3 Single | Single, Multi | Single        | [Link][b3-single] |
+| B3 Multi  | Multi, Single | Multi         | [Link][b3-multi]  |
+
+[b3-single]: https://github.com/openzipkin/b3-propagation#single-header
+[b3-multi]: https://github.com/openzipkin/b3-propagation#multiple-headers

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -360,9 +360,8 @@ been established for B3 context propagation.
 When extracting B3, propagators:
 
 * MUST attempt to extract B3 encoded using single and multi-header
-  formats. When configured for B3 single, the single-header format will take
-  precedence, when configured for B3 multi, the multi-header will take
-  precedence.
+  formats. The single-header variant takes precedence over
+  the multi-header version.
 * MUST preserve a debug trace flag, if received, and propagate
   it with subsequent requests. Additionally, an OpenTelemetry implementation
   MUST set the sampled trace flag when the debug flag is set.
@@ -388,7 +387,7 @@ i.e., the headers used for the inject operation.
 | Option    | Extract Order | Inject Format | Specification     |
 |-----------|---------------|---------------| ------------------|
 | B3 Single | Single, Multi | Single        | [Link][b3-single] |
-| B3 Multi  | Multi, Single | Multi         | [Link][b3-multi]  |
+| B3 Multi  | Single, Multi | Multi         | [Link][b3-multi]  |
 
 [b3-single]: https://github.com/openzipkin/b3-propagation#single-header
 [b3-multi]: https://github.com/openzipkin/b3-propagation#multiple-headers

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -361,8 +361,8 @@ When extracting B3, propagators:
 
 * MUST attempt to extract B3 encoded using single and multi-header
   formats. When configured for B3 single, the single-header format will take
-  precendence, when configured for B3 multi, the multi-header will take
-  precendence.
+  precedence, when configured for B3 multi, the multi-header will take
+  precedence.
 * MUST preserve a debug trace flag, if received, and propagate
   it with subsequent requests. Additionally, an OpenTelemetry implementation
   MUST set the sampled trace flag when the debug flag is set.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -378,6 +378,11 @@ When injecting B3, propagators:
 * MUST NOT propagate `X-B3-ParentSpanId` as OpenTelemetry does not support
   reusing the same id for both sides of a request.
 
+#### Fields
+
+Fields MUST return the header names that correspond to the configured format,
+i.e., the headers used for the inject operation.
+
 #### Configuration
 
 | Option    | Extract Order | Inject Format | Specification     |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -41,8 +41,8 @@ Known values for OTEL_PROPAGATORS are:
 
 - `"tracecontext"`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
 - `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
-- `"b3"`: [B3 Single](https://github.com/openzipkin/b3-propagation#single-header)
-- `"b3multi"`: [B3 Multi](https://github.com/openzipkin/b3-propagation#multiple-headers)
+- `"b3"`: [B3 Single](./context/api-propagators#configuration)
+- `"b3multi"`: [B3 Multi](./context/api-propagators#configuration)
 - `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
 - `"ottrace"`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -41,8 +41,8 @@ Known values for OTEL_PROPAGATORS are:
 
 - `"tracecontext"`: [W3C Trace Context](https://www.w3.org/TR/trace-context/)
 - `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
-- `"b3"`: [B3 Single](./context/api-propagators#configuration)
-- `"b3multi"`: [B3 Multi](./context/api-propagators#configuration)
+- `"b3"`: [B3 Single](./context/api-propagators.md#configuration)
+- `"b3multi"`: [B3 Multi](./context/api-propagators.md#configuration)
 - `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
 - `"ottrace"`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)


### PR DESCRIPTION
Fixes #1562

## Changes

This PR updates the spec as discussed in #1562. It clarifies that b3 propagators for single and multi-header formats should extract both formats. The B3 single propagator should give precedence to b3 single when extracting, and inject using the single format only. Similarly, the B3 multi propagator should give precedence to b3 multi extracting and inject using only the multi format.
