### PR TITLE
Clarify OTLP server components MUST support none/gzip compression.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ release.
 ### OpenTelemetry Protocol
 
 - Add environment variables for configuring the OTLP exporter protocol (`grpc`, `http/protobuf`, `http/json`) ([#1880](https://github.com/open-telemetry/opentelemetry-specification/pull/1880))
-- Clarify OTLP transports MUST support none/gzip compression ([#1955](https://github.com/open-telemetry/opentelemetry-specification/pull/1955))
+- Clarify OTLP server components MUST support none/gzip compression ([#1955](https://github.com/open-telemetry/opentelemetry-specification/pull/1955))
 
 ### SDK Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ release.
 ### OpenTelemetry Protocol
 
 - Add environment variables for configuring the OTLP exporter protocol (`grpc`, `http/protobuf`, `http/json`) ([#1880](https://github.com/open-telemetry/opentelemetry-specification/pull/1880))
+- Clarify OTLP transports MUST support none/gzip compression ([#1955](https://github.com/open-telemetry/opentelemetry-specification/pull/1955))
 
 ### SDK Configuration
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -70,6 +70,12 @@ OTLP is a request/response style protocols: the clients send requests, the
 server replies with corresponding responses. This document defines one requests
 and response type: `Export`.
 
+All transports MUST support in the client and server components the following
+compression options:
+
+* No compression, denoted by `none`.
+* Gzip compression, denoted by `gzip`.
+
 ### OTLP/gRPC
 
 **Status**: [Stable](../document-status.md)

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -70,10 +70,9 @@ OTLP is a request/response style protocols: the clients send requests, the
 server replies with corresponding responses. This document defines one requests
 and response type: `Export`.
 
-All transports MUST support in the client and server components the following
-compression options:
+All transports MUST support in the server components the following compression options:
 
-* No compression, denoted by `none`.
+* No compression.
 * Gzip compression, denoted by `gzip`.
 
 ### OTLP/gRPC

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -70,7 +70,7 @@ OTLP is a request/response style protocols: the clients send requests, the
 server replies with corresponding responses. This document defines one requests
 and response type: `Export`.
 
-All transports MUST support in the server components the following compression options:
+All server components MUST support the following transport compression options:
 
 * No compression, denotated by `none`.
 * Gzip compression, denoted by `gzip`.

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -72,7 +72,7 @@ and response type: `Export`.
 
 All transports MUST support in the server components the following compression options:
 
-* No compression.
+* No compression, denotated by `none`.
 * Gzip compression, denoted by `gzip`.
 
 ### OTLP/gRPC


### PR DESCRIPTION
As mentioned in #1923 we need to be explicit on the compression support for the transports on the client AND server side (i.e.g collector receivers at this time).

cc @tigrannajaryan @bogdandrutu 