### PR TITLE
Add specification for otlp retry configuration parameters and defaults

### DIFF
--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -66,16 +66,16 @@ For OTLP/HTTP, the errors `408 (Request Timeout)` and `5xx (Server Errors)` are 
 
 SDKs MAY use the built-in [gRPC Retry](https://github.com/grpc/proposal/blob/master/A6-client-retries.md) mechanism to facilitate exponential back-off. If the built-in gRPC mechanism is used, the following values SHOULD be available for configuration:
 
-- `maxAttempts`: The maximum number of attempts, including the original request. Must be an integer greater than 1 and less than 6. (The built-in gRPC mechanism treats values greater than 5 as 5.) Defaults to `5`.
-- `initialBackoff`: Must be a duration greater than 0. Defaults to `1s`
-- `maxBackoff`: Must be a duration greater than 0. Defaults to `5s`.
-- `backoffMultiplier` Must be a number greater than 0. Defaults to `1.5`.
+- `maxAttempts`: The maximum number of attempts, including the original request. Must be an integer greater than 1 and less than 6.
+- `initialBackoff`: Must be a duration greater than 0.
+- `maxBackoff`: Must be a duration greater than 0.
+- `backoffMultiplier` Must be a number greater than 0.
 
-These properties are used to compute the backoff as follows:
+SDKs have unspecified default values for these properties. They are used to compute the backoff as follows:
 
 - The initial retry attempt will occur after `random(0, initialBackoff)`
 - The `n`-th retry attempt will occur after `random(0, min(initialBackoff*backoffMultiplier**(n-1), maxBackoff))`
 
-Language SDKs SHOULD have retry configuration and mechanics that are consistent across protocols. For example, if the built-in gRPC Retry mechanism is used for the `grpc` protocol, the `http/protobuf` and `http/json` protocols should expose the same configuration options and compute the backoff duration in the same manner.
+Language SDKs SHOULD have retry configuration and mechanics that are consistent across OTLP protocols. For example, if the built-in gRPC Retry mechanism is used for the `grpc` protocol, the `http/protobuf` and `http/json` protocols should expose the same configuration options and compute the backoff duration in the same manner.
 
 [otlphttp-req]: otlp.md#otlphttp-request

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -64,18 +64,8 @@ Transient errors MUST be handled with a retry strategy. This retry strategy MUST
 
 For OTLP/HTTP, the errors `408 (Request Timeout)` and `5xx (Server Errors)` are defined as transient, detailed information about errors can be found in the [HTTP failures section](otlp.md#failures). For the OTLP/gRPC, the full list of the gRPC retryable status codes can be found in the [gRPC response section](otlp.md#otlpgrpc-response).
 
-SDKs MAY use the built-in [gRPC Retry](https://github.com/grpc/proposal/blob/master/A6-client-retries.md) mechanism to facilitate exponential back-off. If the built-in gRPC mechanism is used, the following values SHOULD be available for configuration:
+SDKs MAY use the built-in [gRPC Retry](https://github.com/grpc/proposal/blob/master/A6-client-retries.md) mechanism to facilitate exponential back-off.
 
-- `maxAttempts`: The maximum number of attempts, including the original request. Must be an integer greater than 1 and less than 6.
-- `initialBackoff`: Must be a duration greater than 0.
-- `maxBackoff`: Must be a duration greater than 0.
-- `backoffMultiplier` Must be a number greater than 0.
-
-SDKs have unspecified default values for these properties. They are used to compute the backoff as follows:
-
-- The initial retry attempt will occur after `random(0, initialBackoff)`
-- The `n`-th retry attempt will occur after `random(0, min(initialBackoff*backoffMultiplier**(n-1), maxBackoff))`
-
-Language SDKs SHOULD have retry configuration and mechanics that are consistent across OTLP protocols. For example, if the built-in gRPC Retry mechanism is used for the `grpc` protocol, the `http/protobuf` and `http/json` protocols should expose the same configuration options and compute the backoff duration in the same manner.
+SDKs SHOULD have retry configuration and mechanics that are consistent across OTLP protocols. For example, if the built-in gRPC Retry mechanism is used for the `grpc` protocol, the `http/protobuf` and `http/json` protocols should expose the same configuration options and compute the backoff duration in the same manner.
 
 [otlphttp-req]: otlp.md#otlphttp-request


### PR DESCRIPTION
Fixes #1742.

## Changes

Expand the OTLP exporter retry language to include language for using the built-in gRPC retry mechanism. This allows SDKs to leverage the mechanism as a standard without precluding the use of other retry mechanisms (such as the one [used in the collector](https://github.com/open-telemetry/opentelemetry-collector/blob/0e3b991f9f2a5310ad60b26dfba8897d7bb94745/exporter/exporterhelper/queued_retry.go#L255)).

It also establishes declares the configurable parameters if the built-in gRPC retry mechanism is used, with default values. 

Related issues #

- opentelemetry-java [PR #3636](https://github.com/open-telemetry/opentelemetry-java/pull/3636) prototypes adding a retry mechanism but is blocked on spec language
- opentelemetry-php [Issue #328](https://github.com/open-telemetry/opentelemetry-php/issues/328) requests an OTLP retry implementation
- opentelemetry-dotnet [Issue #1779](https://github.com/open-telemetry/opentelemetry-dotnet/issues/1779) requests an OTLP retry implementation