### PR TITLE
Add missing fields to logs mapping from universal model to Splunk HEC

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -748,6 +748,24 @@ When mapping from the unified model to HEC, we apply this additional mapping:
     <td>Short event identifier that does not contain varying parts.</td>
     <td>fields['otel.log.name']</td>
   </tr>
+  <tr>
+    <td>TraceId</td>
+    <td>string</td>
+    <td>Request trace id.</td>
+    <td>fields['otel.log.trace_id']</td>
+  </tr>
+  <tr>
+    <td>SpanId</td>
+    <td>string</td>
+    <td>Request span id.</td>
+    <td>fields['otel.log.span_id']</td>
+  </tr>
+  <tr>
+    <td>TraceFlags</td>
+    <td>string</td>
+    <td>W3C trace flags.</td>
+    <td>fields['otel.log.trace_flags']</td>
+  </tr>  
 </table>
 
 ### Log4j

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -752,19 +752,19 @@ When mapping from the unified model to HEC, we apply this additional mapping:
     <td>TraceId</td>
     <td>string</td>
     <td>Request trace id.</td>
-    <td>fields['otel.log.trace_id']</td>
+    <td>fields['trace_id']</td>
   </tr>
   <tr>
     <td>SpanId</td>
     <td>string</td>
     <td>Request span id.</td>
-    <td>fields['otel.log.span_id']</td>
+    <td>fields['span_id']</td>
   </tr>
   <tr>
     <td>TraceFlags</td>
     <td>string</td>
     <td>W3C trace flags.</td>
-    <td>fields['otel.log.trace_flags']</td>
+    <td>fields['trace_flags']</td>
   </tr>  
 </table>
 


### PR DESCRIPTION
Since we already have logs mapping from the unified model to Splunk HEC, we should define it for all fields in the unified model. This PR adds missing request context fields to the mapping.