### PR TITLE
Change mapping for log_name of Google Cloud Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ release.
   ([#2196](https://github.com/open-telemetry/opentelemetry-specification/pull/2196))
 - Added ObservedTimestamp to the Log Data Model.
   ([#2184](https://github.com/open-telemetry/opentelemetry-specification/pull/2184))
+- Change mapping for log_name of Google Cloud Logging.
+  ([#2092](https://github.com/open-telemetry/opentelemetry-specification/pull/2092))
 
 ### Resource
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -993,7 +993,7 @@ Field            | Type               | Description                             
 -----------------|--------------------| ------------------------------------------------------- | ---------------------------
 timestamp        | string             | The time the event described by the log entry occurred. | Timestamp
 resource         | MonitoredResource  | The monitored resource that produced this log entry.    | Resource
-log_name         | string             | The URL-encoded LOG_ID suffix of the log_name field identifies which log stream this entry belongs to. | Name
+log_name         | string             | The URL-encoded LOG_ID suffix of the log_name field identifies which log stream this entry belongs to. | Attributes["com.google.log_name"]
 json_payload     | google.protobuf.Struct | The log entry payload, represented as a structure that is expressed as a JSON object. | Body
 proto_payload    | google.protobuf.Any | The log entry payload, represented as a protocol buffer. | Body
 text_payload     | string             | The log entry payload, represented as a Unicode string (UTF-8). | Body


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/1808

The log_name should not map to Name, they are not the same thing.

log_name description: The resource name of the log to which this log entry belongs.
(See https://cloud.google.com/logging/docs/reference/v2/rpc/google.logging.v2#logentry)

Name description: Short event identifier that does not contain varying parts.

log_name is now mapped to a Google-specific attribute. If better mapping is known
I can change to that but I don't see anything else in log data model log_name maps
nicely to.

