### PR TITLE
Clarify OTLP/HTTP port handling.

### DIFF
--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -48,6 +48,12 @@ for each signal as follow:
    Non-normatively, this could be implemented by ensuring that the base URL ends with
    a slash and then appending the relative URLs as strings.
 
+If no port is given, the URL MUST be used without any extra port modification,
+letting the HTTP library use whatever default port it normally uses for the scheme
+(i.e., 443 for `https://` and 80 for `http://`, though some libraries/configurations
+might allow overriding that by some means like
+[`/etc/services`](https://man7.org/linux/man-pages/man5/services.5.html))
+
 #### Example 1
 
 The following configuration sends all signals to the same collector:
@@ -71,7 +77,7 @@ export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://collector.example.com/v1/metr
 This will send traces directly to the root path `http://collector:4318/`
 (`/v1/traces` is only automatically added when using the non-signal-specific
 environment variable) and metrics
-to `https://collector.example.com/v1/metrics`.
+to `https://collector.example.com/v1/metrics`, using the default https port (443).
 
 #### Example 3
 
@@ -83,9 +89,10 @@ export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://collector.example.com/v1/metr
 ```
 
 Traces are sent to `http://collector:4318/mycollector/v1/traces`
-and metrics to `https://collector.example.com/v1/metrics/`
-(other signals, would they be defined, would be sent to their specific paths
-relative to `http://collector:4318/mycollector/`).
+and metrics to `https://collector.example.com/v1/metrics/`, using the default
+https port (443).
+Other signals, (if there were any) would be sent to their specific paths
+relative to `http://collector:4318/mycollector/`.
 
 ### Specify Protocol
 


### PR DESCRIPTION
Clarifies that default ports for the URL schemes, not default OTLP/HTTP port should be used if no port is given in URL.

See https://github.com/open-telemetry/opentelemetry-specification/pull/1975#discussion_r719238784
