### PR TITLE
Add wikipedia link for word cross-cutting concern

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -51,7 +51,7 @@ Each signal provides a specialized form of observability. For example, tracing, 
 Signals share a common subsystem – **context propagation** – but they function independently from each other.
 
 Each signal provides a mechanism for software to describe itself. A codebase, such as web framework or a database client, takes a dependency on various signals in order to describe itself. OpenTelemetry instrumentation code can then be mixed into the other code within that codebase.
-This makes OpenTelemetry a **cross-cutting concern** - a piece of software which is mixed into many other pieces of software in order to provide value. Cross-cutting concerns, by their very nature, violate a core design principle – separation of concerns. As a result, OpenTelemetry client design requires extra care and attention to avoid creating issues for the codebases which depend upon these cross-cutting APIs.
+This makes OpenTelemetry a [**cross-cutting concern**](https://en.wikipedia.org/wiki/Cross-cutting_concern) - a piece of software which is mixed into many other pieces of software in order to provide value. Cross-cutting concerns, by their very nature, violate a core design principle – separation of concerns. As a result, OpenTelemetry client design requires extra care and attention to avoid creating issues for the codebases which depend upon these cross-cutting APIs.
 
 OpenTelemetry clients are designed to separate the portion of each signal which must be imported as cross-cutting concerns from the portions which can be managed independently. OpenTelemetry clients are also designed to be an extensible framework.
 To accomplish these goals, each signal consists of four types of packages: API, SDK, Semantic Conventions, and Contrib.


### PR DESCRIPTION
The word cross-cutting is explained in short in the Readme, but it would be better to link to some other article that could explain with examples to give a better understanding. I have linked to the Wikipedia article but this [Stack Overflow](https://stackoverflow.com/questions/23700540/cross-cutting-concern-example) is also good