### PR TITLE
Spec out the MeterProvider ForceFlush and Shutdown requirement

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -85,22 +85,28 @@ to make the shutdown timeout configurable.
 
 ### ForceFlush
 
-This method provides a way for provider to immediately export all metrics data
-that have not yet been exported. Note: unlike [Push Metric
-Exporter](#push-metric-exporter) which can send data on its own schedule, [Pull
-Metric Exporter](#pull-metric-exporter) can only send the data when it is being
-asked by the scraper, so `ForceFlush` would not make sense.
+This method provides a way for provider to notify the registered
+[MetricReader](#metricreader) and [MetricExporter](#metricexporter) instances,
+so they can do as much as they could to consume or send the metrics. Note:
+unlike [Push Metric Exporter](#push-metric-exporter) which can send data on its
+own schedule, [Pull Metric Exporter](#pull-metric-exporter) can only send the
+data when it is being asked by the scraper, so `ForceFlush` would not make much
+sense.
 
 `ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
-failed or timed out.
+failed or timed out. `ForceFlush` SHOULD return some **ERROR** status if there
+is an error condition; and if there is no error condition, it should return some
+**NO ERROR** status, language implementations MAY decide how to model **ERROR**
+and **NO ERROR**.
 
 `ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
 implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. OpenTelemetry client authors can decide if they want
 to make the flush timeout configurable.
 
-`ForceFlush` MUST invoke `ForceFlush` on all registered [push
-exporters](#push-metric-exporter).
+`ForceFlush` MUST invoke `ForceFlush` on all registered
+[MetricReader](#metricreader) [Push Metric Exporter](#push-metric-exporter)
+instances.
 
 ### View
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -81,7 +81,7 @@ via a callback or an event. OpenTelemetry client authors can decide if they want
 to make the shutdown timeout configurable.
 
 `Shutdown` MUST be implemented at least by invoking `Shutdown` on all registered
-[exporters](#metricexporter).
+[MetricReader](#metricreader) and [MetricExporter](#metricexporter) instances.
 
 ### ForceFlush
 
@@ -105,7 +105,7 @@ via a callback or an event. OpenTelemetry client authors can decide if they want
 to make the flush timeout configurable.
 
 `ForceFlush` MUST invoke `ForceFlush` on all registered
-[MetricReader](#metricreader) [Push Metric Exporter](#push-metric-exporter)
+[MetricReader](#metricreader) and [Push Metric Exporter](#push-metric-exporter)
 instances.
 
 ### View

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -64,11 +64,41 @@ configuration only via this reference.
 
 ### Shutdown
 
-TODO
+This method provides a way for provider to do any cleanup required.
+
+`Shutdown` MUST be called only once for each `MeterProvider` instance. After the
+call to `Shutdown`, subsequent attempts to get a `Meter` are not allowed. SDKs
+SHOULD return a valid no-op Meter for these calls, if possible.
+
+`Shutdown` SHOULD provide a way to let the caller know whether it succeeded,
+failed or timed out.
+
+`Shutdown` SHOULD complete or abort within some timeout. `Shutdown` can be
+implemented as a blocking API or an asynchronous API which notifies the caller
+via a callback or an event. OpenTelemetry client authors can decide if they want
+to make the shutdown timeout configurable.
+
+`Shutdown` MUST be implemented at least by invoking `Shutdown` on all registered
+[exporters](#metricexporter).
 
 ### ForceFlush
 
-TODO
+This method provides a way for provider to immediately export all metrics data
+that have not yet been exported. Unlike [Push Metric
+Exporter](#push-metric-exporter) which can send data on its own schedule, [Pull
+Metric Exporter](#pull-metric-exporter) can only send the data when it is being
+asked by the scraper, so `ForceFlush` would not make sense.
+
+`ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
+failed or timed out.
+
+`ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
+implemented as a blocking API or an asynchronous API which notifies the caller
+via a callback or an event. OpenTelemetry client authors can decide if they want
+to make the flush timeout configurable.
+
+`ForceFlush` MUST invoke `ForceFlush` on all registered [push
+exporters](#push-metric-exporter).
 
 ### View
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -84,7 +84,7 @@ to make the shutdown timeout configurable.
 ### ForceFlush
 
 This method provides a way for provider to immediately export all metrics data
-that have not yet been exported. Unlike [Push Metric
+that have not yet been exported. Note: unlike [Push Metric
 Exporter](#push-metric-exporter) which can send data on its own schedule, [Pull
 Metric Exporter](#pull-metric-exporter) can only send the data when it is being
 asked by the scraper, so `ForceFlush` would not make sense.


### PR DESCRIPTION
This was previously left as TODO since it has dependency on the exporter (#1864) and reader (#1888) interface.