### PR TITLE
Remove MeasurementProcessor from the Metrics SDK spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ release.
   [#1828](https://github.com/open-telemetry/opentelemetry-specification/pull/1828),
   [#1888](https://github.com/open-telemetry/opentelemetry-specification/pull/1888),
   [#1912](https://github.com/open-telemetry/opentelemetry-specification/pull/1912),
-  [#1913](https://github.com/open-telemetry/opentelemetry-specification/pull/1913))
+  [#1913](https://github.com/open-telemetry/opentelemetry-specification/pull/1913),
+  [#1938](https://github.com/open-telemetry/opentelemetry-specification/pull/1938))
 
 ### Logs
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -402,13 +402,18 @@ series and it requires further analysis.
 
 ## Exemplar
 
-An [Exemplar](./datamodel.md#exemplars) is a recorded measurement that exposes
-the following pieces of information:
+An [Exemplar](./datamodel.md#exemplars) is a recorded
+[Measurement](./api.md#measurement) that exposes the following pieces of
+information:
 
 - The `value` that was recorded.
-- The `time` the measurement was seen.
-- The set of [Attributes](../common/common.md#attributes) associated with the measurement not already included in a metric data point.
-- The associated [trace id and span id](../trace/api.md#retrieving-the-traceid-and-spanid) of the active [Span within Context](../trace/api.md#determining-the-parent-span-from-a-context) of the measurement.
+- The `time` the `Measurement` was seen.
+- The set of [Attributes](../common/common.md#attributes) associated with the
+  `Measurement` not already included in a metric data point.
+- The associated [trace id and span
+  id](../trace/api.md#retrieving-the-traceid-and-spanid) of the active [Span
+  within Context](../trace/api.md#determining-the-parent-span-from-a-context) of
+  the `Measurement`.
 
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements.
 
@@ -427,14 +432,16 @@ A Metric SDK SHOULD provide extensible hooks for Exemplar sampling, specifically
 ### ExemplarFilter
 
 The `ExemplarFilter` interface MUST provide a method to determine if a
-measurement should be sampled.  
+measurement should be sampled.
 
 This interface SHOULD have access to:
 
-- The value of the measurement.
-- The complete set of `Attributes` of the measurment.
-- the `Context` of the measuremnt.
-- The timestamp of the measurement.
+- The `value` of the measurement.
+- The complete set of `Attributes` of the measurement.
+- The [Context](../context/context.md) of the measurement, which covers the
+  [Baggage](../baggage/api.md) and the current actve
+  [Span](../trace/api.md#span).
+- The `timestamp` of the measurement.
 
 See [Defaults and Configuration](#defaults-and-configuration) for built-in
 filters.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -439,9 +439,9 @@ This interface SHOULD have access to:
 - The `value` of the measurement.
 - The complete set of `Attributes` of the measurement.
 - The [Context](../context/context.md) of the measurement, which covers the
-  [Baggage](../baggage/api.md) and the current actve
+  [Baggage](../baggage/api.md) and the current active
   [Span](../trace/api.md#span).
-- The `timestamp` of the measurement.
+- A `timestamp` that best represents when the measurement was taken.
 
 See [Defaults and Configuration](#defaults-and-configuration) for built-in
 filters.
@@ -456,9 +456,9 @@ The "offer" method SHOULD accept measurements, including:
 - The `value` of the measurement.
 - The complete set of `Attributes` of the measurement.
 - The [Context](../context/context.md) of the measurement, which covers the
-  [Baggage](../baggage/api.md) and the current actve
+  [Baggage](../baggage/api.md) and the current active
   [Span](../trace/api.md#span).
-- The `timestamp` of the measurement.
+- A `timestamp` that best represents when the measurement was taken.
 
 The "offer" method SHOULD have the ability to pull associated trace and span
 information without needing to record full context.  In other words, current

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -453,10 +453,12 @@ to the reservoir and another to collect accumulated Exemplars.
 
 The "offer" method SHOULD accept measurements, including:
 
-- value
-- `Attributes` (complete set)
-- `Context`
-- timestamp
+- The `value` of the measurement.
+- The complete set of `Attributes` of the measurement.
+- The [Context](../context/context.md) of the measurement, which covers the
+  [Baggage](../baggage/api.md) and the current actve
+  [Span](../trace/api.md#span).
+- The `timestamp` of the measurement.
 
 The "offer" method SHOULD have the ability to pull associated trace and span
 information without needing to record full context.  In other words, current

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -9,7 +9,6 @@ Table of Contents
 
 * [MeterProvider](#meterprovider)
 * [Attribute Limits](#attribute-limits)
-* [MeasurementProcessor](#measurementprocessor)
 * [Exemplar](#exemplar)
   * [ExemplarFilter](#exemplarfilter)
   * [ExemplarReservoir](#exemplarreservoir)
@@ -40,14 +39,14 @@ to create an
 [`InstrumentationLibrary`](https://github.com/open-telemetry/oteps/blob/main/text/0083-component.md)
 instance which is stored on the created `Meter`.
 
-Configuration (i.e., [MeasurementProcessors](#measurementprocessor),
-[MetricExporters](#metricexporter), [MetricReaders](#metricreader) and
-[Views](#view)) MUST be managed solely by the `MeterProvider` and the SDK MUST
-provide a way to configure all options that are implemented by the SDK. This MAY
-be done at the time of MeterProvider creation if appropriate.
+Configuration (i.e., [MetricExporters](#metricexporter),
+[MetricReaders](#metricreader) and [Views](#view)) MUST be managed solely by the
+`MeterProvider` and the SDK MUST provide a way to configure all options that are
+implemented by the SDK. This MAY be done at the time of MeterProvider creation
+if appropriate.
 
 The `MeterProvider` MAY provide methods to update the configuration. If
-configuration is updated (e.g., adding a `MeasurementProcessor`), the updated
+configuration is updated (e.g., adding a `MetricReader`), the updated
 configuration MUST also apply to all already returned `Meters` (i.e. it MUST NOT
 matter whether a `Meter` was obtained from the `MeterProvider` before or after
 the configuration change). Note: Implementation-wise, this could mean that
@@ -400,47 +399,6 @@ Attributes which belong to Metrics are exempt from the
 [common rules of attribute limits](../common/common.md#attribute-limits) at this
 time. Attribute truncation or deletion could affect identitity of metric time
 series and it requires further analysis.
-
-## MeasurementProcessor
-
-`MeasurementProcessor` is an interface which allows hooks when a
-[Measurement](./api.md#measurement) is recorded by an
-[Instrument](./api.md#instrument).
-
-`MeasurementProcessor` MUST have access to:
-
-* The `Measurement`
-* The `Instrument`, which is used to report the `Measurement`
-* The `Resource`, which is associated with the `MeterProvider`
-
-In addition to things listed above, if the `Measurement` is reported by a
-synchronous `Instrument` (e.g. [Counter](./api.md#counter)),
-`MeasurementProcessor` MUST have access to:
-
-* [Baggage](../baggage/api.md)
-* [Context](../context/context.md)
-* The [Span](../trace/api.md#span) which is associated with the `Measurement`
-
-Depending on the programming language and runtime model, these can be provided
-explicitly (e.g. as input arguments) or implicitly (e.g. [implicit
-Context](../context/context.md#optional-global-operations) and the [currently
-active span](../trace/api.md#context-interaction)).
-
-```text
-+------------------+
-| MeterProvider    |                 +----------------------+            +-----------------+
-|   Meter A        | Measurements... |                      | Metrics... |                 |
-|     Instrument X +-----------------> MeasurementProcessor +------------> In-memory state |
-|     Instrument Y |                 |                      |            |                 |
-|   Meter B        |                 +----------------------+            +-----------------+
-|     Instrument Z |
-|     ...          |                 +----------------------+            +-----------------+
-|     ...          | Measurements... |                      | Metrics... |                 |
-|     ...          +-----------------> MeasurementProcessor +------------> In-memory state |
-|     ...          |                 |                      |            |                 |
-|     ...          |                 +----------------------+            +-----------------+
-+------------------+
-```
 
 ## Exemplar
 


### PR DESCRIPTION
This was discussed during the [08/12/2021 #186 Metrics SIG at 11am PT](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit#heading=h.rf686wxmv2ru) and we concluded that `MeasurementProcessor` should be removed.

I didn't make the change at that time because we were focusing on getting the initial Experimental version done (which is achieved now).

**Note:** this CAN be part of the [spec v1.7.0 release](https://github.com/open-telemetry/opentelemetry-specification/pull/1926#issuecomment-921932216), although it does NOT HAVE TO be.