### PR TITLE
Capture HTTP request/response headers as span attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ release.
   ([#1810](https://github.com/open-telemetry/opentelemetry-specification/pull/1810))
 - Clarifications for `http.client_ip` and `http.host`.
   ([#1890](https://github.com/open-telemetry/opentelemetry-specification/pull/1890))
+- Add HTTP request and response headers semantic conventions.
+  ([#1898](https://github.com/open-telemetry/opentelemetry-specification/pull/1898))
 
 ### Compatibility
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -94,7 +94,7 @@ It is recommended to also use the general [network attributes][], especially `ne
 | `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.request.header.Content-Type=["application/json"]`; `http.request.header.X-Forwarded-for=["1.2.3.4", "1.2.3.5"]` | No |
 | `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.response.header.Content-Type=["application/json"]`; `http.response.header.My-custom-header=["abc", "def"]` | No |
 
-**[1]:** Instrumentations SHOULD require an explicit configuration of which headers are to be captured (e.g. an allowlist).
+**[1]:** Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
 Including all request/response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
 
 Some HTTP headers - `Host` and `User-Agent` - are already captured in the `http.host` and `http.user_agent` attributes.

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -87,6 +87,17 @@ Don't set the span status description if the reason can be inferred from `http.s
 
 It is recommended to also use the general [network attributes][], especially `net.peer.ip`. If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
+### HTTP request and response headers
+
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] | `http.request.header.Content-Type=["application/json"]`; `http.request.header.X-Forwarded-for=["1.2.3.4", "1.2.3.5"]` | No |
+| `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] | `http.response.header.Content-Type=["application/json"]`; `http.response.header.My-custom-header=["abc", "def"]` | No |
+
+**[1]:** Certain headers MAY be sanitized or omitted to avoid leaking sensitive information.
+
+**[2]:** The attribute value MAY contain separate header value as separate items, or concatenated header values as one item, depending on the way the HTTP library provides access to headers.
+
 [network attributes]: span-general.md#general-network-connection-attributes
 
 ## HTTP client

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -94,7 +94,11 @@ It is recommended to also use the general [network attributes][], especially `ne
 | `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.request.header.Content-Type=["application/json"]`; `http.request.header.X-Forwarded-for=["1.2.3.4", "1.2.3.5"]` | No |
 | `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.response.header.Content-Type=["application/json"]`; `http.response.header.My-custom-header=["abc", "def"]` | No |
 
-**[1]:** Certain headers MAY be sanitized or omitted to avoid leaking sensitive information.
+**[1]:** Instrumentations SHOULD require an explicit configuration of which headers are to be captured (e.g. an allowlist).
+Including all request/response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
+
+Some HTTP headers - `Host` and `User-Agent` - are already captured in the `http.host` and `http.user_agent` attributes.
+These headers SHOULD NOT be captured as a part of this convention.
 
 **[2]:** The attribute value MAY contain separate header value as separate items, or concatenated header values as one item, depending on the way the HTTP library provides access to headers.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -91,8 +91,8 @@ It is recommended to also use the general [network attributes][], especially `ne
 
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] | `http.request.header.Content-Type=["application/json"]`; `http.request.header.X-Forwarded-for=["1.2.3.4", "1.2.3.5"]` | No |
-| `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] | `http.response.header.Content-Type=["application/json"]`; `http.response.header.My-custom-header=["abc", "def"]` | No |
+| `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.request.header.Content-Type=["application/json"]`; `http.request.header.X-Forwarded-for=["1.2.3.4", "1.2.3.5"]` | No |
+| `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.response.header.Content-Type=["application/json"]`; `http.response.header.My-custom-header=["abc", "def"]` | No |
 
 **[1]:** Certain headers MAY be sanitized or omitted to avoid leaking sensitive information.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -98,7 +98,7 @@ It is recommended to also use the general [network attributes][], especially `ne
 Including all request/response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.
 
 Some HTTP headers - `Host` and `User-Agent` - are already captured in the `http.host` and `http.user_agent` attributes.
-These headers SHOULD NOT be captured as a part of this convention.
+Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
 
 **[2]:** The attribute value MAY contain separate header value as separate items, or concatenated header values as one item, depending on the way the HTTP library provides access to headers.
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -101,7 +101,7 @@ Including all request/response headers can be a security risk - explicit configu
 Some HTTP headers - `Host` and `User-Agent` - are already captured in the `http.host` and `http.user_agent` attributes.
 Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
 
-**[2]:** The attribute value MAY contain multiple header values as an array of strings, or as a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
+**[2]:** The attribute value MUST consist of either multiple header values as an array of strings or a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
 
 [network attributes]: span-general.md#general-network-connection-attributes
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -101,7 +101,7 @@ Including all request/response headers can be a security risk - explicit configu
 Some HTTP headers - `Host` and `User-Agent` - are already captured in the `http.host` and `http.user_agent` attributes.
 Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
 
-**[2]:** The attribute value MAY contain multiple header values as an array of strings, or as a single, possibly comma-concatenated, string, depending on the way the HTTP library provides access to headers.
+**[2]:** The attribute value MAY contain multiple header values as an array of strings, or as a single-item array containing a possibly comma-concatenated string, depending on the way the HTTP library provides access to headers.
 
 [network attributes]: span-general.md#general-network-connection-attributes
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -14,6 +14,7 @@ and various HTTP versions like 1.1, 2 and SPDY.
   - [Name](#name)
   - [Status](#status)
   - [Common Attributes](#common-attributes)
+    - [HTTP request and response headers](#http-request-and-response-headers)
   - [HTTP client](#http-client)
   - [HTTP server](#http-server)
     - [HTTP server definitions](#http-server-definitions)
@@ -91,8 +92,8 @@ It is recommended to also use the general [network attributes][], especially `ne
 
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.request.header.Content-Type=["application/json"]`; `http.request.header.X-Forwarded-for=["1.2.3.4", "1.2.3.5"]` | No |
-| `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the HTTP Header name (case preserving), the value being the header values. [1] [2] | `http.response.header.Content-Type=["application/json"]`; `http.response.header.My-custom-header=["abc", "def"]` | No |
+| `http.request.header.<key>` | string[] | HTTP request headers, `<key>` being the normalized HTTP Header name (lowercase, with `-` characters replaced by `_`), the value being the header values. [1] [2] | `http.request.header.content_type=["application/json"]`; `http.request.header.x_forwarded_for=["1.2.3.4", "1.2.3.5"]` | No |
+| `http.response.header.<key>` | string[] | HTTP response headers, `<key>` being the normalized HTTP Header name (lowercase, with `-` characters replaced by `_`), the value being the header values. [1] [2] | `http.response.header.content_type=["application/json"]`; `http.response.header.my_custom_header=["abc", "def"]` | No |
 
 **[1]:** Instrumentations SHOULD require an explicit configuration of which headers are to be captured.
 Including all request/response headers can be a security risk - explicit configuration helps avoid leaking sensitive information.

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -101,7 +101,7 @@ Including all request/response headers can be a security risk - explicit configu
 Some HTTP headers - `Host` and `User-Agent` - are already captured in the `http.host` and `http.user_agent` attributes.
 Users MAY explicitly configure instrumentations to capture them even though it is not recommended.
 
-**[2]:** The attribute value MAY contain separate header value as separate items, or concatenated header values as one item, depending on the way the HTTP library provides access to headers.
+**[2]:** The attribute value MAY contain multiple header values as an array of strings, or as a single, possibly comma-concatenated, string, depending on the way the HTTP library provides access to headers.
 
 [network attributes]: span-general.md#general-network-connection-attributes
 


### PR DESCRIPTION
Fixes #1061

## Changes

- Add semantic conventions for capturing HTTP request and response headers.

