### PR TITLE
Adjust .NET casing

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -14,7 +14,7 @@ formats is required. Implementing more than one format is optional.
 
 ## Traces
 
-| Feature                                                                                          | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .Net | Swift |
+| Feature                                                                                          | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 |--------------------------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | [TracerProvider](specification/trace/api.md#tracerprovider-operations)                           |          |    |      |    |        |      |        |     |      |     |      |       |
 | Create TracerProvider                                                                            |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
@@ -84,20 +84,20 @@ formats is required. Implementing more than one format is optional.
 
 ## Baggage
 
-| Feature                            | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .Net | Swift |
+| Feature                            | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 |------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | Basic support                      |          | +  | +    | +  | +      | +    | +      |     | +    |  +  | +    | +     |
 | Use official header name `baggage` |          | +  | +    | +  | +      | +    | +      |     | +    |  +  | +    | +     |
 
 ## Metrics
 
-|Feature                                       |Optional|Go|Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|Swift|
+|Feature                                       |Optional|Go|Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.NET|Swift|
 |----------------------------------------------|--------|--|----|---|------|----|------|---|----|---|----|-----|
 |TBD|
 
 ## Resource
 
-| Feature                                                                                                                                     | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .Net | Swift |
+| Feature                                                                                                                                     | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 |---------------------------------------------------------------------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | Create from Attributes                                                                                                                      |          | +  | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
 | Create empty                                                                                                                                |          | +  | +    | +  | +      | +    | +      |     | +    | +   | +    | +     |
@@ -107,7 +107,7 @@ formats is required. Implementing more than one format is optional.
 
 ## Context Propagation
 
-| Feature                                                                          | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .Net | Swift |
+| Feature                                                                          | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 |----------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | Create Context Key                                                               |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Get value from Context                                                           |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
@@ -130,7 +130,7 @@ formats is required. Implementing more than one format is optional.
 
 Note: Support for environment variables is optional.
 
-|Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.Net|Swift|
+|Feature                                       |Go |Java|JS |Python|Ruby|Erlang|PHP|Rust|C++|.NET|Swift|
 |----------------------------------------------|---|----|---|------|----|------|---|----|---|----|-----|
 |OTEL_RESOURCE_ATTRIBUTES                      | + | +  | + | +    | +  | +    | - | +  | + | +  | -   |
 |OTEL_SERVICE_NAME                             | + |    |   |      |    |      |   |    |   |    |     |
@@ -155,7 +155,7 @@ Note: Support for environment variables is optional.
 
 ## Exporters
 
-| Feature                                                                        | Optional | Go | Java | JS | Python   | Ruby | Erlang | PHP | Rust | C++ | .Net | Swift |
+| Feature                                                                        | Optional | Go | Java | JS | Python   | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 |--------------------------------------------------------------------------------|----------|----|------|----|----------|------|--------|-----|------|-----|------|-------|
 | [Exporter interface](specification/trace/sdk.md#span-exporter)                 |          |    | + |    | +           |      |        |     | +    |     | +    |       |
 | [Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2) |          |    | + |    | [-][py1779] | +    |        |     | -    |     |      |       |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -200,7 +200,7 @@ Examples of where `thread.id` and `thread.name` can be extracted from:
 | Launguage or platform | `thread.id`                            | `thread.name`                      |
 |-----------------------|----------------------------------------|------------------------------------|
 | JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()` |
-| .Net                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
+| .NET                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
 | Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
 | Ruby                  |                                        | `Thread.current.name`              |
 | C++                   | `std::this_thread::get_id()`             |                                    |


### PR DESCRIPTION
Adjusts the `.NET` casing to follow their brand as described in the guidelines: https://github.com/dotnet/brand/blob/main/dotnet-brand-guidelines.pdf
