### PR TITLE
Add execution-unit to glossary.md

### DIFF
--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -126,7 +126,7 @@ MUST be done by the Shim layer in order to retain these invariants.
 
 Because of the previous requirement, a given OpenTelemetry `Span`
 MUST be associated with ONE AND ONLY ONE `SpanContext` Shim object at all times
-for ALL execution units, in order to keep any linked `Baggage` consistent
+for ALL [execution units](../glossary.md#execution-unit), in order to keep any linked `Baggage` consistent
 at all times. It MUST BE safe to get and set the associated `SpanContext` Shim
 object for a specified OpenTelemetry `Span` from different execution units.
 

--- a/specification/context/context.md
+++ b/specification/context/context.md
@@ -21,7 +21,7 @@ Table of Contents
 ## Overview
 
 A `Context` is a propagation mechanism which carries execution-scoped values
-across API boundaries and between logically associated execution units.
+across API boundaries and between logically associated [execution units](../glossary.md#execution-unit).
 Cross-cutting concerns access their data in-process using the same shared
 `Context` object.
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -27,6 +27,7 @@ Some other fundamental terms are documented in the [overview document](overview.
   * [Instrumented Library](#instrumented-library)
   * [Instrumentation Library](#instrumentation-library)
   * [Tracer Name / Meter Name](#tracer-name--meter-name)
+  * [Execution Unit](#execution-unit)
 - [Logs](#logs)
   * [Log Record](#log-record)
   * [Log](#log)
@@ -152,6 +153,10 @@ Synonyms: *Instrumenting Library*.
 This refers to the `name` and (optional) `version` arguments specified when
 creating a new `Tracer` or `Meter` (see [Obtaining a Tracer](trace/api.md#tracerprovider)/[Obtaining a Meter](metrics/api.md#meterprovider)).
 The name/version pair identifies the [Instrumentation Library](#instrumentation-library).
+
+### Execution Unit
+
+An umbrella term for the smallest unit of sequential code execution, used in different concepts of multitasking. Examples are threads, coroutines or fibers.
 
 ## Logs
 


### PR DESCRIPTION
Fixes #1511 ; since I was looking into adding the term service already, I thought I could also give this one a try. Hope it helps:)

## Changes

- Update glossary to contain a definition of the term execution unit
- Link back from opentracing.md and context.md where this term is used