### PR TITLE
Log Data Model: Fix case typo reported in #1621

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -916,19 +916,19 @@ All other fields |                    |                                         
     <td>@timestamp</td>
     <td>datetime</td>
     <td>Time the event was recorded</td>
-    <td>timestamp</td>
+    <td>Timestamp</td>
   </tr>
   <tr>
     <td>message</td>
     <td>string</td>
     <td>Any type of message</td>
-    <td>body</td>
+    <td>Body</td>
   </tr>
   <tr>
     <td>labels</td>
     <td>key/value</td>
     <td>Arbitrary labels related to the event</td>
-    <td>attributes[*]</td>
+    <td>Attributes[*]</td>
   </tr>
   <tr>
     <td>tags</td>
@@ -952,157 +952,157 @@ All other fields |                    |                                         
     <td>agent.ephemeral_id</td>
     <td>string</td>
     <td>Ephemeral ID created by agent</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>agent.id</td>
     <td>string</td>
     <td>Unique identifier of this agent</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>agent.name</td>
     <td>string</td>
     <td>Name given to the agent</td>
-    <td>resource["telemetry.sdk.name"]</td>
+    <td>Resource["telemetry.sdk.name"]</td>
   </tr>
   <tr>
     <td>agent.type</td>
     <td>string</td>
     <td>Type of agent</td>
-    <td>resource["telemetry.sdk.language"]</td>
+    <td>Resource["telemetry.sdk.language"]</td>
   </tr>
   <tr>
     <td>agent.version</td>
     <td>string</td>
     <td>Version of agent</td>
-    <td>resource["telemetry.sdk.version"]</td>
+    <td>Resource["telemetry.sdk.version"]</td>
   </tr>
   <tr>
     <td>source.ip, client.ip</td>
     <td>string</td>
     <td>The IP address that the request was made from.</td>
-    <td>attributes["net.peer.ip"] or attributes["net.host.ip"]</td>
+    <td>Attributes["net.peer.ip"] or Attributes["net.host.ip"]</td>
   </tr>
   <tr>
     <td>cloud.account.id</td>
     <td>string</td>
     <td>ID of the account in the given cloud</td>
-    <td>resource["cloud.account.id"]</td>
+    <td>Resource["cloud.account.id"]</td>
   </tr>
   <tr>
     <td>cloud.availability_zone</td>
     <td>string</td>
     <td>Availability zone in which this host is running.</td>
-    <td>resource["cloud.zone"]</td>
+    <td>Resource["cloud.zone"]</td>
   </tr>
   <tr>
     <td>cloud.instance.id</td>
     <td>string</td>
     <td>Instance ID of the host machine.</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>cloud.instance.name</td>
     <td>string</td>
     <td>Instance name of the host machine.</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>cloud.machine.type</td>
     <td>string</td>
     <td>Machine type of the host machine.</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>cloud.provider</td>
     <td>string</td>
     <td>Name of the cloud provider. Example values are aws, azure, gcp, or digitalocean.</td>
-    <td>resource["cloud.provider"]</td>
+    <td>Resource["cloud.provider"]</td>
   </tr>
   <tr>
     <td>cloud.region</td>
     <td>string</td>
     <td>Region in which this host is running.</td>
-    <td>resource["cloud.region"]</td>
+    <td>Resource["cloud.region"]</td>
   </tr>
   <tr>
     <td>cloud.image.id*</td>
     <td>string</td>
     <td></td>
-    <td>resource["host.image.name"]</td>
+    <td>Resource["host.image.name"]</td>
   </tr>
   <tr>
     <td>container.id</td>
     <td>string</td>
     <td>Unique container id</td>
-    <td>resource["container.id"]</td>
+    <td>Resource["container.id"]</td>
   </tr>
   <tr>
     <td>container.image.name</td>
     <td>string</td>
     <td>Name of the image the container was built on.</td>
-    <td>resource["container.image.name"]</td>
+    <td>Resource["container.image.name"]</td>
   </tr>
   <tr>
     <td>container.image.tag</td>
     <td>Array of string</td>
     <td>Container image tags.</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>container.labels</td>
     <td>key/value</td>
     <td>Image labels.</td>
-    <td>attributes[*]</td>
+    <td>Attributes[*]</td>
   </tr>
   <tr>
     <td>container.name</td>
     <td>string</td>
     <td>Container name.</td>
-    <td>resource["container.name"]</td>
+    <td>Resource["container.name"]</td>
   </tr>
   <tr>
     <td>container.runtime</td>
     <td>string</td>
     <td>Runtime managing this container. Example: "docker"</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>destination.address</td>
     <td>string</td>
     <td>Destination address for the event</td>
