### PR TITLE
Update trace example for Kafka messaging

### DIFF
--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -263,8 +263,8 @@ Process CB:                           | Span Rcv2 |
 | Field or Attribute | Span Prod1 | Span Rcv1 | Span Proc1 | Span Prod2 | Span Rcv2
 |-|-|-|-|-|-|
 | Span name | `"T1 send"` | `"T1 receive"` | `"T1 process"` | `"T2 send"` | `"T2 receive`" |
-| Parent |  | Span Prod1 | Span Rcv1 |  | Span Prod2 |
-| Links |  |  | | Span Prod1 |  |
+| Parent |  | Span Prod1 | Span Rcv1 | Span Rcv1 | Span Prod2 |
+| Links |  |  | |  |  |
 | SpanKind | `PRODUCER` | `CONSUMER` | `CONSUMER` | `PRODUCER` | `CONSUMER` |
 | Status | `Ok` | `Ok` | `Ok` | `Ok` | `Ok` |
 | `peer.service` | `"myKafka"` |  |  | `"myKafka"` |  |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -253,7 +253,7 @@ One process, CA, receives the message and publishes a new message to a topic T2 
 Frameworks such as Quarkus and Spring Boot separate processing of a received message from producing subsequent messages out.
 For this reason, receiving (Span Rcv1) is the parent of both processing (Span Proc1) and producing a new message (Span Prod2).
 The span representing message receiving (Span Rcv1) should not set `messaging.operation` to `receive`,
-as the work is hidden away by frameworks such as Quarkus and Spring Boot.
+as it does not only receive the message but also converts the input message to something suitable for the processing operation to consume and creates the output message from the result of processing.
 
 ```
 Process P:  | Span Prod1 |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -245,10 +245,15 @@ Process CB:                 | Span CB1 |
 | `messaging.operation` |  | `"process"` | `"process"` |
 | `messaging.message_id` | `"a1"` | `"a1"`| `"a1"` |
 
-### Apache Kafka Example
+### Apache Kafka with Quarkus or Spring Boot Example
 
 Given is a process P, that publishes a message to a topic T1 on Apache Kafka.
 One process, CA, receives the message and publishes a new message to a topic T2 that is then received and processed by CB.
+
+Frameworks such as Quarkus and Spring Boot separate processing of a received message from producing subsequent messages out.
+For this reason, receiving (Span Rcv1) is the parent of both processing (Span Proc1) and producing a new message (Span Prod2).
+The span representing message receiving (Span Rcv1) should not set `messaging.operation` to `receive`,
+as the work is hidden away by frameworks such as Quarkus and Spring Boot.
 
 ```
 Process P:  | Span Prod1 |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -272,7 +272,7 @@ Process CB:                           | Span Rcv2 |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
 | `messaging.destination` | `"T1"` | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
 | `messaging.destination_kind` | `"topic"` | `"topic"` | `"topic"` | `"topic"` | `"topic"` |
-| `messaging.operation` |  | `"receive"` | `"process"` |  | `"receive"` |
+| `messaging.operation` |  |  | `"process"` |  | `"receive"` |
 | `messaging.kafka.message_key` | `"myKey"` | `"myKey"` | `"myKey"` | `"anotherKey"` | `"anotherKey"` |
 | `messaging.kafka.consumer_group` |  | `"my-group"` | `"my-group"` |  | `"another-group"` |
 | `messaging.kafka.client_id` |  | `"5"` | `"5"` | `"5"` | `"8"` |

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -21,7 +21,7 @@
     + [Apache Kafka](#apache-kafka)
 - [Examples](#examples)
   * [Topic with multiple consumers](#topic-with-multiple-consumers)
-  * [Apache Kafka Example](#apache-kafka-example)
+  * [Apache Kafka with Quarkus or Spring Boot Example](#apache-kafka-with-quarkus-or-spring-boot-example)
   * [Batch receiving](#batch-receiving)
   * [Batch processing](#batch-processing)
 


### PR DESCRIPTION
Minor update to the Kafka messaging example for tracing, as after seeing a real-life example of this situation it didn't look right. I now realize it makes more sense for the second producer to be a child of the receiver, as opposed to no parent and a link to the first producer.