### PR TITLE
Clarify confusing aspects of exemplar specification.

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -461,13 +461,16 @@ api.context.with(api.trace.setSpan(api.context.active(), span), () => {
 })
 ```
 
-Then an examplar would consist of:
+Then an examplar output in OTLP would consist of:
 
 - The `value` of 1.
 - The `time` when the `add` method was called
 - The `Attributes` of `{"Z": "z-value"}`, as these are not preserved in the
   resulting metric point.
 - The trace/span id for the `makeRequest` span.
+
+While the metric data point for the counter would carry the attributes `X` and
+`Y`.
 
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements
 via the `ExemplarFilter` and `ExemplarReservoir` hooks.
@@ -527,8 +530,10 @@ MAY further sample beyond the `ExemplarFilter`.
 
 The "collect" method MUST return accumulated `Exemplar`s. Exemplars are expected
 to abide by the `AggregationTemporality` of any metric point they are recorded
-with. SDKs are free to decide whether "collect" should also reset internal
-storage for delta aggregation collection, or use a more optimal implementation.
+with. In other words, Exemplars reported against a metric data point SHOULD have
+occured within the start/stop timestamps of that point.  SDKs are free to decide
+whether "collect" should also reset internal storage for delta temporal
+aggregation collection, or use a more optimal implementation.
 
 `Exemplar`s MUST retain any attributes available in the measurement that
 are not preserved by aggregation or view configuration. Specifically, at a

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -531,8 +531,8 @@ MAY further sample beyond the `ExemplarFilter`.
 The "collect" method MUST return accumulated `Exemplar`s. Exemplars are expected
 to abide by the `AggregationTemporality` of any metric point they are recorded
 with. In other words, Exemplars reported against a metric data point SHOULD have
-occured within the start/stop timestamps of that point.  SDKs are free to decide
-whether "collect" should also reset internal storage for delta temporal
+occurred within the start/stop timestamps of that point.  SDKs are free to
+decide whether "collect" should also reset internal storage for delta temporal
 aggregation collection, or use a more optimal implementation.
 
 `Exemplar`s MUST retain any attributes available in the measurement that

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -469,7 +469,6 @@ Then an examplar would consist of:
   resulting metric point.
 - The trace/span id for the `makeRequest` span.
 
-
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements
 via the `ExemplarFilter` and `ExemplarReservoir` hooks.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -530,7 +530,7 @@ to abide by the `AggregationTemporality` of any metric point they are recorded
 with. SDKs are free to decide whether "collect" should also reset internal
 storage for delta aggregation collection, or use a more optimal implementation.
 
-`Exemplar`s MUST retain the any attributes available in the measurement that
+`Exemplar`s MUST retain any attributes available in the measurement that
 are not preserved by aggregation or view configuration. Specifically, at a
 minimum, joining together attributes on an `Exemplar` with those available
 on its associated metric data point should result in the full set of attributes


### PR DESCRIPTION
Fixes #2155
Fixes #2193

- improves description of Exemplars, including use-case.
- Clarify `measurement` as coming from API, and record time.
- Clarify `reset` behavior for `num_measurements` counters.