### PR TITLE
Move metrics API to Feature-freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Metrics API specification Feature-freeze.
+  ([#1833](https://github.com/open-telemetry/opentelemetry-specification/pull/1833))
+
 ### Logs
 
 ### Resource

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -1,6 +1,6 @@
 # Metrics API
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Feature-freeze](../document-status.md)
 
 <details>
 <summary>


### PR DESCRIPTION
Discussed during the [07/27/2021 Metrics SIG Meeting](https://docs.google.com/document/d/1-bCYkN-DWJq4jw1ybaDZYYmx-WAe6HnwfWbkm8d57v8/edit#), we are moving Metrics API to Feature-freeze.

There are several things which we will not cover in the initial metrics specification, we will revisit them after the metrics specification went Stable:
* [Hint](https://github.com/open-telemetry/opentelemetry-specification/pull/1753)
* [Dedicated Instrument for timing/duration](https://github.com/open-telemetry/opentelemetry-specification/issues/464)
* https://github.com/open-telemetry/opentelemetry-specification/issues/1732