### PR TITLE
Add `device.manufacturer` to semantic conventions for resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ release.
 
 - Prohibit usage of retired names in semantic conventions.
   ([#2191](https://github.com/open-telemetry/opentelemetry-specification/pull/2191))
+- Add `device.manufacturer` to describe mobile device manufacturers.
+  ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
 
 ### Compatibility
 
@@ -68,8 +70,6 @@ release.
 - Add `none` as a possible value for `OTEL_PROPAGATORS` to disable context
   propagation.
   ([#2052](https://github.com/open-telemetry/opentelemetry-specification/pull/2052))
-- Add `device.manufacturer` to describe mobile device manufacturers.
-  ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
 
 ### Traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,9 @@ release.
 - Add `none` as a possible value for `OTEL_PROPAGATORS` to disable context
   propagation.
   ([#2052](https://github.com/open-telemetry/opentelemetry-specification/pull/2052))
-
+- Add `device.manufacturer` to describe mobile device manufacturers 
+  ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
+  
 ### Traces
 
 - No changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ release.
 - Add `none` as a possible value for `OTEL_PROPAGATORS` to disable context
   propagation.
   ([#2052](https://github.com/open-telemetry/opentelemetry-specification/pull/2052))
-- Add `device.manufacturer` to describe mobile device manufacturers 
+- Add `device.manufacturer` to describe mobile device manufacturers.
   ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
 
 ### Traces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ release.
   ([#2052](https://github.com/open-telemetry/opentelemetry-specification/pull/2052))
 - Add `device.manufacturer` to describe mobile device manufacturers 
   ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
-  
+
 ### Traces
 
 - No changes.

--- a/semantic_conventions/resource/device.yaml
+++ b/semantic_conventions/resource/device.yaml
@@ -36,5 +36,5 @@ groups:
         type: string
         brief: 'The name of the device manufacturer'
         note: >
-          Android devices provide this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER)
+          The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
         examples: ['Apple', 'Samsung']

--- a/semantic_conventions/resource/device.yaml
+++ b/semantic_conventions/resource/device.yaml
@@ -32,3 +32,9 @@ groups:
           It's recommended this value represents a human readable version of the
           device model rather than a machine readable alternative.
         examples: ['iPhone 6s Plus', 'Samsung Galaxy S6']
+      - id: manufacturer
+        type: string
+        brief: 'The name of the device manufacturer'
+        note: >
+          Android devices provide this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER)
+        examples: ['Apple', 'Samsung']

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -12,10 +12,14 @@
 | `device.id` | string | A unique identifier representing the device [1] | `2ab2916d-a51f-4ac8-80ee-45ac31a28092` | No |
 | `device.model.identifier` | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | No |
 | `device.model.name` | string | The marketing name for the device model [3] | `iPhone 6s Plus`; `Samsung Galaxy S6` | No |
+| `device.manufacturer.name` | string | The name of the device manufacturer [4] | `Apple`; `Samsung` | No |
 
 **[1]:** The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
 
 **[2]:** It's recommended this value represents a machine readable version of the model identifier rather than the market or consumer-friendly name of the device.
 
 **[3]:** It's recommended this value represents a human readable version of the device model rather than a machine readable alternative.
+
+**[4]:** Android devices provide this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER)
+
 <!-- endsemconv -->

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -21,5 +21,4 @@
 **[3]:** It's recommended this value represents a human readable version of the device model rather than a machine readable alternative.
 
 **[4]:** Android devices provide this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER)
-
 <!-- endsemconv -->

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -20,5 +20,5 @@
 
 **[3]:** It's recommended this value represents a human readable version of the device model rather than a machine readable alternative.
 
-**[4]:** Android devices provide this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER)
+**[4]:** The Android OS provides this field via [Build](https://developer.android.com/reference/android/os/Build#MANUFACTURER). iOS apps SHOULD hardcode the value `Apple`.
 <!-- endsemconv -->

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -12,7 +12,7 @@
 | `device.id` | string | A unique identifier representing the device [1] | `2ab2916d-a51f-4ac8-80ee-45ac31a28092` | No |
 | `device.model.identifier` | string | The model identifier for the device [2] | `iPhone3,4`; `SM-G920F` | No |
 | `device.model.name` | string | The marketing name for the device model [3] | `iPhone 6s Plus`; `Samsung Galaxy S6` | No |
-| `device.manufacturer.name` | string | The name of the device manufacturer [4] | `Apple`; `Samsung` | No |
+| `device.manufacturer` | string | The name of the device manufacturer [4] | `Apple`; `Samsung` | No |
 
 **[1]:** The device identifier MUST only be defined using the values outlined below. This value is not an advertising identifier and MUST NOT be used as such. On iOS (Swift or Objective-C), this value MUST be equal to the [vendor identifier](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor). On Android (Java or Kotlin), this value MUST be equal to the Firebase Installation ID or a globally unique UUID which is persisted across sessions in your application. More information can be found [here](https://developer.android.com/training/articles/user-data-ids) on best practices and exact implementation details. Caution should be taken when storing personal data or anything which can identify a user. GDPR and data protection laws may apply, ensure you do your own due diligence.
 


### PR DESCRIPTION
## Changes

- Proposed manufacturer field
