### PR TITLE
adding environment variable for OTEL_LOGS_EXPORTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ release.
 ### Logs
 
 - Add OTEL_LOGS_EXPORTER environment variable.
-  ([#](https://github.com/open-telemetry/opentelemetry-specification/pull/))
+  ([#2196](https://github.com/open-telemetry/opentelemetry-specification/pull/2196))
 
 ### Resource
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ release.
 
 ### Logs
 
+- Add OTEL_LOGS_EXPORTER environment variable.
+  ([#](https://github.com/open-telemetry/opentelemetry-specification/pull/))
+
 ### Resource
 
 ### Semantic Conventions

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -247,6 +247,7 @@ Note: Support for environment variables is optional.
 |OTEL_EXPORTER_ZIPKIN_*                        | - |    |   |      |    | -    | - | -  | - | +  | -   |
 |OTEL_TRACES_EXPORTER                          | - | +  |   | +    | +  | +    |   | -  | - |    |     |
 |OTEL_METRICS_EXPORTER                         | - | +  |   | +    | -  | -    |   | -  | - | -  | -   |
+|OTEL_LOGS_EXPORTER                            |   |    |   |      |    |      |   |    |   |    |     |
 |OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT               | - | +  |   | +    | +  | -    |   | +  | - |    |     |
 |OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT        |   |    |   |      |    |      |   |    |   |    |     |
 |OTEL_SPAN_EVENT_COUNT_LIMIT                   | - | +  |   | +    | +  | -    |   | +  | - |    |     |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -171,6 +171,7 @@ We define environment variables for setting one or more exporters per signal.
 | ------------- | ---------------------------------------------------------------------------- | ------- |
 | OTEL_TRACES_EXPORTER | Trace exporter to be used | "otlp"  |
 | OTEL_METRICS_EXPORTER | Metrics exporter to be used | "otlp"  |
+| OTEL_LOGS_EXPORTER | Logs exporter to be used | "otlp"  |
 
 The SDK MAY accept a comma-separated list to enable setting multiple exporters.
 
@@ -186,6 +187,11 @@ Known values for `OTEL_METRICS_EXPORTER` are:
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
 - `"none"`: No automatically configured exporter for metrics.
+
+Known values for `OTEL_LOGS_EXPORTER` are:
+
+- `"otlp"`: [OTLP](./protocol/otlp.md)
+- `"none"`: No automatically configured exporter for logs.
 
 ## Metrics SDK Configuration
 


### PR DESCRIPTION
This PR adds the environment variable to support configuration of log exporters as is supported for metrics and traces today.

This variable was mentioned in the conversation here https://github.com/open-telemetry/opentelemetry-specification/issues/1309#issuecomment-751991068