### PR TITLE
Use UCUM units in Metrics Semantic Conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ release.
   ([#2154](https://github.com/open-telemetry/opentelemetry-specification/pull/2154))
 - Mark In-memory, OTLP and Stdout exporter specs as Stable.
   ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
+- Use UCUM units in Metrics Semantic Conventions.
+  ([#2199](https://github.com/open-telemetry/opentelemetry-specification/pull/2199))
 
 ### Logs
 

--- a/specification/metrics/semantic_conventions/faas-metrics.md
+++ b/specification/metrics/semantic_conventions/faas-metrics.md
@@ -32,22 +32,22 @@ type and units.
 
 Below is a table of FaaS invocation metric instruments.
 
-| Name | Instrument | Units | Description |
-|------|------------|----|-------------|
-| `faas.invoke_duration` | Histogram | ms | Measures the duration of the invocation in milliseconds |
-| `faas.init_duration` | Histogram | ms | Measures the duration of the function's initialization, such as a cold start, in milliseconds |
-| `faas.coldstarts` | Counter | 1 | Number of invocation cold starts. |
-| `faas.errors` | Counter | 1 | Number of invocation errors. |
-| `faas.executions` | Counter | 1 | Number of successful invocations. |
-| `faas.timeouts` | Counter | 1 | Number of invocation timeouts. |
+| Name | Instrument | Unit | Unit (UCUM) | Description |
+|------|------------|------|-------------|-------------|
+| `faas.invoke_duration` | Histogram | milliseconds |`ms` | Measures the duration of the invocation |
+| `faas.init_duration` | Histogram | milliseconds | `ms` | Measures the duration of the function's initialization, such as a cold start |
+| `faas.coldstarts` | Counter | default unit | `{coldstarts}` | Number of invocation cold starts. |
+| `faas.errors` | Counter | default unit | `{errors}` | Number of invocation errors. |
+| `faas.executions` | Counter | default unit |`{executions}` | Number of successful invocations. |
+| `faas.timeouts` | Counter | default unit | `{timeouts}` | Number of invocation timeouts. |
 
 Optionally, when applicable:
 
-| Name | Instrument | Units | Description |
-|------|------------|----|-------------|
-| `faas.mem_usage` | Histogram | By | Distribution of max memory usage per invocation in bytes |
-| `faas.cpu_usage` | Histogram | ms | Distribution of cpu usage per invocation in milliseconds |
-| `faas.net_io` | Histogram | By | Distribution of net I/O usage per invocation in bytes|
+| Name | Instrument | Unit | Unit (UCUM) | Description |
+|------|------------|------|-------------|-------------|
+| `faas.mem_usage` | Histogram | Bytes | `By` | Distribution of max memory usage per invocation |
+| `faas.cpu_usage` | Histogram | milliseconds | `ms` | Distribution of cpu usage per invocation |
+| `faas.net_io` | Histogram | Bytes | `By` | Distribution of net I/O usage per invocation |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/faas-metrics.md
+++ b/specification/metrics/semantic_conventions/faas-metrics.md
@@ -32,19 +32,19 @@ type and units.
 
 Below is a table of FaaS invocation metric instruments.
 
-| Name | Instrument | Unit | Unit (UCUM) | Description |
-|------|------------|------|-------------|-------------|
-| `faas.invoke_duration` | Histogram | milliseconds |`ms` | Measures the duration of the invocation |
+| Name | Instrument | Unit | Unit ([UCUM](README.md#instrument-units)) | Description |
+|------|------------|------|-------------------------------------------|-------------|
+| `faas.invoke_duration` | Histogram | milliseconds | `ms` | Measures the duration of the invocation |
 | `faas.init_duration` | Histogram | milliseconds | `ms` | Measures the duration of the function's initialization, such as a cold start |
 | `faas.coldstarts` | Counter | default unit | `{coldstarts}` | Number of invocation cold starts. |
 | `faas.errors` | Counter | default unit | `{errors}` | Number of invocation errors. |
-| `faas.executions` | Counter | default unit |`{executions}` | Number of successful invocations. |
+| `faas.executions` | Counter | default unit | `{executions}` | Number of successful invocations. |
 | `faas.timeouts` | Counter | default unit | `{timeouts}` | Number of invocation timeouts. |
 
 Optionally, when applicable:
 
-| Name | Instrument | Unit | Unit (UCUM) | Description |
-|------|------------|------|-------------|-------------|
+| Name | Instrument | Unit | Unit ([UCUM](README.md#instrument-units)) | Description |
+|------|------------|------|-------------------------------------------|-------------|
 | `faas.mem_usage` | Histogram | Bytes | `By` | Distribution of max memory usage per invocation |
 | `faas.cpu_usage` | Histogram | milliseconds | `ms` | Distribution of cpu usage per invocation |
 | `faas.net_io` | Histogram | Bytes | `By` | Distribution of net I/O usage per invocation |

--- a/specification/metrics/semantic_conventions/faas-metrics.md
+++ b/specification/metrics/semantic_conventions/faas-metrics.md
@@ -34,20 +34,20 @@ Below is a table of FaaS invocation metric instruments.
 
 | Name | Instrument | Units | Description |
 |------|------------|----|-------------|
-| `faas.invoke_duration` | Histogram | milliseconds | Measures the duration of the invocation |
-| `faas.init_duration` | Histogram | milliseconds | Measures the duration of the function's initialization, such as a cold start |
-| `faas.coldstarts` | Counter | default unit | Number of invocation cold starts. |
-| `faas.errors` | Counter | default unit | Number of invocation errors. |
-| `faas.executions` | Counter | default unit  | Number of successful invocations. |
-| `faas.timeouts` | Counter | default unit | Number of invocation timeouts. |
+| `faas.invoke_duration` | Histogram | ms | Measures the duration of the invocation |
+| `faas.init_duration` | Histogram | ms | Measures the duration of the function's initialization, such as a cold start |
+| `faas.coldstarts` | Counter | 1 | Number of invocation cold starts. |
+| `faas.errors` | Counter | 1 | Number of invocation errors. |
+| `faas.executions` | Counter | 1 | Number of successful invocations. |
+| `faas.timeouts` | Counter | 1 | Number of invocation timeouts. |
 
 Optionally, when applicable:
 
 | Name | Instrument | Units | Description |
 |------|------------|----|-------------|
-| `faas.mem_usage` | Histogram | bytes | Distribution of max memory usage per invocation |
-| `faas.cpu_usage` | Histogram | milliseconds | Distribution of cpu usage per invocation |
-| `faas.net_io` | Histogram | bytes | Distribution of net I/O usage per invocation |
+| `faas.mem_usage` | Histogram | By | Distribution of max memory usage per invocation |
+| `faas.cpu_usage` | Histogram | ms | Distribution of cpu usage per invocation |
+| `faas.net_io` | Histogram | By | Distribution of net I/O usage per invocation |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/faas-metrics.md
+++ b/specification/metrics/semantic_conventions/faas-metrics.md
@@ -34,8 +34,8 @@ Below is a table of FaaS invocation metric instruments.
 
 | Name | Instrument | Units | Description |
 |------|------------|----|-------------|
-| `faas.invoke_duration` | Histogram | ms | Measures the duration of the invocation |
-| `faas.init_duration` | Histogram | ms | Measures the duration of the function's initialization, such as a cold start |
+| `faas.invoke_duration` | Histogram | ms | Measures the duration of the invocation in milliseconds |
+| `faas.init_duration` | Histogram | ms | Measures the duration of the function's initialization, such as a cold start, in milliseconds |
 | `faas.coldstarts` | Counter | 1 | Number of invocation cold starts. |
 | `faas.errors` | Counter | 1 | Number of invocation errors. |
 | `faas.executions` | Counter | 1 | Number of successful invocations. |
@@ -45,9 +45,9 @@ Optionally, when applicable:
 
 | Name | Instrument | Units | Description |
 |------|------------|----|-------------|
-| `faas.mem_usage` | Histogram | By | Distribution of max memory usage per invocation |
-| `faas.cpu_usage` | Histogram | ms | Distribution of cpu usage per invocation |
-| `faas.net_io` | Histogram | By | Distribution of net I/O usage per invocation |
+| `faas.mem_usage` | Histogram | By | Distribution of max memory usage per invocation in bytes |
+| `faas.cpu_usage` | Histogram | ms | Distribution of cpu usage per invocation in milliseconds |
+| `faas.net_io` | Histogram | By | Distribution of net I/O usage per invocation in bytes|
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -17,18 +17,18 @@ type and units.
 
 Below is a table of HTTP server metric instruments.
 
-| Name                          | Instrument                 | Unit         | Unit (UCUM)  | Description |
-|-------------------------------|----------------------------|--------------|--------------|-------------|
-| `http.server.duration`        | Histogram                  | milliseconds | `ms`         | measures the duration of the inbound HTTP request |
-| `http.server.active_requests` | Asynchronous UpDownCounter | requests     | `{requests}` | measures the number of concurrent HTTP requests that are currently in-flight |
+| Name                          | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|-------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
+| `http.server.duration`        | Histogram                  | milliseconds | `ms`                                      | measures the duration of the inbound HTTP request |
+| `http.server.active_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | measures the number of concurrent HTTP requests that are currently in-flight |
 
 ### HTTP Client
 
 Below is a table of HTTP client metric instruments.
 
-| Name                   | Instrument | Unit         | Unit (UCUM) | Description |
-|------------------------|------------|--------------|-------------|-------------|
-| `http.client.duration` | Histogram  | milliseconds | `ms`        | measure the duration of the outbound HTTP request |
+| Name                   | Instrument | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|------------------------|------------|--------------|-------------------------------------------|-------------|
+| `http.client.duration` | Histogram  | milliseconds | `ms`                                      | measure the duration of the outbound HTTP request |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -19,7 +19,7 @@ Below is a table of HTTP server metric instruments.
 
 | Name                          | Instrument                 | Units      | Description |
 |-------------------------------|----------------------------|------------|-------------|
-| `http.server.duration`        | Histogram                  | ms         | measures the duration of the inbound HTTP request |
+| `http.server.duration`        | Histogram                  | ms         | measures the duration of the inbound HTTP request in milliseconds |
 | `http.server.active_requests` | Asynchronous UpDownCounter | {requests} | measures the number of concurrent HTTP requests that are currently in-flight |
 
 ### HTTP Client
@@ -28,7 +28,7 @@ Below is a table of HTTP client metric instruments.
 
 | Name                   | Instrument | Units | Description |
 |------------------------|------------|-------|-------------|
-| `http.client.duration` | Histogram  | ms    | measure the duration of the outbound HTTP request |
+| `http.client.duration` | Histogram  | ms    | measure the duration of the outbound HTTP request in milliseconds |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -17,18 +17,18 @@ type and units.
 
 Below is a table of HTTP server metric instruments.
 
-| Name                          | Instrument                 | Units        | Description |
-|-------------------------------|----------------------------|--------------|-------------|
-| `http.server.duration`        | Histogram                  | milliseconds | measures the duration of the inbound HTTP request |
-| `http.server.active_requests` | Asynchronous UpDownCounter | requests     | measures the number of concurrent HTTP requests that are currently in-flight |
+| Name                          | Instrument                 | Units      | Description |
+|-------------------------------|----------------------------|------------|-------------|
+| `http.server.duration`        | Histogram                  | ms         | measures the duration of the inbound HTTP request |
+| `http.server.active_requests` | Asynchronous UpDownCounter | {requests} | measures the number of concurrent HTTP requests that are currently in-flight |
 
 ### HTTP Client
 
 Below is a table of HTTP client metric instruments.
 
-| Name                   | Instrument | Units        | Description |
-|------------------------|------------|--------------|-------------|
-| `http.client.duration` | Histogram  | milliseconds | measure the duration of the outbound HTTP request |
+| Name                   | Instrument | Units | Description |
+|------------------------|------------|-------|-------------|
+| `http.client.duration` | Histogram  | ms    | measure the duration of the outbound HTTP request |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -17,18 +17,18 @@ type and units.
 
 Below is a table of HTTP server metric instruments.
 
-| Name                          | Instrument                 | Units      | Description |
-|-------------------------------|----------------------------|------------|-------------|
-| `http.server.duration`        | Histogram                  | ms         | measures the duration of the inbound HTTP request in milliseconds |
-| `http.server.active_requests` | Asynchronous UpDownCounter | {requests} | measures the number of concurrent HTTP requests that are currently in-flight |
+| Name                          | Instrument                 | Unit         | Unit (UCUM)  | Description |
+|-------------------------------|----------------------------|--------------|--------------|-------------|
+| `http.server.duration`        | Histogram                  | milliseconds | `ms`         | measures the duration of the inbound HTTP request |
+| `http.server.active_requests` | Asynchronous UpDownCounter | requests     | `{requests}` | measures the number of concurrent HTTP requests that are currently in-flight |
 
 ### HTTP Client
 
 Below is a table of HTTP client metric instruments.
 
-| Name                   | Instrument | Units | Description |
-|------------------------|------------|-------|-------------|
-| `http.client.duration` | Histogram  | ms    | measure the duration of the outbound HTTP request in milliseconds |
+| Name                   | Instrument | Unit         | Unit (UCUM) | Description |
+|------------------------|------------|--------------|-------------|-------------|
+| `http.client.duration` | Histogram  | milliseconds | `ms`        | measure the duration of the outbound HTTP request |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -33,11 +33,11 @@ Below is a table of RPC server metric instruments.
 
 | Name | Instrument | Units | Description | Status | Streaming |
 |------|------------|-------|-------------|--------|-----------|
-| `rpc.server.duration` | Histogram  | milliseconds | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
-| `rpc.server.request.size` | Histogram  | bytes | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.server.response.size` | Histogram  | bytes | measures size of RPC response messages (uncompressed) | Optional | Recorded per response in a streaming batch |
-| `rpc.server.requests_per_rpc` | Histogram  | count | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
-| `rpc.server.responses_per_rpc` | Histogram  | count | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| `rpc.server.duration` | Histogram  | ms | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.server.request.size` | Histogram  | By | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.server.response.size` | Histogram  | By | measures size of RPC response messages (uncompressed) | Optional | Recorded per response in a streaming batch |
+| `rpc.server.requests_per_rpc` | Histogram  | {count} | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| `rpc.server.responses_per_rpc` | Histogram  | {count} | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 
 ### RPC Client
 
@@ -46,11 +46,11 @@ RPC usage, not streaming RPCs.
 
 | Name | Instrument | Units | Description | Status | Streaming |
 |------|------------|-------|-------------|--------|-----------|
-| `rpc.client.duration` | Histogram | milliseconds | measures duration of outbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
-| `rpc.client.request.size` | Histogram | bytes | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.client.response.size` | Histogram | bytes | measures size of RPC response messages (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.client.requests_per_rpc` | Histogram | count | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
-| `rpc.client.responses_per_rpc` | Histogram | count | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| `rpc.client.duration` | Histogram | ms | measures duration of outbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.client.request.size` | Histogram | By | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.client.response.size` | Histogram | By | measures size of RPC response messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.client.requests_per_rpc` | Histogram | {count} | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| `rpc.client.responses_per_rpc` | Histogram | {count} | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 
 ## Attributes
 

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -31,8 +31,8 @@ MUST be of the specified type and units.
 
 Below is a table of RPC server metric instruments.
 
-| Name | Instrument | Unit | Unit (UCUM) | Description | Status | Streaming |
-|------|------------|------|-------------|-------------|--------|-----------|
+| Name | Instrument | Unit | Unit ([UCUM](README.md#instrument-units)) | Description | Status | Streaming |
+|------|------------|------|-------------------------------------------|-------------|--------|-----------|
 | `rpc.server.duration` | Histogram  | Bytes | `ms` | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
 | `rpc.server.request.size` | Histogram  | Bytes | `By` | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
 | `rpc.server.response.size` | Histogram  | Bytes | `By` | measures size of RPC response messages (uncompressed) | Optional | Recorded per response in a streaming batch |
@@ -44,8 +44,8 @@ Below is a table of RPC server metric instruments.
 Below is a table of RPC client metric instruments.  These apply to traditional
 RPC usage, not streaming RPCs.
 
-| Name | Instrument | Unit | Unit (UCUM) | Description | Status | Streaming |
-|------|------------|------|-------------|-------------|--------|-----------|
+| Name | Instrument | Unit | Unit ([UCUM](README.md#instrument-units)) | Description | Status | Streaming |
+|------|------------|------|-------------------------------------------|-------------|--------|-----------|
 | `rpc.client.duration` | Histogram | milliseconds | `ms` | measures duration of outbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
 | `rpc.client.request.size` | Histogram | Bytes | `By` | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
 | `rpc.client.response.size` | Histogram | Bytes | `By` | measures size of RPC response messages (uncompressed) | Optional | Recorded per message in a streaming batch |

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -33,9 +33,9 @@ Below is a table of RPC server metric instruments.
 
 | Name | Instrument | Units | Description | Status | Streaming |
 |------|------------|-------|-------------|--------|-----------|
-| `rpc.server.duration` | Histogram  | ms | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
-| `rpc.server.request.size` | Histogram  | By | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.server.response.size` | Histogram  | By | measures size of RPC response messages (uncompressed) | Optional | Recorded per response in a streaming batch |
+| `rpc.server.duration` | Histogram  | ms | measures duration of inbound RPC in milliseconds | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.server.request.size` | Histogram  | By | measures size of RPC request messages in bytes (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.server.response.size` | Histogram  | By | measures size of RPC response messages in bytes (uncompressed) | Optional | Recorded per response in a streaming batch |
 | `rpc.server.requests_per_rpc` | Histogram  | {count} | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 | `rpc.server.responses_per_rpc` | Histogram  | {count} | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 
@@ -46,9 +46,9 @@ RPC usage, not streaming RPCs.
 
 | Name | Instrument | Units | Description | Status | Streaming |
 |------|------------|-------|-------------|--------|-----------|
-| `rpc.client.duration` | Histogram | ms | measures duration of outbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
-| `rpc.client.request.size` | Histogram | By | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.client.response.size` | Histogram | By | measures size of RPC response messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.client.duration` | Histogram | ms | measures duration of outbound RPC in milliseconds | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.client.request.size` | Histogram | By | measures size of RPC request messages in bytes (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.client.response.size` | Histogram | By | measures size of RPC response messages in bytes (uncompressed) | Optional | Recorded per message in a streaming batch |
 | `rpc.client.requests_per_rpc` | Histogram | {count} | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 | `rpc.client.responses_per_rpc` | Histogram | {count} | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -33,7 +33,7 @@ Below is a table of RPC server metric instruments.
 
 | Name | Instrument | Unit | Unit ([UCUM](README.md#instrument-units)) | Description | Status | Streaming |
 |------|------------|------|-------------------------------------------|-------------|--------|-----------|
-| `rpc.server.duration` | Histogram  | Bytes | `ms` | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.server.duration` | Histogram  | milliseconds | `ms` | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
 | `rpc.server.request.size` | Histogram  | Bytes | `By` | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
 | `rpc.server.response.size` | Histogram  | Bytes | `By` | measures size of RPC response messages (uncompressed) | Optional | Recorded per response in a streaming batch |
 | `rpc.server.requests_per_rpc` | Histogram  | count | `{count}` | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -31,26 +31,26 @@ MUST be of the specified type and units.
 
 Below is a table of RPC server metric instruments.
 
-| Name | Instrument | Units | Description | Status | Streaming |
-|------|------------|-------|-------------|--------|-----------|
-| `rpc.server.duration` | Histogram  | ms | measures duration of inbound RPC in milliseconds | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
-| `rpc.server.request.size` | Histogram  | By | measures size of RPC request messages in bytes (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.server.response.size` | Histogram  | By | measures size of RPC response messages in bytes (uncompressed) | Optional | Recorded per response in a streaming batch |
-| `rpc.server.requests_per_rpc` | Histogram  | {count} | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
-| `rpc.server.responses_per_rpc` | Histogram  | {count} | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| Name | Instrument | Unit | Unit (UCUM) | Description | Status | Streaming |
+|------|------------|------|-------------|-------------|--------|-----------|
+| `rpc.server.duration` | Histogram  | Bytes | `ms` | measures duration of inbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.server.request.size` | Histogram  | Bytes | `By` | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.server.response.size` | Histogram  | Bytes | `By` | measures size of RPC response messages (uncompressed) | Optional | Recorded per response in a streaming batch |
+| `rpc.server.requests_per_rpc` | Histogram  | count | `{count}` | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| `rpc.server.responses_per_rpc` | Histogram  | count | `{count}` | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 
 ### RPC Client
 
 Below is a table of RPC client metric instruments.  These apply to traditional
 RPC usage, not streaming RPCs.
 
-| Name | Instrument | Units | Description | Status | Streaming |
-|------|------------|-------|-------------|--------|-----------|
-| `rpc.client.duration` | Histogram | ms | measures duration of outbound RPC in milliseconds | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
-| `rpc.client.request.size` | Histogram | By | measures size of RPC request messages in bytes (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.client.response.size` | Histogram | By | measures size of RPC response messages in bytes (uncompressed) | Optional | Recorded per message in a streaming batch |
-| `rpc.client.requests_per_rpc` | Histogram | {count} | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
-| `rpc.client.responses_per_rpc` | Histogram | {count} | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| Name | Instrument | Unit | Unit (UCUM) | Description | Status | Streaming |
+|------|------------|------|-------------|-------------|--------|-----------|
+| `rpc.client.duration` | Histogram | milliseconds | `ms` | measures duration of outbound RPC | Recommended | N/A.  While streaming RPCs may record this metric as start-of-batch to end-of-batch, it's hard to interpret in practice. |
+| `rpc.client.request.size` | Histogram | Bytes | `By` | measures size of RPC request messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.client.response.size` | Histogram | Bytes | `By` | measures size of RPC response messages (uncompressed) | Optional | Recorded per message in a streaming batch |
+| `rpc.client.requests_per_rpc` | Histogram | count | `{count}` | measures the number of messages received per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
+| `rpc.client.responses_per_rpc` | Histogram | count | `{count}` | measures the number of messages sent per RPC.  Should be 1 for all non-streaming RPCs | Optional | Required |
 
 ## Attributes
 


### PR DESCRIPTION
As outlined in #2186 and #1794, the [General Metric Semantic Conventions](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions#instrument-units) suggest that [UCUM](http://unitsofmeasure.org/ucum.html) units should be used. 

This PR addresses this by changing the Units in

- `specification/metrics/semantic_conventions/faas-metrics.md`
- `specification/metrics/semantic_conventions/http-metrics.md`
- `specification/metrics/semantic_conventions/rpc-metrics.md`

to these UCUM-compliant units while still retaining the original semantics.

Resolves #1794, resolves #2186
