### PR TITLE
Update Kafka messaging example

### DIFF
--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -258,8 +258,8 @@ Process CB:                           | Span Rcv2 |
 | Field or Attribute | Span Prod1 | Span Rcv1 | Span Proc1 | Span Prod2 | Span Rcv2
 |-|-|-|-|-|-|
 | Span name | `"T1 send"` | `"T1 receive"` | `"T1 process"` | `"T2 send"` | `"T2 receive`" |
-| Parent |  | Span Prod1 | Span Rcv1 |  | Span Prod2 |
-| Links |  |  | | Span Prod1 |  |
+| Parent |  | Span Prod1 | Span Rcv1 | Span Proc1 | Span Prod2 |
+| Links |  |  | | |  |
 | SpanKind | `PRODUCER` | `CONSUMER` | `CONSUMER` | `PRODUCER` | `CONSUMER` |
 | Status | `Ok` | `Ok` | `Ok` | `Ok` | `Ok` |
 | `peer.service` | `"myKafka"` |  |  | `"myKafka"` |  |


### PR DESCRIPTION
I think(?) this was just an oversight in the example, and "Span Prod2" should parent "Span Proc1" (and no need for a link to "Span Prod1").