### PR TITLE
Add the metrics API Hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Add Metrics API Hint
+  ([#1753](https://github.com/open-telemetry/opentelemetry-specification/pull/1753)).
+
 ### Logs
 
 ### Resource


### PR DESCRIPTION
Related to #1730.

## Changes

* Added `Hint` to the metrics API spec.

The SDK PR #1730 is a bit stuck because Instrument, View and Hint are entangled. As discussed in the [06/03/2021 Metric API/SDK SIG Meeting](https://docs.google.com/document/d/1-bCYkN-DWJq4jw1ybaDZYYmx-WAe6HnwfWbkm8d57v8/edit#heading=h.dkfc4w2jg62a) we've decided to make progress on the Hint API spec, so we can reference it in the SDK spec PR.

In this PR I try to focus on why (why do we need Hint at all) and what (what do we need from Hint). The actual "how" part will be addressed in the SDK spec (most likely I will need to update #1730).

Related [oteps](https://github.com/open-telemetry/oteps) [OTEP146](https://github.com/open-telemetry/oteps/blob/main/text/metrics/0146-metrics-prototype-scenarios.md).