### PR TITLE
Map Syslog Emergency to FATAL instead of ERROR3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ release.
 
 ### Logs
 
+- Map Syslog Emergency to FATAL instead of ERROR3.
+  ([#2087](https://github.com/open-telemetry/opentelemetry-specification/pull/2087))
+- Map Syslog Alert to ERROR3 instead of FATAL.
+  ([#2087](https://github.com/open-telemetry/opentelemetry-specification/pull/2087))
+
 ### Resource
 
 ### Semantic Conventions

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -1316,8 +1316,8 @@ for an exhaustive list.
 |Warning      |Warning    |WARN  |Warn  | WARNING         |WARN          |
 |Error        |Error      |ERROR |Error | SEVERE          |ERROR         |
 |Critical     |Critical   |      |Dpanic|                 |ERROR2        |
-|Emergency    |           |      |Panic |                 |ERROR3        |
-|Alert        |           |FATAL |Fatal |                 |FATAL         |
+|Alert        |           |      |Panic |                 |ERROR3        |
+|Emergency    |           |FATAL |Fatal |                 |FATAL         |
 
 ## References
 


### PR DESCRIPTION
Fixes #2042

## Changes

- Map Syslog Emergency to FATAL instead of ERROR3.
- Map Syslog Alert to ERROR3 instead of FATAL.