### PR TITLE
Add bytes (byte array) support to Log Data Model

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -105,6 +105,8 @@ Value of type `any` can be one of the following:
 
 - A scalar value: number, string or boolean,
 
+- A byte array,
+
 - An array (a list) of `any` values,
 
 - A `map<string, any>`.


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-specification/issues/780

OTLP already supports bytes as a data type for Any value, see:
https://github.com/open-telemetry/opentelemetry-proto/blob/de4fc37940d39370194fb774e634ca408dacd865/opentelemetry/proto/common/v1/common.proto#L37

Byte arrays are an important case for unparsed, unstrusctured log data, so we are
formally adding them as a supported data type to the Log Data Model.

TODO: consider adding bytes to Trace API too.
