### PR TITLE
Add Resource browser and app attributes, clarify device attributes as client-side only

### DIFF
--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -90,6 +90,23 @@ namespace = Company
 service.name = Shop.shoppingcart
 ```
 
+## App
+
+**type:** `app`
+
+**Description:** A client application instance.
+
+<!-- semconv service -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `app.name` | string | Logical name of the client application. [1] | `web storefront` | Yes |
+| `app.namespace` | string | A namespace for `app.name`. [2] | `Shop` | No |
+| `app.version` | string | The version string of the app build or implementation. | `2.0.0` | No |
+
+**[1]:** MUST be the same for all instances of the application running on individual client devices. If the value was not specified, SDKs MUST fallback to `unknown_application`.
+
+**[2]:** A string value having a meaning that helps to distinguish a group of client applications, for example the team name that owns a group of applications or web site name that consists of multiple components. `app.name` is expected to be unique within the same namespace. If `app.namespace` is not specified in the Resource then `app.name` is expected to be unique for all applications that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
 ## Telemetry SDK
 
 **type:** `telemetry.sdk`

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -27,7 +27,6 @@ This document defines standard attributes for resources. These attributes are ty
 ## TODOs
 
 * Add more compute units: AppEngine unit, etc.
-* Add Web Browser.
 * Decide if lower case strings only.
 * Consider to add optional/required for each attribute and combination of attributes
   (e.g when supplying a k8s resource all k8s may be required).
@@ -151,11 +150,12 @@ Attributes defining a computing instance (e.g. host):
 Attributes defining a running environment (e.g. Operating System, Cloud, Data Center, Deployment Service):
 
 - [Operating System](./os.md)
-- [Device](./device.md)
+- [Device](./device.md) (client-side)
 - [Cloud](./cloud.md)
 - Deployment:
   - [Deployment Environment](./deployment_environment.md)
   - [Kubernetes](./k8s.md)
+- [Browser](./browser.md)
 
 ## Version attributes
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -101,11 +101,19 @@ service.name = Shop.shoppingcart
 |---|---|---|---|---|
 | `app.name` | string | Logical name of the client application. [1] | `web storefront` | Yes |
 | `app.namespace` | string | A namespace for `app.name`. [2] | `Shop` | No |
-| `app.version` | string | The version string of the app build or implementation. | `2.0.0` | No |
+| `app.bundle` | string | Name of the bundle or package. [3] | `ShopApplication`, `com.example.ShopApplication` | No |
+| `app.version` | string | The version string of the app build or implementation. This can include more verbose information, such as the build number. [4] | `2.0.0` | No |
+| `app.shortVersion` | string | Human-readable version or version used to identify a release to end users. [5] | `10.14.1` | No |
 
 **[1]:** MUST be the same for all instances of the application running on individual client devices. If the value was not specified, SDKs MUST fallback to `unknown_application`.
 
 **[2]:** A string value having a meaning that helps to distinguish a group of client applications, for example the team name that owns a group of applications or web site name that consists of multiple components. `app.name` is expected to be unique within the same namespace. If `app.namespace` is not specified in the Resource then `app.name` is expected to be unique for all applications that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
+
+**[3]:** For iOS bundles, this equates to the `CFBundleName` property, and for Android to the `android:package` attribute.
+
+**[4]:** For iOS bundles, this equates to the `CFBundleVersion` property, and for Android to the `android:versionCode` attribute.
+
+**[5]:** For iOS bundles, this equates to the `CFBundleShortVersionString` property, and for Android to the `android:versionName` attribute.
 
 ## Telemetry SDK
 

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -103,7 +103,7 @@ service.name = Shop.shoppingcart
 | `app.namespace` | string | A namespace for `app.name`. [2] | `Shop` | No |
 | `app.bundle` | string | Name of the bundle or package. [3] | `ShopApplication`, `com.example.ShopApplication` | No |
 | `app.version` | string | The version string of the app build or implementation. This can include more verbose information, such as the build number. [4] | `2.0.0` | No |
-| `app.shortVersion` | string | Human-readable version or version used to identify a release to end users. [5] | `10.14.1` | No |
+| `app.short_version` | string | Human-readable version or version used to identify a release to end users. [5] | `10.14.1` | No |
 
 **[1]:** MUST be the same for all instances of the application running on individual client devices. If the value was not specified, SDKs MUST fallback to `unknown_application`.
 

--- a/specification/resource/semantic_conventions/browser.md
+++ b/specification/resource/semantic_conventions/browser.md
@@ -13,3 +13,6 @@
 | `browser.version` | string | The web browser version | `90` | No |
 | `browser.platform` | string | The operating system | `Windows` | No |
 | `browser.mobile` | boolean | Flag indicating a mobile device | | No |
+| `browser.userAgent` | string | Full user-agent string provided by the browser [1] | `'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36'` | No |
+
+**[1]:** The user-agent value should be provided only from browsers that do not have a mechanism to retrieve name, version, and platform individually (for example from the User-Agent Client Hints API). 

--- a/specification/resource/semantic_conventions/browser.md
+++ b/specification/resource/semantic_conventions/browser.md
@@ -13,6 +13,6 @@
 | `browser.version` | string | The web browser version | `90` | No |
 | `browser.platform` | string | The operating system | `Windows` | No |
 | `browser.mobile` | boolean | Flag indicating a mobile device | | No |
-| `browser.userAgent` | string | Full user-agent string provided by the browser [1] | `'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36'` | No |
+| `browser.user_agent` | string | Full user-agent string provided by the browser [1] | `'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.54 Safari/537.36'` | No |
 
 **[1]:** The user-agent value should be provided only from browsers that do not have a mechanism to retrieve name, version, and platform individually (for example from the User-Agent Client Hints API). 

--- a/specification/resource/semantic_conventions/browser.md
+++ b/specification/resource/semantic_conventions/browser.md
@@ -4,7 +4,7 @@
 
 **type:** `browser`
 
-**Description**: The web browser in which the application represented by the resource is running. The `browser.*` attributes MUST be used only for resources that represent client-side devices - the presence of these attributes can be used to identify client-side telemetry.
+**Description**: The web browser in which the application represented by the resource is running. The `browser.*` attributes MUST be used only for resources that represent applications running in a web browser. The presence of these attributes is intended to identify client-side telemetry.
 
 <!-- semconv device -->
 | Attribute  | Type | Description  | Examples  | Required |

--- a/specification/resource/semantic_conventions/browser.md
+++ b/specification/resource/semantic_conventions/browser.md
@@ -1,0 +1,15 @@
+# Browser
+
+**Status**: [Experimental](../../document-status.md)
+
+**type:** `browser`
+
+**Description**: The web browser in which the application represented by the resource is running. The `browser.*` attributes MUST be used only for resources that represent client-side devices - the presence of these attributes can be used to identify client-side telemetry.
+
+<!-- semconv device -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `browser.name` | string | The web browser name | `Chrome` | No |
+| `browser.version` | string | The web browser version | `90` | No |
+| `browser.platform` | string | The operating system | `Windows` | No |
+| `browser.mobile` | boolean | Flag indicating a mobile device | | No |

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -4,7 +4,7 @@
 
 **type:** `device`
 
-**Description**: The device on which the process represented by this resource is running. The `device.*` attributes MUST be used only for resources that represent client-side devices - the presence of these attributes can be used to identify client-side telemetry.
+**Description**: The device on which the process represented by this resource is running. The `device.*` attributes MUST be used only for resources that are not part of a private infrastructure, for example a mobile or IoT device.
 
 <!-- semconv device -->
 | Attribute  | Type | Description  | Examples  | Required |

--- a/specification/resource/semantic_conventions/device.md
+++ b/specification/resource/semantic_conventions/device.md
@@ -4,7 +4,7 @@
 
 **type:** `device`
 
-**Description**: The device on which the process represented by this resource is running.
+**Description**: The device on which the process represented by this resource is running. The `device.*` attributes MUST be used only for resources that represent client-side devices - the presence of these attributes can be used to identify client-side telemetry.
 
 <!-- semconv device -->
 | Attribute  | Type | Description  | Examples  | Required |


### PR DESCRIPTION
In order to identify client-side telemetry, this PR specifies that `device` attributes should be used only for client-side devices. It also adds a section for `browser` attributes. The presence of either a `device` or `browser` attribute would be used to distinguish that the signal comes from a client-side instrumentation.

This was discussed in the Client-side SIG as well as [Spec SIG on 11/2/21](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit#heading=h.erc0axt1ayqq) 