### PR TITLE
Mark In-Memory/OTLP/Stdout exporters as Stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ release.
   ([#2131](https://github.com/open-telemetry/opentelemetry-specification/pull/2131))
 - Remove the concept of supported temporality, keep preferred.
   ([#2154](https://github.com/open-telemetry/opentelemetry-specification/pull/2154))
+- Mark In-memory, OTLP and Stdout exporter specs as Stable.
+  ([#TBD](https://github.com/open-telemetry/opentelemetry-specification/pull/TBD))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ release.
 - Remove the concept of supported temporality, keep preferred.
   ([#2154](https://github.com/open-telemetry/opentelemetry-specification/pull/2154))
 - Mark In-memory, OTLP and Stdout exporter specs as Stable.
-  ([#TBD](https://github.com/open-telemetry/opentelemetry-specification/pull/TBD))
+  ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
 
 ### Logs
 

--- a/specification/metrics/sdk_exporters/in-memory.md
+++ b/specification/metrics/sdk_exporters/in-memory.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - In-memory
 
-**Status**: [Feature-freeze](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 In-memory Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which accumulates metrics data in the

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - OTLP
 
-**Status**: [Feature-freeze](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 OTLP Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which sends metrics via the

--- a/specification/metrics/sdk_exporters/stdout.md
+++ b/specification/metrics/sdk_exporters/stdout.md
@@ -1,6 +1,6 @@
 # OpenTelemetry Metrics Exporter - Standard output
 
-**Status**: [Feature-freeze](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 "Standard output" Metrics Exporter is a [Push Metric
 Exporter](../sdk.md#push-metric-exporter) which outputs the metrics to


### PR DESCRIPTION
This has a dependency on the MetricExporter spec, so it should wait for #2150 to be merged.