### PR TITLE
Auto assign issues.

### DIFF
--- a/.github/auto_assign_issue.yml
+++ b/.github/auto_assign_issue.yml
@@ -1,0 +1,20 @@
+# Set to true to add reviewers to issues/PRs
+addReviewers: false
+
+# Set to true to add assignees to issues/PRs
+addAssignees: true
+
+# A list of assignees, overrides reviewers if set
+assignees:
+   - arminru
+   - bogdandrutu
+   - carlosalberto
+   - jmacd
+   - SergeyKanzhelev
+   - tigrannajaryan
+   - yurishkuro
+
+# A number of assignees to add to the issues/PRs
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 1

--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -6,7 +6,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - uses: bubkoo/auto-assign@v1
+      - uses: bubkoo/auto-assign@d5c3a5711d7fd917f7fbd746e9c6fc044f29009f
         with:
           CONFIG_FILE: ".github/auto_assign_issue.yml"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-assign-issue.yml
+++ b/.github/workflows/auto-assign-issue.yml
@@ -1,0 +1,12 @@
+name: 'Auto Assign Issue'
+on:
+  issues:
+    types: [opened]
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: bubkoo/auto-assign@v1
+        with:
+          CONFIG_FILE: ".github/auto_assign_issue.yml"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is now done similarly to what we do for PRs. One thing that we had considered was to include the @open-telemetry/specs-trace-approvers team as part of this 'rotation'. Any opinions?