### PR TITLE
Consistently format enums, fix non-identifier IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ release.
 
 ### Semantic Conventions
 
+- BREAKING: Change enum member IDs to lowercase without spaces, not starting with numbers.
+  Change values of `net.host.connection.subtype` to match.
+  ([#1863](https://github.com/open-telemetry/opentelemetry-specification/pull/1863))
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -8,16 +8,16 @@ groups:
         type:
           allow_custom_values: true
           members:
-            - id: Alibaba Cloud
+            - id: 'alibaba_cloud'
               value: 'alibaba_cloud'
               brief: 'Alibaba Cloud'
-            - id: AWS
+            - id: 'aws'
               value: 'aws'
               brief: 'Amazon Web Services'
-            - id: Azure
+            - id: 'azure'
               value: 'azure'
               brief: 'Microsoft Azure'
-            - id: GCP
+            - id: 'gcp'
               value: 'gcp'
               brief: 'Google Cloud Platform'
         brief: >

--- a/semantic_conventions/trace/faas.yaml
+++ b/semantic_conventions/trace/faas.yaml
@@ -154,16 +154,16 @@ groups:
         type:
           allow_custom_values: true
           members:
-            - id: Alibaba Cloud
+            - id: 'alibaba_cloud'
               value: 'alibaba_cloud'
               brief: 'Alibaba Cloud'
-            - id: AWS
+            - id: 'aws'
               value: 'aws'
               brief: 'Amazon Web Services'
-            - id: Azure
+            - id: 'azure'
               value: 'azure'
               brief: 'Microsoft Azure'
-            - id: GCP
+            - id: 'gcp'
               value: 'gcp'
               brief: 'Google Cloud Platform'
         required: always

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -79,48 +79,69 @@ groups:
         type:
           allow_custom_values: true
           members:
-            - id: GPRS
-              value: "GPRS"
-            - id: EDGE
-              value: "EDGE"
-            - id: UMTS
-              value: "UMTS"
-            - id: CDMA
-              value: "CDMA"
-            - id: EVDO_0
-              value: "EVDO_0"
-            - id: EVDO_A
-              value: "EVDO_A"
-            - id: 1xRTT
-              value: "1xRTT"
-            - id: HSDPA
-              value: "HSDPA"
-            - id: HSUPA
-              value: "HSUPA"
-            - id: HSPA
-              value: "HSPA"
-            - id: IDEN
-              value: "IDEN"
-            - id: EVDO_B
-              value: "EVDO_B"
-            - id: LTE
-              value: "LTE"
-            - id: EHRPD
-              value: "EHRPD"
-            - id: HSPAP
-              value: "HSPAP"
-            - id: GSM
-              value: "GSM"
-            - id: TD_SCDMA
-              value: "TD_SCDMA"
-            - id: IWLAN
-              value: "IWLAN"
-            - id: NR
-              value: "NR"
-            - id: NRNSA
-              value: "NRNSA"
-            - id: LTE_CA
-              value: "LTE_CA"
+            - id: gprs
+              brief: GPRS
+              value: "gprs"
+            - id: edge
+              brief: EDGE
+              value: "edge"
+            - id: umts
+              brief: UMTS
+              value: "umts"
+            - id: cdma
+              brief: CDMA
+              value: "cdma"
+            - id: evdo_0
+              brief: EVDO Rel. 0
+              value: "evdo_0"
+            - id: evdo_a
+              brief: "EVDO Rev. A"
+              value: "evdo_a"
+            - id: cdma2000_1xrtt
+              brief: CDMA2000 1XRTT
+              value: "cdma2000_1xrtt"
+            - id: hsdpa
+              brief: HSDPA
+              value: "hsdpa"
+            - id: hsupa
+              brief: HSUPA
+              value: "hsupa"
+            - id: hspa
+              brief: HSPA
+              value: "hspa"
+            - id: iden
+              brief: IDEN
+              value: "iden"
+            - id: evdo_b
+              brief: "EVDO Rev. B"
+              value: "evdo_b"
+            - id: lte
+              brief: LTE
+              value: "lte"
+            - id: ehrpd
+              brief: EHRPD
+              value: "ehrpd"
+            - id: hspap
+              brief: HSPAP
+              value: "hspap"
+            - id: gsm
+              brief: GSM
+              value: "gsm"
+            - id: td_scdma
+              brief: TD-SCDMA
+              value: "td_scdma"
+            - id: iwlan
+              brief: IWLAN
+              value: "iwlan"
+            - id: nr
+              brief: "5G NR (New Radio)"
+              value: "nr"
+            - id: nrnsa
+              brief: "5G NRNSA (New Radio Non-Standalone)"
+              value: "nrnsa"
+            - id: lte_ca
+              brief: LTE CA
+              value: "lte_ca"
         brief: 'This describes more details regarding the connection.type. It may be the type of cell technology connection, but it could be used for describing details about a wifi connection.'
         examples: 'LTE'
       - id: host.carrier.name

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -46,19 +46,19 @@ groups:
           # encode checks that only accept the listed values.
           allow_custom_values: true
           members:
-            - id: HTTP_1_0
+            - id: http_1_0
               value: '1.0'
               brief: 'HTTP 1.0'
-            - id: HTTP_1_1
+            - id: http_1_1
               value: '1.1'
               brief: 'HTTP 1.1'
-            - id: HTTP_2_0
+            - id: http_2_0
               value: '2.0'
               brief: 'HTTP 2'
-            - id: SPDY
+            - id: spdy
               value: 'SPDY'
               brief: 'SPDY protocol.'
-            - id: QUIC
+            - id: quic
               value: 'QUIC'
               brief: 'QUIC protocol.'
         brief: 'Kind of HTTP protocol used.'

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -54,39 +54,56 @@ groups:
       - id: status_code
         type:
           members:
-            - id: OK
+            - id: ok
+              brief: OK
               value: 0
-            - id: CANCELLED
+            - id: cancelled
+              brief: CANCELLED
               value: 1
-            - id: UNKNOWN
+            - id: unknown
+              brief: UNKNOWN
               value: 2
-            - id: INVALID_ARGUMENT
+            - id: invalid_argument
+              brief: INVALID_ARGUMENT 
               value: 3
-            - id: DEADLINE_EXCEEDED
+            - id: deadline_exceeded
+              brief: DEADLINE_EXCEEDED
               value: 4
-            - id: NOT_FOUND
+            - id: not_found
+              brief: NOT_FOUND
               value: 5
-            - id: ALREADY_EXISTS
+            - id: already_exists
+              brief: ALREADY_EXISTS
               value: 6
-            - id: PERMISSION_DENIED
+            - id: permission_denied
+              brief: PERMISSION_DENIED
               value: 7
-            - id: RESOURCE_EXHAUSTED
+            - id: resource_exhausted
+              brief: RESOURCE_EXHAUSTED
               value: 8
-            - id: FAILED_PRECONDITION
+            - id: failed_precondition
+              brief: FAILED_PRECONDITION
               value: 9
-            - id: ABORTED
+            - id: aborted
+              brief: ABORTED
               value: 10
-            - id: OUT_OF_RANGE
+            - id: out_of_range
+              brief: OUT_OF_RANGE
               value: 11
-            - id: UNIMPLEMENTED
+            - id: unimplemented
+              brief: UNIMPLEMENTED
               value: 12
-            - id: INTERNAL
+            - id: internal
+              brief: INTERNAL
               value: 13
-            - id: UNAVAILABLE
+            - id: unavailable
+              brief: UNAVAILABLE
               value: 14
-            - id: DATA_LOSS
+            - id: data_loss
+              brief: DATA_LOSS
               value: 15
-            - id: UNAUTHENTICATED
+            - id: unauthenticated
+              brief: UNAUTHENTICATED
               value: 16
         required: always
         brief: "The [numeric status code](https://github.com/grpc/grpc/blob/v1.33.2/doc/statuscodes.md) of the gRPC request."

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -64,7 +64,7 @@ groups:
               brief: UNKNOWN
               value: 2
             - id: invalid_argument
-              brief: INVALID_ARGUMENT 
+              brief: INVALID_ARGUMENT
               value: 3
             - id: deadline_exceeded
               brief: DEADLINE_EXCEEDED

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -76,27 +76,27 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 
 | Value  | Description |
 |---|---|
-| `GPRS` | GPRS |
-| `EDGE` | EDGE |
-| `UMTS` | UMTS |
-| `CDMA` | CDMA |
-| `EVDO_0` | EVDO_0 |
-| `EVDO_A` | EVDO_A |
-| `1xRTT` | 1xRTT |
-| `HSDPA` | HSDPA |
-| `HSUPA` | HSUPA |
-| `HSPA` | HSPA |
-| `IDEN` | IDEN |
-| `EVDO_B` | EVDO_B |
-| `LTE` | LTE |
-| `EHRPD` | EHRPD |
-| `HSPAP` | HSPAP |
-| `GSM` | GSM |
-| `TD_SCDMA` | TD_SCDMA |
-| `IWLAN` | IWLAN |
-| `NR` | NR |
-| `NRNSA` | NRNSA |
-| `LTE_CA` | LTE_CA |
+| `gprs` | GPRS |
+| `edge` | EDGE |
+| `umts` | UMTS |
+| `cdma` | CDMA |
+| `evdo_0` | EVDO Rel. 0 |
+| `evdo_a` | EVDO Rev. A |
+| `cdma2000_1xrtt` | CDMA2000 1XRTT |
+| `hsdpa` | HSDPA |
+| `hsupa` | HSUPA |
+| `hspa` | HSPA |
+| `iden` | IDEN |
+| `evdo_b` | EVDO Rev. B |
+| `lte` | LTE |
+| `ehrpd` | EHRPD |
+| `hspap` | HSPAP |
+| `gsm` | GSM |
+| `td_scdma` | TD-SCDMA |
+| `iwlan` | IWLAN |
+| `nr` | 5G NR (New Radio) |
+| `nrnsa` | 5G NRNSA (New Radio Non-Standalone) |
+| `lte_ca` | LTE CA |
 <!-- endsemconv -->
 
 For `Unix` and `pipe`, since the connection goes over the file system instead of being directly to a known peer, `net.peer.name` is the only attribute that usually makes sense (see description of `net.peer.name` below).


### PR DESCRIPTION
Fixes #1519 (again) and also fixes some `id`s containing spaces (`Alibaba Cloud` -> `alibaba_cloud`) or starting with numbers (`1xRTT` -> `csma2000_1xrtt`) which tripped up code generators (open-telemetry/build-tools#59).

## Changes

Changes enum IDs to be lowercase.

Also changes values and briefs of `net.host.connection.subtype` and `rpc.grpc.status_code` to match the IDs. http.flavor is left unchanged since it is already quite old (but http.flavor should probably be refactored anyway separately).
