### PR TITLE
Fix typo in metrics/sdk

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -420,7 +420,7 @@ This Aggregation informs the SDK to collect:
 
 Attributes which belong to Metrics are exempt from the
 [common rules of attribute limits](../common/common.md#attribute-limits) at this
-time. Attribute truncation or deletion could affect identitity of metric time
+time. Attribute truncation or deletion could affect identity of metric time
 series and it requires further analysis.
 
 ## Exemplar


### PR DESCRIPTION
Fixes a typo in `specification/metrics/sdk.md`.
