### PR TITLE
Add distro name and version to Resource.

### DIFF
--- a/semantic_conventions/resource/telemetry.yaml
+++ b/semantic_conventions/resource/telemetry.yaml
@@ -48,7 +48,7 @@ groups:
       - id: distro.name
         type: string
         brief: >
-          The name string of the distribution, if used.
+          The name of the distribution, if applicable.
         examples: ["acme"]
       - id: distro.version
         type: string

--- a/semantic_conventions/resource/telemetry.yaml
+++ b/semantic_conventions/resource/telemetry.yaml
@@ -45,3 +45,13 @@ groups:
         brief: >
           The version string of the auto instrumentation agent, if used.
         examples: ["1.2.3"]
+      - id: distro.name
+        type: string
+        brief: >
+          The name string of the distribution, if used.
+        examples: ["acme"]
+      - id: distro.version
+        type: string
+        brief: >
+          The version string of the distribution, if used.
+        examples: ["1.2.3"]

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -27,6 +27,7 @@ Some other fundamental terms are documented in the [overview document](overview.
   * [Instrumented Library](#instrumented-library)
   * [Instrumentation Library](#instrumentation-library)
   * [Tracer Name / Meter Name](#tracer-name--meter-name)
+  * [OpenTelemetry Distro](#opentelemetry-distro)
 - [Logs](#logs)
   * [Log Record](#log-record)
   * [Log](#log)
@@ -152,6 +153,14 @@ Synonyms: *Instrumenting Library*.
 This refers to the `name` and (optional) `version` arguments specified when
 creating a new `Tracer` or `Meter` (see [Obtaining a Tracer](trace/api.md#tracerprovider)/[Obtaining a Meter](metrics/api.md#meterprovider)).
 The name/version pair identifies the [Instrumentation Library](#instrumentation-library).
+
+### OpenTelemetry Distro
+
+This refers to any pre-configured OpenTelemetry compliant client or library,
+commonly associated with a specific working group, such as a telemetry vendor.
+OpenTelemetry Distros exist in order to encapsulate setup and configuration,
+and they may include a specific set of instrumentation libraries, plugins,
+samplers and other additional components.
 
 ## Logs
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -111,6 +111,8 @@ The identifier SHOULD be stable across different versions of an implementation.
 | `telemetry.sdk.language` | string | The language of the telemetry SDK. | `cpp` | No |
 | `telemetry.sdk.version` | string | The version string of the telemetry SDK. | `1.2.3` | No |
 | `telemetry.auto.version` | string | The version string of the auto instrumentation agent, if used. | `1.2.3` | No |
+| `telemetry.distro.name` | string | The name string of the distribution, if used. | `acme` | No |
+| `telemetry.distro.version` | string | The version string of the distribution, if used. | `1.2.3` | No |
 
 `telemetry.sdk.language` MUST be one of the following or, if none of the listed values apply, a custom value:
 


### PR DESCRIPTION
Fixes #1786 

Added as well an entry in the glossary for "OpenTelemetry Distro". One interesting thing @trask mentioned was deprecation of `telemetry.auto.version`.