### PR TITLE
fix: add net.transport to http semcov

### DIFF
--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -105,7 +105,7 @@ groups:
       - any_of:
           - [http.url]
           - [http.scheme, http.host, http.target]
-          - [http.scheme, net.peer.transport, net.peer.name, net.peer.port, http.target]
+          - [http.scheme, net.transport, net.peer.name, net.peer.port, http.target]
           - [http.scheme, net.peer.ip, net.peer.port, http.target]
 
   - id: http.server

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -105,7 +105,7 @@ groups:
       - any_of:
           - [http.url]
           - [http.scheme, http.host, http.target]
-          - [http.scheme, net.peer.name, net.peer.port, http.target]
+          - [http.scheme, net.peer.transport, net.peer.name, net.peer.port (IP only), http.target]
           - [http.scheme, net.peer.ip, net.peer.port, http.target]
 
   - id: http.server
@@ -140,6 +140,6 @@ groups:
     constraints:
       - any_of:
           - [http.scheme, http.host, http.target]
-          - [http.scheme, http.server_name, net.host.port, http.target]
-          - [http.scheme, net.host.name, net.host.port, http.target]
+          - [http.scheme, http.server_name, net.host.port (ip only), http.target]
+          - [http.scheme, net.host.name, net.host.port (ip only), http.target]
           - [http.url]

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -105,7 +105,8 @@ groups:
       - any_of:
           - [http.url]
           - [http.scheme, http.host, http.target]
-          - [http.scheme, net.transport, net.peer.name, net.peer.port, http.target]
+          - [http.scheme, net.peer.name, net.peer.port, http.target]
+          - [http.scheme, net.peer.name, net.transport, http.target]
           - [http.scheme, net.peer.ip, net.peer.port, http.target]
 
   - id: http.server

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -105,7 +105,7 @@ groups:
       - any_of:
           - [http.url]
           - [http.scheme, http.host, http.target]
-          - [http.scheme, net.peer.transport, net.peer.name, net.peer.port (IP only), http.target]
+          - [http.scheme, net.peer.transport, net.peer.name, net.peer.port, http.target]
           - [http.scheme, net.peer.ip, net.peer.port, http.target]
 
   - id: http.server
@@ -140,6 +140,6 @@ groups:
     constraints:
       - any_of:
           - [http.scheme, http.host, http.target]
-          - [http.scheme, http.server_name, net.host.port (ip only), http.target]
-          - [http.scheme, net.host.name, net.host.port (ip only), http.target]
+          - [http.scheme, http.server_name, net.host.port, http.target]
+          - [http.scheme, net.host.name, net.host.port, http.target]
           - [http.url]

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -196,7 +196,7 @@ For example, `http.server_name` has shown great value in practice, as bogus HTTP
 
 It is strongly recommended to set `http.server_name` to allow associating requests with some logical server entity.
 
-Note that `net.host.port` is only applicable for ip transports and therefore only required if IP transport is used.
+Note that `net.host.port` is only applicable for IP transports and therefore only required if IP transport is used.
 
 ## HTTP client-server example
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -102,7 +102,8 @@ before any HTTP-redirects that may happen when executing the request.
 
 * `http.url`
 * `http.scheme`, `http.host`, `http.target`
-* `http.scheme`, [`net.transport`](span-general.md), [`net.peer.name`](span-general.md), [`net.peer.port`](span-general.md), `http.target`
+* `http.scheme`, [`net.peer.name`](span-general.md), [`net.peer.port`](span-general.md), `http.target`
+* `http.scheme`, [`net.peer.name`](span-general.md), [`net.transport`](span-general.md), `http.target`
 * `http.scheme`, [`net.peer.ip`](span-general.md), [`net.peer.port`](span-general.md), `http.target`
 <!-- endsemconv -->
 
@@ -111,7 +112,7 @@ from the `net.peer.name`
 used to look up the `net.peer.ip` that is actually connected to.
 In that case it is strongly recommended to set the `net.peer.name` attribute in addition to `http.host`.
 
-Note that `net.peer.port` is only applicable for ip transports and therefore only required if IP transport is used.
+If transport is not based on IP `net.peer.port` is not applicable. Instead `net.transport` must be set.
 
 ## HTTP server
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -102,7 +102,7 @@ before any HTTP-redirects that may happen when executing the request.
 
 * `http.url`
 * `http.scheme`, `http.host`, `http.target`
-* `http.scheme`, [`net.peer.name`](span-general.md), [`net.peer.port`](span-general.md), `http.target`
+* `http.scheme`, [`net.transport`](span-general.md), [`net.peer.name`](span-general.md), [`net.peer.port`](span-general.md), `http.target`
 * `http.scheme`, [`net.peer.ip`](span-general.md), [`net.peer.port`](span-general.md), `http.target`
 <!-- endsemconv -->
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -111,6 +111,8 @@ from the `net.peer.name`
 used to look up the `net.peer.ip` that is actually connected to.
 In that case it is strongly recommended to set the `net.peer.name` attribute in addition to `http.host`.
 
+Note that `net.peer.port` is only applicable for ip transports and therefore only required if IP transport is used.
+
 ## HTTP server
 
 To understand the attributes defined in this section, it is helpful to read the "Definitions" subsection.
@@ -193,6 +195,8 @@ Of course, more than the required attributes can be supplied, but this is recomm
 For example, `http.server_name` has shown great value in practice, as bogus HTTP Host headers occur often in the wild.
 
 It is strongly recommended to set `http.server_name` to allow associating requests with some logical server entity.
+
+Note that `net.host.port` is only applicable for ip transports and therefore only required if IP transport is used.
 
 ## HTTP client-server example
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -112,8 +112,6 @@ from the `net.peer.name`
 used to look up the `net.peer.ip` that is actually connected to.
 In that case it is strongly recommended to set the `net.peer.name` attribute in addition to `http.host`.
 
-If transport is not based on IP `net.peer.port` is not applicable. Instead `net.transport` must be set.
-
 ## HTTP server
 
 To understand the attributes defined in this section, it is helpful to read the "Definitions" subsection.
@@ -196,8 +194,6 @@ Of course, more than the required attributes can be supplied, but this is recomm
 For example, `http.server_name` has shown great value in practice, as bogus HTTP Host headers occur often in the wild.
 
 It is strongly recommended to set `http.server_name` to allow associating requests with some logical server entity.
-
-Note that `net.host.port` is only applicable for IP transports and therefore only required if IP transport is used.
 
 ## HTTP client-server example
 


### PR DESCRIPTION
## Changes

http semconv requires net.peer.name/net.peer.port. But port doesn't exist
for pipe/socket based transport.

Add requirement for net.transport and make net.peer.port required for IP
only.

