### PR TITLE
Experimentation attributes

### DIFF
--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -11,6 +11,7 @@ i.e.:
 * [Trace semantic conventions](../specification/trace/semantic_conventions/README.md)
 * [Metric semantic conventions](../specification/metrics/semantic_conventions/README.md)
 * [Resource semantic conventions](../specification/resource/semantic_conventions/README.md)
+* [Experimentation semantic conventions](../specification/resource/semantic_conventions/README.md)
 
 ## Writing semantic conventions
 

--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -11,7 +11,6 @@ i.e.:
 * [Trace semantic conventions](../specification/trace/semantic_conventions/README.md)
 * [Metric semantic conventions](../specification/metrics/semantic_conventions/README.md)
 * [Resource semantic conventions](../specification/resource/semantic_conventions/README.md)
-* [Experimentation semantic conventions](../specification/resource/semantic_conventions/README.md)
 
 ## Writing semantic conventions
 

--- a/semantic_conventions/trace/experimentation.yaml
+++ b/semantic_conventions/trace/experimentation.yaml
@@ -1,0 +1,22 @@
+groups:
+  - id: experimentation
+    prefix: experimentation
+    brief: 'This document defines semantic conventions for adding experimentation information to Spans.'
+    attributes:
+      - id: seed
+        type: string
+        brief: 'The seed used to calculate which variants to use'
+        examples: ["k43l24kl2l43lj32"]
+  - id: experiment_name
+    prefix: experimentation.experiment_name
+    brief: 'This document defines semantic conventions for adding experimentation information to Spans for a specific named experiment.'
+    attributes:
+      - id: variant
+        type: string
+        brief: 'The variant of the experiment being used'
+        examples: ["A", "B", "C", "DEFAULT"]
+      - id: id
+        type: string
+        brief: 'The id of the experiment'
+        examples: [ "43223", "j3lkjl2j3", "b282f9d1-d22a-49d1-999a-96d3487a571d" ]
+

--- a/semantic_conventions/trace/experimentation.yaml
+++ b/semantic_conventions/trace/experimentation.yaml
@@ -1,6 +1,6 @@
 groups:
-  - id: experimentation
-    prefix: experimentation
+  - id: experiment
+    prefix: experiment
     brief: 'This document defines semantic conventions for adding experimentation information to Spans.'
     attributes:
       - id: seed
@@ -8,7 +8,7 @@ groups:
         brief: 'The seed used to calculate which variants to use'
         examples: ["k43l24kl2l43lj32"]
   - id: experiment_name
-    prefix: experimentation.experiment_name
+    prefix: experiment.experiment_name
     brief: 'This document defines semantic conventions for adding experimentation information to Spans for a specific named experiment.'
     attributes:
       - id: variant

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -226,8 +226,8 @@ about the span.
 ## Experimentation Attributes
 
 Experiments are sometimes used to measure the result of a change within an application.
