### PR TITLE
[editorial] trace/semantic_conventions/http: add missing markdown link definition

### DIFF
--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -182,6 +182,7 @@ Some servers allow to bind the same HTTP application to multiple `(virtual host,
 
 > TODO: Find way to trace HTTP application and application root ([opentelemetry/opentelementry-specification#335][])
 
+[HTTP host header]: https://tools.ietf.org/html/rfc7230#section-5.4
 [PEP 3333]: https://www.python.org/dev/peps/pep-3333/
 [modwsgisetup]: https://modwsgi.readthedocs.io/en/develop/user-guides/quick-configuration-guide.html
 [context root]: https://docs.jboss.org/jbossas/guides/webguide/r2/en/html/ch06.html


### PR DESCRIPTION
- Fixes #2079 
- Related to work on https://github.com/open-telemetry/opentelemetry.io/pull/866

/cc @austinlparker 