### PR TITLE
Add environment variable for third party AWS X-Ray Sampler

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -56,6 +56,7 @@ Known values for `OTEL_TRACES_SAMPLER` are:
 - `"parentbased_always_on"`: `ParentBased(root=AlwaysOnSampler)`
 - `"parentbased_always_off"`: `ParentBased(root=AlwaysOffSampler)`
 - `"parentbased_traceidratio"`: `ParentBased(root=TraceIdRatioBased)`
+- `"xray"`: [AWS X-Ray Centralized Sampling](https://docs.aws.amazon.com/xray/latest/devguide/xray-console-sampling.html) (_third party_)
 
 Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may be set as follows:
 


### PR DESCRIPTION
## Changes

Adds an environment variable value for the AWS X-Ray Sampler. Being a vendor sampler, it doesn't make much sense to define the Sampler itself in the spec, this is only to make sure language-specific SDK extensions offer a consistent experience for environment variables, similar to the AWS propagator.
