### PR TITLE
add note about reporting dropped attributes/events/links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+- Add note about reporting dropped counts for attributes, events, links. ([#1699](https://github.com/open-telemetry/opentelemetry-specification/pull/1699))
+
 ### Metrics
 
 - Expand `Gauge` metric description in the data model ([#1661](https://github.com/open-telemetry/opentelemetry-specification/pull/1661))

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -356,6 +356,9 @@ There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log
 should not be emitted once per span, or per discarded attribute, event, or links.
 
+Attributes, events and links dropped due to collection limits MUST be reported at export
+time.
+
 ## Id Generators
 
 The SDK MUST by default randomly generate both the `TraceId` and the `SpanId`.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -92,6 +92,10 @@ Thus, the SDK specification defines sets of possible requirements for
   (some languages might implement this by having an end timestamp of `null`,
   others might have an explicit `hasEnded` boolean).
 
+  Counts for attributes, events and links dropped due to collection limits MUST be
+  available for exporters to report as described in the [exporters](./sdk_exporters/non-otlp.md#dropped-attributes-count)
+  specification.
+
   A function receiving this as argument might not be able to modify the Span.
 
   Note: Typically this will be implemented with a new interface or
@@ -355,10 +359,6 @@ public final class SpanLimits {
 There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log
 should not be emitted once per span, or per discarded attribute, event, or links.
-
-Counts for attributes, events and links dropped due to collection limits MUST be
-available for exporters to report as described in the [exporters](./sdk_exporters/non-otlp.md#dropped-attributes-count)
-specification.
 
 ## Id Generators
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -356,8 +356,9 @@ There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log
 should not be emitted once per span, or per discarded attribute, event, or links.
 
-Attributes, events and links dropped due to collection limits MUST be reported at export
-time.
+Counts for attributes, events and links dropped due to collection limits MUST be reported
+at export time as described in the [exporters](./sdk_exporters/non-otlp.md#dropped-attributes-count)
+specification.
 
 ## Id Generators
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -356,8 +356,8 @@ There SHOULD be a log emitted to indicate to the user that an attribute, event,
 or link was discarded due to such a limit. To prevent excessive logging, the log
 should not be emitted once per span, or per discarded attribute, event, or links.
 
-Counts for attributes, events and links dropped due to collection limits MUST be reported
-at export time as described in the [exporters](./sdk_exporters/non-otlp.md#dropped-attributes-count)
+Counts for attributes, events and links dropped due to collection limits MUST be
+available for exporters to report as described in the [exporters](./sdk_exporters/non-otlp.md#dropped-attributes-count)
 specification.
 
 ## Id Generators


### PR DESCRIPTION
Fixes #1698 

## Changes

Clarify that dropped counts should be reported from the SDK. Would love feedback from reviewers on whether or not this change should include a change to the matrix.

Related issues #1656 