### PR TITLE
Add ObservedTimestamp to the Log Data Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ release.
 
 - Add OTEL_LOGS_EXPORTER environment variable.
   ([#2196](https://github.com/open-telemetry/opentelemetry-specification/pull/2196))
+- Added ObservedTimestamp to the Log Data Model.
+  ([#2184](https://github.com/open-telemetry/opentelemetry-specification/pull/2184))
 
 ### Resource
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -178,6 +178,7 @@ Here is the list of fields in a log record:
 Field Name     |Description
 ---------------|--------------------------------------------
 Timestamp      |Time when the event occurred.
+ObservedTimestamp|Time when the event was observed.
 TraceId        |Request trace id.
 SpanId         |Request span id.
 TraceFlags     |W3C trace flag.
@@ -196,6 +197,24 @@ Type: Timestamp, uint64 nanoseconds since Unix epoch.
 
 Description: Time when the event occurred measured by the origin clock. This
 field is optional, it may be missing if the timestamp is unknown.
+
+### Field: `ObservedTimestamp`
+
+Type: Timestamp, uint64 nanoseconds since Unix epoch.
+
+Description: Time when the event was observed by the collection system. For
+events that originate in OpenTelemetry this timestamp is typically set at the
+generation time and is equal to Timestamp. For events originating externally and
+collected by OpenTelemetry (e.g. using Collector) this is the time when the
+OpenTelemetry's code observed the event measure by the clock of the
+OpenTelemetry code. This field SHOULD be set once the event is observed by
+OpenTelemetry.
+
+For converting OpenTelemetry log data to formats that support only one timestamp
+or when receiving OpenTelemetry log data by recipients that support only one
+timestamp internally the following logic is recommended:
+
+- Use `Timestamp` if it is present, otherwise use `ObservedTimestamp`.
 
 ### Trace Context Fields
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -203,12 +203,12 @@ field is optional, it may be missing if the timestamp is unknown.
 Type: Timestamp, uint64 nanoseconds since Unix epoch.
 
 Description: Time when the event was observed by the collection system. For
-events that originate in OpenTelemetry this timestamp is typically set at the
-generation time and is equal to Timestamp. For events originating externally and
-collected by OpenTelemetry (e.g. using Collector) this is the time when the
-OpenTelemetry's code observed the event measure by the clock of the
-OpenTelemetry code. This field SHOULD be set once the event is observed by
-OpenTelemetry.
+events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
+this timestamp is typically set at the generation time and is equal to
+Timestamp. For events originating externally and collected by OpenTelemetry
+(e.g. using Collector) this is the time when OpenTelemetry's code observed the
+event measured by the clock of the OpenTelemetry code. This field SHOULD be set
+once the event is observed by OpenTelemetry.
 
 For converting OpenTelemetry log data to formats that support only one timestamp
 or when receiving OpenTelemetry log data by recipients that support only one


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-specification/issues/1875

See the issue above for the detailed discussion. A summary here:

Currently, logs data model describes a single (optional) [`Timestamp` field](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-timestamp) which describes when the event occurred

Unlike for e.g. spans, there are at least three ways a log record can have timestamp associated:

1. It can be set by a library supporting OTLP natively
2. It can be parsed out from the log Body or Attributes (e.g. using [timestamp operator](https://github.com/open-telemetry/opentelemetry-log-collection/blob/main/docs/types/timestamp.md) for filelogreceiver)
3. It can be set to receipt timestamp (which is a good fallback when the others are not available or fail)

While the first two can be considered mutually exclusive (if the record had timestamp already assigned, it does not make much sense to attempt parsing log body for it), this is not true with the last one. However, there's only one field where all of them can fit. 

This brings several problems, such as:
* Inability to fallback to receipt timestamp when parsing yielded incorrect value (also, no easy ability to find records with potential timestamp parsing errors)
* No way to to tell using what method the timestamp was assigned to the record 
* Lack of data to measure delay between log occurrence and log being collected

E.g. currently `filelogreceiver` sets `Timestamp` to receipt time - by default, or parsed timestamp - when timestamp operator is used. This makes it impossible to tell later if the log timestamp was parsed or not.

**Proposed solution**

This adds another field to the log record which would store the receipt timestamp (`ObservedTimestamp`). It is filled in the record when OpenTelemetry first observes the log record. 

See also the clarification about the `Timestamp` field here https://github.com/open-telemetry/opentelemetry-specification/pull/2183

The net result is that we are aiming for 2 timestamp fields like this:

- `Timestamp` - Time when the event occurred measured by the origin clock, i.e. the time at the source. This field is optional, it may be missing if the source timestamp is unknown.
- `ObservedTimestamp` - Time when the event was observed by the collection system. For events that originate in OpenTelemetry this timestamp is typically set at the generation time and is equal to `Timestamp`. For events originating externally and collected by OpenTelemetry (e.g. using Collector) this is the time when any of OpenTelemetry's code observed the event measure by the clock of the OpenTelemetry code. This field SHOULD be set once the event is observed by OpenTelemetry.