### PR TITLE
Update link to Prometheus Receiver Design Document

### DIFF
--- a/specification/metrics/semantic_conventions/openmetrics-guidelines.md
+++ b/specification/metrics/semantic_conventions/openmetrics-guidelines.md
@@ -20,7 +20,7 @@ Prometheus exposition format in two ways:
 
 The OpenTelemetry collector implements a Prometheus receiver, which reads
 metrics in the OpenMetrics exposition format. For more information, refer to the
-[Prometheus Receiver Design Document](https://github.com/open-telemetry/opentelemetry-collector/blob/master/receiver/prometheusreceiver/DESIGN.md).
+[Prometheus Receiver Design Document](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/prometheusreceiver/DESIGN.md).
 
 ### OpenTelemetry to OpenMetrics
 


### PR DESCRIPTION
Since it was moved to opentelemetry-collector-contrib repo