### PR TITLE
Add cockroachdb to db.system semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ release.
 - Add JSON RPC specific conventions ([#1643](https://github.com/open-telemetry/opentelemetry-specification/pull/1643)).
 - Add Memcached to Database specific conventions ([#1689](https://github.com/open-telemetry/opentelemetry-specification/pull/1689)).
 - Add semantic convention attributes for the host device and added OS name and version ([#1596](https://github.com/open-telemetry/opentelemetry-specification/pull/1596)).
+- Add CockroachDB to Database specific conventions ([#1725](https://github.com/open-telemetry/opentelemetry-specification/pull/1725)).
 
 ### Compatibility
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -150,6 +150,9 @@ groups:
               - id: memcached
                 value: 'memcached'
                 brief: 'Memcached'
+              - id: cockroachdb
+                value: 'cockroachdb'
+                brief: 'CockroachDB'
         - id: connection_string
           tag: connection-level
           type: string

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -107,6 +107,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `geode` | Apache Geode |
 | `elasticsearch` | Elasticsearch |
 | `memcached` | Memcached |
+| `cockroachdb` | CockroachDB |
 <!-- endsemconv -->
 
 ### Notes and well-known identifiers for `db.system`


### PR DESCRIPTION
## Changes

Adds the [CockroachDB](https://www.cockroachlabs.com/) DBMS to the list of well-known identifiers for `db.system`
