### PR TITLE
Clarify acceptable attribute value types

### DIFF
--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -16,7 +16,7 @@ Table of Contents
 Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have the following properties:
 
 - The attribute key, which MUST be a non-`null` and non-empty string.
-- The attribute value, which for logs is any type, but for traces and metrics is either:
+- The attribute value, which for logs is [any](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#type-any) type, but for traces and metrics is either:
   - A primitive type: string, boolean, double precision floating point (IEEE 754-1985) or signed 64 bit integer.
   - An array of primitive type values. The array MUST be homogeneous,
     i.e. it MUST NOT contain values of different types. For protocols that do

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -16,7 +16,7 @@ Table of Contents
 Attributes are a list of zero or more key-value pairs. An `Attribute` MUST have the following properties:
 
 - The attribute key, which MUST be a non-`null` and non-empty string.
-- The attribute value, which is either:
+- The attribute value, which for logs is any type, but for traces and metrics is either:
   - A primitive type: string, boolean, double precision floating point (IEEE 754-1985) or signed 64 bit integer.
   - An array of primitive type values. The array MUST be homogeneous,
     i.e. it MUST NOT contain values of different types. For protocols that do


### PR DESCRIPTION
The [log data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-attributes) indicates that attribute values may be of any data type. To the best of my knowledge, this reflects the broad consensus of stakeholders in the logs community.

This pull request proposes a change to a stable document, which itself warrants discussion. I would like to suggest that the current specification was designed for a subset of signal types, and therefore implicitly specifies constraints for only those signals. Therefore, this change would be a clarification and extension of the specification, rather than a breaking change.