-When an experiment is running different requests may execute different code paths.
-By adding experiment information ont traces it allows for experiment specific issues to be found and also understand how experiments change the flow of a request.
+When an experiment is running, different requests may execute different code paths.
+By adding experiment information onto traces, it allows for experiment specific issues to be found and also understand how experiments change the flow of a request.
 
 To make sure requests/customers receive a consistent experience an experiment seed may be used.
 The seed is used to initialise a pseudorandom number generator which is then used to decide which version of the code to execute.

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -221,3 +221,27 @@ about the span.
 | `code.filepath` | string | The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path). | `/usr/local/MyApplication/content_root/app/index.php` | No |
 | `code.lineno` | int | The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`. | `42` | No |
 <!-- endsemconv -->
+
+## Experimentation Attributes
+
+The attributes are split into two sections, global and experiment specific.
+Experiments can run anywhere within the code and therefore be on ony span.
+
+## Trace Scoped Attributes
+
+<!-- semconv experimentation -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `experimentation.seed` | string | The seed used to calculate which variants to use | `k43l24kl2l43lj32` | No |
+<!-- endsemconv -->
+
+## Experiment specific Attributes
+
+`experiment_name` MUST be replaced with the name of the experiment.
+
+<!-- semconv experiment_name -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `experimentation.experiment_name.variant` | string | The variant of the experiment being used | `A` | No |
+| `experimentation.experiment_name.id` | string | The id of the experiment | `43223`; `j3lkjl2j3`; `b282f9d1-d22a-49d1-999a-96d3487a571d` | No |
+<!-- endsemconv -->

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -229,10 +229,10 @@ Experiments can run anywhere within the code and therefore be on ony span.
 
 #### Trace Scoped Attributes
 
-<!-- semconv experimentation -->
+<!-- semconv experiment -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `experimentation.seed` | string | The seed used to calculate which variants to use | `k43l24kl2l43lj32` | No |
+| `experiment.seed` | string | The seed used to calculate which variants to use | `k43l24kl2l43lj32` | No |
 <!-- endsemconv -->
 
 #### Experiment specific Attributes
@@ -242,6 +242,6 @@ Experiments can run anywhere within the code and therefore be on ony span.
 <!-- semconv experiment_name -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `experimentation.experiment_name.variant` | string | The variant of the experiment being used | `A`; `B`; `C`; `DEFAULT` | No |
-| `experimentation.experiment_name.id` | string | The id of the experiment | `43223`; `j3lkjl2j3`; `b282f9d1-d22a-49d1-999a-96d3487a571d` | No |
+| `experiment.experiment_name.variant` | string | The variant of the experiment being used | `A`; `B`; `C`; `DEFAULT` | No |
+| `experiment.experiment_name.id` | string | The id of the experiment | `43223`; `j3lkjl2j3`; `b282f9d1-d22a-49d1-999a-96d3487a571d` | No |
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -227,7 +227,7 @@ about the span.
 The attributes are split into two sections, global and experiment specific.
 Experiments can run anywhere within the code and therefore be on ony span.
 
-#### Trace Scoped Attributes
+### Trace Scoped Attributes
 
 <!-- semconv experiment -->
 | Attribute  | Type | Description  | Examples  | Required |
@@ -235,7 +235,7 @@ Experiments can run anywhere within the code and therefore be on ony span.
 | `experiment.seed` | string | The seed used to calculate which variants to use | `k43l24kl2l43lj32` | No |
 <!-- endsemconv -->
 
-#### Experiment specific Attributes
+### Experiment specific Attributes
 
 `experiment_name` MUST be replaced with the name of the experiment.
 

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -227,7 +227,7 @@ about the span.
 The attributes are split into two sections, global and experiment specific.
 Experiments can run anywhere within the code and therefore be on ony span.
 
-## Trace Scoped Attributes
+#### Trace Scoped Attributes
 
 <!-- semconv experimentation -->
 | Attribute  | Type | Description  | Examples  | Required |
@@ -235,13 +235,13 @@ Experiments can run anywhere within the code and therefore be on ony span.
 | `experimentation.seed` | string | The seed used to calculate which variants to use | `k43l24kl2l43lj32` | No |
 <!-- endsemconv -->
 
-## Experiment specific Attributes
+#### Experiment specific Attributes
 
 `experiment_name` MUST be replaced with the name of the experiment.
 
 <!-- semconv experiment_name -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `experimentation.experiment_name.variant` | string | The variant of the experiment being used | `A` | No |
+| `experimentation.experiment_name.variant` | string | The variant of the experiment being used | `A`; `B`; `C`; `DEFAULT` | No |
 | `experimentation.experiment_name.id` | string | The id of the experiment | `43223`; `j3lkjl2j3`; `b282f9d1-d22a-49d1-999a-96d3487a571d` | No |
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -16,6 +16,7 @@ Particular operations may refer to or require some of these attributes.
 - [General identity attributes](#general-identity-attributes)
 - [General thread attributes](#general-thread-attributes)
 - [Source Code Attributes](#source-code-attributes)
+- [Experiment Attributes](#experimentation-attributes)
 
 <!-- tocstop -->
 
@@ -223,6 +224,19 @@ about the span.
 <!-- endsemconv -->
 
 ## Experimentation Attributes
+
+Experiments are sometimes used to measure the result of a change within an application.
+When an experiment is running different requests may execute different code paths.
+By adding experiment information ont traces it allows for experiment specific issues to be found and also understand how experiments change the flow of a request.
+
+To make sure requests/customers receive a consistent experience an experiment seed may be used.
+The seed is used to initialise a pseudorandom number generator which is then used to decide which version of the code to execute.
+
+Multiple experiments may be running within a single application and many may affect a single request.
+To keep track of which variant of an experiment is run the experiment name is included in the attribute name with the variant as the value.
+
+These attributes should be set when experiment frameworks are in use.
+When the framework runs a variant for an experiment the variant name should be added as an attribute to the active span.
 
 The attributes are split into two sections, global and experiment specific.
 Experiments can run anywhere within the code and therefore be on ony span.


### PR DESCRIPTION
## Changes

Adds new semantic conventions for experiment attributes on spans.

### New Attributes
`experiment.seed`
`experiment.experiment_name.variant`
`experiment.experiment_name.id`
