### PR TITLE
Clarify that 64 bit integer numbers are decimal strings in OTLP/JSON

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -363,6 +363,11 @@ they are not base64-encoded like it is defined in the standard
 The hex encoding is used for `trace_id` and `span_id` fields in all OTLP
 Protobuf messages, e.g. the `Span`, `Link`, `LogRecord`, etc. messages.
 
+Note that according to [Protobuf specs](
+https://developers.google.com/protocol-buffers/docs/proto3#json) 64-bit integer
+numbers in JSON-encoded payloads are encoded as decimal strings, and either
+numbers or strings are accepted when decoding.
+
 #### OTLP/HTTP Response
 
 Response body MUST be the appropriate serialized Protobuf message (see below for


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-proto/issues/268

This behavior is already the documented behavior for JSON Protobuf,
see https://developers.google.com/protocol-buffers/docs/proto3#json:

>JSON value will be a decimal string. Either numbers or strings are accepted.
