### PR TITLE
Allow selecting multiple exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ release.
 ### SDK Configuration
 
 - Allow selecting multiple exporters via `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER`
-  by using a comma-seperated list. ([#1758](https://github.com/open-telemetry/opentelemetry-specification/pull/1758))
+  by using a comma-separated list. ([#1758](https://github.com/open-telemetry/opentelemetry-specification/pull/1758))
 
 ## v1.4.0 (2021-06-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ release.
 
 ### SDK Configuration
 
+- Allow selecting multiple exporters via `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER`
+  by using a comma-seperated list. ([#1758](https://github.com/open-telemetry/opentelemetry-specification/pull/1758))
+
 ## v1.4.0 (2021-06-07)
 
 ### Context

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -132,7 +132,7 @@ thrift or protobuf.  As of 1.0 of the specification, there
 
 **Status**: [Stable](document-status.md)
 
-We define environment variables for setting an exporter per signal.
+We define environment variables for setting one or more exporters per signal.
 
 | Name          | Description                                                                  | Default |
 | ------------- | ---------------------------------------------------------------------------- | ------- |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -34,7 +34,7 @@ For example, the value `12000` indicates 12000 milliseconds, i.e., 12 seconds.
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes |                                   | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_SERVICE_NAME        | Sets the value of the [`service.name`](./resource/semantic_conventions/README.md#service) resource attribute | | If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then `OTEL_SERVICE_NAME` takes precedence. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
-| OTEL_PROPAGATORS         | Propagators to be used as a comma separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. |
+| OTEL_PROPAGATORS         | Propagators to be used as a comma-separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. |
 | OTEL_TRACES_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
 | OTEL_TRACES_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACES_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST be otherwise ignored, i.e. the SDK MUST behave as if OTEL_TRACES_SAMPLER_ARG is not set.  |
 
@@ -132,12 +132,14 @@ thrift or protobuf.  As of 1.0 of the specification, there
 
 **Status**: [Stable](document-status.md)
 
-We define environment variables for setting a single exporter per signal.
+We define environment variables for setting an exporter per signal.
 
 | Name          | Description                                                                  | Default |
 | ------------- | ---------------------------------------------------------------------------- | ------- |
 | OTEL_TRACES_EXPORTER | Trace exporter to be used | "otlp"  |
 | OTEL_METRICS_EXPORTER | Metrics exporter to be used | "otlp"  |
+
+The SDK MAY accept a comma-separated list to enable setting multiple exporters.
 
 Known values for OTEL_TRACES_EXPORTER are:
 


### PR DESCRIPTION
Fixes #1755

## Changes

- Allow selecting multiple exporters via `OTEL_TRACES_EXPORTER` and `OTEL_METRICS_EXPORTER`  by using a comma-separated list.

The [exporter selection environmental variables](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md#exporter-selection) allow only to select a SINGLE one. It would be handy to allow selecting more than one e.g. `otlp,console`.
