### PR TITLE
Make it clear that Exemplar is opt-in

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -420,7 +420,7 @@ information:
 
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements.
 
-`Exemplar` sampling MUST be an opt-in feature. When not enabled, the SDK SHOULD not have overhead related to exemplar sampling.
+`Exemplar` sampling MUST be an opt-in feature. When not enabled, the SDK SHOULD NOT have overhead related to exemplar sampling.
 
 A Metric SDK MUST sample `Exemplar`s only from measurements within the context of a sampled trace BY DEFAULT.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -420,7 +420,7 @@ information:
 
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements.
 
-A Metric SDK MUST allow `Exemplar` sampling to be disabled.  In this instance the SDK SHOULD not have overhead related to exemplar sampling.
+`Exemplar` sampling MUST be an opt-in feature. When not enabled, the SDK SHOULD not have overhead related to exemplar sampling.
 
 A Metric SDK MUST sample `Exemplar`s only from measurements within the context of a sampled trace BY DEFAULT.
 
@@ -477,8 +477,6 @@ are not preserved by aggregation or view configuration. Specifically, at a
 minimum, joining together attributes on an `Exemplar` with those available
 on its associated metric data point should result in the full set of attributes
 from the original sample measurement.
-
-The `ExemplarReservoir` SHOULD avoid allocations when sampling exemplars.
 
 ### Exemplar defaults
 


### PR DESCRIPTION
Its not clear if the Exemplar feature is enabled by default or disabled by default. Trying to make it obvious.
I assume this is an opt-in feature. If that's the not the case, happy to reword it accordingly. 

Only goal of this PR is to make it very clear whether its enabled/disabled by default.

Also removed a statement about "allocations" as thats implementation details, and not required in spec.