### PR TITLE
Clarify integer count instrument units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ release.
   ([#2154](https://github.com/open-telemetry/opentelemetry-specification/pull/2154))
 - Mark In-memory, OTLP and Stdout exporter specs as Stable.
   ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
+- Clarify integer count instrument units.
+  ([#2210](https://github.com/open-telemetry/opentelemetry-specification/pull/2210))
 
 ### Logs
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -151,5 +151,5 @@ more clarification in
 total) are dimensionless and SHOULD use the default unit `1` (the unity).
 - Instruments that measure an integer count of something SHOULD only use
 [annotations](https://ucum.org/ucum.html#para-curly) with curly braces to
-give additional meaning *without* the leading default unit (`1`). For example
-`{packets}`, `{errors}`, `{faults}`, etc.
+give additional meaning *without* the leading default unit (`1`). For example,
+use `{packets}`, `{errors}`, `{faults}`, etc.

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -149,5 +149,6 @@ more clarification in
 - Instruments for **utilization** metrics (that measure the fraction out of a
 total) are dimensionless and SHOULD use the default unit `1` (the unity).
 - Instruments that measure an integer count of something SHOULD only use
-annotations with curly braces to give additional meaning without the leading
-default unit (`1`). For example `{packets}`, `{errors}`, `{faults}`, etc.
+[annotations](https://ucum.org/ucum.html#para-curly) with curly braces to
+give additional meaning without the leading default unit (`1`). For example
+`{packets}`, `{errors}`, `{faults}`, etc.

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -148,8 +148,6 @@ more clarification in
 
 - Instruments for **utilization** metrics (that measure the fraction out of a
 total) are dimensionless and SHOULD use the default unit `1` (the unity).
-- Instruments that measure an integer count of something SHOULD use the
-default unit `1` (the unity) and
-[annotations](https://ucum.org/ucum.html#para-curly) with curly braces to
-give additional meaning. For example `{packets}`, `{errors}`, `{faults}`,
-etc.
+- Instruments that measure an integer count of something SHOULD only use
+annotations with curly braces to give additional meaning without the leading
+default unit (`1`). For example `{packets}`, `{errors}`, `{faults}`, etc.

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -142,7 +142,7 @@ instrument creation, but can be added if there is ambiguity.
 
 ### Instrument Units
 
-Units should follow the 
+Units should follow the
 [Unified Code for Units of Measure](http://unitsofmeasure.org/ucum.html) (need
 more clarification in
 [#705](https://github.com/open-telemetry/opentelemetry-specification/issues/705)).

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -142,7 +142,8 @@ instrument creation, but can be added if there is ambiguity.
 
 ### Instrument Units
 
-Units should follow the [UCUM](http://unitsofmeasure.org/ucum.html) (need
+Units should follow the 
+[Unified Code for Units of Measure](http://unitsofmeasure.org/ucum.html) (need
 more clarification in
 [#705](https://github.com/open-telemetry/opentelemetry-specification/issues/705)).
 
@@ -150,5 +151,5 @@ more clarification in
 total) are dimensionless and SHOULD use the default unit `1` (the unity).
 - Instruments that measure an integer count of something SHOULD only use
 [annotations](https://ucum.org/ucum.html#para-curly) with curly braces to
-give additional meaning without the leading default unit (`1`). For example
+give additional meaning *without* the leading default unit (`1`). For example
 `{packets}`, `{errors}`, `{faults}`, etc.


### PR DESCRIPTION
This PR clarifies the units that should be used for instruments that measure an integer count. 

The spec mentioned that

> Instruments that measure an integer count of something SHOULD use the default unit 1 (the unity) and annotations with curly braces to give additional meaning. For example {packets}, {errors}, {faults}, etc.

Which, due to the use of "and" in the language, could be interpreted that units should be written as `1{packets}`, `1{errors}` and `1{faults}`. According to [UCUM](https://ucum.org/ucum.html), however, `{packets}` semantically is equivalent to `1{packets}`.

To prevent this interpretation, this PR clarifies that the leading `1` should be omitted.
