### PR TITLE
Fill out Summary metric details

### DIFF
--- a/specification/metrics/datamodel.md
+++ b/specification/metrics/datamodel.md
@@ -706,6 +706,7 @@ Summary consists of the following:
     - The quantile of a distribution, within the interval `[0.0, 1.0]`.  For
       example, the value `0.9` would represent the 90th-percentile.
     - The value of the quantile.  This MUST be non-negative.
+
 Quantile values 0.0 and 1.0 are defined to be equal to the minimum and maximum values, respectively.
 
 Quantile values do not need to represent values observed between


### PR DESCRIPTION
Fixes #2000

- Add description of Summary points to data model specification.   This more clearly pulls in OpenMetrics specification rather than just a link
- Update TODO on gauge around start timestamp, as Summary needed to use similar language to match OpenMetrics.


Related https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/5667