### PR TITLE
Add 1.6.1 Schema File

### DIFF
--- a/schemas/1.6.0
+++ b/schemas/1.6.0
@@ -1,0 +1,6 @@
+file_format: 1.0.0
+schema_url: https://opentelemetry.io/schemas/1.6.0
+versions:
+  1.6.0:
+  1.5.0:
+  1.4.0:

--- a/schemas/1.6.0
+++ b/schemas/1.6.0
@@ -1,6 +1,0 @@
-file_format: 1.0.0
-schema_url: https://opentelemetry.io/schemas/1.6.0
-versions:
-  1.6.0:
-  1.5.0:
-  1.4.0:

--- a/schemas/1.6.1
+++ b/schemas/1.6.1
@@ -1,0 +1,6 @@
+file_format: 1.0.0
+schema_url: https://opentelemetry.io/schemas/1.6.1
+versions:
+  1.6.1:
+  1.5.0:
+  1.4.0:


### PR DESCRIPTION
Related to the recently 1.6.1 Release.

Note: cannot retire the broken 1.6.0 Schema file too, as per the current build.