### PR TITLE
Add Azure SDK semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ release.
   ([#2191](https://github.com/open-telemetry/opentelemetry-specification/pull/2191))
 - Add `device.manufacturer` to describe mobile device manufacturers.
   ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
+- Add Azure SDK trace semantic conventions
+  ([#2233](https://github.com/open-telemetry/opentelemetry-specification/pull/2233))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/instrumentation/azure-sdk.yml
+++ b/semantic_conventions/trace/instrumentation/azure-sdk.yml
@@ -1,0 +1,129 @@
+# Version: 0.0.0
+# Status: Experimental
+# This document describes Azure SDK trace semantic conventions. For more details refer to https://azure.github.io/azure-sdk/distributed_tracing_conventions.html
+
+groups:
+  # common
+  - id: azure-sdk
+    brief: 'Describes Azure SDK spans.'
+    attributes:
+      - id: az.namespace
+        required: always
+        type: string
+        brief: '[Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against.'
+        examples: ['Microsoft.Storage', 'Microsoft.KeyVault', 'Microsoft.ServiceBus']
+
+  # public API
+  - id: azure-sdk.api
+    span_kind: internal
+    extends: azure-sdk
+    brief: 'Describes Azure SDK API calls spans.'
+    note: 'Represents public surface API calls that wrap an Azure service call.'
+
+  # http
+  - id: azure-sdk.http
+    extends: azure-sdk
+    span_kind: client
+    brief: 'Describes HTTP client spans created per HTTP request (try).'
+    note: >
+      Follows [OpenTelemetry HTTP conventions v1.6.x](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/trace/semantic_conventions/http.md)
+      but omits all optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
+    attributes:
+      - id: request_id
+        type: string
+        required: always
+        brief: 'Value of the [x-ms-client-request-id] header (or other request-id header, depending on the service) sent by the client.'
+        examples: ['eb178587-c05a-418c-a695-ae9466c5303c']
+      - id: service_request_id
+        type: string
+        required: always
+        brief: 'Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response.'
+        examples: ['3f828ae5-ecb9-40ab-88d9-db0420af30c6']
+      - id: http.method
+        type: string
+        required: always
+        sampling_relevant: true
+        brief: 'HTTP request method.'
+        examples: ["GET", "POST", "HEAD"]
+      - id: http.url
+        type: string
+        required: always
+        sampling_relevant: true
+        brief: Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`
+        examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
+      - id: http.status_code
+        type: int
+        required:
+          conditional: If and only if one was received/sent.
+        brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
+        examples: [200]
+      - id: http.user_agent
+        type: string
+        required: always
+        brief: 'Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) or X-MS-UserAgent header sent by the client.'
+        examples: ['CERN-LineMode/2.15 libwww/2.17b3']
+
+  # messaging
+  - id: azure-sdk.messaging
+    brief: 'Describes Azure messaging SDKs spans.'
+    extends: azure-sdk
+    note: Implements OpenTracing MessageBus conventions https://opentracing.io/specification/conventions/
+    attributes:
+      - id: message_bus.destination
+        type: string
+        required: always
+        brief: 'Name of the messaging entity within namespace: e.g EventHubs name, ServiceBus queue or topic name.'
+        examples: ['myqueue', 'myhub']
+      - id: peer.address
+        type: string
+        brief: 'Fully qualified messaging service name.'
+        required: always
+        examples: ['myEventHubNamespace.servicebus.windows.net']
+  - id: azure-sdk.messaging.producer
+    span_kind: producer
+    extends: azure-sdk.messaging
+    brief: 'Describes producer span created per event.'
+
+  - id: azure-sdk.messaging.send
+    span_kind: client
+    extends: azure-sdk.messaging
+    brief: 'Describes send (transport call) span.'
+    note: 'Contains links to all messages contexts being sent.'
+
+  - id: azure-sdk.messaging.process
+    span_kind: consumer
+    extends: azure-sdk.messaging
+    brief: 'Describes consumption span.'
+    note: >
+      Contains links to all messages contexts being consumed. Each link has attribute `enqueuedTime` (with `long` type)
+      attribute with unix epoch time with milliseconds precision representing when message was enqueued.
+
+  # CosmosDB
+  - id: azure-sdk.cosmos
+    span_kind: client
+    brief: 'Describes Azure CosmosDB spans.'
+    note: >
+      Events with additional debug info are added for long running operations.
+      Implements https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md
+    extends: azure-sdk
+    attributes:
+      - id: db.url
+        type: string
+        required: always
+        brief: 'Cosmos DB URI'
+        examples: ['https://my-cosmos.documents.azure.com:443/']
+      - id: db.statement
+        type: string
+        required: always
+        brief: 'Database statement'
+        examples: ['createContainerIfNotExists.myContainer']
+      - id: db.instance
+        type: string
+        required: always
+        brief: 'Database name'
+        examples: ['mydb']
+      - id: db.type
+        type: string
+        required: always
+        brief: 'Database type'
+        examples: ['Cosmos']

--- a/semantic_conventions/trace/instrumentation/azure-sdk.yml
+++ b/semantic_conventions/trace/instrumentation/azure-sdk.yml
@@ -4,31 +4,30 @@
 
 groups:
   # common
-  - id: azure.sdk
-    brief: 'Describes Azure SDK spans.'
+  - id: azure
+    brief: 'Describes Azure spans.'
     attributes:
       - id: az.namespace
         required: always
         type: string
         sampling_relevant: true
-        brief: '[Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against.'
+        brief: '[Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service that the request is made against.'
         examples: ['Microsoft.Storage', 'Microsoft.KeyVault', 'Microsoft.ServiceBus']
 
   # public API
   - id: azure.sdk.api
     span_kind: internal
-    extends: azure.sdk
-    brief: 'Describes Azure SDK API calls spans.'
-    note: 'Represents public surface API calls that wrap an Azure service call.'
+    extends: azure
+    brief: 'Describes Azure SDK API calls that wrap an Azure service call(s).'
 
   # http
   - id: azure.sdk.http
-    extends: azure.sdk
+    extends: azure
     span_kind: client
-    brief: 'Describes HTTP client spans created per HTTP request (try).'
+    brief: 'Describes HTTP client spans created per HTTP request.'
     note: >
       Follows [OpenTelemetry HTTP conventions v1.8.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md)
-      but omits all optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
+      but omits optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
     attributes:
       - id: request_id
         type: string
@@ -56,7 +55,7 @@ groups:
   # messaging
   - id: azure.sdk.messaging
     brief: 'Describes Azure messaging SDKs spans.'
-    extends: azure.sdk
+    extends: azure
     note: Implements OpenTracing MessageBus conventions https://opentracing.io/specification/conventions/
     attributes:
       - id: message_bus.destination
@@ -72,7 +71,7 @@ groups:
   - id: azure.sdk.messaging.producer
     span_kind: producer
     extends: azure.sdk.messaging
-    brief: 'Describes producer span created per event.'
+    brief: 'Describes producer span created per message.'
 
   - id: azure.sdk.messaging.send
     span_kind: client
@@ -93,9 +92,9 @@ groups:
     span_kind: client
     brief: 'Describes Azure CosmosDB spans.'
     note: >
-      Events with additional debug info are added for long running operations.
+      Events with additional debug info are added for long running or failed operations.
       Implements https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md
-    extends: azure.sdk
+    extends: azure
     attributes:
       - id: db.url
         type: string

--- a/semantic_conventions/trace/instrumentation/azure-sdk.yml
+++ b/semantic_conventions/trace/instrumentation/azure-sdk.yml
@@ -6,8 +6,9 @@ groups:
   # common
   - id: azure
     brief: 'Describes Azure spans.'
+    prefix: az
     attributes:
-      - id: az.namespace
+      - id: namespace
         required: always
         type: string
         sampling_relevant: true
@@ -32,12 +33,12 @@ groups:
       - id: request_id
         type: string
         required: always
-        brief: 'Value of the [x-ms-client-request-id] header (or other request-id header, depending on the service) sent by the client.'
+        brief: 'Value of the "x-ms-client-request-id" header (or other "*-request-id" header, depending on the service) sent by the client.'
         examples: ['eb178587-c05a-418c-a695-ae9466c5303c']
       - id: service_request_id
         type: string
         required: always
-        brief: 'Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response.'
+        brief: 'Value of the "x-ms-request-id" header (or other "*-request-id" header, depending on the service) sent by the server in response.'
         examples: ['3f828ae5-ecb9-40ab-88d9-db0420af30c6']
       - ref: http.method
         required: always

--- a/semantic_conventions/trace/instrumentation/azure-sdk.yml
+++ b/semantic_conventions/trace/instrumentation/azure-sdk.yml
@@ -1,10 +1,10 @@
 # Version: 0.0.0
 # Status: Experimental
-# This document describes Azure SDK trace semantic conventions. For more details refer to https://azure.github.io/azure-sdk/distributed_tracing_conventions.html
+# This document describes Azure SDK trace semantic conventions. For more details refer to https://azure.github.io/azure.sdk/distributed_tracing_conventions.html
 
 groups:
   # common
-  - id: azure-sdk
+  - id: azure.sdk
     brief: 'Describes Azure SDK spans.'
     attributes:
       - id: az.namespace
@@ -14,19 +14,19 @@ groups:
         examples: ['Microsoft.Storage', 'Microsoft.KeyVault', 'Microsoft.ServiceBus']
 
   # public API
-  - id: azure-sdk.api
+  - id: azure.sdk.api
     span_kind: internal
-    extends: azure-sdk
+    extends: azure.sdk
     brief: 'Describes Azure SDK API calls spans.'
     note: 'Represents public surface API calls that wrap an Azure service call.'
 
   # http
-  - id: azure-sdk.http
-    extends: azure-sdk
+  - id: azure.sdk.http
+    extends: azure.sdk
     span_kind: client
     brief: 'Describes HTTP client spans created per HTTP request (try).'
     note: >
-      Follows [OpenTelemetry HTTP conventions v1.6.x](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.6.x/specification/trace/semantic_conventions/http.md)
+      Follows [OpenTelemetry HTTP conventions v1.8.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md)
       but omits all optional attributes, providing only `http.url` to describe destination. It adds request-id attributes supported by Azure services.
     attributes:
       - id: request_id
@@ -64,9 +64,9 @@ groups:
         examples: ['CERN-LineMode/2.15 libwww/2.17b3']
 
   # messaging
-  - id: azure-sdk.messaging
+  - id: azure.sdk.messaging
     brief: 'Describes Azure messaging SDKs spans.'
-    extends: azure-sdk
+    extends: azure.sdk
     note: Implements OpenTracing MessageBus conventions https://opentracing.io/specification/conventions/
     attributes:
       - id: message_bus.destination
@@ -79,33 +79,33 @@ groups:
         brief: 'Fully qualified messaging service name.'
         required: always
         examples: ['myEventHubNamespace.servicebus.windows.net']
-  - id: azure-sdk.messaging.producer
+  - id: azure.sdk.messaging.producer
     span_kind: producer
-    extends: azure-sdk.messaging
+    extends: azure.sdk.messaging
     brief: 'Describes producer span created per event.'
 
-  - id: azure-sdk.messaging.send
+  - id: azure.sdk.messaging.send
     span_kind: client
-    extends: azure-sdk.messaging
+    extends: azure.sdk.messaging
     brief: 'Describes send (transport call) span.'
     note: 'Contains links to all messages contexts being sent.'
 
-  - id: azure-sdk.messaging.process
+  - id: azure.sdk.messaging.process
     span_kind: consumer
-    extends: azure-sdk.messaging
+    extends: azure.sdk.messaging
     brief: 'Describes consumption span.'
     note: >
-      Contains links to all messages contexts being consumed. Each link has attribute `enqueuedTime` (with `long` type)
+      Contains links to all messages contexts being consumed. Each link has `enqueued_time` (with `long` type)
       attribute with unix epoch time with milliseconds precision representing when message was enqueued.
 
   # CosmosDB
-  - id: azure-sdk.cosmos
+  - id: azure.sdk.cosmos
     span_kind: client
     brief: 'Describes Azure CosmosDB spans.'
     note: >
       Events with additional debug info are added for long running operations.
       Implements https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md
-    extends: azure-sdk
+    extends: azure.sdk
     attributes:
       - id: db.url
         type: string

--- a/semantic_conventions/trace/instrumentation/azure-sdk.yml
+++ b/semantic_conventions/trace/instrumentation/azure-sdk.yml
@@ -10,6 +10,7 @@ groups:
       - id: az.namespace
         required: always
         type: string
+        sampling_relevant: true
         brief: '[Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against.'
         examples: ['Microsoft.Storage', 'Microsoft.KeyVault', 'Microsoft.ServiceBus']
 
@@ -39,29 +40,18 @@ groups:
         required: always
         brief: 'Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response.'
         examples: ['3f828ae5-ecb9-40ab-88d9-db0420af30c6']
-      - id: http.method
-        type: string
+      - ref: http.method
         required: always
         sampling_relevant: true
-        brief: 'HTTP request method.'
-        examples: ["GET", "POST", "HEAD"]
-      - id: http.url
-        type: string
+      - ref: http.url
         required: always
         sampling_relevant: true
-        brief: Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`
-        examples: ['https://www.foo.bar/search?q=OpenTelemetry#SemConv']
-      - id: http.status_code
-        type: int
-        required:
-          conditional: If and only if one was received/sent.
-        brief: '[HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6).'
-        examples: [200]
-      - id: http.user_agent
-        type: string
+      - ref: http.status_code
         required: always
+      - ref: http.user_agent
+        required: always
+        sampling_relevant: true
         brief: 'Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) or X-MS-UserAgent header sent by the client.'
-        examples: ['CERN-LineMode/2.15 libwww/2.17b3']
 
   # messaging
   - id: azure.sdk.messaging
@@ -112,10 +102,8 @@ groups:
         required: always
         brief: 'Cosmos DB URI'
         examples: ['https://my-cosmos.documents.azure.com:443/']
-      - id: db.statement
-        type: string
+      - ref: db.statement
         required: always
-        brief: 'Database statement'
         examples: ['createContainerIfNotExists.myContainer']
       - id: db.instance
         type: string

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -27,6 +27,7 @@ The following library-specific semantic conventions are defined:
 
 * [AWS Lambda](instrumentation/aws-lambda.md): For AWS Lambda spans.
 * [AWS SDK](instrumentation/aws-sdk.md): For AWS SDK spans.
+* [Azure SDK](instrumentation/azure-sdk.md): For Azure SDK spans.
 
 Apart from semantic conventions for traces and [metrics](../../metrics/semantic_conventions/README.md),
 OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own

--- a/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
+++ b/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
@@ -15,16 +15,16 @@ Azure SDK produces spans for public API calls and nested HTTP client spans. Non-
 
 Azure SDK semantic conventions pin specific versions of OpenTelemetry semantic conventions (where applicable) and are not updated regularly to the latest OpenTelemetry semantic conventions version. However OpenTelemetry-compatible changes should be expected.
 
-Azure SDK plans to fully adopt OpenTelemetry semantic conventions once conventions reach `Stable` status.
+Azure SDK plans to fully adopt OpenTelemetry semantic conventions once they reach `Stable` status.
 
 ## Common Attributes
 
 All Azure SDKs spans have `az.namespace` attribute to uniquely identify *Azure SDK* request is made *from*, usually the value matches the destination Azure service, but in some cases client library can support multiple services.
 
-<!-- semconv azure.sdk -->
+<!-- semconv azure -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `az.namespace` | string | [Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against. | `Microsoft.Storage`; `Microsoft.KeyVault`; `Microsoft.ServiceBus` | Yes |
+| `az.namespace` | string | [Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service that the request is made against. | `Microsoft.Storage`; `Microsoft.KeyVault`; `Microsoft.ServiceBus` | Yes |
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
@@ -42,7 +42,7 @@ Azure SDKs create a span for public API call (that involves communication with A
 
 ## HTTP Client
 
-Azure SDKs implement a valid subset of [OpenTelemetry HTTP conventions v1.6.x](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md) and create a span per HTTP call (try).
+Azure SDK implements a valid subset of [OpenTelemetry HTTP conventions v1.8.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md) and create a span per HTTP call (try).
 
 <!-- semconv azure.sdk.http -->
 | Attribute  | Type | Description  | Examples  | Required |
@@ -63,28 +63,28 @@ Following attributes MUST be provided **at span creation time** (when provided a
 * [`http.user_agent`](../http.md)
 <!-- endsemconv -->
 
-Instrumentation support [W3C Trace context](https://w3c.github.io/trace-context/) propagation and Azure Services legacy correlation protocols. Propagator configuration is not supported.
+Instrumentation supports [W3C Trace context](https://w3c.github.io/trace-context/) propagation and Azure legacy correlation protocols. Propagator configuration is not supported.
 
 ## Messaging SDKs
 
 Messaging span semantics apply to Azure Event Hubs and Service Bus SDKs.
 
-Attribute names predate OpenTelemetry and originates from [OpenTracing semantic conventions](https://opentracing.io/specification/conventions/)
+Attribute names predate OpenTelemetry and originate from [OpenTracing semantic conventions](https://opentracing.io/specification/conventions/)
 
 Messaging SDKs produce three kinds of spans:
 
 - `PRODUCER` - describes message creation and associates unique context with the message to trace them when they are sent in batches.
-  - Producer spans name follows `<ClientType>.message` pattern (e.g. `EventHubs.message`)
+  - Producer spans name follows `<client>.message` pattern (e.g. `EventHubs.message`)
 
 - `CLIENT` - describes message (or batch) publishing.
   - It has links pointing to each message being sent.
   - Links don't have attributes.
-  - Send spans name follows `<ClientType>.send` pattern (e.g. `EventHubs.send`)
+  - Send spans name follows `<client>.send` pattern (e.g. `EventHubs.send`)
 
 - `CONSUMER` - describes message (or batch) processing.
   - It is created when user leverages handler APIs that wrap message or batch processing.
   - Processing span has links to each message being processed (when context is present).
-  - Each link has `enqueued_time` attribute with `long` value with unix epoch time with milliseconds precision representing when message was enqueued on the broker.
+  - Each link has `enqueued_time` attribute with `long` value with unix epoch time (with milliseconds precision) representing when message was enqueued on the broker.
 
 ### Messaging attributes
 
@@ -98,7 +98,7 @@ Messaging SDKs produce three kinds of spans:
 ## CosmosDB
 
 CosmosDB SDK in [Direct mode](https://docs.microsoft.com/azure/cosmos-db/sql/sql-sdk-connection-modes#available-connectivity-modes) uses TCP-based protocol and traces public API calls only.
-CosmosDB trace conventions pinned to OpenTelemetry [Semantic Conventions v0.5.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md) version.
+CosmosDB semantic conventions are pinned to OpenTelemetry [Semantic Conventions v0.5.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md) version.
 
 Spans have `CLIENT` kind and the name matches `db.statement` value. When CosmosDB detects an error or long operation (with configurable threshold), it adds a span event with extended `CosmosDiagnostics` information.
 

--- a/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
+++ b/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
@@ -2,7 +2,7 @@
 
 **Status**: [Experimental](../../../document-status.md)
 
-This document describes tracing semantic conventions adopted by Azure ClientLibraries (SDK). Instrumentations live in Azure SDK repos and are shipped along with Azure SDK artifacts. Instrumentations cover all modern (track 2) SDKs.
+This document describes tracing semantic conventions adopted by Azure SDK. Instrumentations live in Azure SDK repos and are shipped along with Azure SDK artifacts. Instrumentations cover all modern (track 2) Azure client libraries.
 
 - [Java](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core/azure-core-tracing-opentelemetry)
 - [JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-tracing)
@@ -13,26 +13,30 @@ Azure SDK produces spans for public API calls and nested HTTP client spans. Non-
 
 ## Versioning
 
-Azure SDK semantic conventions pin specific versions of OpenTelemetry semantic conventions (where applicable) and are not updated regularly to the latest OpenTelemetry semantic conventions version. However OpenTelemetry-compatible changes should be expected from time to time.
+Azure SDK semantic conventions pin specific versions of OpenTelemetry semantic conventions (where applicable) and are not updated regularly to the latest OpenTelemetry semantic conventions version. However OpenTelemetry-compatible changes should be expected.
 
-Azure SDKs plan to fully adopt OpenTelemetry semantic conventions once they reach `Stable` status.
+Azure SDK plans to fully adopt OpenTelemetry semantic conventions once conventions reach `Stable` status.
 
 ## Common Attributes
 
-All Azure SDKs spans have `az.namespace` attribute to uniquely identify *Azure SDK* request is made from, usually the value matches the destination Azure Service (in some cases SDK support multiple services).
+All Azure SDKs spans have `az.namespace` attribute to uniquely identify *Azure SDK* request is made *from*, usually the value matches the destination Azure service, but in some cases client library can support multiple services.
 
 <!-- semconv azure.sdk -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `az.namespace` | string | [Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against. | `Microsoft.Storage`; `Microsoft.KeyVault`; `Microsoft.ServiceBus` | Yes |
+
+Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
+
+* `az.namespace`
 <!-- endsemconv -->
 
 ## Public API calls
 
-Azure SDKs create a span for public API call (that involve communication with Azure services).
+Azure SDKs create a span for public API call (that involves communication with Azure services).
 
-- Spans representing public APIs have names following `ClientType.Method` pattern, which is language-specific.
-- For HTTP-based SDKs public API spans have `INTERNAL` kind.
+- Spans representing public APIs have names following `client.method` pattern, which is language-specific.
+- For HTTP-based SDKs, public API spans have `INTERNAL` kind.
 
 [Messaging](#messaging-sdks) and [CosmosDb](#cosmosdb) sections below describe non-HTTP semantics.
 
@@ -45,18 +49,21 @@ Azure SDKs implement a valid subset of [OpenTelemetry HTTP conventions v1.6.x](h
 |---|---|---|---|---|
 | `request_id` | string | Value of the [x-ms-client-request-id] header (or other request-id header, depending on the service) sent by the client. | `eb178587-c05a-418c-a695-ae9466c5303c` | Yes |
 | `service_request_id` | string | Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response. | `3f828ae5-ecb9-40ab-88d9-db0420af30c6` | Yes |
-| `http.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Yes |
-| `http.url` | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` | Yes |
-| `http.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If and only if one was received/sent. |
-| `http.user_agent` | string | Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) or X-MS-UserAgent header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Yes |
+| [`http.method`](../http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Yes |
+| [`http.status_code`](../http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Yes |
+| [`http.url`](../http.md) | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. [1] | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` | Yes |
+| [`http.user_agent`](../http.md) | string | Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) or X-MS-UserAgent header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Yes |
+
+**[1]:** `http.url` MUST NOT contain credentials passed via URL in form of `https://username:password@www.example.com/`. In such case the attribute's value should be `https://www.example.com/`.
 
 Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
 
-* `http.method`
-* `http.url`
+* [`http.method`](../http.md)
+* [`http.url`](../http.md)
+* [`http.user_agent`](../http.md)
 <!-- endsemconv -->
 
-SDKs support [W3C Trace context](https://w3c.github.io/trace-context/) propagation and Azure Services legacy correlation protocols.
+Instrumentation support [W3C Trace context](https://w3c.github.io/trace-context/) propagation and Azure Services legacy correlation protocols. Propagator configuration is not supported.
 
 ## Messaging SDKs
 
@@ -88,12 +95,12 @@ Messaging SDKs produce three kinds of spans:
 | `peer.address` | string | Fully qualified messaging service name. | `myEventHubNamespace.servicebus.windows.net` | Yes |
 <!-- endsemconv -->
 
-## CosmosDb
+## CosmosDB
 
-CosmosDb SDK in [Direct mode](https://docs.microsoft.com/azure/cosmos-db/sql/sql-sdk-connection-modes#available-connectivity-modes) uses TCP-based protocol and traces public API calls only.
-CosmosDb trace conventions pinned to [OpenTelemetry 0.5.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md) version.
+CosmosDB SDK in [Direct mode](https://docs.microsoft.com/azure/cosmos-db/sql/sql-sdk-connection-modes#available-connectivity-modes) uses TCP-based protocol and traces public API calls only.
+CosmosDB trace conventions pinned to OpenTelemetry [Semantic Conventions v0.5.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md) version.
 
-Spans have `CLIENT` kind and the name matches `db.statement` value. When CosmosDb detects an error or long operation (with configurable threshold), it adds a span event with extended `CosmosDiagnostics` information.
+Spans have `CLIENT` kind and the name matches `db.statement` value. When CosmosDB detects an error or long operation (with configurable threshold), it adds a span event with extended `CosmosDiagnostics` information.
 
 ### CosmosDB attributes
 
@@ -101,7 +108,9 @@ Spans have `CLIENT` kind and the name matches `db.statement` value. When CosmosD
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `db.url` | string | Cosmos DB URI | `https://my-cosmos.documents.azure.com:443/` | Yes |
-| `db.statement` | string | Database statement | `createContainerIfNotExists.myContainer` | Yes |
 | `db.instance` | string | Database name | `mydb` | Yes |
 | `db.type` | string | Database type | `Cosmos` | Yes |
+| [`db.statement`](../database.md) | string | The database statement being executed. [1] | `createContainerIfNotExists.myContainer` | Yes |
+
+**[1]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
+++ b/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
@@ -42,13 +42,13 @@ Azure SDKs create a span for public API call (that involves communication with A
 
 ## HTTP Client
 
-Azure SDK implements a valid subset of [OpenTelemetry HTTP conventions v1.8.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md) and create a span per HTTP call (try).
+Azure SDK implements a valid subset of [OpenTelemetry HTTP conventions v1.8.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md) and create a span per HTTP call (attempt).
 
 <!-- semconv azure.sdk.http -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `request_id` | string | Value of the [x-ms-client-request-id] header (or other request-id header, depending on the service) sent by the client. | `eb178587-c05a-418c-a695-ae9466c5303c` | Yes |
-| `service_request_id` | string | Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response. | `3f828ae5-ecb9-40ab-88d9-db0420af30c6` | Yes |
+| `request_id` | string | Value of the "x-ms-client-request-id" header (or other "*-request-id" header, depending on the service) sent by the client. | `eb178587-c05a-418c-a695-ae9466c5303c` | Yes |
+| `service_request_id` | string | Value of the "x-ms-request-id" header (or other "*-request-id" header, depending on the service) sent by the server in response. | `3f828ae5-ecb9-40ab-88d9-db0420af30c6` | Yes |
 | [`http.method`](../http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Yes |
 | [`http.status_code`](../http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Yes |
 | [`http.url`](../http.md) | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]`. Usually the fragment is not transmitted over HTTP, but if it is known, it should be included nevertheless. [1] | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` | Yes |

--- a/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
+++ b/specification/trace/semantic_conventions/instrumentation/azure-sdk.md
@@ -1,0 +1,107 @@
+# Semantic conventions for Azure SDK
+
+**Status**: [Experimental](../../../document-status.md)
+
+This document describes tracing semantic conventions adopted by Azure ClientLibraries (SDK). Instrumentations live in Azure SDK repos and are shipped along with Azure SDK artifacts. Instrumentations cover all modern (track 2) SDKs.
+
+- [Java](https://github.com/Azure/azure-sdk-for-java/tree/main/sdk/core/azure-core-tracing-opentelemetry)
+- [JavaScript](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/core/core-tracing)
+- [Python](https://github.com/Azure/azure-sdk-for-python/tree/main/sdk/core/azure-core-tracing-opentelemetry)
+- [.NET](https://github.com/Azure/azure-sdk-for-net/blob/5ce907df6490e68c2e632d97048a6b6ee95c01f0/sdk/core/Azure.Core/samples/Diagnostics.md#activitysource-support)
+
+Azure SDK produces spans for public API calls and nested HTTP client spans. Non-HTTP transport-level calls (AMQP, CosmosDB TCP-based protocol) are not traced.
+
+## Versioning
+
+Azure SDK semantic conventions pin specific versions of OpenTelemetry semantic conventions (where applicable) and are not updated regularly to the latest OpenTelemetry semantic conventions version. However OpenTelemetry-compatible changes should be expected from time to time.
+
+Azure SDKs plan to fully adopt OpenTelemetry semantic conventions once they reach `Stable` status.
+
+## Common Attributes
+
+All Azure SDKs spans have `az.namespace` attribute to uniquely identify *Azure SDK* request is made from, usually the value matches the destination Azure Service (in some cases SDK support multiple services).
+
+<!-- semconv azure.sdk -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `az.namespace` | string | [Namespace](https://docs.microsoft.com/azure/azure-resource-manager/management/azure-services-resource-providers) of Azure service request is made against. | `Microsoft.Storage`; `Microsoft.KeyVault`; `Microsoft.ServiceBus` | Yes |
+<!-- endsemconv -->
+
+## Public API calls
+
+Azure SDKs create a span for public API call (that involve communication with Azure services).
+
+- Spans representing public APIs have names following `ClientType.Method` pattern, which is language-specific.
+- For HTTP-based SDKs public API spans have `INTERNAL` kind.
+
+[Messaging](#messaging-sdks) and [CosmosDb](#cosmosdb) sections below describe non-HTTP semantics.
+
+## HTTP Client
+
+Azure SDKs implement a valid subset of [OpenTelemetry HTTP conventions v1.6.x](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/trace/semantic_conventions/http.md) and create a span per HTTP call (try).
+
+<!-- semconv azure.sdk.http -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `request_id` | string | Value of the [x-ms-client-request-id] header (or other request-id header, depending on the service) sent by the client. | `eb178587-c05a-418c-a695-ae9466c5303c` | Yes |
+| `service_request_id` | string | Value of the [x-ms-request-id]  header (or other request-id header, depending on the service) sent by the server in response. | `3f828ae5-ecb9-40ab-88d9-db0420af30c6` | Yes |
+| `http.method` | string | HTTP request method. | `GET`; `POST`; `HEAD` | Yes |
+| `http.url` | string | Full HTTP request URL in the form `scheme://host[:port]/path?query[#fragment]` | `https://www.foo.bar/search?q=OpenTelemetry#SemConv` | Yes |
+| `http.status_code` | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | If and only if one was received/sent. |
+| `http.user_agent` | string | Value of the [HTTP User-Agent](https://tools.ietf.org/html/rfc7231#section-5.5.3) or X-MS-UserAgent header sent by the client. | `CERN-LineMode/2.15 libwww/2.17b3` | Yes |
+
+Following attributes MUST be provided **at span creation time** (when provided at all), so they can be considered for sampling decisions:
+
+* `http.method`
+* `http.url`
+<!-- endsemconv -->
+
+SDKs support [W3C Trace context](https://w3c.github.io/trace-context/) propagation and Azure Services legacy correlation protocols.
+
+## Messaging SDKs
+
+Messaging span semantics apply to Azure Event Hubs and Service Bus SDKs.
+
+Attribute names predate OpenTelemetry and originates from [OpenTracing semantic conventions](https://opentracing.io/specification/conventions/)
+
+Messaging SDKs produce three kinds of spans:
+
+- `PRODUCER` - describes message creation and associates unique context with the message to trace them when they are sent in batches.
+  - Producer spans name follows `<ClientType>.message` pattern (e.g. `EventHubs.message`)
+
+- `CLIENT` - describes message (or batch) publishing.
+  - It has links pointing to each message being sent.
+  - Links don't have attributes.
+  - Send spans name follows `<ClientType>.send` pattern (e.g. `EventHubs.send`)
+
+- `CONSUMER` - describes message (or batch) processing.
+  - It is created when user leverages handler APIs that wrap message or batch processing.
+  - Processing span has links to each message being processed (when context is present).
+  - Each link has `enqueued_time` attribute with `long` value with unix epoch time with milliseconds precision representing when message was enqueued on the broker.
+
+### Messaging attributes
+
+<!-- semconv azure.sdk.messaging -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `message_bus.destination` | string | Name of the messaging entity within namespace: e.g EventHubs name, ServiceBus queue or topic name. | `myqueue`; `myhub` | Yes |
+| `peer.address` | string | Fully qualified messaging service name. | `myEventHubNamespace.servicebus.windows.net` | Yes |
+<!-- endsemconv -->
+
+## CosmosDb
+
+CosmosDb SDK in [Direct mode](https://docs.microsoft.com/azure/cosmos-db/sql/sql-sdk-connection-modes#available-connectivity-modes) uses TCP-based protocol and traces public API calls only.
+CosmosDb trace conventions pinned to [OpenTelemetry 0.5.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v0.5.0/specification/trace/semantic_conventions/database.md) version.
+
+Spans have `CLIENT` kind and the name matches `db.statement` value. When CosmosDb detects an error or long operation (with configurable threshold), it adds a span event with extended `CosmosDiagnostics` information.
+
+### CosmosDB attributes
+
+<!-- semconv azure.sdk.cosmos -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `db.url` | string | Cosmos DB URI | `https://my-cosmos.documents.azure.com:443/` | Yes |
+| `db.statement` | string | Database statement | `createContainerIfNotExists.myContainer` | Yes |
+| `db.instance` | string | Database name | `mydb` | Yes |
+| `db.type` | string | Database type | `Cosmos` | Yes |
+<!-- endsemconv -->


### PR DESCRIPTION
Adds yml spec for Azure SDK trace semantic conventions. This doc only documents the current state, it is not stable and has experimental status.

As Otel conventions stabilize, Azure SDKs will gradually onboard onto them.

- HTTP client: compliant with Otel [http conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/9216eb8ff1832ae790369e49ce326cb6bc3d1c80/semantic_conventions/trace/http.yaml) (is a valid subset of)
- Messaging: predates otel conventions
- DB -  represents an older version of Otel convention prior to https://github.com/open-telemetry/opentelemetry-specification/pull/575

