### PR TITLE
Add semantic conventions for process metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ release.
   ([#2210](https://github.com/open-telemetry/opentelemetry-specification/pull/2210))
 - Use UCUM units in Metrics Semantic Conventions.
   ([#2199](https://github.com/open-telemetry/opentelemetry-specification/pull/2199))
+- Add semantic conventions for process metrics.
+  [#2032](https://github.com/open-telemetry/opentelemetry-specification/pull/2061)
 
 ### Logs
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -121,8 +121,10 @@ for the total amount of memory on a system.
 amount of memory in a each state. Where appropriate, the sum of **usage**
 over all attribute values SHOULD be equal to the **limit**.
 
-  A measure of the amount of an unlimited resource consumed is differentiated
-  from **usage**.
+  A measure of the amount consumed of an unlimited resource, or of a resource
+  whose limit is unknowable, is differentiated from **usage**. For example, the
+  maximum possible amount of virtual memory that a process may consume may
+  fluctuate over time and is not typically known.
 
 - **utilization** - an instrument that measures the *fraction* of **usage**
 out of its **limit** should be called `entity.utilization`. For example,

--- a/specification/metrics/semantic_conventions/process-metrics.md
+++ b/specification/metrics/semantic_conventions/process-metrics.md
@@ -16,9 +16,24 @@ metrics](runtime-environment-metrics.md).
 <!-- toc -->
 
 - [Metric Instruments](#metric-instruments)
+  * [Process](#process)
+- [Attributes](#attributes)
 
 <!-- tocstop -->
 
 ## Metric Instruments
 
-TODO
+### Process
+
+Below is a table of Process metric instruments.
+
+| Name | Instrument | Units | Description | Labels |
+|------|------------|-------|-------------|--------|
+| `process.cpu.time` | Asynchronous Counter | s | Total CPU seconds broken down by different states. | `state`, if specified, SHOULD be one of: `system`, `user`, `wait`. A process SHOULD be characterized _either_ by data points with no `state` labels, _or only_ data points with `state` labels. |
+| `process.memory.usage` | Asynchronous UpDownCounter | By | The amount of physical memory in use. |  |
+| `process.memory.virtual` | Asynchronous UpDownCounter | By | The amount of committed virtual memory. |  |
+| `process.disk.io` | Asynchronous Counter | By | Disk bytes transferred. | `direction` SHOULD be one of: `read`, `write` |
+
+## Attributes
+
+Process metrics SHOULD be associated with a [`process`](../../resource/semantic_conventions/process.md#process) resource whose attributes provide additional context about the process.


### PR DESCRIPTION
## Changes

Adds semantic conventions for process metrics

Resolves #1817 

Prerequisite for [(collector) #4232](https://github.com/open-telemetry/opentelemetry-collector/issues/4232)

## Notes

I would appreciate perspectives on `process.cpu.time`, in regards to nuances described [here](https://github.com/open-telemetry/opentelemetry-collector/issues/4232#issuecomment-952130568).