### PR TITLE
Add detail about explicit histogram buckets and boundaries

### DIFF
--- a/specification/metrics/datamodel.md
+++ b/specification/metrics/datamodel.md
@@ -398,6 +398,21 @@ denotes Delta temporality where accumulated event counts are reset to zero after
 and a new aggregation occurs. Cumulative, on the other hand, continues to
 aggregate events, resetting with the use of a new start time.
 
+Buckets and counts are optional.  A Histogram without buckets conveys
+a population in terms of only the sum and count, and may be
+interpreted as a histogram with single bucket covering `(-Inf, +Inf)`.
+
+Bucket upper-bounds are inclusive while bucket lower-bounds are
+exclusive. That is, buckets express the number of values that are
+greater than their lower bound and less than or equal to their upper
+bound.  Importers and exporters working with OpenTelemetry Metrics
+data are meant to disregard this specification when translating to and
+from histogram formats that use inclusive lower bounds and exclusive
+upper bounds.  Changing the inclusivity and exclusivity of bounds is
+an example of worst-case Histogram error; users should choose
+Histogram boundaries so that worst-case error is within their error
+tolerance.
+
 ### Summary (Legacy)
 
 [Summary](https://github.com/open-telemetry/opentelemetry-proto/blob/v0.9.0/opentelemetry/proto/metrics/v1/metrics.proto#L268)


### PR DESCRIPTION
While working on a fix for #1932, I noticed some details of the current explicit-boundary histogram are not spelled out in the data model on Histogram.

## Changes

States what it means when a histogram has no buckets. 
Discusses exclusive and inclusive boundaries.

Related issues #1932 
Related proto PR https://github.com/open-telemetry/opentelemetry-proto/pull/322