### PR TITLE
Update host field in mapping from HEC to the Unified model

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -687,7 +687,7 @@ We apply this mapping from HEC to the unified model:
     <td>host</td>
     <td>string</td>
     <td>The host value to assign to the event data. This is typically the host name of the client that you are sending data from.</td>
-    <td>Resource["host.hostname"]</td>
+    <td>Resource["host.name"]</td>
   </tr>
   <tr>
     <td>source</td>


### PR DESCRIPTION
`host.hostname` attributed  was removed from unified model https://github.com/open-telemetry/opentelemetry-specification/pull/838. We want to use `host.name` attribute to represent Splunk HEC  "host" field instead.

`host.name` attribute already being used for HEC <-> unified model translation. This PR is just up update the spec