### PR TITLE
Add clarification about async vs. sync instruments

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -242,12 +242,17 @@ instrument. It MUST be treated as an opaque string from the API and SDK.
 Instruments can be categorized based on whether they are synchronous or
 asynchronous:
 
+<a name="synchronous-instrument"></a>
+
 * Synchronous instruments (e.g. [Counter](#counter)) are meant to be invoked by
   the user (e.g. a library developer or an application developer). For example,
   an HTTP client could use a Counter to record the number of bytes it has
   received. [Measurements](#measurement) recorded by synchronous instruments can
   be associated with [Baggage](../baggage/api.md) and
   [Context](../context/context.md).
+
+<a name="asynchronous-instrument"></a>
+
 * Asynchronous instruments (e.g. [Asynchronous Gauge](#asynchronous-Gauge)) give
   the user a way to register callback function, and the callback function will
   only be invoked upon collection. For example, an embedded software could use
@@ -263,7 +268,8 @@ pattern](https://en.wikipedia.org/wiki/Asynchronous_method_invocation).
 
 ### Counter
 
-`Counter` is a synchronous Instrument which supports non-negative increments.
+`Counter` is a [synchronous Instrument](#synchronous-instrument) which supports
+non-negative increments.
 
 Example uses for `Counter`:
 
@@ -354,9 +360,9 @@ counterPowerUsed.Add(200, new PowerConsumption { customer = "Jerry" }, ("is_gree
 
 ### Asynchronous Counter
 
-Asynchronous Counter is an asynchronous Instrument which reports
-[monotonically](https://wikipedia.org/wiki/Monotonic_function) increasing
-value(s) when the instrument is being observed.
+Asynchronous Counter is an [asynchronous Instrument](#asynchronous-instrument)
+which reports [monotonically](https://wikipedia.org/wiki/Monotonic_function)
+increasing value(s) when the instrument is being observed.
 
 Example uses for Asynchronous Counter:
 
@@ -478,9 +484,9 @@ operation is provided by the `callback`, which is registered during the
 
 ### Histogram
 
-`Histogram` is a synchronous Instrument which can be used to report arbitrary
-values that are likely to be statistically meaningful. It is intended for
-statistics such as histograms, summaries, and percentile.
+`Histogram` is a [synchronous Instrument](#synchronous-instrument) which can be
+used to report arbitrary values that are likely to be statistically meaningful.
+It is intended for statistics such as histograms, summaries, and percentile.
 
 Example uses for `Histogram`:
 
@@ -562,10 +568,10 @@ httpServerDuration.Record(100, new HttpRequestAttributes { method = "GET", schem
 
 ### Asynchronous Gauge
 
-Asynchronous Gauge is an asynchronous Instrument which reports non-additive
-value(s) (_e.g. the room temperature - it makes no sense to report the
-temperature value from multiple rooms and sum them up_) when the instrument is
-being observed.
+Asynchronous Gauge is an [asynchronous Instrument](#asynchronous-instrument)
+which reports non-additive value(s) (_e.g. the room temperature - it makes no
+sense to report the temperature value from multiple rooms and sum them up_) when
+the instrument is being observed.
 
 Note: if the values are additive (_e.g. the process heap size - it makes sense
 to report the heap size from multiple processes and sum them up, so we get the
@@ -689,8 +695,8 @@ operation is provided by the `callback`, which is registered during the
 
 ### UpDownCounter
 
-`UpDownCounter` is a synchronous Instrument which supports increments and
-decrements.
+`UpDownCounter` is a [synchronous Instrument](#synchronous-instrument) which
+supports increments and decrements.
 
 Note: if the value grows
 [monotonically](https://wikipedia.org/wiki/Monotonic_function), use
@@ -827,10 +833,11 @@ customersInStore.Add(-1, new Account { Type = "residential" });
 
 ### Asynchronous UpDownCounter
 
-Asynchronous UpDownCounter is an asynchronous Instrument which reports additive
-value(s) (_e.g. the process heap size - it makes sense to report the heap size
-from multiple processes and sum them up, so we get the total heap usage_) when
-the instrument is being observed.
+Asynchronous UpDownCounter is an [asynchronous
+Instrument](#asynchronous-instrument) which reports additive value(s) (_e.g. the
+process heap size - it makes sense to report the heap size from multiple
+processes and sum them up, so we get the total heap usage_) when the instrument
+is being observed.
 
 Note: if the value grows
 [monotonically](https://wikipedia.org/wiki/Monotonic_function), use

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -253,7 +253,7 @@ asynchronous:
 
 <a name="asynchronous-instrument"></a>
 
-* Asynchronous instruments (e.g. [Asynchronous Gauge](#asynchronous-Gauge)) give
+* Asynchronous instruments (e.g. [Asynchronous Gauge](#asynchronous-gauge)) give
   the user a way to register callback function, and the callback function will
   only be invoked upon collection. For example, a piece of embedded software
   could use an asynhronous gauge to collect the temperature from a sensor every

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -255,15 +255,15 @@ asynchronous:
 
 * Asynchronous instruments (e.g. [Asynchronous Gauge](#asynchronous-Gauge)) give
   the user a way to register callback function, and the callback function will
-  only be invoked upon collection. For example, an embedded software could use
-  an asynhronous gauge to collect the temperature from a sensor every 15
-  seconds, which means the callback function will only be invoked every 15
+  only be invoked upon collection. For example, a piece of embedded software
+  could use an asynhronous gauge to collect the temperature from a sensor every
+  15 seconds, which means the callback function will only be invoked every 15
   seconds. [Measurements](#measurement) recorded by asynchronous instruments
   cannot be associated with [Baggage](../baggage/api.md) and
   [Context](../context/context.md).
 
 Please note that the term _synchronous_ and _asynchronous_ have nothing to do
-with [asynchronous
+with the [asynchronous
 pattern](https://en.wikipedia.org/wiki/Asynchronous_method_invocation).
 
 ### Counter

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -256,7 +256,7 @@ asynchronous:
 * Asynchronous instruments (e.g. [Asynchronous Gauge](#asynchronous-gauge)) give
   the user a way to register callback function, and the callback function will
   only be invoked upon collection. For example, a piece of embedded software
-  could use an asynhronous gauge to collect the temperature from a sensor every
+  could use an asynchronous gauge to collect the temperature from a sensor every
   15 seconds, which means the callback function will only be invoked every 15
   seconds. [Measurements](#measurement) recorded by asynchronous instruments
   cannot be associated with [Baggage](../baggage/api.md) and

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -244,11 +244,11 @@ asynchronous:
 
 <a name="synchronous-instrument"></a>
 
-* Synchronous instruments (e.g. [Counter](#counter)) are meant to be invoked by
-  the user (e.g. a library developer or an application developer). For example,
-  an HTTP client could use a Counter to record the number of bytes it has
-  received. [Measurements](#measurement) recorded by synchronous instruments can
-  be associated with [Baggage](../baggage/api.md) and
+* Synchronous instruments (e.g. [Counter](#counter)) are meant to be invoked
+  directly by the user (e.g. a library developer or an application developer).
+  For example, an HTTP client could use a Counter to record the number of bytes
+  it has received. [Measurements](#measurement) recorded by synchronous
+  instruments can be associated with [Baggage](../baggage/api.md) and
   [Context](../context/context.md).
 
 <a name="asynchronous-instrument"></a>

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -245,10 +245,10 @@ asynchronous:
 <a name="synchronous-instrument"></a>
 
 * Synchronous instruments (e.g. [Counter](#counter)) are meant to be invoked
-  directly by the user (e.g. a library developer or an application developer).
-  For example, an HTTP client could use a Counter to record the number of bytes
-  it has received. [Measurements](#measurement) recorded by synchronous
-  instruments can be associated with [Baggage](../baggage/api.md) and
+  inline with application/business processing logic. For example, an HTTP client
+  could use a Counter to record the number of bytes it has received.
+  [Measurements](#measurement) recorded by synchronous instruments can be
+  associated with [Baggage](../baggage/api.md) and
   [Context](../context/context.md).
 
 <a name="asynchronous-instrument"></a>

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -239,6 +239,28 @@ instrument. It MUST be treated as an opaque string from the API and SDK.
 * It MUST support at least 1023 characters. Individual language clients can
   decide if they want to support more.
 
+Instruments can be categorized based on whether they are synchronous or
+asynchronous:
+
+* Synchronous instruments (e.g. [Counter](#counter)) are meant to be invoked by
+  the user (e.g. a library developer or an application developer). For example,
+  an HTTP client could use a Counter to record the number of bytes it has
+  received. [Measurements](#measurement) recorded by synchronous instruments can
+  be associated with [Baggage](../baggage/api.md) and
+  [Context](../context/context.md).
+* Asynchronous instruments (e.g. [Asynchronous Gauge](#asynchronous-Gauge)) give
+  the user a way to register callback function, and the callback function will
+  only be invoked upon collection. For example, an embedded software could use
+  an asynhronous gauge to collect the temperature from a sensor every 15
+  seconds, which means the callback function will only be invoked every 15
+  seconds. [Measurements](#measurement) recorded by asynchronous instruments
+  cannot be associated with [Baggage](../baggage/api.md) and
+  [Context](../context/context.md).
+
+Please note that the term _synchronous_ and _asynchronous_ have nothing to do
+with [asynchronous
+pattern](https://en.wikipedia.org/wiki/Asynchronous_method_invocation).
+
 ### Counter
 
 `Counter` is a synchronous Instrument which supports non-negative increments.

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -248,8 +248,7 @@ asynchronous:
   inline with application/business processing logic. For example, an HTTP client
   could use a Counter to record the number of bytes it has received.
   [Measurements](#measurement) recorded by synchronous instruments can be
-  associated with [Baggage](../baggage/api.md) and
-  [Context](../context/context.md).
+  associated with the [Context](../context/context.md).
 
 <a name="asynchronous-instrument"></a>
 
@@ -259,8 +258,7 @@ asynchronous:
   could use an asynchronous gauge to collect the temperature from a sensor every
   15 seconds, which means the callback function will only be invoked every 15
   seconds. [Measurements](#measurement) recorded by asynchronous instruments
-  cannot be associated with [Baggage](../baggage/api.md) and
-  [Context](../context/context.md).
+  cannot be associated with the [Context](../context/context.md).
 
 Please note that the term _synchronous_ and _asynchronous_ have nothing to do
 with the [asynchronous


### PR DESCRIPTION
## Changes

* Editorial change - added clarification and examples about sync vs. async instruments.

Related [oteps](https://github.com/open-telemetry/oteps) [OTEP146](https://github.com/open-telemetry/oteps/blob/main/text/metrics/0146-metrics-prototype-scenarios.md)
