### PR TITLE
Add Device (Mobile) and OS Version Resource Semantic Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ release.
 ### Semantic Conventions
 
 - Add JSON RPC specific conventions ([#1643](https://github.com/open-telemetry/opentelemetry-specification/pull/1643)).
-
 - Add Memcached to Database specific conventions ([#1689](https://github.com/open-telemetry/opentelemetry-specification/pull/1689)).
+- Add semantic convention attributes for the host device and added OS name and version ([#1596](https://github.com/open-telemetry/opentelemetry-specification/pull/1596)).
 
 ### Compatibility
 
@@ -112,7 +112,6 @@ release.
 - Add details for filling semantic conventions for AWS Lambda ([#1442](https://github.com/open-telemetry/opentelemetry-specification/pull/1442))
 - Update semantic conventions to distinguish between int and double ([#1550](https://github.com/open-telemetry/opentelemetry-specification/pull/1550))
 - Add semantic convention for AWS ECS task revision ([#1581](https://github.com/open-telemetry/opentelemetry-specification/pull/1581))
-- Add semantic convention attributes for the host device and added OS name and version ([#1596](https://github.com/open-telemetry/opentelemetry-specification/pull/1596))
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ release.
 - Add details for filling semantic conventions for AWS Lambda ([#1442](https://github.com/open-telemetry/opentelemetry-specification/pull/1442))
 - Update semantic conventions to distinguish between int and double ([#1550](https://github.com/open-telemetry/opentelemetry-specification/pull/1550))
 - Add semantic convention for AWS ECS task revision ([#1581](https://github.com/open-telemetry/opentelemetry-specification/pull/1581))
+- Add semantic convention attributes for the host device and added OS name and version ([#1596](https://github.com/open-telemetry/opentelemetry-specification/pull/1596))
 
 ### Compatibility
 

--- a/semantic_conventions/resource/device.yaml
+++ b/semantic_conventions/resource/device.yaml
@@ -1,0 +1,20 @@
+groups:
+  - id: device
+    prefix: device
+    brief: >
+        The device on which the process represented by this resource is running.
+    attributes:
+      - id: id
+        type: string
+        brief: 'A unique identifier representing the device'
+        note: >
+          For example, in an iOS application this might be the 
+          [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
+        examples: ['2ab2916d-a51f-4ac8-80ee-45ac31a28092']
+      - id: model
+        type: string
+        brief: 'The model identifier for the device'
+        note: >
+          It's recommended this value represents a machine readable version of the model identifier rather than
+          the market or consumer-friendly name of the device.
+        examples: ['iPhone3,4', 'SM-G920F']

--- a/semantic_conventions/resource/device.yaml
+++ b/semantic_conventions/resource/device.yaml
@@ -8,11 +8,14 @@ groups:
         type: string
         brief: 'A unique identifier representing the device'
         note: >
-          For example, in an iOS application this might be the
-          [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
-          Caution should be taken when storing personal data or anything which
-          can identify a user. GDPR and data protection laws may apply, ensure
-          you do your own due diligence.
+          The device identifier MUST only be defined using the values outlined below. This value is not an advertising
+          identifier and MUST NOT be used as such.
+          On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
+          On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique
+          UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids)
+          on best practices and exact implementation details.
+          Caution should be taken when storing personal data or anything which can identify a user. GDPR and
+          data protection laws may apply, ensure you do your own due diligence.
         examples: ['2ab2916d-a51f-4ac8-80ee-45ac31a28092']
       - id: model.identifier
         type: string

--- a/semantic_conventions/resource/device.yaml
+++ b/semantic_conventions/resource/device.yaml
@@ -8,13 +8,24 @@ groups:
         type: string
         brief: 'A unique identifier representing the device'
         note: >
-          For example, in an iOS application this might be the 
+          For example, in an iOS application this might be the
           [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
+          Caution should be taken when storing personal data or anything which
+          can identify a user. GDPR and data protection laws may apply, ensure
+          you do your own due diligence.
         examples: ['2ab2916d-a51f-4ac8-80ee-45ac31a28092']
-      - id: model
+      - id: model.identifier
         type: string
         brief: 'The model identifier for the device'
         note: >
-          It's recommended this value represents a machine readable version of the model identifier rather than
-          the market or consumer-friendly name of the device.
+          It's recommended this value represents a machine readable version of
+          the model identifier rather than the market or consumer-friendly name
+          of the device.
         examples: ['iPhone3,4', 'SM-G920F']
+      - id: model.name
+        type: string
+        brief: 'The marketing name for the device model'
+        note: >
+          It's recommended this value represents a human readable version of the
+          device model rather than a machine readable alternative.
+        examples: ['iPhone 6s Plus', 'Samsung Galaxy S6']

--- a/semantic_conventions/resource/os.yaml
+++ b/semantic_conventions/resource/os.yaml
@@ -49,6 +49,16 @@ groups:
       - id: description
         type: string
         brief: >
-            Human readable (not intended to be parsed) OS version information,
-            like e.g. reported by `ver` or `lsb_release -a` commands.
+          Human readable (not intended to be parsed) OS version information,
+          like e.g. reported by `ver` or `lsb_release -a` commands.
         examples: ['Microsoft Windows [Version 10.0.18363.778]', 'Ubuntu 18.04.1 LTS']
+      - id: name
+        type: string
+        brief: 'Human readable operating system name.'
+        examples: ['iOS', 'Android', 'Ubuntu']
+      - id: version
+        type: string
+        brief: >
+          The version string of the operating system as defined in
+          [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes).
+        examples: ['14.2.1', '18.04.1']

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -25,7 +25,7 @@ This document defines standard attributes for resources. These attributes are ty
 ## TODOs
 
 * Add more compute units: AppEngine unit, etc.
-* Add Device (mobile) and Web Browser.
+* Add Web Browser.
 * Decide if lower case strings only.
 * Consider to add optional/required for each attribute and combination of attributes
   (e.g when supplying a k8s resource all k8s may be required).
@@ -137,6 +137,7 @@ Attributes defining a computing instance (e.g. host):
 Attributes defining a running environment (e.g. Operating System, Cloud, Data Center, Deployment Service):
 
 - [Operating System](./os.md)
+- [Device](./device.md)
 - [Cloud](./cloud.md)
 - Deployment:
   - [Deployment Environment](./deployment_environment.md)

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -1,0 +1,18 @@
+# Device
+
+**Status**: [Experimental](../../document-status.md)
+
+**type:** `device`
+
+**Description**: The device on which the process represented by this resource is running.
+
+<!-- semconv device -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `device.id` | string | A unique identifier representing the device [1] | `2ab2916d-a51f-4ac8-80ee-45ac31a28092` | No |
+| `device.model` | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | No |
+
+**[1]:** For example, in an iOS application this might be the  [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
+
+**[2]:** It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
+<!-- endsemconv -->

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -13,7 +13,7 @@
 | `device.model.identifier` | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | No |
 | `device.model.name` | string | The marketing name for the device model [3] | `iPhone 6s Plus`; `Samsung Galaxy S6` | No |
 
-**[1]:** For example, in an iOS application this might be the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
+**[1]:** The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
 
 **[2]:** It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
 

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -10,9 +10,12 @@
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `device.id` | string | A unique identifier representing the device [1] | `2ab2916d-a51f-4ac8-80ee-45ac31a28092` | No |
-| `device.model` | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | No |
+| `device.model.identifier` | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | No |
+| `device.model.name` | string | The marketing name for the device model [3] | `iPhone 6s Plus`; `Samsung Galaxy S6` | No |
 
-**[1]:** For example, in an iOS application this might be the  [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor).
+**[1]:** For example, in an iOS application this might be the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
 
 **[2]:** It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
+
+**[3]:** It's recommended this value represents a human readable version of the device model rather than a machine readable alternative.
 <!-- endsemconv -->

--- a/specification/resource/semantic_conventions/os.md
+++ b/specification/resource/semantic_conventions/os.md
@@ -13,6 +13,8 @@ In case of virtualized environments, this is the operating system as it is obser
 |---|---|---|---|---|
 | `os.type` | string | The operating system type. | `windows` | Yes |
 | `os.description` | string | Human readable (not intended to be parsed) OS version information, like e.g. reported by `ver` or `lsb_release -a` commands. | `Microsoft Windows [Version 10.0.18363.778]`; `Ubuntu 18.04.1 LTS` | No |
+| `os.name` | string | Human readable operating system name. | `iOS`; `Android`; `Ubuntu` | No |
+| `os.version` | string | The version string of the operating system as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes). | `14.2.1`; `18.04.1` | No |
 
 `os.type` MUST be one of the following or, if none of the listed values apply, a custom value:
 


### PR DESCRIPTION
Fixes #1499

Hey folks 👋 

Apologies, I'm not fully clued up on the running process of adding new semantic attributes, only just starting to contribute to OpenTelemetry. I've created this pull request based on the suggestions of the issue above as well as my own beliefs - but I'm more hoping this will prompt a conversation. Please let me know if there's a better way to go about this.

## Changes

All changes are purely additive, no breaking changes.

### OS Additions

I've added an operating system name attribute, I believe this to be different enough to the existing `os.type` to justify its own attribute. While `os.type` will specify a more generalised "Linux" value (in this example), `os.name` can be the specific distro such as Ubuntu or Fedora. In a mobile world, from which I'm from, the `os.name` allows us to distinguish between multiple Darwin based Apple OS's such as iOS and watchOS.

I've also added an `os.version` value. This is intended to be machine readable and to follow the existing standards of what a version attribute should be.

### Device Additions

I've added a `device.model` value which is the machine readable model identifier of the device. Importantly this is not necessarily the same as the promotional or market/consumer friendly name - though this could be an optional extra attribute if people think it's suitable. The reason I've opted for this method is because on both iOS and Android it is not currently possible to get the market model name without large switch statements which become quickly out of date - it is more feasible to have mapping logic (through a processing pipeline) at the collector level or indeed at the visualisation layer.

I've also added a `device.id` value which represents a unique device identifier.