### PR TITLE
Add Semantic conventions for TLS/SSL encrypted communication

### DIFF
--- a/semantic_conventions/trace/tls.yaml
+++ b/semantic_conventions/trace/tls.yaml
@@ -26,10 +26,6 @@ groups:
     prefix: tls.cipher
     brief: 'Details on the negotiated cipher suite'
     attributes: 
-      - id: name
-        brief: IETF name of the cipher suite.
-        type: string
-        examples: ['TLS_RSA_WITH_3DES_EDE_CBC_SHA', 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256']
       - id: version
         brief: The minimum TLS protocol version supported by this cipher suite.
         type: 
@@ -45,6 +41,10 @@ groups:
               value: 'TLSv1.2'
             - id: TLSv1.3
               value: 'TLSv1.3'
+      - id: name
+        brief: IETF name of the cipher suite.
+        type: string
+        examples: ['TLS_RSA_WITH_3DES_EDE_CBC_SHA', 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256']
   - id: tls.certificate
     prefix: tls
     brief: 'Details on the used certificates'

--- a/semantic_conventions/trace/tls.yaml
+++ b/semantic_conventions/trace/tls.yaml
@@ -1,0 +1,99 @@
+groups:
+  - id: tls
+    prefix: tls
+    brief: 'This document defines semantic conventions for TLS/SSL client and server Spans.'
+    attributes:
+      - id: protocol
+        brief: 'The negotiated SSL/TLS protocol version of the current connection.'
+        type: 
+          allow_custom_values: false
+          members:
+            - id: SSLv3
+              value: SSLv3
+            - id: TLSv1
+              value: 'TLSv1'
+            - id: TLSv1.1
+              value: 'TLSv1.1'
+            - id: TLSv1.1
+              value: 'TLSv1.2'
+            - id: TLSv1.3
+              value: 'TLSv1.3'
+      - id: authorized
+        type: boolean
+        examples: [true]
+        brief: true, if the peer certificate was signed by one of the CAs specified when creating the socket, otherwise false.
+  - id: tls.cipher
+    prefix: tls.cipher
+    brief: 'Details on the negotiated cipher suite'
+    attributes: 
+      - id: name
+        brief: IETF name of the cipher suite.
+        type: string
+        examples: ['TLS_RSA_WITH_3DES_EDE_CBC_SHA', 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256']
+      - id: version
+        brief: The minimum TLS protocol version supported by this cipher suite.
+        type: 
+          allow_custom_values: false
+          members:
+            - id: SSLv3
+              value: SSLv3
+            - id: TLSv1
+              value: 'TLSv1'
+            - id: TLSv1.1
+              value: 'TLSv1.1'
+            - id: TLSv1.1
+              value: 'TLSv1.2'
+            - id: TLSv1.3
+              value: 'TLSv1.3'
+  - id: tls.certificate
+    prefix: tls
+    brief: 'Details on the used certificates'
+    attributes:
+      - id: peer.certificate.subject
+        type: string
+        brief: The peer certificate subject
+        examples: ['C=US, ST=California, L=San Francisco, O=OpenTelemetry, Inc, CN=*.opentelemetry.io']
+      - id: peer.certificate.fingerprint
+        brief: The SHA-1 (or SHA-256) digest of the DER encoded peer certificate
+        type: string
+        examples: ['95:B4:D0:6E:CD:C1:2C:22:92:B8:CD:26:54:79:E4:84:E3:47:34:2E']
+      - id: peer.certificate.serial_number
+        brief: The peer certificate serial number, as a hex string
+        type: string
+        examples: ['04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C']
+      - id: peer.certificate.valid_from
+        type: string
+        brief: The date-time the peer certificate is valid from.
+        examples: ['Mar  9 00:00:00 2021 GMT']
+      - id: peer.certificate.valid_to
+        type: string
+        brief: The date-time the peer certificate is valid to.
+        examples: ['Mar  1 23:59:59 2022 GMT']
+      - id: host.certificate.subject
+        type: string
+        brief: The host certificate subject
+        examples: ['C=US, ST=California, L=San Francisco, O=OpenTelemetry, Inc, CN=*.opentelemetry.io']
+      - id: host.certificate.fingerprint
+        brief: The SHA-1 (or SHA-256) digest of the DER encoded host certificate
+        type: string
+        examples: ['95:B4:D0:6E:CD:C1:2C:22:92:B8:CD:26:54:79:E4:84:E3:47:34:2E']
+      - id: host.certificate.serial_number
+        brief: The host certificate serial number, as a hex string
+        type: string
+        examples: ['04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C']
+      - id: host.certificate.valid_from
+        type: string
+        brief: The timestamp the host certificate is valid from.
+        examples: ['Mar  9 00:00:00 2021 GMT']
+      - id: host.certificate.valid_to
+        type: string
+        brief: The timestamp the host certificate is valid to.
+        examples: ['Mar  1 23:59:59 2022 GMT']
+  - id: tls.alpn
+    prefix: tls.alpn
+    brief: 'Details on the selected ALPN protocol'
+    attributes:
+      - id: protocol
+        type: string
+        brief: The negotiated ALPN protocol
+        examples: ['h2', 'http/1.1']

--- a/semantic_conventions/trace/tls.yaml
+++ b/semantic_conventions/trace/tls.yaml
@@ -5,7 +5,7 @@ groups:
     attributes:
       - id: protocol
         brief: 'The negotiated SSL/TLS protocol version of the current connection.'
-        type: 
+        type:
           allow_custom_values: false
           members:
             - id: SSLv3
@@ -25,10 +25,10 @@ groups:
   - id: tls.cipher
     prefix: tls.cipher
     brief: 'Details on the negotiated cipher suite'
-    attributes: 
+    attributes:
       - id: version
         brief: The minimum TLS protocol version supported by this cipher suite.
-        type: 
+        type:
           allow_custom_values: false
           members:
             - id: SSLv3

--- a/semantic_conventions/trace/tls.yaml
+++ b/semantic_conventions/trace/tls.yaml
@@ -14,7 +14,7 @@ groups:
               value: 'TLSv1'
             - id: TLSv1.1
               value: 'TLSv1.1'
-            - id: TLSv1.1
+            - id: TLSv1.2
               value: 'TLSv1.2'
             - id: TLSv1.3
               value: 'TLSv1.3'
@@ -37,7 +37,7 @@ groups:
               value: 'TLSv1'
             - id: TLSv1.1
               value: 'TLSv1.1'
-            - id: TLSv1.1
+            - id: TLSv1.2
               value: 'TLSv1.2'
             - id: TLSv1.3
               value: 'TLSv1.3'

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -22,6 +22,7 @@ The following semantic conventions for spans are defined:
 * [Messaging](messaging.md): Spans for interaction with messaging systems (queues, publish/subscribe, etc.).
 * [FaaS](faas.md): Spans for Function as a Service (e.g., AWS Lambda).
 * [Exceptions](exceptions.md): Attributes for recording exceptions associated with a span.
+* [TLS/SSL](tls.md): Spans for TLS/SSL encrypted communication.
 
 The following library-specific semantic conventions are defined:
 

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -27,7 +27,7 @@ These attributes may be used for base information of any TLS/SSL encrypted commu
 | `SSLv3` | SSLv3 |
 | `TLSv1` | TLSv1 |
 | `TLSv1.1` | TLSv1.1 |
-| `TLSv1.2` | TLSv1.1 |
+| `TLSv1.2` | TLSv1.2 |
 | `TLSv1.3` | TLSv1.3 |
 <!-- endsemconv -->
 
@@ -48,7 +48,7 @@ These attributes may be used for details on the negotiated cipher suite.
 | `SSLv3` | SSLv3 |
 | `TLSv1` | TLSv1 |
 | `TLSv1.1` | TLSv1.1 |
-| `TLSv1.2` | TLSv1.1 |
+| `TLSv1.2` | TLSv1.2 |
 | `TLSv1.3` | TLSv1.3 |
 <!-- endsemconv -->
 

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -57,8 +57,8 @@ The values allowed for `tls.cipher.name` MUST be one of the `Descriptions` of th
 ## Certificate attributes
 
 These attributes may be used for any operation for details on the certificates.
-Fingerprints and serial numbers MUST be provided in tuples of hexadecimal numbers separated by colon (`:`) with letters `A-F` in uppercase, e.g. `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C`
-This is the widely-used notation by CLI tools like `openssl` or browsers to display those certificate details.'
+Fingerprints and serial numbers MUST be provided in tuples of hexadecimal numbers separated by colon (`:`) with letters `A-F` in uppercase, e.g. `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C`.
+This is a widely-used notation by CLI tools like `openssl` or browsers to display those certificate details.'
 
 <!-- semconv tls.certificate -->
 | Attribute  | Type | Description  | Examples  | Required |

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -1,0 +1,83 @@
+# Semantic conventions for TLS spans
+
+**Status**: [Experimental](../../document-status.md)
+
+This document defines semantic conventions for TLS/SSL client and server Spans.
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+<!-- tocstop -->
+
+## Common Attributes
+
+These attributes may be used for base information of any TLS/SSL encrypted communication.
+
+<!-- semconv tls -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `tls.protocol` | string | The negotiated SSL/TLS protocol version of the current connection. | `SSLv3` | No |
+| `tls.authorized` | boolean | true, if the peer certificate was signed by one of the CAs specified when creating the socket, otherwise false. | `True` | No |
+
+`tls.protocol` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `SSLv3` | SSLv3 |
+| `TLSv1` | TLSv1 |
+| `TLSv1.1` | TLSv1.1 |
+| `TLSv1.2` | TLSv1.1 |
+| `TLSv1.3` | TLSv1.3 |
+<!-- endsemconv -->
+
+## Cipher suite attributes
+
+These attributes may be used for details on the negotiated cipher suite.
+
+<!-- semconv tls.cipher -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `tls.cipher.name` | string | IETF name of the cipher suite. | `TLS_RSA_WITH_3DES_EDE_CBC_SHA`; `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` | No |
+| `tls.cipher.version` | string | The minimum TLS protocol version supported by this cipher suite. | `SSLv3` | No |
+
+`tls.cipher.version` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `SSLv3` | SSLv3 |
+| `TLSv1` | TLSv1 |
+| `TLSv1.1` | TLSv1.1 |
+| `TLSv1.2` | TLSv1.1 |
+| `TLSv1.3` | TLSv1.3 |
+<!-- endsemconv -->
+
+## Certificate attributes
+
+These attributes may be used for any operation for details on the certificates.
+
+<!-- semconv tls.certificate -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `tls.peer.certificate.subject` | string | The peer certificate subject | `C=US, ST=California, L=San Francisco, O=OpenTelemetry, Inc, CN=*.opentelemetry.io` | No |
+| `tls.peer.certificate.fingerprint` | string | The SHA-1 (or SHA-256) digest of the DER encoded peer certificate | `95:B4:D0:6E:CD:C1:2C:22:92:B8:CD:26:54:79:E4:84:E3:47:34:2E` | No |
+| `tls.peer.certificate.serial_number` | string | The peer certificate serial number, as a hex string | `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C` | No |
+| `tls.peer.certificate.valid_from` | string | The date-time the peer certificate is valid from. | `Mar  9 00:00:00 2021 GMT` | No |
+| `tls.peer.certificate.valid_to` | string | The date-time the peer certificate is valid to. | `Mar  1 23:59:59 2022 GMT` | No |
+| `tls.host.certificate.subject` | string | The host certificate subject | `C=US, ST=California, L=San Francisco, O=OpenTelemetry, Inc, CN=*.opentelemetry.io` | No |
+| `tls.host.certificate.fingerprint` | string | The SHA-1 (or SHA-256) digest of the DER encoded host certificate | `95:B4:D0:6E:CD:C1:2C:22:92:B8:CD:26:54:79:E4:84:E3:47:34:2E` | No |
+| `tls.host.certificate.serial_number` | string | The host certificate serial number, as a hex string | `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C` | No |
+| `tls.host.certificate.valid_from` | string | The timestamp the host certificate is valid from. | `Mar  9 00:00:00 2021 GMT` | No |
+| `tls.host.certificate.valid_to` | string | The timestamp the host certificate is valid to. | `Mar  1 23:59:59 2022 GMT` | No |
+<!-- endsemconv -->
+
+## ALPN attributes
+
+
+This attribute may be used if [ALPN](https://datatracker.ietf.org/doc/html/rfc7301) is used within the TLS connection
+
+<!-- semconv tls.alpn -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `tls.alpn.protocol` | string | The negotiated ALPN protocol | `h2`; `http/1.1` | No |
+<!-- endsemconv -->

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -38,8 +38,8 @@ These attributes may be used for details on the negotiated cipher suite.
 <!-- semconv tls.cipher -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `tls.cipher.name` | string | IETF name of the cipher suite. | `TLS_RSA_WITH_3DES_EDE_CBC_SHA`; `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` | No |
 | `tls.cipher.version` | string | The minimum TLS protocol version supported by this cipher suite. | `SSLv3` | No |
+| `tls.cipher.name` | string | IETF name of the cipher suite. | `TLS_RSA_WITH_3DES_EDE_CBC_SHA`; `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256` | No |
 
 `tls.cipher.version` MUST be one of the following:
 
@@ -52,9 +52,13 @@ These attributes may be used for details on the negotiated cipher suite.
 | `TLSv1.3` | TLSv1.3 |
 <!-- endsemconv -->
 
+The values allowed for `tls.cipher.name` MUST be one of the `Descriptions` of the [registered TLS Cipher Suits](https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#table-tls-parameters-4).
+
 ## Certificate attributes
 
 These attributes may be used for any operation for details on the certificates.
+Fingerprints and serial numbers MUST be provided in *hexadecimal colon notation*.
+This is the widely-used notation by CLI tools like `openssl` or browsers to display those certificate details.'
 
 <!-- semconv tls.certificate -->
 | Attribute  | Type | Description  | Examples  | Required |

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -57,7 +57,7 @@ The values allowed for `tls.cipher.name` MUST be one of the `Descriptions` of th
 ## Certificate attributes
 
 These attributes may be used for any operation for details on the certificates.
-Fingerprints and serial numbers MUST be provided in *hexadecimal colon notation*.
+Fingerprints and serial numbers MUST be provided in tuples of hexadecimal numbers separated by colon (`:`) with letters `A-F` in uppercase, e.g. `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C`
 This is the widely-used notation by CLI tools like `openssl` or browsers to display those certificate details.'
 
 <!-- semconv tls.certificate -->

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -73,7 +73,6 @@ These attributes may be used for any operation for details on the certificates.
 
 ## ALPN attributes
 
-
 This attribute may be used if [ALPN](https://datatracker.ietf.org/doc/html/rfc7301) is used within the TLS connection
 
 <!-- semconv tls.alpn -->

--- a/specification/trace/semantic_conventions/tls.md
+++ b/specification/trace/semantic_conventions/tls.md
@@ -57,7 +57,7 @@ The values allowed for `tls.cipher.name` MUST be one of the `Descriptions` of th
 ## Certificate attributes
 
 These attributes may be used for any operation for details on the certificates.
-Fingerprints and serial numbers MUST be provided in tuples of hexadecimal numbers separated by colon (`:`) with letters `A-F` in uppercase, e.g. `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C`.
+Fingerprints and serial numbers MUST be provided as strings of uppercase hexadecimal numbers with every two characters (every byte) separated by colon (`:`), e.g. `04:C8:04:4B:BB:F2:4E:2B:7A:37:25:91:64:00:54:95:91:2C`.
 This is a widely-used notation by CLI tools like `openssl` or browsers to display those certificate details.'
 
 <!-- semconv tls.certificate -->


### PR DESCRIPTION
Fixes #1652

## Changes

This is a follow up to #1652 providing a suggestion to include semantic conventions for TLS/SSL encrypted communication. It would add a lot of value to have those standardised, so there is a common way to find sources of TLS/SSL related issues.
