### PR TITLE
Added value zipkin_json and zipkin_proto as expected values for OTEL_TRACES_EXPORTER

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -167,8 +167,9 @@ Known values for OTEL_TRACES_EXPORTER are:
 
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"jaeger"`: [Jaeger gRPC](https://www.jaegertracing.io/docs/1.21/apis/#protobuf-via-grpc-stable)
-- `"zipkin_proto"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
+- `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
 - `"zipkin_json"`: [Zipkin](https://zipkin.io/zipkin-api/)
+- `"zipkin_proto"`: [Zipkin](https://zipkin.io/zipkin-api/)
 - `"none"`: No automatically configured exporter for traces.
 
 Known values for OTEL_METRICS_EXPORTER are:

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -167,7 +167,8 @@ Known values for OTEL_TRACES_EXPORTER are:
 
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"jaeger"`: [Jaeger gRPC](https://www.jaegertracing.io/docs/1.21/apis/#protobuf-via-grpc-stable)
-- `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
+- `"zipkin_proto"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
+- `"zipkin_json"`: [Zipkin](https://zipkin.io/zipkin-api/)
 - `"none"`: No automatically configured exporter for traces.
 
 Known values for OTEL_METRICS_EXPORTER are:


### PR DESCRIPTION
Fixes #
Added value `zipkin_json` and `zipkin_proto` as expected values for `OTEL_TRACES_EXPORTER`
## Changes

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
