### PR TITLE
Add a link to the Prometheus/OpenMetrics compatibility

### DIFF
--- a/specification/compatibility/openmetrics.md
+++ b/specification/compatibility/openmetrics.md
@@ -1,0 +1,8 @@
+# OpenMetrics Compatibility
+
+**Status**: [Experimental](../document-status.md).
+
+The OpenTelemetry metrics aim to provide compatibility with the
+[OpenMetrics](https://openmetrics.io/) spec. The extend of the compatibility
+and requirements can be found on the
+[Prometheus Working Group](https://github.com/open-telemetry/wg-prometheus/blob/main/specification.md).


### PR DESCRIPTION
As of today, the compatibility work between OTel and OpenMetrics/Prometheus is represented as an experimental spec on the working group. This is change is adding a link to provide more visibility. We will graduate the compatibility spec to this repo once it's more mature.