### PR TITLE
Update env variable values to match other env variables.

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -759,10 +759,10 @@ sampling:
 
 | Name            | Description | Default | Notes |
 |-----------------|---------|-------------|---------|
-| `OTEL_METRICS_EXEMPLAR_FILTER` | Filter for which measurements can become Exemplars. | `"WITH_SAMPLED_TRACE"` | |
+| `OTEL_METRICS_EXEMPLAR_FILTER` | Filter for which measurements can become Exemplars. | `"with_sampled_trace"` | |
 
 Known values for `OTEL_METRICS_EXEMPLAR_FILTER` are:
 
-- `"NONE"`: No measurements are eligble for exemplar sampling.
-- `"ALL"`: All measurements are eligible for exemplar sampling.
-- `"WITH_SAMPLED_TRACE"`: Only allow measurements with a sampled parent span in context.
+- `"none"`: No measurements are eligble for exemplar sampling.
+- `"all"`: All measurements are eligible for exemplar sampling.
+- `"with_sampled_trace"`: Only allow measurements with a sampled parent span in context.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -754,15 +754,4 @@ modeled to interact with other components in the SDK:
 
 ## Defaults and Configuration
 
-The SDK MUST provide the following configuration parameters for Exemplar
-sampling:
-
-| Name            | Description | Default | Notes |
-|-----------------|---------|-------------|---------|
-| `OTEL_METRICS_EXEMPLAR_FILTER` | Filter for which measurements can become Exemplars. | `"with_sampled_trace"` | |
-
-Known values for `OTEL_METRICS_EXEMPLAR_FILTER` are:
-
-- `"none"`: No measurements are eligble for exemplar sampling.
-- `"all"`: All measurements are eligible for exemplar sampling.
-- `"with_sampled_trace"`: Only allow measurements with a sampled parent span in context.
+The SDK MUST provide configuration according to the [SDK environment variables](../sdk-environment-variables.md) specification.

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -178,6 +178,20 @@ Known values for OTEL_METRICS_EXPORTER are:
 - `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
 - `"none"`: No automatically configured exporter for metrics.
 
+## Metrics SDK Configuration
+
+**Status**: [Experimental](document-status.md)
+
+| Name            | Description | Default | Notes |
+|-----------------|---------|-------------|---------|
+| `OTEL_METRICS_EXEMPLAR_FILTER` | Filter for which measurements can become Exemplars. | `"with_sampled_trace"` | |
+
+Known values for `OTEL_METRICS_EXEMPLAR_FILTER` are:
+
+- `"none"`: No measurements are eligble for exemplar sampling.
+- `"all"`: All measurements are eligible for exemplar sampling.
+- `"with_sampled_trace"`: Only allow measurements with a sampled parent span in context.
+
 ## Language Specific Environment Variables
 
 To ensure consistent naming across projects, this specification recommends that language specific environment variables are formed using the following convention:


### PR DESCRIPTION
Exemplar environment variable configuration doesn't match lower-case convention in other SDK environment variable parameters.

Hat tip to @anuraaga for calling this out.

_Note: This change is still ok because Metrics SDK specification is not stable, and this is not a new feature, just a change to an existing one.  I believe there is no (released) implementation  of this feature yet._