### PR TITLE
[semantic conventions] Rename `os.type` value `DRAGONFLYBSD` to `DRAGONFLY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ release.
 ### Semantic Conventions
 
 - Update semantic conventions to distinguish between int and double ([#1550](https://github.com/open-telemetry/opentelemetry-specification/pull/1550))
+- Rename `DRAGONFLYBSD` to `DRAGONFLY` to be consistent with Golang's GOOS values ([#1572](https://github.com/open-telemetry/opentelemetry-specification/pull/1572))
 
 ### Compatibility
 

--- a/semantic_conventions/resource/os.yaml
+++ b/semantic_conventions/resource/os.yaml
@@ -29,8 +29,8 @@ groups:
             - id: OPENBSD
               value: 'OPENBSD'
               brief: "OpenBSD"
-            - id: DRAGONFLYBSD
-              value: 'DRAGONFLYBSD'
+            - id: DRAGONFLY
+              value: 'DRAGONFLY'
               brief: "DragonFly BSD"
             - id: HPUX
               value: 'HPUX'

--- a/specification/resource/semantic_conventions/os.md
+++ b/specification/resource/semantic_conventions/os.md
@@ -24,7 +24,7 @@ In case of virtualized environments, this is the operating system as it is obser
 | `FREEBSD` | FreeBSD |
 | `NETBSD` | NetBSD |
 | `OPENBSD` | OpenBSD |
-| `DRAGONFLYBSD` | DragonFly BSD |
+| `DRAGONFLY` | DragonFly BSD |
 | `HPUX` | HP-UX (Hewlett Packard Unix) |
 | `AIX` | AIX (Advanced Interactive eXecutive) |
 | `SOLARIS` | Oracle Solaris |


### PR DESCRIPTION
## Changes

The `os.type` values seem inspired by the GOOS list (see [here](https://github.com/golang/go/blob/53dd0d78098a43cbca26d6807fea3d58aec64ef7/src/go/build/syslist.go#L10)). All the values present both in the OpenTelemetry specification and the GOOS list match except for the one for Dragonfly BSD, which is named `DRAGONFLYBSD` on the spec and `DRAGONFLY` on the GOOS list.

This PR renames the constant to `DRAGONFLY` in the OpenTelemetry specification. Renaming the constant to `DRAGONFLY` makes implementing this convention on Go easier, removing the need to have a special case for this operating system family.

See summary of current arguments [here](https://github.com/open-telemetry/opentelemetry-specification/pull/1572/#issuecomment-812526521)
