### PR TITLE
Change default value for OTEL_EXPORTER_JAEGER_AGENT_PORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ release.
 
 ### SDK Configuration
 
-- Change default value for OTEL_EXPORTER_JAEGER_AGENT_PORT to 6831. (#1812)
+- Change default value for OTEL_EXPORTER_JAEGER_AGENT_PORT to 6831.
+  ([#1812](https://github.com/open-telemetry/opentelemetry-specification/pull/1812))
 
 ## v1.6.0 (2021-08-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ release.
 
 ### SDK Configuration
 
+- Change default value for OTEL_EXPORTER_JAEGER_AGENT_PORT to 6831. (#1812)
+
 ## v1.6.0 (2021-08-06)
 
 ### Context

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -117,11 +117,13 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 | Name                            | Description                                                      | Default                                                                                          |
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                                    | "localhost"                                                                                      |
-| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent                                        | 6832                                                                                             |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent `compact` Thrift protocol              | 6831                                                                                             |
 | OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                                  | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                | -                                                                                                |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                | -                                                                                                |
+
+See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
 
 ## Zipkin Exporter
 


### PR DESCRIPTION
jaeger-agent accepts traces on two different ports:

- `6831` for the "normal" format used by most Jaeger clients
- `6832` for a Node.js-only format

(see [docs](https://www.jaegertracing.io/docs/1.24/deployment/#agent))

I believe the default value for `OTEL_EXPORTER_JAEGER_AGENT_PORT` should therefore be `6831` and not `6832`.