### PR TITLE
Declare OTLP Logs Beta

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -52,7 +52,7 @@ own maturity level, which in turn applies to **all** the OTLP Transports listed 
 
 * Tracing: **Stable**
 * Metrics: **Stable**
-* Logs: **Alpha**
+* Logs: **Beta**
 
 See [OTLP Maturity Level](https://github.com/open-telemetry/opentelemetry-proto#maturity-level).
 


### PR DESCRIPTION
The Log SIG discussed and made a decision to declare Log data model and Log part of OTLP Beta.

(See SIG meeting notes here https://docs.google.com/document/d/1cX5fWXyWqVVzYHSFUymYUfWxUK5hT97gc23w595LmdM/edit#heading=h.28y76as82bvu)
