### PR TITLE
adding DroppedLinksCount to non-otlp exporters section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+- Add Dropped Links Count to non-otlp exporters section ([#1697](https://github.com/open-telemetry/opentelemetry-specification/pull/1697))
+
 ### Metrics
 
 - Expand `Gauge` metric description in the data model ([#1661](https://github.com/open-telemetry/opentelemetry-specification/pull/1661))

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -22,22 +22,23 @@ See also:
 The following table summarizes the major transformations between OpenTelemetry
 and Jaeger.
 
-| OpenTelemetry            | Jaeger Thrift    | Jaeger Proto     | Notes |
-| ------------------------ | ---------------- | ---------------- | ----- |
-| Span.TraceId             | Span.traceIdLow/High | Span.trace_id | See [IDs](#ids)     |
-| Span.ParentId            | Span.parentSpanId | as SpanReference | See [Parent ID](#parent-id)     |
-| Span.SpanId              | Span.spanId       | Span.span_id     |      |
-| Span.TraceState          | TBD               | TBD              |      |
-| Span.Name                | Span.operationName | Span.operation_name |  |
-| Span.Kind                | Span.tags["span.kind"] | same | See [SpanKind](#spankind) for values mapping |
-| Span.StartTime           | Span.startTime | Span.start_time | See [Unit of time](#unit-of-time) |
-| Span.EndTime             | Span.duration | same | Calculated as EndTime - StartTime. See also [Unit of time](#unit-of-time) |
-| Span.Attributes          | Span.tags | same | See [Attributes](#attributes) for data types for the mapping.            |
+| OpenTelemetry              | Jaeger Thrift    | Jaeger Proto     | Notes |
+| -------------------------- | ---------------- | ---------------- | ----- |
+| Span.TraceId               | Span.traceIdLow/High | Span.trace_id | See [IDs](#ids)     |
+| Span.ParentId              | Span.parentSpanId | as SpanReference | See [Parent ID](#parent-id)     |
+| Span.SpanId                | Span.spanId       | Span.span_id     |      |
+| Span.TraceState            | TBD               | TBD              |      |
+| Span.Name                  | Span.operationName | Span.operation_name |  |
+| Span.Kind                  | Span.tags["span.kind"] | same | See [SpanKind](#spankind) for values mapping |
+| Span.StartTime             | Span.startTime | Span.start_time | See [Unit of time](#unit-of-time) |
+| Span.EndTime               | Span.duration | same | Calculated as EndTime - StartTime. See also [Unit of time](#unit-of-time) |
+| Span.Attributes            | Span.tags | same | See [Attributes](#attributes) for data types for the mapping.            |
 | Span.DroppedAttributesCount| Add to Span.tags | same | See [Dropped Attributes Count](non-otlp.md#dropped-attributes-count) for tag name to use. |
-| Span.Events              | Span.logs | same | See [Events](#events) for the mapping format. |
-| Span.DroppedEventsCount  | Add to Span.tags | same | See [Dropped Events Count](non-otlp.md#dropped-events-count) for tag name to use. |
-| Span.Links               | Span.references | same | See [Links](#links) |
-| Span.Status              | Add to Span.tags | same | See [Status](#status) for tag names to use. |
+| Span.Events                | Span.logs | same | See [Events](#events) for the mapping format. |
+| Span.DroppedEventsCount    | Add to Span.tags | same | See [Dropped Events Count](non-otlp.md#dropped-events-count) for tag name to use. |
+| Span.Links                 | Span.references | same | See [Links](#links) |
+| Span.DroppedLinksCount     | Add to Span.tags | same | See [Dropped Links Count](non-otlp.md#dropped-links-count) for tag name to use. |
+| Span.Status                | Add to Span.tags | same | See [Status](#status) for tag names to use. |
 
 ## Mappings
 

--- a/specification/trace/sdk_exporters/non-otlp.md
+++ b/specification/trace/sdk_exporters/non-otlp.md
@@ -48,8 +48,9 @@ key-value pairs:
 
 OpenTelemetry Span's dropped attributes count MUST be reported as a key-value
 pair associated with the Span. Similarly, Span Event's dropped attributes count
-MUST be reported as a key-value pair associated with the Span Event. In both
-cases the key name MUST be `otel.dropped_attributes_count`.
+MUST be reported as a key-value pair associated with the Span Event and Span Link's
+dropped attributes count MUST be reported as a key-value pair associated with the
+Span Link. In all cases the key name MUST be `otel.dropped_attributes_count`.
 
 This key-value pair should only be recorded when it contains a non-zero value.
 

--- a/specification/trace/sdk_exporters/non-otlp.md
+++ b/specification/trace/sdk_exporters/non-otlp.md
@@ -59,3 +59,10 @@ OpenTelemetry Span's dropped events count MUST be reported as a key-value pair
 associated with the Span. The key name MUST be `otel.dropped_events_count`.
 
 This key-value pair should only be recorded when it contains a non-zero value.
+
+### Dropped Links Count
+
+OpenTelemetry Span's dropped links count MUST be reported as a key-value pair
+associated with the Span. The key name MUST be `otel.dropped_links_count`.
+
+This key-value pair should only be recorded when it contains a non-zero value.

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -41,7 +41,6 @@ OpenTelemetry fields:
 - Resource attributes
 - Tracestate
 - Links
-- dropped links count
 
 Zipkin fields:
 

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -15,22 +15,23 @@ Zipkin's v2 API is defined in the
 The following table summarizes the major transformations between OpenTelemetry
 and Zipkin.
 
-| OpenTelemetry            | Zipkin           | Notes                                                                                         |
-| ------------------------ | ---------------- | --------------------------------------------------------------------------------------------- |
-| Span.TraceId             | Span.trace_id    |                                                                                               |
-| Span.ParentId            | Span.parent_id   |                                                                                               |
-| Span.SpanId              | Span.id          |                                                                                               |
-| Span.TraceState          | TBD              | TBD                                                                                           |
-| Span.Name                | Span.name        |                                                                                               |
-| Span.Kind                | Span.kind        | See [SpanKind](#spankind) for values mapping                                                  |
-| Span.StartTime           | Span.timestamp   | See [Unit of time](#unit-of-time)                                                             |
-| Span.EndTime             | Span.duration    | Duration is calculated based on StartTime and EndTime. See also [Unit of time](#unit-of-time) |
-| Span.Attributes          | Span.tags        | See [Attributes](../../common/common.md#attributes) for data types for the mapping.           |
-| Span.DroppedAttributesCount| Span.tags      | See [Dropped Attributes Count](non-otlp.md#dropped-attributes-count) for tag name to use.     |
-| Span.Events              | Span.annotations | See [Events](#events) for the mapping format.                                                 |
-| Span.DroppedEventsCount  | Span.tags        | See [Dropped Events Count](non-otlp.md#dropped-events-count) for tag name to use.             |
-| Span.Links               | TBD              | TBD                                                                                           |
-| Span.Status              | Add to Span.tags | See [Status](#status) for tag names to use.                                                   |
+| OpenTelemetry              | Zipkin           | Notes                                                                                         |
+| -------------------------- | ---------------- | --------------------------------------------------------------------------------------------- |
+| Span.TraceId               | Span.trace_id    |                                                                                               |
+| Span.ParentId              | Span.parent_id   |                                                                                               |
+| Span.SpanId                | Span.id          |                                                                                               |
+| Span.TraceState            | TBD              | TBD                                                                                           |
+| Span.Name                  | Span.name        |                                                                                               |
+| Span.Kind                  | Span.kind        | See [SpanKind](#spankind) for values mapping                                                  |
+| Span.StartTime             | Span.timestamp   | See [Unit of time](#unit-of-time)                                                             |
+| Span.EndTime               | Span.duration    | Duration is calculated based on StartTime and EndTime. See also [Unit of time](#unit-of-time) |
+| Span.Attributes            | Add to Span.tags | See [Attributes](../../common/common.md#attributes) for data types for the mapping.           |
+| Span.DroppedAttributesCount| Add to Span.tags | See [Dropped Attributes Count](non-otlp.md#dropped-attributes-count) for tag name to use.     |
+| Span.Events                | Span.annotations | See [Events](#events) for the mapping format.                                                 |
+| Span.DroppedEventsCount    | Add to Span.tags | See [Dropped Events Count](non-otlp.md#dropped-events-count) for tag name to use.             |
+| Span.Links                 | TBD              | TBD                                                                                           |
+| Span.DroppedLinksCount     | Add to Span.tags | See [Dropped Links Count](non-otlp.md#dropped-links-count) for tag name to use.               |
+| Span.Status                | Add to Span.tags | See [Status](#status) for tag names to use.                                                   |
 
 TBD : This is work in progress document and it is currently doesn't specify
 mapping for these fields:


### PR DESCRIPTION
Fixes #1696 

## Changes

Adding a similar section to events and attributes limit to the exporter specification.
Related issues https://github.com/open-telemetry/opentelemetry-specification/issues/1656

