### PR TITLE
Add automated Schema File publish action

### DIFF
--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -1,0 +1,35 @@
+name: Update Schema files at OpenTelemetry Website
+
+on:
+  # triggers only on a manual dispatch
+  workflow_dispatch:
+
+jobs:
+  update-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2.3.4
+      - name: make-pr
+        env:
+          API_TOKEN_GITHUB: ${{secrets.DOC_UPDATE_TOKEN}}
+          # Destination repo should always be 'open-telemetry/opentelemetry.io'
+          DESTINATION_REPO: open-telemetry/opentelemetry.io
+          # Destination path should be the absolute path to directory to publish in
+          DESTINATION_PATH: static/schemas
+          # Source path should be 'schemas', all files and folders are copied from here to dest
+          SOURCE_PATH: schemas
+        run: |
+          TARGET_DIR=$(mktemp -d)
+          export GITHUB_TOKEN=$API_TOKEN_GITHUB
+          git config --global user.name austinlparker
+          git config --global user.email austin@lightstep.com
+          git clone "https://$API_TOKEN_GITHUB@github.com/$DESTINATION_REPO.git" "$TARGET_DIR"
+          rsync -av --delete "$SOURCE_PATH/" "$TARGET_DIR/$DESTINATION_PATH/"
+          cd "$TARGET_DIR"
+          git checkout -b docs-$GITHUB_REPOSITORY-$GITHUB_SHA
+          git add .
+          git commit -m "Docs update from $GITHUB_REPOSITORY"
+          git push -u origin HEAD:docs-$GITHUB_REPOSITORY-$GITHUB_SHA
+          gh pr create -t "Docs Update from $GITHUB_REPOSITORY" -b "This is an automated pull request." -B main -H docs-$GITHUB_REPOSITORY-$GITHUB_SHA
+          echo "done"

--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -27,9 +27,9 @@ jobs:
           git clone "https://$API_TOKEN_GITHUB@github.com/$DESTINATION_REPO.git" "$TARGET_DIR"
           rsync -av --delete "$SOURCE_PATH/" "$TARGET_DIR/$DESTINATION_PATH/"
           cd "$TARGET_DIR"
-          git checkout -b docs-$GITHUB_REPOSITORY-$GITHUB_SHA
+          git checkout -b schemas-$GITHUB_REPOSITORY-$GITHUB_SHA
           git add .
-          git commit -m "Docs update from $GITHUB_REPOSITORY"
-          git push -u origin HEAD:docs-$GITHUB_REPOSITORY-$GITHUB_SHA
-          gh pr create -t "Docs Update from $GITHUB_REPOSITORY" -b "This is an automated pull request." -B main -H docs-$GITHUB_REPOSITORY-$GITHUB_SHA
+          git commit -m "Schemas update from $GITHUB_REPOSITORY"
+          git push -u origin HEAD:schemas-$GITHUB_REPOSITORY-$GITHUB_SHA
+          gh pr create -t "Schemas Update from $GITHUB_REPOSITORY" -b "This is an automated pull request." -B main -H schemas-$GITHUB_REPOSITORY-$GITHUB_SHA
           echo "done"


### PR DESCRIPTION
The action should be triggered manually after every spec release
and will copy/update schema files from this repository to the
website repository so that they become available publicly.

The publish-schemas action after manual triggering will create a PR
in https://github.com/open-telemetry/opentelemetry.io repo, and the
PR needs to be approved and merged manually.

This is similar to how we publish doc updates from language repos
to the website repo.

Resolves https://github.com/open-telemetry/opentelemetry.io/issues/577
Resolves https://github.com/open-telemetry/opentelemetry-specification/issues/1693
