### PR TITLE
Align runtime metric and resource namespaces

### DIFF
--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -62,8 +62,8 @@ where similar metrics have significantly different implementations across the
 breadth of all existing metrics. For example, every garbage collected runtime
 has slightly different strategies and measures. Using a single set of metric
 names for GC, not divided by the runtime, could create dissimilar comparisons
-and confusion for end users. (For example, prefer `runtime.java.gc*` over
-`runtime.gc.*`.) Measures of many operating system metrics are similarly
+and confusion for end users. (For example, prefer `process.runtime.java.gc*` over
+`process.runtime.gc.*`.) Measures of many operating system metrics are similarly
 ambiguous.
 
 ### Units

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -13,7 +13,8 @@ semantic conventions when instrumenting runtime environments.
 <!-- toc -->
 
 - [Metric Instruments](#metric-instruments)
-  * [Runtime Environment Specific Metrics - `runtime.{environment}.`](#runtime-environment-specific-metrics---runtimeenvironment)
+  * [Runtime Environment Specific Metrics - `process.runtime.{environment}.`](#runtime-environment-specific-metrics---processruntimeenvironment)
+- [Attributes](#attributes)
 
 <!-- tocstop -->
 
@@ -27,10 +28,10 @@ does not propose any standard top-level runtime metric instruments. See [OTEP
 108](https://github.com/open-telemetry/oteps/pull/108/files) for additional
 discussion.
 
-### Runtime Environment Specific Metrics - `runtime.{environment}.`
+### Runtime Environment Specific Metrics - `process.runtime.{environment}.`
 
 Metrics specific to a certain runtime environment should be prefixed with
-`runtime.{environment}.` and follow the semantic conventions outlined in
+`process.runtime.{environment}.` and follow the semantic conventions outlined in
 [general metric semantic
 conventions](README.md#general-metric-semantic-conventions). Authors of
 runtime instrumentations are responsible for the choice of `{environment}` to
@@ -40,7 +41,11 @@ For example, some programming languages have multiple runtime environments
 that vary significantly in their implementation, like [Python which has many
 implementations](https://wiki.python.org/moin/PythonImplementations). For
 such languages, consider using specific `{environment}` prefixes to avoid
-ambiguity, like `runtime.cpython.` and `runtime.pypy.`.
+ambiguity, like `process.runtime.cpython.` and `process.runtime.pypy.`.
 
 There are other dimensions even within a given runtime environment to
 consider, for example pthreads vs green thread implementations.
+
+## Attributes
+
+[`process.runtime`](../../resource/semantic_conventions/process.md#process-runtimes) resource attributes SHOULD be included on runtime metric events as appropriate.


### PR DESCRIPTION
A 'process.runtime' namespace is currently defined in the resource
semantic conventions. The metric semantic conventions suggest that
runtime metrics use a 'runtime' namespace. Since the runtime metrics
are directly related to the runtime resources, they ought to share a
common namespace.

Related to issue #2061, discussed in [this comment](https://github.com/open-telemetry/opentelemetry-specification/pull/2061#discussion_r740509308).
