### PR TITLE
add rabbitmq to semantic conventions yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ release.
 
 - Fix the inconsistent formatting of semantic convention enums ([#1598](https://github.com/open-telemetry/opentelemetry-specification/pull/1598/))
 - Add details for filling resource for AWS Lambda([#1610](https://github.com/open-telemetry/opentelemetry-specification/pull/1610))
+- Add already specified `messaging.rabbitmq.routing_key` span attribute key to the respective YAML file.
 
 ### Compatibility
 

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -130,7 +130,7 @@ groups:
         - id: routing_key
           type: string
           required:
-            conditional: Unless it is empty.          
+            conditional: Unless it is empty.
           brief: >
             RabbitMQ message routing key.
           examples: 'myKey'

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -129,9 +129,10 @@ groups:
       attributes:
         - id: routing_key
           type: string
+          required:
+            conditional: Unless it is empty.          
           brief: >
             In RabbitMQ, the destination is defined by an exchange and a routing key.
-            The routing key MUST be provided to this attribute, unless it is empty.
           examples: 'myKey'
 
     - id: messaging.kafka

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -121,6 +121,18 @@ groups:
         Semantic convention for servers that consume messages received from messaging systems
         and always send back replies directed to the producers of these messages.
 
+    - id: messaging.rabbitmq
+      prefix: messaging.rabbitmq
+      extends: messaging
+      brief: >
+        Attributes for RabbitMQ
+      attributes:
+        - id: routing_key
+          type: string
+          brief: >
+            In RabbitMQ, the destination is defined by an exchange and a routing key.
+            The routing key MUST be provided to this attribute, unless it is empty.
+
     - id: messaging.kafka
       prefix: messaging.kafka
       extends: messaging

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -132,6 +132,7 @@ groups:
           brief: >
             In RabbitMQ, the destination is defined by an exchange and a routing key.
             The routing key MUST be provided to this attribute, unless it is empty.
+          examples: 'myKey'
 
     - id: messaging.kafka
       prefix: messaging.kafka

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -132,7 +132,7 @@ groups:
           required:
             conditional: Unless it is empty.          
           brief: >
-            In RabbitMQ, the destination is defined by an exchange and a routing key.
+            RabbitMQ message routing key.
           examples: 'myKey'
 
     - id: messaging.kafka

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -189,7 +189,12 @@ Instead span kind should be set to either `CONSUMER` or `SERVER` according to th
 
 In RabbitMQ, the destination is defined by an _exchange_ and a _routing key_.
 `messaging.destination` MUST be set to the name of the exchange. This will be an empty string if the default exchange is used.
-The routing key MUST be provided to the attribute `messaging.rabbitmq.routing_key`, unless it is empty.
+
+<!-- semconv messaging.rabbitmq -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `messaging.rabbitmq.routing_key` | string | RabbitMQ message routing key. | `myKey` | Unless it is empty. |
+<!-- endsemconv -->
 
 #### Apache Kafka
 


### PR DESCRIPTION
In trace semantic conventions markdown there is a [section about rabbitmq](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#rabbitmq) with attribute `messaging.rabbitmq.routing_key`.
This attribute is not reflected in the `messaging.yaml` file [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/messaging.yaml).

opentelemetry-js auto-generate the attributes from this yaml, thus it is [currently missing](https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-semantic-conventions/src/trace/SemanticAttributes.ts)