### PR TITLE
Bump semconvgen to 0.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MISSPELL = $(TOOLS_DIR)/$(MISSPELL_BINARY)
 MARKDOWN_LINK_CHECK=markdown-link-check
 MARKDOWN_LINT=markdownlint
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
-SEMCONVGEN_VERSION=0.3.1
+SEMCONVGEN_VERSION=0.4.1
 
 .PHONY: install-misspell
 install-misspell:

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -55,8 +55,8 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | `other` | Something else (non IP-based). |
 
 **[1]:** Signals that there is only in-process communication not using a "real" network protocol in cases where network attributes would normally be expected. Usually all other network attributes can be left out in that case.
-
 <!-- endsemconv -->
+
 For `Unix` and `pipe`, since the connection goes over the file system instead of being directly to a known peer, `net.peer.name` is the only attribute that usually makes sense (see description of `net.peer.name` below).
 
 <a name="net.name"></a>


### PR DESCRIPTION
Pulls in the fix introduced in https://github.com/open-telemetry/build-tools/pull/48 and unblocks #1759.

See https://github.com/open-telemetry/build-tools/releases for the changelog.