### PR TITLE
Add 1.6.0 Schema File

### DIFF
--- a/schemas/1.6.0
+++ b/schemas/1.6.0
@@ -1,0 +1,6 @@
+file_format: 1.0.0
+schema_url: https://opentelemetry.io/schemas/1.6.0
+versions:
+  1.6.0:
+  1.5.0:
+  1.4.0:


### PR DESCRIPTION
No schema changes since 1.5.0, so 1.6.0 section is empty in the file.
