### PR TITLE
Define how to enable Meter attributes for Prometheus Exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ release.
 - Add clarifications on how to determine aggregation temporality.
   ([#2013](https://github.com/open-telemetry/opentelemetry-specification/pull/2013),
   [#2032](https://github.com/open-telemetry/opentelemetry-specification/pull/2032))
+- Define how Prometheus should handle Meter attributes.
+  ([#2035](https://github.com/open-telemetry/opentelemetry-specification/pull/2035))
 
 ### Logs
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -5,3 +5,10 @@
 Prometheus Exporter is a [Pull Metric Exporter](../sdk.md#pull-metric-exporter)
 which reacts to the Prometheus scraper and report the metrics passively to
 [Prometheus](https://prometheus.io/).
+
+Prometheus Exporter MUST export Meter `name` and `version` information when
+enabled by the [Metrics SDK Configuration](../../sdk-environment-variables.md#metrics-sdk-configuration).
+The Prometheus Exporter MUST respect the configuration preferences of the application
+provide a method to configure whether these data are exported as
+[Attributes](../common/common.md#attributes). The `name` and `version` information
+will follow the same naming as [trace exporters.](../../trace/sdk_exporters/non-otlp.md#instrumentationlibrary)

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -149,8 +149,14 @@ thrift or protobuf.  As of 1.0 of the specification, there
 
 | Name                          | Description                     | Default                      |
 | ----------------------------- | --------------------------------| ---------------------------- |
-| OTEL_EXPORTER_PROMETHEUS_HOST | Host used by the Prometheus exporter | All addresses: "0.0.0.0"|
-| OTEL_EXPORTER_PROMETHEUS_PORT | Port used by the Prometheus exporter | 9464                    |
+| `OTEL_EXPORTER_PROMETHEUS_HOST` | Host used by the Prometheus exporter | All addresses: "0.0.0.0"|
+| `OTEL_EXPORTER_PROMETHEUS_PORT` | Port used by the Prometheus exporter | 9464                    |
+| `OTEL_EXPORTER_PROMETHEUS_ADD_METER_ATTRIBUTES` | Filter for if `name` and `version` from [Meter](./metrics/api.md#get-a-meter) are exported. | `false` | |
+
+Known values for `OTEL_EXPORTER_PROMETHEUS_ADD_METER_ATTRIBUTES` are:
+
+- `true` : Add the Meter `name` and `version` as Attributes on the metrics exported.
+- `false` : Don't add Meter `name` and `version` as Attributes on the metrics exported.
 
 ## Exporter Selection
 


### PR DESCRIPTION
Fixes #1906

## Changes

* Add `OTEL_METRICS_LIBRARY_ATTRIBUTES` variable
* Update Metric SDK to clarify when Meter attributes should be exported.

Related issues #1953
