### PR TITLE
Probability sampling specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ release.
 ### Traces
 
 - Adding SDK configuration for Jaeger remote sampler ([#1791](https://github.com/open-telemetry/opentelemetry-specification/pull/1791))
+- Adds specification for probability sampling, updates the definition of the built-in Samplers.
 
 ### Metrics
 


### PR DESCRIPTION
This proposes changes in the specification implied by OTEPs 168 and 170:

https://github.com/open-telemetry/oteps/pull/168
https://github.com/open-telemetry/oteps/pull/170

The justification for these changes is given in those two OTEPs. Our goal is to ensure that Span-to-Metrics pipelines can be built to statistically count spans after they have been sampled and before they have been assembled into traces.

The two OTEPs are not receiving enough attention. This PR is meant to consolidate the implied changes of those two OTEPs combined in a way that makes it easier to see what is being specified (WHAT) without all the related justification (WHY). If you approve these changes, please also review and approve those OTEPs first.

Fixes #1413.
Part of #1819.

This cannot be merged before OTEPs 168 and 170 are merged, but this is also not a draft, it is a complete proposal. This has been prototyped twice, once in Java and once in Go. See OTEP 170 for more detail about these prototypes.
