### PR TITLE
Discourage faas.trigger for client/outgoing spans.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ release.
   ([#1810](https://github.com/open-telemetry/opentelemetry-specification/pull/1810))
 - Clarifications for `http.client_ip` and `http.host`.
   ([#1890](https://github.com/open-telemetry/opentelemetry-specification/pull/1890))
+- Change meaning and discourage use of `faas.trigger` for FaaS clients (outgoing).
+  ([#????](https://github.com/open-telemetry/opentelemetry-specification/pull/????))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/faas.yaml
+++ b/semantic_conventions/trace/faas.yaml
@@ -10,10 +10,12 @@ groups:
         required:
           conditional: >
             On FaaS instances, faas.trigger MUST be set on incoming invocations.
-            Clients invoking FaaS instances MUST set `faas.trigger` on outgoing
-            invocations, if it is known to the client. This is, for example, not
-            the case, when the transport layer is abstracted in a FaaS client
-            framework without access to its configuration.
+            Clients invoking FaaS instances usually cannot set `faas.trigger`,
+            since they would typically need to look in the payload to determine
+            the event type. If clients set it, it should be the same as the
+            trigger that corresponding incoming would have (i.e., this has
+            nothing to do with the underlying transport used to make the API
+            call to invoke the lambda, which is often HTTP).
         brief: 'Type of the trigger on which the function is executed.'
         type:
           allow_custom_values: false

--- a/specification/trace/semantic_conventions/faas.md
+++ b/specification/trace/semantic_conventions/faas.md
@@ -37,7 +37,7 @@ If Spans following this convention are produced, a Resource of type `faas` MUST 
 | `faas.trigger` | string | Type of the trigger on which the function is executed. | `datasource` | Conditional [1] |
 | `faas.execution` | string | The execution ID of the current function execution. | `af9d5aa4-a685-4c5f-a22b-444f80b3cc28` | No |
 
-**[1]:** On FaaS instances, faas.trigger MUST be set on incoming invocations. Clients invoking FaaS instances MUST set `faas.trigger` on outgoing invocations, if it is known to the client. This is, for example, not the case, when the transport layer is abstracted in a FaaS client framework without access to its configuration.
+**[1]:** On FaaS instances, faas.trigger MUST be set on incoming invocations. Clients invoking FaaS instances usually cannot set `faas.trigger`, since they would typically need to look in the payload to determine the event type. If clients set it, it should be the same as the trigger that corresponding incoming would have (i.e., this has nothing to do with the underlying transport used to make the API call to invoke the lambda, which is often HTTP).
 
 `faas.trigger` MUST be one of the following:
 


### PR DESCRIPTION
## Changes

faas.trigger does not really make sense for outgoing calls. Change wording to discourage its use for client spans..
