### PR TITLE
Rework FaaS semantic conventions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ release.
 ### Semantic Conventions
 
 - Clean up FaaS semantic conventions, add `aws.lambda.invoked_arn`.
-  ([#????](https://github.com/open-telemetry/opentelemetry-specification/pull/????))
+  ([#1781](https://github.com/open-telemetry/opentelemetry-specification/pull/1781))
 - Remove `rpc.jsonrpc.method`, clarify that `rpc.method` should be used instead.
   ([#1748](https://github.com/open-telemetry/opentelemetry-specification/pull/1748))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ release.
 
 ### Semantic Conventions
 
+- Clean up FaaS semantic conventions, add `aws.lambda.invoked_arn`.
+  ([#????](https://github.com/open-telemetry/opentelemetry-specification/pull/????))
 - Remove `rpc.jsonrpc.method`, clarify that `rpc.method` should be used instead.
   ([#1748](https://github.com/open-telemetry/opentelemetry-specification/pull/1748))
 

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -21,7 +21,8 @@ groups:
           Take care not to use the "invoked ARN" directly but replace any
           [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
           different aliases.
-          * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names), * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+          * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
+          * ***Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
 
           On some providers, it may not be possible to determine the full ID at startup,
           which is why this field cannot be made required. For example, on AWS the account ID
@@ -33,7 +34,7 @@ groups:
         type: string
         brief: The immutable version of the function being executed.
         note: |
-          Depending on the cloud provider, use:
+          Depending on the cloud provider and platform, use:
 
           * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
             (an integer represented as a decimal string).

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -9,6 +9,12 @@ groups:
         required: always
         brief: >
           The name of the single function that this runtime instance executes.
+        note:
+          This is the name of the function as configured/deployed on the FaaS
+          platform and is usually different from the name of the callback
+          function (which may be stored in the
+          [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-general.md#source-code-attributes)
+          span attributes).
         examples: ['my-function']
       - id: id
         type: string
@@ -22,7 +28,7 @@ groups:
           [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
           different aliases.
           * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
-          * ***Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+          * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
 
           On some providers, it may not be possible to determine the full ID at startup,
           which is why this field cannot be made required. For example, on AWS the account ID

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -8,32 +8,49 @@ groups:
         type: string
         required: always
         brief: >
-          The name of the function being executed.
+          The name of the single function that this runtime instance executes.
         examples: ['my-function']
       - id: id
         type: string
-        required: always
         brief: >
-          The unique ID of the function
-          being executed.
+          The unique ID of the single function that this runtime instance executes.
         note: >
-          For example, in AWS Lambda this field corresponds to the
-          [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
-          value, in GCP to the URI of the resource, and in Azure to the
-          [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function)
-          field.
+          Depending on the cloud provider, use:
+
+          * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
+          Take care not to use the "invoked ARN" directly but replace any
+          [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
+          different aliases.
+          * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names), * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+
+          On some providers, it may not be possible to determine the full ID at startup,
+          which is why this field cannot be made required. For example, on AWS the account ID
+          part of the ARN is not available without calling another AWS API
+          which may be deemed too slow for a short-running lambda function.
+          As an alternative, consider setting `faas.id` as a span attribute instead.
+
         examples: ['arn:aws:lambda:us-west-2:123456789012:function:my-function']
       - id: version
         type: string
-        brief: >
-          The version string of the function being executed as defined in
-          [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes).
-        examples: ['2.0.0']
+        brief: The immutable version of the function being executed.
+        note: >
+          Depending on the cloud provider, use:
+
+          * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
+            (an integer represented as a decimal string).
+          * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
+            (i.e., the function name plus the revision suffix).
+          * **Google Cloud Functions:** Not applicable. Do not set this attribute.
+          * **Azure Functions:** Not applicable. Do not set this attribute.
+        examples: ['26', 'pinkfroid-00002']
       - id: instance
         type: string
         brief: >
-          The execution environment ID as a string.
-        examples: ['my-function:instance-0001']
+          The execution environment ID as a string, that will be potentially reused
+          for other invocations to the same function/function version.
+        note: >
+          * **AWS Lambda:** Use the (full) log stream name.
+        examples: ['2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de']
       - id: max_memory
         type: int
         brief: >

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -14,7 +14,7 @@ groups:
         type: string
         brief: >
           The unique ID of the single function that this runtime instance executes.
-        note: >
+        note: |
           Depending on the cloud provider, use:
 
           * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
@@ -28,12 +28,11 @@ groups:
           part of the ARN is not available without calling another AWS API
           which may be deemed too slow for a short-running lambda function.
           As an alternative, consider setting `faas.id` as a span attribute instead.
-
         examples: ['arn:aws:lambda:us-west-2:123456789012:function:my-function']
       - id: version
         type: string
         brief: The immutable version of the function being executed.
-        note: >
+        note: |
           Depending on the cloud provider, use:
 
           * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -40,7 +40,8 @@ groups:
             (an integer represented as a decimal string).
           * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
             (i.e., the function name plus the revision suffix).
-          * **Google Cloud Functions:** Not applicable. Do not set this attribute.
+          * **Google Cloud Functions:** The value of the
+            [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
           * **Azure Functions:** Not applicable. Do not set this attribute.
         examples: ['26', 'pinkfroid-00002']
       - id: instance

--- a/semantic_conventions/trace/aws/lambda.yaml
+++ b/semantic_conventions/trace/aws/lambda.yaml
@@ -1,0 +1,13 @@
+groups:
+  - id: aws.lambda
+    prefix: aws.lambda
+    brief: >
+      Span attributes used by AWS Lambda (in addition to general `faas` attributes).
+    attributes:
+      - id: invoked_arn
+        type: string
+        brief: >
+          The full invoked ARN as provided on the `Context` passed to the function
+          (`Lambda-Runtime-Invoked-Function-Arn` header on the `/runtime/invocation/next` applicable).
+        note: This may be different from `faas.id` if an alias is involved.
+        examples: ['arn:aws:lambda:us-east-1:123456:function:myfunction:myalias']

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -14,20 +14,22 @@ See also:
 <!-- semconv faas_resource -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `faas.name` | string | The name of the single function that this runtime instance executes. | `my-function` | Yes |
-| `faas.id` | string | The unique ID of the single function that this runtime instance executes. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | No |
-| `faas.version` | string | The immutable version of the function being executed. [2] | `26`; `pinkfroid-00002` | No |
-| `faas.instance` | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [3] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | No |
-| `faas.max_memory` | int | The amount of memory available to the serverless function in MiB. [4] | `128` | No |
+| `faas.name` | string | The name of the single function that this runtime instance executes. [1] | `my-function` | Yes |
+| `faas.id` | string | The unique ID of the single function that this runtime instance executes. [2] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | No |
+| `faas.version` | string | The immutable version of the function being executed. [3] | `26`; `pinkfroid-00002` | No |
+| `faas.instance` | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [4] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | No |
+| `faas.max_memory` | int | The amount of memory available to the serverless function in MiB. [5] | `128` | No |
 
-**[1]:** Depending on the cloud provider, use:
+**[1]:** This is the name of the function as configured/deployed on the FaaS platform and is usually different from the name of the callback function (which may be stored in the [`code.namespace`/`code.function`](../../trace/semantic_conventions/span-general.md#source-code-attributes) span attributes).
+
+**[2]:** Depending on the cloud provider, use:
 
 * **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
 Take care not to use the "invoked ARN" directly but replace any
 [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
 different aliases.
 * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
-* ***Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+* **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
 
 On some providers, it may not be possible to determine the full ID at startup,
 which is why this field cannot be made required. For example, on AWS the account ID
@@ -35,7 +37,7 @@ part of the ARN is not available without calling another AWS API
 which may be deemed too slow for a short-running lambda function.
 As an alternative, consider setting `faas.id` as a span attribute instead.
 
-**[2]:** Depending on the cloud provider and platform, use:
+**[3]:** Depending on the cloud provider and platform, use:
 
 * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).
@@ -45,9 +47,9 @@ As an alternative, consider setting `faas.id` as a span attribute instead.
   [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
 * **Azure Functions:** Not applicable. Do not set this attribute.
 
-**[3]:** * **AWS Lambda:** Use the (full) log stream name.
+**[4]:** * **AWS Lambda:** Use the (full) log stream name.
 
-**[4]:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
+**[5]:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
 <!-- endsemconv -->
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -26,7 +26,8 @@ See also:
 Take care not to use the "invoked ARN" directly but replace any
 [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
 different aliases.
-* **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names), * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+* **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names)
+* ***Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
 
 On some providers, it may not be possible to determine the full ID at startup,
 which is why this field cannot be made required. For example, on AWS the account ID
@@ -34,7 +35,7 @@ part of the ARN is not available without calling another AWS API
 which may be deemed too slow for a short-running lambda function.
 As an alternative, consider setting `faas.id` as a span attribute instead.
 
-**[2]:** Depending on the cloud provider, use:
+**[2]:** Depending on the cloud provider and platform, use:
 
 * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -29,7 +29,9 @@ On some providers, it may not be possible to determine the full ID at startup, w
   (an integer represented as a decimal string).
 * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
   (i.e., the function name plus the revision suffix).
-* **Google Cloud Functions:** Not applicable. Do not set this attribute. * **Azure Functions:** Not applicable. Do not set this attribute.
+* **Google Cloud Functions:** The value of the
+  [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
+* **Azure Functions:** Not applicable. Do not set this attribute.
 
 **[3]:** * **AWS Lambda:** Use the (full) log stream name.
 

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -21,10 +21,21 @@ See also:
 | `faas.max_memory` | int | The amount of memory available to the serverless function in MiB. [4] | `128` | No |
 
 **[1]:** Depending on the cloud provider, use:
-* **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html). Take care not to use the "invoked ARN" directly but replace any [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple different aliases. * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names), * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
-On some providers, it may not be possible to determine the full ID at startup, which is why this field cannot be made required. For example, on AWS the account ID part of the ARN is not available without calling another AWS API which may be deemed too slow for a short-running lambda function. As an alternative, consider setting `faas.id` as a span attribute instead.
+
+* **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html).
+Take care not to use the "invoked ARN" directly but replace any
+[alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple
+different aliases.
+* **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names), * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+
+On some providers, it may not be possible to determine the full ID at startup,
+which is why this field cannot be made required. For example, on AWS the account ID
+part of the ARN is not available without calling another AWS API
+which may be deemed too slow for a short-running lambda function.
+As an alternative, consider setting `faas.id` as a span attribute instead.
 
 **[2]:** Depending on the cloud provider, use:
+
 * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).
 * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -4,20 +4,36 @@
 
 **type:** `faas`
 
-**Description:** A serverless instance.
+**Description:** A "function as a service" aka "serverless function" instance.
+
+See also:
+
+- The [Trace semantic conventions for FaaS](../../trace/semantic_conventions/faas.md)
+- The [Cloud resource conventions](cloud.md)
 
 <!-- semconv faas_resource -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `faas.name` | string | The name of the function being executed. | `my-function` | Yes |
-| `faas.id` | string | The unique ID of the function being executed. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | Yes |
-| `faas.version` | string | The version string of the function being executed as defined in [Version Attributes](../../resource/semantic_conventions/README.md#version-attributes). | `2.0.0` | No |
-| `faas.instance` | string | The execution environment ID as a string. | `my-function:instance-0001` | No |
-| `faas.max_memory` | int | The amount of memory available to the serverless function in MiB. [2] | `128` | No |
+| `faas.name` | string | The name of the single function that this runtime instance executes. | `my-function` | Yes |
+| `faas.id` | string | The unique ID of the single function that this runtime instance executes. [1] | `arn:aws:lambda:us-west-2:123456789012:function:my-function` | No |
+| `faas.version` | string | The immutable version of the function being executed. [2] | `26`; `pinkfroid-00002` | No |
+| `faas.instance` | string | The execution environment ID as a string, that will be potentially reused for other invocations to the same function/function version. [3] | `2021/06/28/[$LATEST]2f399eb14537447da05ab2a2e39309de` | No |
+| `faas.max_memory` | int | The amount of memory available to the serverless function in MiB. [4] | `128` | No |
 
-**[1]:** For example, in AWS Lambda this field corresponds to the [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) value, in GCP to the URI of the resource, and in Azure to the [FunctionDirectory](https://github.com/Azure/azure-functions-host/wiki/Retrieving-information-about-the-currently-running-function) field.
+**[1]:** Depending on the cloud provider, use:
+* **AWS Lambda:** The function [ARN](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html). Take care not to use the "invoked ARN" directly but replace any [alias suffix](https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html) with the resolved function version, as the same runtime instance may be invokable with multiple different aliases. * **GCP:** The [URI of the resource](https://cloud.google.com/iam/docs/full-resource-names), * **Azure:** The [Fully Qualified Resource ID](https://docs.microsoft.com/en-us/rest/api/resources/resources/get-by-id).
+On some providers, it may not be possible to determine the full ID at startup, which is why this field cannot be made required. For example, on AWS the account ID part of the ARN is not available without calling another AWS API which may be deemed too slow for a short-running lambda function. As an alternative, consider setting `faas.id` as a span attribute instead.
 
-**[2]:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
+**[2]:** Depending on the cloud provider, use:
+* **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
+  (an integer represented as a decimal string).
+* **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
+  (i.e., the function name plus the revision suffix).
+* **Google Cloud Functions:** Not applicable. Do not set this attribute. * **Azure Functions:** Not applicable. Do not set this attribute.
+
+**[3]:** * **AWS Lambda:** Use the (full) log stream name.
+
+**[4]:** It's recommended to set this attribute since e.g. too little memory can easily stop a Java AWS Lambda function from working correctly. On AWS Lambda, the environment variable `AWS_LAMBDA_FUNCTION_MEMORY_SIZE` provides this information.
 <!-- endsemconv -->
 
 Note: The resource attribute `faas.instance` differs from the span attribute `faas.execution`. For more information see the [Semantic conventions for FaaS spans](../../trace/semantic_conventions/faas.md#difference-between-execution-and-instance).

--- a/specification/trace/semantic_conventions/faas.md
+++ b/specification/trace/semantic_conventions/faas.md
@@ -5,6 +5,8 @@
 This document defines how to describe an instance of a function that runs without provisioning
 or managing of servers (also known as serverless functions or Function as a Service (FaaS)) with spans.
 
+See also the [additional instructions for instrumenting AWS Lambda](instrumentation/aws-lambda.md).
+
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 
 <!-- toc -->


### PR DESCRIPTION
Fixes #1280 (through introduction of aws.lambda.invoked_arn span attribute, @mateuszrzeszutek please check if that is OK).
Addresses #1778.

## Changes

- More clearly describe some FaaS attributes, in particular ID-related ones.
- Add `aws.lambda.invoked_arn` and clarify that alias must be stripped from `faas.id` resource attribute for AWS Lambda.
- Describe what IDs to use for Azure and GCP (Note: It might be impractical to collect these IDs client-side).

CC @skonto 