### PR TITLE
Add semantic conventions for k8s tagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ release.
 
 ### Semantic Conventions
 
+- Add semantic convention attributes for namespace and pod resources ([#1723](https://github.com/open-telemetry/opentelemetry-specification/pull/1723)).
 - Add JSON RPC specific conventions ([#1643](https://github.com/open-telemetry/opentelemetry-specification/pull/1643)).
 - Add Memcached to Database specific conventions ([#1689](https://github.com/open-telemetry/opentelemetry-specification/pull/1689)).
 - Add semantic convention attributes for the host device and added OS name and version ([#1596](https://github.com/open-telemetry/opentelemetry-specification/pull/1596)).

--- a/semantic_conventions/resource/k8s.yaml
+++ b/semantic_conventions/resource/k8s.yaml
@@ -36,6 +36,19 @@ groups:
         brief: >
           The name of the namespace that the pod is running in.
         examples: ['default']
+      - id: uid
+        type: string
+        brief: >
+          The UID of the Namespace.
+        examples: [ 'bb219a0e-a465-4a0e-aaec-a3731ecc7fe1' ]
+      - id: start_time
+        type: string
+        note: >
+          This is a string representing an RFC 3339 date of the date and time the namespace object was created.
+          [kubernetes api conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+        brief: >
+          The creation time of the namespace.
+        examples: [ '2021-05-13 17:23:11' ]
 
   - id: k8s.pod
     prefix: k8s.pod
@@ -52,6 +65,14 @@ groups:
         brief: >
           The name of the Pod.
         examples: ['opentelemetry-pod-autoconf']
+      - id: start_time
+        type: string
+        note: >
+          This is a string representing an RFC 3339 date of the date and time the pod object was created.
+          [kubernetes api conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+        brief: >
+          The creation time of the Pod.
+        examples: [ '2021-05-25 23:36:44' ]
 
   - id: k8s.container
     prefix: k8s.container

--- a/specification/resource/semantic_conventions/k8s.md
+++ b/specification/resource/semantic_conventions/k8s.md
@@ -53,6 +53,10 @@ a namespace, but not across namespaces.
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `k8s.namespace.name` | string | The name of the namespace that the pod is running in. | `default` | No |
+| `k8s.namespace.uid` | string | The UID of the Namespace. | `bb219a0e-a465-4a0e-aaec-a3731ecc7fe1` | No |
+| `k8s.namespace.start_time` | string | The creation time of the namespace. [1] | `2021-05-13 17:23:11` | No |
+
+**[1]:** This is a string representing an RFC 3339 date of the date and time the namespace object was created. [kubernetes api conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 <!-- endsemconv -->
 
 ## Pod
@@ -69,6 +73,9 @@ containers on your cluster.
 |---|---|---|---|---|
 | `k8s.pod.uid` | string | The UID of the Pod. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | No |
 | `k8s.pod.name` | string | The name of the Pod. | `opentelemetry-pod-autoconf` | No |
+| `k8s.pod.start_time` | string | The creation time of the Pod. [1] | `2021-05-25 23:36:44` | No |
+
+**[1]:** This is a string representing an RFC 3339 date of the date and time the pod object was created. [kubernetes api conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
 <!-- endsemconv -->
 
 ## Container


### PR DESCRIPTION
Changes:
Adds k8s.namespace.uid k8s.namespace.start_time k8s.pod.start_time from k8s-tagger to semantic conventions
Related issues https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3384
