### PR TITLE
Clarify the semantics of the Log Timestamp field

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -194,8 +194,9 @@ Below is the detailed description of each field.
 
 Type: Timestamp, uint64 nanoseconds since Unix epoch.
 
-Description: Time when the event occurred measured by the origin clock. This
-field is optional, it may be missing if the timestamp is unknown.
+Description: Time when the event occurred measured by the origin clock, i.e. the
+time at the source. This field is optional, it may be missing if the source
+timestamp is unknown.
 
 ### Trace Context Fields
 


### PR DESCRIPTION
Contributes to https://github.com/open-telemetry/opentelemetry-specification/issues/1875

This is part 1 of the change. Part 2 will add the observed timestamp field. See the issue
for the discussion and the description of the source vs observed timestamps.
