### PR TITLE
Get Tracer operation should use an empty string if the specified `name` is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ release.
 
 ### Traces
 
-- `Get Tracer` should use an emptry string if the specified `name` is null. ([#1654](https://github.com/open-telemetry/opentelemetry-specification/pull/1654))
+- `Get Tracer` should use an empty string if the specified `name` is null. ([#1654](https://github.com/open-telemetry/opentelemetry-specification/pull/1654))
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ release.
 
 ### Traces
 
+- `Get Tracer` should use an emptry string if the specified `name` is null. ([#1654](https://github.com/open-telemetry/opentelemetry-specification/pull/1654))
+
 ### Metrics
 
 ### Logs

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -110,7 +110,7 @@ This API MUST accept the following parameters:
   or application.
   In case an invalid name (null or empty string) is specified, a working
   Tracer implementation MUST be returned as a fallback rather than returning
-  null or throwing an exception, its `name` property SHOULD keep the original invalid value,
+  null or throwing an exception, its `name` property SHOULD be set to an **empty** string,
   and a message reporting that the specified value is invalid SHOULD be logged.
   A library, implementing the OpenTelemetry API *may* also ignore this name and
   return a default instance for all calls, if it does not support "named"


### PR DESCRIPTION
Fixes #1619 - as discussed previously in a previous SIG call.

The `Get Tracer` operation, upon receiving an invalid value, should set the `name` to an empty string, instead of allowing null values to pass through. 