### PR TITLE
Added mobile carrier info related semantic conventions to span spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ release.
 - Clarify usage of "otel." attribute namespace. ([#1640](https://github.com/open-telemetry/opentelemetry-specification/pull/1640))
 - Add possibility to disable `db.statement` via instrumentation configuration. ([#1659](https://github.com/open-telemetry/opentelemetry-specification/pull/1659))
 - Add mobile related network state: `net.host.connection_type` & `net.host.carrier.*` [#1647](https://github.com/open-telemetry/opentelemetry-specification/issues/1647)
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ release.
 - Add already specified `messaging.rabbitmq.routing_key` span attribute key to the respective YAML file.
 - Clarify usage of "otel." attribute namespace. ([#1640](https://github.com/open-telemetry/opentelemetry-specification/pull/1640))
 - Add possibility to disable `db.statement` via instrumentation configuration. ([#1659](https://github.com/open-telemetry/opentelemetry-specification/pull/1659))
-
+- Add mobile related network state: `net.host.connection_type` & `net.host.carrier.*` [#1647](https://github.com/open-telemetry/opentelemetry-specification/issues/1647)
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -41,7 +41,25 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | `net.host.ip` | string | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host. | `192.168.0.1` | No |
 | `net.host.port` | int | Like `net.peer.port` but for the host port. | `35555` | No |
 | `net.host.name` | string | Local hostname or similar, see note below. | `localhost` | No |
+| `net.host.connection_type` | string | The current network connection type in common terms | `wifi` | No |
+| `net.host.carrier.name` | string | Name of the mobile carrier. | `sprint` | No |
+| `net.host.carrier.mcc` | string | [Mobile country code](https://en.wikipedia.org/wiki/Mobile_country_code) | `310` | No | 
+| `net.host.carrier.mnc` | string | [Mobile network code](https://en.wikipedia.org/wiki/Mobile_country_code) | `001` | No |
+| `net.host.carrier.icc` | string | [ISO country code (two character)](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) | `DE` | No |
 
+`net.host.connection_type` SHOULD be one of the following : 
+
+| Value | Description |
+| --- | --- |
+| `wifi` | connected via wifi | 
+| `1G` |  connected via a first gen cellular technology, such as `AMPS` or equivalent | 
+| `2G` | connected via a second gen cellular technology, such as `GPRS` |
+| `3G` | connected via a third gen cellular technology, such as `UMTS` or `1xEV-DO` | 
+| `4G` | connected via a fourth gen cellular technology, such as `eHRPD` or `LTE` |
+| `5G` | connected via a fifth gen cellular technology, such as `5G NR` | 
+| `unavailable` | network is disconnected or unavailable. | 
+
+ 
 `net.transport` MUST be one of the following:
 
 | Value  | Description |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -52,6 +52,7 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | Value | Description |
 | --- | --- |
 | `wifi` | connected via wifi | 
+| `wired` | connected via a hard-wire | 
 | `1G` |  connected via a first gen cellular technology, such as `AMPS` or equivalent | 
 | `2G` | connected via a second gen cellular technology, such as `GPRS` |
 | `3G` | connected via a third gen cellular technology, such as `UMTS` or `1xEV-DO` | 


### PR DESCRIPTION
Fixes #
Adds semantic conventions defining mobile carrier data defined in [#1647](https://github.com/open-telemetry/opentelemetry-specification/issues/1647)

## Changes
- adds `net.host.carrier.*`
- adds `net.host.connection_type`

Related issues #
#1647 : `Add semantic convention for describing network connectivity conditions`