### PR TITLE
Add schema file and a script with minimal checks that verifies them

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -62,3 +62,10 @@ jobs:
     - uses: actions/checkout@v1
     - name: verify semantic convention tables
       run: make table-check
+
+  schemas-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: verify schemas
+      run: make schema-check

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ table-check:
 	docker run --rm -v $(PWD)/semantic_conventions:/source -v $(PWD)/specification:/spec \
 		otel/semconvgen:$(SEMCONVGEN_VERSION) -f /source markdown -md /spec --md-check
 
+.PHONY: schema-check
+schema-check:
+	cd tools && ./schema_check.sh
+
 # Run all checks in order of speed / likely failure.
 .PHONY: check
 check: misspell markdownlint markdown-link-check

--- a/schemas/1.4.0
+++ b/schemas/1.4.0
@@ -1,0 +1,4 @@
+file_format: 1.0.0
+schema_url: https://opentelemetry.io/schemas/1.4.0
+versions:
+  1.4.0:

--- a/tools/schema_check.sh
+++ b/tools/schema_check.sh
@@ -6,8 +6,8 @@
 
 set -e
 
-# This is the list of vesions that were releaed before the schemas were
-# introded and which did not require a schema file.
+# This is the list of vesions that were released before the schemas were
+# introduced and which did not require a schema file.
 declare -a skip_versions=("1.0.0" "1.0.1" "1.1.0" "1.2.0" "1.3.0")
 
 schemas_dir="../schemas"

--- a/tools/schema_check.sh
+++ b/tools/schema_check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# This script does some minimal sanity checks of schema files.
+# It expects to find a schema file for each version listed in CHANGELOG.md
+# since 1.0.0 release.
+
+set -e
+
+# This is the list of vesions that were releaed before the schemas were
+# introded and which did not require a schema file.
+declare -a skip_versions=("1.0.0" "1.0.1" "1.1.0" "1.2.0" "1.3.0")
+
+schemas_dir="../schemas"
+
+# Find all version sections in CHANGELOG that start with a number in 1..9 range.
+grep -o -e '## v[1-9].*\s' ../CHANGELOG.md | grep -o '[1-9].*' | while read ver; do
+  if [[ " ${skip_versions[*]} " == *" $ver "* ]]; then
+    # Skip this version, it does not need a schema file.
+    continue
+  fi
+
+  file="$schemas_dir/$ver"
+  echo -n "Ensure schema file $file exists... "
+
+  # Check that the schema for the version exists.
+  if [ -f "$file" ]; then
+    echo "OK, exists."
+  else
+    echo "FAILED: $file does not exist. The schema file must exist because the version is declared in CHANGELOG.md."
+    exit 3
+  fi
+done
+
+# Now check the content of all schema files in the ../shemas directory.
+for file in $schemas_dir/*; do
+  # Filename is the version number.
+  ver=$(basename $file)
+
+  echo -n "Checking schema file $file for version $ver... "
+
+  # Check that the version is defined in the schema file. 
+  if ! grep -q "\s$ver:" $file; then
+    echo "FAILED: $ver version definition is not found in $file"
+    exit 1
+  fi
+
+  # Check that the schema_url matches the version.
+  if ! grep -q "schema_url: https://opentelemetry.io/schemas/$ver" $file; then
+    echo "FAILED: schema_url is not found in $file"
+    exit 2
+  fi
+  echo "OK"
+done


### PR DESCRIPTION
This adds some minimal sanity checks to make sure we don't forget
to add the schema file when we make a release. The checks are tied
to the CHANGELOG.md.

In the future we can do more thorough verifications, e.g. parse the content
of the schema YAML file and ensure it includes the changes that we can
detect by looking at the changes at the semantic convention files.
