### PR TITLE
Remove examples from enums.

### DIFF
--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -19,7 +19,6 @@ groups:
               brief: 'Google Cloud Platform'
         brief: >
           Name of the cloud provider.
-        examples: 'gcp'
       - id: account.id
         type: string
         brief: >
@@ -95,4 +94,3 @@ groups:
           The cloud platform in use.
         note: >
           The prefix of the service SHOULD match the one specified in `cloud.provider`.
-        examples: ['aws_ec2', 'azure_vm', 'gcp_compute_engine']

--- a/semantic_conventions/resource/cloud_provider/aws/ecs.yaml
+++ b/semantic_conventions/resource/cloud_provider/aws/ecs.yaml
@@ -24,7 +24,6 @@ groups:
               value: "fargate"
         brief: >
           The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task.
-        examples: ['ec2', 'fargate']
       - id: task.arn
         type: string
         brief: >
@@ -40,4 +39,3 @@ groups:
         brief: >
           The revision for this task definition.
         examples: ["8", "26"]
-      

--- a/semantic_conventions/trace/faas.yaml
+++ b/semantic_conventions/trace/faas.yaml
@@ -169,7 +169,6 @@ groups:
         note: >
           SHOULD be equal to the `cloud.provider` resource attribute of the
           invoked function.
-        examples: 'aws'
       - id: invoked_region
         type: string
         required:

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -33,7 +33,6 @@ groups:
               brief: 'Something else (non IP-based).'
         brief: >
           Transport protocol used. See note below.
-        examples: 'ip_tcp'
       - id: peer.ip
         type: string
         brief: >

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -65,7 +65,6 @@ groups:
         note: >
           If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor`
           is `QUIC`, in which case `IP.UDP` is assumed.
-        examples: ['1.0']
       - id: user_agent
         type: string
         brief: 'Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) header sent by the client.'

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -90,7 +90,6 @@ groups:
                 value: 16
           required: always
           brief: "The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request."
-          examples: [0, 1, 16]
     - id: rpc.jsonrpc
       prefix: rpc.jsonrpc
       extends: rpc

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -9,11 +9,11 @@
 <!-- semconv cloud -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `cloud.provider` | string | Name of the cloud provider. | `gcp` | No |
+| `cloud.provider` | string | Name of the cloud provider. | `aws` | No |
 | `cloud.account.id` | string | The cloud account ID the resource is assigned to. | `111111111111`; `opentelemetry` | No |
 | `cloud.region` | string | The geographical region the resource is running. Refer to your provider's docs to see the available regions, for example [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), or [Google Cloud regions](https://cloud.google.com/about/locations). | `us-central1`; `us-east-1` | No |
 | `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [1] | `us-east-1c` | No |
-| `cloud.platform` | string | The cloud platform in use. [2] | `aws_ec2`; `azure_vm`; `gcp_compute_engine` | No |
+| `cloud.platform` | string | The cloud platform in use. [2] | `aws_ec2` | No |
 
 **[1]:** Availability zones are called "zones" on Google Cloud.
 

--- a/specification/resource/semantic_conventions/cloud_provider/aws/ecs.md
+++ b/specification/resource/semantic_conventions/cloud_provider/aws/ecs.md
@@ -11,7 +11,7 @@
 |---|---|---|---|---|
 | `aws.ecs.container.arn` | string | The Amazon Resource Name (ARN) of an [ECS container instance](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ECS_instances.html). | `arn:aws:ecs:us-west-1:123456789123:container/32624152-9086-4f0e-acae-1a75b14fe4d9` | No |
 | `aws.ecs.cluster.arn` | string | The ARN of an [ECS cluster](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/clusters.html). | `arn:aws:ecs:us-west-2:123456789123:cluster/my-cluster` | No |
-| `aws.ecs.launchtype` | string | The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task. | `ec2`; `fargate` | No |
+| `aws.ecs.launchtype` | string | The [launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/launch_types.html) for an ECS task. | `ec2` | No |
 | `aws.ecs.task.arn` | string | The ARN of an [ECS task definition](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definitions.html). | `arn:aws:ecs:us-west-1:123456789123:task/10838bed-421f-43ef-870a-f43feacbbb5b` | No |
 | `aws.ecs.task.family` | string | The task definition family this task definition is a member of. | `opentelemetry-family` | No |
 | `aws.ecs.task.revision` | string | The revision for this task definition. | `8`; `26` | No |

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -112,7 +112,7 @@ For remote procedure calls via [gRPC][], additional conventions are described in
 <!-- semconv rpc.grpc -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `rpc.grpc.status_code` | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0`; `1`; `16` | Yes |
+| `rpc.grpc.status_code` | int | The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request. | `0` | Yes |
 
 `rpc.grpc.status_code` MUST be one of the following:
 


### PR DESCRIPTION
## Changes

Remove examples for enum from YAML, as the enum members are already perfectly fine examples.

The semantic convention generator apparently uses the first enum member as example automatically.