### PR TITLE
Revert "Add InstrumentationLibrary to Sampler.ShouldSample (#1850)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ release.
 
 - Prefer global user defined limits over model-sepcific default values.
   ([#1893](https://github.com/open-telemetry/opentelemetry-specification/pull/1893))
-- Add InstrumentationLibrary to Sampler.ShouldSample.
-  ([#1850](https://github.com/open-telemetry/opentelemetry-specification/pull/1850))
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -75,7 +75,6 @@ formats is required. Implementing more than one format is optional.
 | [Sampling](specification/trace/sdk.md#sampling)                                                  |          |    |      |    |        |      |        |     |      |     |      |       |
 | Allow samplers to modify tracestate                                                              |          | +  | +    |    | +      | +    | +      |     | +    | +   | -    | +     |
 | ShouldSample gets full parent Context                                                            |          | +  | +    | +  | +      | +    | +      |     | +    | +   | -    | +     |
-| ShouldSample gets InstrumentationLibrary                                                         |          |    |      |    |        |      |        |     |      |     |      |       |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          | +  | +    |    | +      | +    | +      |     | +    | +   | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          | +  | +    |    | +      | +    |        |     | +    | +   |      | +     |
 | [SpanLimits](specification/trace/sdk.md#span-limits)                                             | X        | +  | +    |    | +      | +    |        |     |      | -   |      | +     |

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -210,7 +210,6 @@ Returns the sampling Decision for a `Span` to be created.
 * Collection of links that will be associated with the `Span` to be created.
   Typically useful for batch operations, see
   [Links Between Spans](../overview.md#links-between-spans).
-* `InstrumentationLibrary` (name and version) of the `Span` to be created.
 
 Note: Implementations may "bundle" all or several arguments together in a single
 object.


### PR DESCRIPTION
This reverts commit f936f2e941ad10bf9b16b5ab15067f775f479cdb.

During today Maintainers meeting @jmacd expressed his concern about https://github.com/open-telemetry/opentelemetry-specification/pull/1658 and the direction that it moves SDK: runtime decisions in `Samplers` as opposed to configuration-time decisions of configuring SDK and/or `Tracers` with the correct `Samplers`. His opinion was that we should use the latter: all decisions based on `Resources` and `InstrumentationLibraries` can be done before providing `Tracers` to the users. Thus those `Tracers` can already use `Samplers` chosen/narrowed down based on that information. Thus they don't need to accept it in `ShouldSample` method.

Several attendees, myself including, agreed that this is a reasonable idea. It was thus decided to revert introducing `InstrumentationLibrary` to `ShouldSample` method and get back to the drawing board to choose between two approaches:
either pass both `Resources` and `InstrumentationLibrary` to `ShouldSample` in one spec release OR don't pass neither of them and allow SDKs to configure specific `Sampler` for a specific `Tracer`.
