### PR TITLE
Exempt resources from attribute limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ release.
 
 ### Resource
 
+- Exempt Resource from attribute limits.
+  ([#1892](https://github.com/open-telemetry/opentelemetry-specification/pull/1892))
+
 ### Semantic Conventions
 
 - BREAKING: Change enum member IDs to lowercase without spaces, not starting with numbers.

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -89,6 +89,14 @@ general limit.
 
 #### Exempt Entities
 
+Resource attributes SHOULD be exempt from the limits described above as resources
+are not susceptible to the scenarios (auto-instrumentation) that result in
+excessive attributes count or size. Resources are also sent only once per batch
+instead of per span so it is relatively cheaper to have more/larger attributes
+on them. Resources are also immutable by design and they are generally passed
+down to TracerProvider along with limits. This makes it awkward to implement
+attribute limits for Resources.
+
 Attributes, which belong to Metrics, are exempt from the limits described above
 at this time, as discussed in
 [Metrics Attribute Limits](../metrics/sdk.md#attribute-limits).


### PR DESCRIPTION
Resources are not susceptible to scenarios where excessive attributes
can be recorded unlike Spans. Resources are also immutable and it can be
hard for some SDKs to apply the limits at source at the time the
attributes are added to a resource. Also Limits and Resources
both are generally defined and passed on to a TracerProvider which
forces a TracerProvider to either mutate the resource or generate a new
one with duplicate attributes in order to apply the limits to it.

I propose we explicitly exempt Resources from attribute limits.

## Changes

Exempt Resources from attribute limits.


