### PR TITLE
Add data model links to various places where it was marked WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ Technical committee holds regular meetings, notes are held
   - [Resource](specification/resource/sdk.md)
   - [Configuration](specification/sdk-configuration.md)
 - Data Specification
-  - [Semantic Conventions](specification/overview.md#semantic-conventions)
+  - [Semantic Conventions](specification/overview.md#semantic-conventions)]
   - [Protocol](specification/protocol/README.md)
+    - [Metrics](specification/metrics/datamodel.md)
+    - [Logs](specification/logs/data-model.md)
 - About the Project
   - [Timeline](#project-timeline)
   - [Notation Conventions and Compliance](#notation-conventions-and-compliance)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Technical committee holds regular meetings, notes are held
   - [Resource](specification/resource/sdk.md)
   - [Configuration](specification/sdk-configuration.md)
 - Data Specification
-  - [Semantic Conventions](specification/overview.md#semantic-conventions)]
+  - [Semantic Conventions](specification/overview.md#semantic-conventions)
   - [Protocol](specification/protocol/README.md)
     - [Metrics](specification/metrics/datamodel.md)
     - [Logs](specification/logs/data-model.md)

--- a/specification/metrics/README.md
+++ b/specification/metrics/README.md
@@ -30,7 +30,7 @@ Table of Contents
 * [Specifications](#specifications)
   * [Metrics API](./api.md)
   * Metrics SDK (not available yet)
-  * Metrics Data Model and Protocol (not available yet)
+  * [Metrics Data Model and Protocol](datamodel.md)
   * [Semantic Conventions](./semantic_conventions/README.md)
 
 </details>
@@ -108,7 +108,7 @@ SDK](../overview.md#sdk) concept concept for more information.
 
 * [Metrics API](./api.md)
 * Metrics SDK (not available yet)
-* Metrics Data Model and Protocol (not available yet)
+* [Metrics Data Model and Protocol](datamodel.md)
 * [Semantic Conventions](./semantic_conventions/README.md)
 
 ## References


### PR DESCRIPTION
- Where metrics data model was called out, but not linked, add links.
- Add a link to logs/metrics data model specification under protocol, as it's non-obvious how to find these.