### PR TITLE
Adjust the metrics SDK spec wording regarding exporter and aggregated…

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -663,7 +663,7 @@ The goal of the interface is to minimize burden of implementation for
 protocol-dependent telemetry exporters. The protocol exporter is expected to be
 primarily a simple telemetry data encoder and transmitter.
 
-Metric Exporter has access to the [pre-aggregated metrics
+Metric Exporter has access to the [aggregated metrics
 data](./datamodel.md#timeseries-model).
 
 There could be multiple [Push Metric Exporters](#push-metric-exporter) or [Pull


### PR DESCRIPTION
Minor change related to #2157.

There are other places (outside the Metrics SDK spec) where the terms could be confusing, e.g. https://github.com/open-telemetry/opentelemetry-specification/search?q=pre-aggregated. Not covered by this PR.