### PR TITLE
Allow implementations to use their own default for OTLP compression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ release.
 ### OpenTelemetry Protocol
 
 - Add environment variables for configuring the OTLP exporter protocol (`grpc`, `http/protobuf`, `http/json`) ([#1880](https://github.com/open-telemetry/opentelemetry-specification/pull/1880))
+- Allow SIGs to use their own default for OTLP compression ([#1923](https://github.com/open-telemetry/opentelemetry-specification/pull/1923))
 
 ### SDK Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ release.
 ### OpenTelemetry Protocol
 
 - Add environment variables for configuring the OTLP exporter protocol (`grpc`, `http/protobuf`, `http/json`) ([#1880](https://github.com/open-telemetry/opentelemetry-specification/pull/1880))
-- Allow SIGs to use their own default for OTLP compression ([#1923](https://github.com/open-telemetry/opentelemetry-specification/pull/1923))
+- Allow implementations to use their own default for OTLP compression, with `none` denotating no compression
+  ([#1923](https://github.com/open-telemetry/opentelemetry-specification/pull/1923))
 
 ### SDK Configuration
 

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -20,7 +20,7 @@ The following configuration options MUST be available to configure the OTLP expo
 | Protocol             | The transport protocol. Options MAY include `grpc`, `http/protobuf`, and `http/json`. See [Specify Protocol](./exporter.md#specify-protocol) for more details. | n/a               | `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` |
 
 **[1]**: If no compression value is explicitly specified, SIGs can default to the value they deem
-most useful among the supported options. This is specially important in presence of technical constraints,
+most useful among the supported options. This is especially important in the presence of technical constraints,
 e.g. directly sending telemetry data from mobile devices to backend servers.
 
 Supported values for `OTEL_EXPORTER_OTLP_*COMPRESSION` options:

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -25,7 +25,7 @@ e.g. directly sending telemetry data from mobile devices to backend servers.
 
 Supported values for `OTEL_EXPORTER_OTLP_*COMPRESSION` options:
 
-- `` if compression is disabled.
+- `none` if compression is disabled.
 - `gzip` is the only specified compression method for now.
 
 Example 1

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -15,14 +15,17 @@ The following configuration options MUST be available to configure the OTLP expo
 | Insecure             | Whether to enable client transport security for the exporter's gRPC connection. This option only applies to OTLP/gRPC - OTLP/HTTP always uses the scheme provided for the `endpoint`. Implementations MAY choose to not implement the `insecure` option if it is not required or supported by the underlying gRPC client implementation. | `false` | `OTEL_EXPORTER_OTLP_INSECURE` `OTEL_EXPORTER_OTLP_SPAN_INSECURE` `OTEL_EXPORTER_OTLP_METRIC_INSECURE` |
 | Certificate File     | The trusted certificate to use when verifying a server's TLS credentials. Should only be used for a secure connection. | n/a               | `OTEL_EXPORTER_OTLP_CERTIFICATE` `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE` |
 | Headers              | Key-value pairs to be used as headers associated with gRPC or HTTP requests. See [Specifying headers](./exporter.md#specifying-headers-via-environment-variables) for more details.                   | n/a               | `OTEL_EXPORTER_OTLP_HEADERS` `OTEL_EXPORTER_OTLP_TRACES_HEADERS` `OTEL_EXPORTER_OTLP_METRICS_HEADERS` |
-| Compression          | Compression key for supported compression types. Supported compression: `gzip`| No value              | `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION` |
+| Compression          | Compression key for supported compression types. Supported compression: `gzip`| No value [1]          | `OTEL_EXPORTER_OTLP_COMPRESSION` `OTEL_EXPORTER_OTLP_TRACES_COMPRESSION` `OTEL_EXPORTER_OTLP_METRICS_COMPRESSION` |
 | Timeout              | Maximum time the OTLP exporter will wait for each batch export. | 10s               | `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` |
 | Protocol             | The transport protocol. Options MAY include `grpc`, `http/protobuf`, and `http/json`. See [Specify Protocol](./exporter.md#specify-protocol) for more details. | n/a               | `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` |
+
+**[1]**: Although compression disabled by default is recommended, SIGs may use any of the supported methods by default instead,
+given technical constraints, e.g. directly sending telemetry data from mobile devices to backend servers.
 
 Supported values for `OTEL_EXPORTER_OTLP_*COMPRESSION` options:
 
 - If the value is missing, then compression is disabled.
-- `gzip` is the only specified compression method for now. Other options MAY be supported by language SDKs and should be documented for each particular language.
+- `gzip` is the only specified compression method for now.
 
 Example 1
 

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -19,12 +19,13 @@ The following configuration options MUST be available to configure the OTLP expo
 | Timeout              | Maximum time the OTLP exporter will wait for each batch export. | 10s               | `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` |
 | Protocol             | The transport protocol. Options MAY include `grpc`, `http/protobuf`, and `http/json`. See [Specify Protocol](./exporter.md#specify-protocol) for more details. | n/a               | `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` |
 
-**[1]**: Although compression disabled by default is recommended, SIGs may use any of the supported methods by default instead,
-given technical constraints, e.g. directly sending telemetry data from mobile devices to backend servers.
+**[1]**: If no explicit compression value is specified, SIGs can default to the value they deem
+most useful among the supported options. This is specially important in presence of technical constraints,
+e.g. directly sending telemetry data from mobile devices to backend servers.
 
 Supported values for `OTEL_EXPORTER_OTLP_*COMPRESSION` options:
 
-- If the value is missing, then compression is disabled.
+- `none` if compression is disabled.
 - `gzip` is the only specified compression method for now.
 
 Example 1

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -19,13 +19,13 @@ The following configuration options MUST be available to configure the OTLP expo
 | Timeout              | Maximum time the OTLP exporter will wait for each batch export. | 10s               | `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` |
 | Protocol             | The transport protocol. Options MAY include `grpc`, `http/protobuf`, and `http/json`. See [Specify Protocol](./exporter.md#specify-protocol) for more details. | n/a               | `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL` |
 
-**[1]**: If no explicit compression value is specified, SIGs can default to the value they deem
+**[1]**: If no compression value is explicitly specified, SIGs can default to the value they deem
 most useful among the supported options. This is specially important in presence of technical constraints,
 e.g. directly sending telemetry data from mobile devices to backend servers.
 
 Supported values for `OTEL_EXPORTER_OTLP_*COMPRESSION` options:
 
-- `none` if compression is disabled.
+- `` if compression is disabled.
 - `gzip` is the only specified compression method for now.
 
 Example 1


### PR DESCRIPTION
As discussed in yesterday's Spec SIG call, allow SIGs to define their own default. Specially important as OTel JS will be going GA very soon, and we want to allow it to use gzip as their default (at least for the browser case) - also a motivating reason to include this change in this week's Specification release.

(Also removed the mention of SIGs supporting other compression methods, as they should be vetted first by the Collector, etc)

Alternative to #1895 

cc @dyladan @bogdandrutu 