### PR TITLE
Change golang namespace to 'go', rather than 'gc'

### DIFF
--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -78,10 +78,30 @@ Example:
 
 ### Go Runtimes
 
-| Value | Description |
-| --- | --- |
-| `go` | Go compiler |
-| `gccgo` | GCC Go frontend |
+Go Runtimes should fill in the as follows:
+
+- `process.runtime.name` - Fill in an interpretation of Go's `runtime.Compiler` constant, according to the following rule: If the value is `gc`, fill in `go`. Otherwise, fill in the exact value of `runtime.Compiler`.
+
+  This can be implemented with the following Go snippet:
+
+  ```go
+  import "runtime"
+  
+  func getRuntimeName() string {
+    if runtime.Compiler == "gc" {
+      return "go"
+    }
+    return runtime.Compiler
+  }
+  ```
+
+- `process.runtime.version` - Fill in the exact value returned by `runtime.Version()`, i.e. `go1.17`.
+- `process.runtime.description` - Fill in a description corresponding to the value of `process.runtime.name`, as defined by the table below.
+
+| `runtime.Compiler` | `process.runtime.name` | `process.runtime.description` |
+| --- | --- | --- |
+| `gc` | go | cmd/compile |
+| `gccgo` | gccgo | gccgo front end |
 
 ### Java runtimes
 

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -78,11 +78,9 @@ Example:
 
 ### Go Runtimes
 
-TODO(<https://github.com/open-telemetry/opentelemetry-go/issues/1181>): Confirm the contents here
-
 | Value | Description |
 | --- | --- |
-| `gc` | Go compiler |
+| `go` | Go compiler |
 | `gccgo` | GCC Go frontend |
 
 ### Java runtimes

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -97,12 +97,7 @@ Go Runtimes should fill in the as follows:
   ```
 
 - `process.runtime.version` - Fill in the exact value returned by `runtime.Version()`, i.e. `go1.17`.
-- `process.runtime.description` - Fill in a description corresponding to the value of `process.runtime.name`, as defined by the table below.
-
-| `runtime.Compiler` | `process.runtime.name` | `process.runtime.description` |
-| --- | --- | --- |
-| `gc` | go | cmd/compile |
-| `gccgo` | gccgo | gccgo front end |
+- `process.runtime.description` - Use of this field is not recommended.
 
 ### Java runtimes
 

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -99,6 +99,12 @@ Go Runtimes should fill in the as follows:
 - `process.runtime.version` - Fill in the exact value returned by `runtime.Version()`, i.e. `go1.17`.
 - `process.runtime.description` - Use of this field is not recommended.
 
+| `process.runtime.name` | Description |
+| --- | --- |
+| `go` | Official Go compiler. Also known as `cmd/compile`. |
+| `gccgo` | [gccgo](https://go.dev/doc/install/gccgo) is a Go [front end for GCC](https://gcc.gnu.org/frontends.html). |
+| `tinygo` | [TinyGo](https://tinygo.org/) compiler. |
+
 ### Java runtimes
 
 Java instrumentation should fill in the values by copying from system properties.

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -80,7 +80,8 @@ Example:
 
 Go Runtimes should fill in the as follows:
 
-- `process.runtime.name` - Fill in an interpretation of Go's `runtime.Compiler` constant, according to the following rule: If the value is `gc`, fill in `go`. Otherwise, fill in the exact value of `runtime.Compiler`.
+- `process.runtime.name` - Fill in an interpretation of Go's [`runtime.Compiler`](https://pkg.go.dev/runtime#Compiler) constant, according to the following rule:
+  If the value is `gc`, fill in `go`. Otherwise, fill in the exact value of `runtime.Compiler`.
 
   This can be implemented with the following Go snippet:
 

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -99,6 +99,8 @@ Go Runtimes should fill in the as follows:
 - `process.runtime.version` - Fill in the exact value returned by `runtime.Version()`, i.e. `go1.17`.
 - `process.runtime.description` - Use of this field is not recommended.
 
+Examples for some Go compilers/runtimes:
+
 | `process.runtime.name` | Description |
 | --- | --- |
 | `go` | Official Go compiler. Also known as `cmd/compile`. |


### PR DESCRIPTION
Resolves [opentelemetry-go-contrib #350](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/350).

This was discussed briefly in the Golang SIG in December. Consensus at the time was that `go` is clearer than `gc` and sufficiently appropriate. The move away from `gc` is helpful in part because the namespace is used to mean "garbage collector" elsewhere in the semantic conventions.

Related issues #

[opentelemetry-go-contrib #1456](https://github.com/open-telemetry/opentelemetry-go-contrib/issues/1456)
