### PR TITLE
Add span.TracerProvider() method definition to trace API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ release.
 
 ### Traces
 
-- Add `span.TracerProvider()` method to API. (#TBD)
+- Add `span.TracerProvider()` method to API. ([#1770](https://github.com/open-telemetry/opentelemetry-specification/pull/1770))
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+- Add `span.TracerProvider()` method to API. (#TBD)
+
 ### Metrics
 
 ### Logs

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -52,6 +52,7 @@ formats is required. Implementing more than one format is optional.
 | events collection size limit                                                                     |          | +  | +    | +  | +      | +    | -      |     | +    | -   | -    | +     |
 | attribute collection size limit                                                                  |          | +  | +    | +  | +      | +    | -      |     | +    | -   | -    | +     |
 | links collection size limit                                                                      |          | +  | +    | +  | +      | +    | -      |     | +    | -   | -    | +     |
+| get TracerProvider                                                                               |          | +  |      |    |        |      |        |     |      |     |      |       |
 | [Span attributes](specification/trace/api.md#set-attributes)                                     |          |    |      |    |        |      |        |     |      |     |      |       |
 | SetAttribute                                                                                     |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Set order preserved                                                                              | X        | +  | -    | +  | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -665,6 +665,17 @@ Note: `RecordException` may be seen as a variant of `AddEvent` with
 additional exception-specific parameters and all other parameters being optional
 (because they have defaults from the exception semantic convention).
 
+#### Get TracerProvider
+
+To simplify the configuration of instrumented libraries that may not rely on a
+global `TracerProvider` instance, a `Span` SHOULD provide a method to retrieve
+the `TracerProvider` instance that was used to create the `Tracer` that created
+the `Span`.  If this method is provided but accessing the `TracerProvider`
+instance is not possible, then a `Span` MUST return a no-op `TracerProvider`.
+
+The returned value MUST be the same for the entire Span lifetime. This method
+SHOULD be called `TracerProvider`.
+
 ### Span lifetime
 
 Span lifetime represents the process of recording the start and the end


### PR DESCRIPTION
## Changes

Defines a method on `Span` for accessing the `TracerProvider` used to create the `Span`.  This minimizes the configuration overhead of instrumentation libraries and can simplify the handling of multiple `TracerProvider` configurations by enabling instrumentation to simply follow the lead of the `Span` that is currently active in the context.
