### PR TITLE
Move Metrics In-memory/OTLP/Stdout exporters to Feature-freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ release.
 
 - Rename None aggregation to Drop.
   ([#2101](https://github.com/open-telemetry/opentelemetry-specification/pull/2101))
+- Mark In-memory, OTLP and Stdout exporter specs as Feature-freeze.
+  ([#2131](https://github.com/open-telemetry/opentelemetry-specification/pull/2131))
 
 ### Logs
 

--- a/specification/metrics/sdk_exporters/in-memory.md
+++ b/specification/metrics/sdk_exporters/in-memory.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - In-memory
 
-**Status**: [Feature-freeze](../document-status.md)
+**Status**: [Feature-freeze](../../document-status.md)
 
 In-memory Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which accumulates metrics data in the

--- a/specification/metrics/sdk_exporters/in-memory.md
+++ b/specification/metrics/sdk_exporters/in-memory.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - In-memory
 
-**Status**: [Experimental](../../document-status.md)
+**Status**: [Feature-freeze](../document-status.md)
 
 In-memory Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which accumulates metrics data in the

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - OTLP
 
-**Status**: [Experimental](../../document-status.md)
+**Status**: [Feature-freeze](../document-status.md)
 
 OTLP Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which sends metrics via the

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - OTLP
 
-**Status**: [Feature-freeze](../document-status.md)
+**Status**: [Feature-freeze](../../document-status.md)
 
 OTLP Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which sends metrics via the

--- a/specification/metrics/sdk_exporters/stdout.md
+++ b/specification/metrics/sdk_exporters/stdout.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - Standard output
 
-**Status**: [Experimental](../../document-status.md)
+**Status**: [Feature-freeze](../document-status.md)
 
 "Standard output" Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which outputs the metrics to

--- a/specification/metrics/sdk_exporters/stdout.md
+++ b/specification/metrics/sdk_exporters/stdout.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - Standard output
 
-**Status**: [Feature-freeze](../document-status.md)
+**Status**: [Feature-freeze](../../document-status.md)
 
 "Standard output" Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which outputs the metrics to


### PR DESCRIPTION
Move the metrics exporters spec to feature-freeze (except for Prometheus exporter, which will need more time).