### PR TITLE
Clarify usage of "otel." attribute namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ release.
 - Fix the inconsistent formatting of semantic convention enums ([#1598](https://github.com/open-telemetry/opentelemetry-specification/pull/1598/))
 - Add details for filling resource for AWS Lambda([#1610](https://github.com/open-telemetry/opentelemetry-specification/pull/1610))
 - Add already specified `messaging.rabbitmq.routing_key` span attribute key to the respective YAML file.
+- Clarify usage of "otel." attribute namespace ([#1640](https://github.com/open-telemetry/opentelemetry-specification/pull/1640)).
 
 ### Compatibility
 

--- a/specification/common/attribute-and-label-naming.md
+++ b/specification/common/attribute-and-label-naming.md
@@ -130,3 +130,17 @@ It is recommended to limit names to printable Basic Latin characters
 (more precisely to
 [U+0021 .. U+007E](https://en.wikipedia.org/wiki/Basic_Latin_(Unicode_block)#Table_of_characters)
 subset of Unicode code points).
+
+## otel.* Namespace
+
+Attribute and label names that start with `otel.` are reserved to be defined by
+OpenTelemetry specification. These are typically used to express OpenTelemetry
+concepts in formats that don't have a corresponding concept.
+
+For example, the `otel.library.name` attribute is used to record the
+instrumentation library name, which is an OpenTelemetry concept that is natively
+represented in OTLP, but does not have an equivalent in other telemetry formats
+and protocols.
+
+Any additions to the `otel.*` namespace MUST be approved as part of
+OpenTelemetry specification.


### PR DESCRIPTION
I noticed developers adding their own attributes to this namespace
without going through the specification. We need to regulate this
namespace through the specification, just like we do it for other
semantic conventions.
