### PR TITLE
Prohibit usage of retired names in semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ release.
 
 ### Semantic Conventions
 
+- Prohibit usage of retired names in semantic conventions.
+  ([#2191](https://github.com/open-telemetry/opentelemetry-specification/pull/2191))
+
 ### Compatibility
 
 - Simplify Baggage handling in the OpenTracing Shim layer.

--- a/specification/common/attribute-naming.md
+++ b/specification/common/attribute-naming.md
@@ -70,9 +70,8 @@ Names SHOULD follow these rules:
 
 ## Name Reuse Prohibition
 
-It is prohibited to introduce a new attribute with a name that matches a name of
-an attribute that existed in the past but was renamed (with a corresponding
-schema file).
+A new attribute MUST NOT be added with the same name as an attribute that
+existed in the past but was renamed (with a corresponding schema file).
 
 When introducing a new attribute name check all existing schema files to make
 sure the name does not appear as a key of any "rename_attributes" section (keys

--- a/specification/common/attribute-naming.md
+++ b/specification/common/attribute-naming.md
@@ -8,6 +8,7 @@
 <!-- toc -->
 
 - [Name Pluralization guidelines](#name-pluralization-guidelines)
+- [Name Reuse Prohibition](#name-reuse-prohibition)
 - [Recommendations for OpenTelemetry Authors](#recommendations-for-opentelemetry-authors)
 - [Recommendations for Application Developers](#recommendations-for-application-developers)
 - [otel.* Namespace](#otel-namespace)
@@ -66,6 +67,16 @@ Names SHOULD follow these rules:
 - When an attribute represents a measurement,
   [Metric Name Pluralization Guidelines](../metrics/semantic_conventions/README.md#pluralization)
   SHOULD be followed for the attribute name.
+
+## Name Reuse Prohibition
+
+It is prohibited to introduce a new attribute with a name that matches a name of
+an attribute that existed in the past but was renamed (with a corresponding
+schema file).
+
+When introducing a new attribute name check all existing schema files to make
+sure the name does not appear as a key of any "rename_attributes" section (keys
+denote old attribute names in rename operations).
 
 ## Recommendations for OpenTelemetry Authors
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -69,9 +69,8 @@ ambiguous.
 
 ### Name Reuse Prohibition
 
-It is prohibited to introduce a new metric with a name that matches a name of
-a metric that existed in the past but was renamed (with a corresponding
-schema file).
+A new metric MUST NOT be added with the same name as a metric that existed in
+the past but was renamed (with a corresponding schema file).
 
 When introducing a new metric name check all existing schema files to make sure
 the name does not appear as a key of any "rename_metrics" section (keys denote

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -7,6 +7,7 @@
 <!-- toc -->
 
 - [General Guidelines](#general-guidelines)
+  * [Name Reuse Prohibition](#name-reuse-prohibition)
   * [Units](#units)
   * [Pluralization](#pluralization)
 - [General Metric Semantic Conventions](#general-metric-semantic-conventions)
@@ -65,6 +66,16 @@ names for GC, not divided by the runtime, could create dissimilar comparisons
 and confusion for end users. (For example, prefer `process.runtime.java.gc*` over
 `process.runtime.gc.*`.) Measures of many operating system metrics are similarly
 ambiguous.
+
+### Name Reuse Prohibition
+
+It is prohibited to introduce a new metric with a name that matches a name of
+a metric that existed in the past but was renamed (with a corresponding
+schema file).
+
+When introducing a new metric name check all existing schema files to make sure
+the name does not appear as a key of any "rename_metrics" section (keys denote
+old metric names in rename operations).
 
 ### Units
 

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -34,9 +34,8 @@ OpenTelemetry also defines the concept of overarching [Resources](../../resource
 
 ## Event Name Reuse Prohibition
 
-It is prohibited to introduce a new event with a name that matches a name of an
-event that existed in the past but was renamed (with a corresponding schema
-file).
+A new event MUST NOT be added with the same name as an event that existed in
+the past but was renamed (with a corresponding schema file).
 
 When introducing a new event name check all existing schema files to make sure
 the name does not appear as a key of any "rename_events" section (keys denote

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -31,3 +31,13 @@ The following library-specific semantic conventions are defined:
 Apart from semantic conventions for traces and [metrics](../../metrics/semantic_conventions/README.md),
 OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own
 [Resource Semantic Conventions](../../resource/semantic_conventions/README.md).
+
+## Event Name Reuse Prohibition
+
+It is prohibited to introduce a new event with a name that matches a name of an
+event that existed in the past but was renamed (with a corresponding schema
+file).
+
+When introducing a new event name check all existing schema files to make sure
+the name does not appear as a key of any "rename_events" section (keys denote
+old event names in rename operations).


### PR DESCRIPTION
This change adds a prohibition clause that requires that no old
metric or attribute name is used for a new attribute.

This is important to ensure reversibility of schema transformation
(converting from a new version to an old version of schema).

Without this restriction the following is possible:

Schema version 1. Attribute A exists.
Schema version 2. Attribute A is renamed to B. Appropriate schema file is created.
Schema version 3. Attribute A is introduced (a completely different new attribute).

Now attempting to go from Version 3 to version 1 is impossible since it requires
renaming B to A (for the change in version 2), but a different attribute A already exists.