-    <td>attributes["destination.address"]</td>
+    <td>Attributes["destination.address"]</td>
   </tr>
   <tr>
     <td>error.code</td>
     <td>string</td>
     <td>Error code describing the error.</td>
-    <td>attributes["error.code"]</td>
+    <td>Attributes["error.code"]</td>
   </tr>
   <tr>
     <td>error.id</td>
     <td>string</td>
     <td>Unique identifier for the error.</td>
-    <td>attributes["error.id"]</td>
+    <td>Attributes["error.id"]</td>
   </tr>
   <tr>
     <td>error.message</td>
     <td>string</td>
     <td>Error message.</td>
-    <td>attributes["error.message"]</td>
+    <td>Attributes["error.message"]</td>
   </tr>
   <tr>
     <td>error.stack_trace</td>
     <td>string</td>
     <td>The stack trace of this error in plain text.</td>
-    <td>attributes["error.stack_trace]</td>
+    <td>Attributes["error.stack_trace]</td>
   </tr>
   <tr>
     <td>host.architecture</td>
     <td>string</td>
     <td>Operating system architecture</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>host.domain</td>
@@ -1111,7 +1111,7 @@ All other fields |                    |                                         
 
 For example, on Windows this could be the host’s Active Directory domain or NetBIOS domain name. For Linux this could be the domain of the host’s LDAP provider.</td>
 
-<td>**resource</td>
+<td>**Resource</td>
   </tr>
   <tr>
     <td>host.hostname</td>
@@ -1120,26 +1120,26 @@ For example, on Windows this could be the host’s Active Directory domain or Ne
 
 It normally contains what the hostname command returns on the host machine.</td>
 
-<td>resource["host.hostname"]</td>
+<td>Resource["host.hostname"]</td>
 
   </tr>
   <tr>
     <td>host.id</td>
     <td>string</td>
     <td>Unique host id.</td>
-    <td>resource["host.id"]</td>
+    <td>Resource["host.id"]</td>
   </tr>
   <tr>
     <td>host.ip</td>
     <td>Array of string</td>
     <td>Host IP</td>
-    <td>resource["host.ip"]</td>
+    <td>Resource["host.ip"]</td>
   </tr>
   <tr>
     <td>host.mac</td>
     <td>array of string</td>
     <td>MAC addresses of the host</td>
-    <td>resource["host.mac"]</td>
+    <td>Resource["host.mac"]</td>
   </tr>
   <tr>
     <td>host.name</td>
@@ -1148,14 +1148,14 @@ It normally contains what the hostname command returns on the host machine.</td>
 
 It may contain what hostname returns on Unix systems, the fully qualified, or a name specified by the user. </td>
 
-<td>resource["host.name"]</td>
+<td>Resource["host.name"]</td>
 
   </tr>
   <tr>
     <td>host.type</td>
     <td>string</td>
     <td>Type of host.</td>
-    <td>resource["host.type"]</td>
+    <td>Resource["host.type"]</td>
   </tr>
   <tr>
     <td>host.uptime</td>
@@ -1169,43 +1169,43 @@ It may contain what hostname returns on Unix systems, the fully qualified, or a 
 </td>
     <td>string</td>
     <td>Ephemeral identifier of this service</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>service.id</td>
     <td>string</td>
     <td>Unique identifier of the running service. If the service is comprised of many nodes, the service.id should be the same for all nodes.</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>service.name</td>
     <td>string</td>
     <td>Name of the service data is collected from.</td>
-    <td>resource["service.name"]</td>
+    <td>Resource["service.name"]</td>
   </tr>
   <tr>
     <td>service.node.name</td>
     <td>string</td>
     <td>Specific node serving that service</td>
-    <td>resource["service.instance.id"]</td>
+    <td>Resource["service.instance.id"]</td>
   </tr>
   <tr>
     <td>service.state</td>
     <td>string</td>
     <td>Current state of the service.</td>
-    <td>attributes["service.state"]</td>
+    <td>Attributes["service.state"]</td>
   </tr>
   <tr>
     <td>service.type</td>
     <td>string</td>
     <td>The type of the service data is collected from.</td>
-    <td>**resource</td>
+    <td>**Resource</td>
   </tr>
   <tr>
     <td>service.version</td>
     <td>string</td>
     <td>Version of the service the data was collected from.</td>
-    <td>resource["service.version"]</td>
+    <td>Resource["service.version"]</td>
   </tr>
   <tr>
     <td></td>


### PR DESCRIPTION
Fixes #1621

## Changes

[Log Data Model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body): Fix case typo in the mapping between Elastic Common Schema and OpenTelemetry's Unified Model.

The correct case is "Attributes", "Resources", "Body", and "Timestamp" instead of "attributes", "resources", "body", and "timestamp".

Related issues: #1621
