### PR TITLE
Clarify SDK must apply a default aggregation if not specified.

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -163,7 +163,7 @@ are the inputs:
   * The `extra dimensions` which come from Baggage/Context (optional). If not
     provided, no extra dimension will be used. Please note that this only
     applies to [synchronous Instruments](./api.md#synchronous-instrument).
-  * The `aggregation` (optional) to be used. If not provided, the SDK SHOULD
+  * The `aggregation` (optional) to be used. If not provided, the SDK MUST
     apply a [default aggregation](#default-aggregation). If the aggregation
     outputs metric points that use aggregation temporality (e.g. Histogram,
     Sum), the SDK SHOULD handle the aggregation temporality based on the


### PR DESCRIPTION
If the SDK doesn't apply a default aggregation, what can it do? This seemed like a MUST to me but if not, I think this could be changed to also mention a potential alternative.