### PR TITLE
Adding environment variables for event and link attribute limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+- Adding environment variables for event and link attribute limits.
+
 ### Metrics
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ release.
 
 ### Traces
 
-- Adding environment variables for event and link attribute limits.
+- Adding environment variables for event and link attribute limits. ([#1751](https://github.com/open-telemetry/opentelemetry-specification/pull/1751))
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -143,8 +143,8 @@ Note: Support for environment variables is optional.
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               | - | +  |   | +    | +  | -    |   | +  | - |    |     |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   | - | +  |   | +    | +  | -    |   | +  | - |    |     |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    | - | +  |   | +    | +  | -    |   | +  | - |    |     |
-|OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT     |   |    |   |      |    |      |   |    |   |    |     |
-|OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT      |   |    |   |      |    |      |   |    |   |    |     |
+|OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT              |   |    |   |      |    |      |   |    |   |    |     |
+|OTEL_LINK_ATTRIBUTE_COUNT_LIMIT               |   |    |   |      |    |      |   |    |   |    |     |
 |OTEL_TRACES_SAMPLER                           | - | +  |   | +    | +  | +    |   | -  | - |    |     |
 |OTEL_TRACES_SAMPLER_ARG                       | - | +  |   | +    | +  | +    |   | -  | - |    |     |
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -143,6 +143,8 @@ Note: Support for environment variables is optional.
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               | - | +  |   | +    | +  | -    |   | +  | - |    |     |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   | - | +  |   | +    | +  | -    |   | +  | - |    |     |
 |OTEL_SPAN_LINK_COUNT_LIMIT                    | - | +  |   | +    | +  | -    |   | +  | - |    |     |
+|OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT     |   |    |   |      |    |      |   |    |   |    |     |
+|OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT      |   |    |   |      |    |      |   |    |   |    |     |
 |OTEL_TRACES_SAMPLER                           | - | +  |   | +    | +  | +    |   | -  | - |    |     |
 |OTEL_TRACES_SAMPLER_ARG                       | - | +  |   | +    | +  | +    |   | -  | - |    |     |
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -78,11 +78,13 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 See the SDK [Span Limits](trace/sdk.md#span-limits) section for the definition of the limits.
 
-| Name                            | Description                          | Default | Notes |
-| ------------------------------- | ------------------------------------ | ------- | ----- |
-| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | Maximum allowed span attribute count | 128     |       |
-| OTEL_SPAN_EVENT_COUNT_LIMIT     | Maximum allowed span event count     | 128     |       |
-| OTEL_SPAN_LINK_COUNT_LIMIT      | Maximum allowed span link count      | 128     |       |
+| Name                                      | Description                                    | Default | Notes |
+| ----------------------------------------- | ---------------------------------------------- | ------- | ----- |
+| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT           | Maximum allowed span attribute count           | 128     |       |
+| OTEL_SPAN_EVENT_COUNT_LIMIT               | Maximum allowed span event count               | 128     |       |
+| OTEL_SPAN_LINK_COUNT_LIMIT                | Maximum allowed span link count                | 128     |       |
+| OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT | Maximum allowed attribute per span event count | 128     |       |
+| OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT  | Maximum allowed attribute per span link count  | 128     |       |
 
 ## OTLP Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -78,13 +78,13 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 See the SDK [Span Limits](trace/sdk.md#span-limits) section for the definition of the limits.
 
-| Name                                      | Description                                    | Default | Notes |
-| ----------------------------------------- | ---------------------------------------------- | ------- | ----- |
-| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT           | Maximum allowed span attribute count           | 128     |       |
-| OTEL_SPAN_EVENT_COUNT_LIMIT               | Maximum allowed span event count               | 128     |       |
-| OTEL_SPAN_LINK_COUNT_LIMIT                | Maximum allowed span link count                | 128     |       |
-| OTEL_SPAN_ATTRIBUTE_PER_EVENT_COUNT_LIMIT | Maximum allowed attribute per span event count | 128     |       |
-| OTEL_SPAN_ATTRIBUTE_PER_LINK_COUNT_LIMIT  | Maximum allowed attribute per span link count  | 128     |       |
+| Name                             | Description                                    | Default | Notes |
+| -------------------------------- | ---------------------------------------------- | ------- | ----- |
+| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT  | Maximum allowed span attribute count           | 128     |       |
+| OTEL_SPAN_EVENT_COUNT_LIMIT      | Maximum allowed span event count               | 128     |       |
+| OTEL_SPAN_LINK_COUNT_LIMIT       | Maximum allowed span link count                | 128     |       |
+| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT | Maximum allowed attribute per span event count | 128     |       |
+| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT  | Maximum allowed attribute per span link count  | 128     |       |
 
 ## OTLP Exporter
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -342,9 +342,9 @@ public final class SpanLimits {
 
   public int getAttributeCountLimit();
 
-  public int getAttributePerEventCountLimit();
+  public int getAttributeCountPerEventLimit();
 
-  public int getAttributePerLinkCountLimit();
+  public int getAttributeCountPerLinkLimit();
 
   public int getEventCountLimit();
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -342,6 +342,10 @@ public final class SpanLimits {
 
   public int getAttributeCountLimit();
 
+  public int getAttributePerEventCountLimit();
+
+  public int getAttributePerLinkCountLimit();
+
   public int getEventCountLimit();
 
   public int getLinkCountLimit();


### PR DESCRIPTION
Fixes #1750 

## Changes

Adding environment variable definitions for span event and link attributes.