### PR TITLE
Update Baggage propagator to reference API Propagators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ release.
 - Define the fallback tracer name for invalid values.
   ([#1534](https://github.com/open-telemetry/opentelemetry-specification/pull/1534))
 - Remove the Included Propagators section from trace API specification that was a duplicate of the Propagators Distribution of the context specification. ([#1556](https://github.com/open-telemetry/opentelemetry-specification/pull/1556))
+- Remove the Baggage API propagator notes that conflict with the API Propagators Operations section and fix [#1526](https://github.com/open-telemetry/opentelemetry-specification/pull/1526). (TBD)
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ release.
 - Define the fallback tracer name for invalid values.
   ([#1534](https://github.com/open-telemetry/opentelemetry-specification/pull/1534))
 - Remove the Included Propagators section from trace API specification that was a duplicate of the Propagators Distribution of the context specification. ([#1556](https://github.com/open-telemetry/opentelemetry-specification/pull/1556))
-- Remove the Baggage API propagator notes that conflict with the API Propagators Operations section and fix [#1526](https://github.com/open-telemetry/opentelemetry-specification/pull/1526). (TBD)
+- Remove the Baggage API propagator notes that conflict with the API Propagators Operations section and fix [#1526](https://github.com/open-telemetry/opentelemetry-specification/issues/1526). ([#1575](https://github.com/open-telemetry/opentelemetry-specification/pull/1575))
 
 ### Metrics
 

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -154,14 +154,9 @@ to the optional metadata.
 
 On `extract`, the propagator should store all metadata as a single metadata instance per entry.
 On `inject`, the propagator should append the metadata per the W3C specification format.
-
-Notes:
-
-If the propagator is unable to parse the incoming `baggage`, `extract` MUST return
-a `Context` with no baggage entries in it.
-
-If the incoming `baggage` is present, but contains no entries, `extract` MUST
-return a `Context` with no baggage entries in it.
+Refer to the API Propagators
+[Operation](../context/api-propagators.md#operations) section for the
+additional requirements these operations need to follow.
 
 ## Conflict Resolution
 


### PR DESCRIPTION
The current notes in the Baggage API contradict how the API Propagators Operation section specifies how failure to extract/inject should not clear any pre-existing Baggage. This removes the notes and instead links to the relevant section of the API Propagators.

Resolves #1526 
Resolves https://github.com/open-telemetry/opentelemetry-go/issues/1685