### PR TITLE
Align Jaeger remote sampler endpoint with OTLP endpoint

### DIFF
--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -72,10 +72,10 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 - For `traceidratio` and `parentbased_traceidratio` samplers: Sampling probability, a number in the [0..1] range, e.g. "0.25". Default is 1.0 if unset.
 - For `jaeger_remote`: The value is a comma separated list:
-  - `endpoint`: the endpoint in form of `host:port` of gRPC server that serves the sampling strategy for the service ([sampling.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/sampling.proto)).
+  - `endpoint`: the endpoint in form of `scheme://host:port` of gRPC server that serves the sampling strategy for the service ([sampling.proto](https://github.com/jaegertracing/jaeger-idl/blob/master/proto/api_v2/sampling.proto)).
   - `pollingIntervalMs`:  in milliseconds indicating how often the sampler will poll the backend for updates to sampling strategy.
   - `initialSamplingRate`:  in the [0..1] range, which is used as the sampling probability when the backend cannot be reached to retrieve a sampling strategy. This value stops having an effect once a sampling strategy is retrieved successfully, as the remote strategy will be used until a new update is retrieved.
-  - Example: `endpoint=localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`
+  - Example: `endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`
 
 ## Batch Span Processor
 


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This is related to https://github.com/open-telemetry/opentelemetry-java/pull/4043 which ports Jaeger remote sampler to gRPC lite implementation.

This change has to benefits: 
1. aligns with OTLP endpoint semantics
2. allows using HTTPS for Jaeger remote sampler


@anuraaga could you please review, you have the most context here.


