### PR TITLE
Prefer global limit over model-specific default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+- Prefer global user defined limits over model-sepcific default values.
+  ([#1893](https://github.com/open-telemetry/opentelemetry-specification/pull/1893))
 - Add InstrumentationLibrary to Sampler.ShouldSample.
   ([#1850](https://github.com/open-telemetry/opentelemetry-specification/pull/1850))
 

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -79,7 +79,7 @@ An SDK MAY implement model-specific limits, for example
 `SpanAttributeCountLimit`. If both a general and a model-specific limit are
 implemented, then the SDK MUST first attempt to use the model-specific limit, if
 it isn't set, then the SDK MUST attempt to use the general limit. If neither are
-defined, then the SDK must try to use the model-specific limit default value,
+defined, then the SDK MUST try to use the model-specific limit default value,
 followed by the global limit default value.
 
 <a name="attribute-limits-configuration"></a>

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -78,8 +78,9 @@ in the list below.
 An SDK MAY implement model-specific limits, for example
 `SpanAttributeCountLimit`. If both a general and a model-specific limit are
 implemented, then the SDK MUST first attempt to use the model-specific limit, if
-it isn't set and doesn't have a default, then the SDK MUST attempt to use the
-general limit.
+it isn't set, then the SDK MUST attempt to use the general limit. If neither are
+defined, then the SDK must try to use the model-specific limit default value,
+followed by the global limit default value.
 
 <a name="attribute-limits-configuration"></a>
 **Configurable parameters:**


### PR DESCRIPTION
Fixes #1878 

## Changes

Prefer global limit over model-specific limit default when model-specific limit is not set.


