### PR TITLE
added JSON RPC specific attributes

### DIFF
--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -78,3 +78,33 @@ groups:
           required: always
           brief: "The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request."
           examples: [0, 1, 16]
+    - id: rpc.jsonrpc
+      prefix: rpc.jsonrpc
+      extends: rpc
+      brief: 'Tech-specific attributes for JSON RPC.'
+      attributes:
+        - id: version
+          type: string
+          required:
+            conditional: 'If missing, it is assumed to be "2.0".'
+          brief: "Protocol version as in `jsonrpc` property of request/response. Since first protocol version does not specify this, value can be omitted entirely."
+          examples: ['2.0', '1.0']
+        - id: method
+          type: string
+          required: always
+          brief: "`method` property from request. Unlike `rpc.method`, this may not relate to the actual method being called."
+          examples: ['users.create', 'get_users']
+        - id: id
+          type: string
+          brief: "`id` property of request. Since protocol allows id to be int, string, `null` or missing (for notifications), value is expected to be cast to string for simplicity. Omit if this is a notification."
+          examples: ['10', 'request-7', '']
+        - id: error_code
+          type: int
+          required:
+            conditional: 'If missing, response is assumed to be successful.'
+          brief: "`error.code` property of response if it is an error response."
+          examples: [-32700, 100]
+        - id: error_message
+          type: string
+          brief: "`error.message` property of response if it is an error response."
+          examples: ['Parse error', 'User already exists']


### PR DESCRIPTION
Tracing attributes for [JSON RPC protocol](https://www.jsonrpc.org/specification).

## Changes

Added attributes:

```
rpc.jsonrpc.version
rpc.jsonrpc.method
rpc.jsonrpc.id
rpc.jsonrpc.error_code
rpc.jsonrpc.error_message
```

Not sure if `null` values are OK for attributes, maybe need to change `rpc.jsonrpc.id` a bit. Also not sure if `error_message` is OK because it is arbitrary (but short!) text, can impact cardinality.

Related issue: #1601 

