### PR TITLE
Rename observer result to observable result

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -416,7 +416,7 @@ function(s) independently.
 approach. Here are some examples:
 
 * Return a list (or tuple, generator, enumerator, etc.) of `Measurement`s.
-* Use an observer result argument to allow individual `Measurement`s to be
+* Use an observable result argument to allow individual `Measurement`s to be
   reported.
 
 User code is recommended not to provide more than one `Measurement` with the
@@ -628,7 +628,7 @@ function(s) independently.
 approach. Here are some examples:
 
 * Return a list (or tuple, generator, enumerator, etc.) of `Measurement`s.
-* Use an observer result argument to allow individual `Measurement`s to be reported.
+* Use an observable result argument to allow individual `Measurement`s to be reported.
 
 User code is recommended not to provide more than one `Measurement` with the
 same `attributes` in a single callback. If it happens, the
@@ -905,7 +905,7 @@ function(s) independently.
 approach. Here are some examples:
 
 * Return a list (or tuple, generator, enumerator, etc.) of `Measurement`s.
-* Use an observer result argument to allow individual `Measurement`s to be
+* Use an observable result argument to allow individual `Measurement`s to be
   reported.
 
 User code is recommended not to provide more than one `Measurement` with the


### PR DESCRIPTION
Follow up of https://github.com/open-telemetry/opentelemetry-specification/pull/1645

## Changes

1. Rename the remaining usages of "Observer" to "Observable".

Related issues: 
1. https://github.com/open-telemetry/opentelemetry-js/pull/2687#discussion_r774716669