### PR TITLE
OTLP: add Collector/* statuses to Signals Maturity Level section

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -50,6 +50,9 @@ of OpenTelemetry project.
 Each signal has different support and stability in OTLP, described through its
 own maturity level, which in turn applies to **all** the OTLP Transports listed below.
 
+* Collector/trace: **Stable**
+* Collector/metrics: **Stable**
+* Collector/logs: **Beta**
 * Tracing: **Stable**
 * Metrics: **Stable**
 * Logs: **Beta**
@@ -259,7 +262,7 @@ Here is a sample Go code to illustrate:
   }
 
   return st.Err()
-  
+
   ...
 
   // Do this on client side.


### PR DESCRIPTION
- This PR adds `Collector/*` statuses to the [OpenTelemetry Protocol Specification > Signals Maturity Level] section.
- The statuses are taken from [OTLP Maturity Level].
- This change is motivated by https://github.com/open-telemetry/opentelemetry.io/pull/959, which automates the update of the [opentelemetry.io Status page] by reading statuses from the officially published specification.
- (Should more statuses from [OTLP Maturity Level] be added?)

/cc @austinlparker 

[opentelemetry.io Status page]: https://opentelemetry.io/docs/status/
[OTLP Maturity Level]: https://github.com/open-telemetry/opentelemetry-proto#maturity-level
[OpenTelemetry Protocol Specification > Signals Maturity Level]: https://opentelemetry.io/docs/reference/specification/protocol/otlp/#signals-maturity-level