### PR TITLE
Add jvm memory runtime metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ release.
   ([#2191](https://github.com/open-telemetry/opentelemetry-specification/pull/2191))
 - Add `device.manufacturer` to describe mobile device manufacturers.
   ([2100](https://github.com/open-telemetry/opentelemetry-specification/pull/2100))
+- Add JVM memory runtime semantic
+  conventions. ([#2272](https://github.com/open-telemetry/opentelemetry-specification/pull/2272))
 
 ### Compatibility
 

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -15,6 +15,7 @@ semantic conventions when instrumenting runtime environments.
 - [Metric Instruments](#metric-instruments)
   * [Runtime Environment Specific Metrics - `process.runtime.{environment}.`](#runtime-environment-specific-metrics---processruntimeenvironment)
 - [Attributes](#attributes)
+- [JVM Metrics](#jvm-metrics)
 
 <!-- tocstop -->
 
@@ -49,3 +50,10 @@ consider, for example pthreads vs green thread implementations.
 ## Attributes
 
 [`process.runtime`](../../resource/semantic_conventions/process.md#process-runtimes) resource attributes SHOULD be included on runtime metric events as appropriate.
+
+## JVM Metrics
+
+**Description:** Java Virtual Machine (JVM) metrics captured under `process.runtime.jvm.`
+
+| Name | Description | Units | Instrument Type | Value Type | Attribute Key | Attribute Values |
+|------|-------------|-------|-----------------|------------|---------------|------------------|

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -55,5 +55,18 @@ consider, for example pthreads vs green thread implementations.
 
 **Description:** Java Virtual Machine (JVM) metrics captured under `process.runtime.jvm.`
 
-| Name | Description | Units | Instrument Type | Value Type | Attribute Key | Attribute Values |
-|------|-------------|-------|-----------------|------------|---------------|------------------|
+| Name                                 | Description                         | Unit  | Unit ([UCUM](README.md#instrument-units)) | Instrument Type            | Value Type | Attribute Key | Attribute Values |
+|--------------------------------------|-------------------------------------|-------|-------------------------------------------|----------------------------|------------|---------------|------------------|
+| process.runtime.jvm.memory.usage     | Measure of memory used              | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
+| process.runtime.jvm.memory.init      | Measure of initial memory requested | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
+| process.runtime.jvm.memory.committed | Measure of memory committed         | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
+| process.runtime.jvm.memory.max       | Measure of max obtainable memory    | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
+
+**[1]**: Pool names are generally obtained
+via [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName())
+. Examples include `G1 Old Gen`, `G1 Eden space`, `G1 Survivor Space`
+, `Metaspace`, etc.

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -55,6 +55,8 @@ consider, for example pthreads vs green thread implementations.
 
 **Description:** Java Virtual Machine (JVM) metrics captured under `process.runtime.jvm.`
 
+All JVM metric attributes are required unless otherwise indicated. 
+
 | Name                                 | Description                         | Unit  | Unit ([UCUM](README.md#instrument-units)) | Instrument Type            | Value Type | Attribute Key | Attribute Values |
 |--------------------------------------|-------------------------------------|-------|-------------------------------------------|----------------------------|------------|---------------|------------------|
 | process.runtime.jvm.memory.usage     | Measure of memory used              | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -57,16 +57,16 @@ consider, for example pthreads vs green thread implementations.
 
 All JVM metric attributes are required unless otherwise indicated.
 
-| Name                                 | Description                         | Unit  | Unit ([UCUM](README.md#instrument-units)) | Instrument Type            | Value Type | Attribute Key | Attribute Values |
-|--------------------------------------|-------------------------------------|-------|-------------------------------------------|----------------------------|------------|---------------|------------------|
-| process.runtime.jvm.memory.usage     | Measure of memory used              | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | `"heap"`, `"nonheap"`    |
-|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
-| process.runtime.jvm.memory.init      | Measure of initial memory requested | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
-|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
-| process.runtime.jvm.memory.committed | Measure of memory committed         | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
-|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
-| process.runtime.jvm.memory.max       | Measure of max obtainable memory    | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
-|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
+| Name                                 | Description                         | Unit  | Unit ([UCUM](README.md#instrument-units)) | Instrument Type            | Value Type | Attribute Key | Attribute Values      |
+|--------------------------------------|-------------------------------------|-------|-------------------------------------------|----------------------------|------------|---------------|-----------------------|
+| process.runtime.jvm.memory.usage     | Measure of memory used              | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | `"heap"`, `"nonheap"` |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1]      |
+| process.runtime.jvm.memory.init      | Measure of initial memory requested | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | `"heap"`, `"nonheap"` |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1]      |
+| process.runtime.jvm.memory.committed | Measure of memory committed         | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | `"heap"`, `"nonheap"` |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1]      |
+| process.runtime.jvm.memory.max       | Measure of max obtainable memory    | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | `"heap"`, `"nonheap"` |
+|                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1]      |
 
 **[1]**: Pool names are generally obtained
 via [MemoryPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html#getName())

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -55,7 +55,7 @@ consider, for example pthreads vs green thread implementations.
 
 **Description:** Java Virtual Machine (JVM) metrics captured under `process.runtime.jvm.`
 
-All JVM metric attributes are required unless otherwise indicated. 
+All JVM metric attributes are required unless otherwise indicated.
 
 | Name                                 | Description                         | Unit  | Unit ([UCUM](README.md#instrument-units)) | Instrument Type            | Value Type | Attribute Key | Attribute Values |
 |--------------------------------------|-------------------------------------|-------|-------------------------------------------|----------------------------|------------|---------------|------------------|

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -59,7 +59,7 @@ All JVM metric attributes are required unless otherwise indicated.
 
 | Name                                 | Description                         | Unit  | Unit ([UCUM](README.md#instrument-units)) | Instrument Type            | Value Type | Attribute Key | Attribute Values |
 |--------------------------------------|-------------------------------------|-------|-------------------------------------------|----------------------------|------------|---------------|------------------|
-| process.runtime.jvm.memory.usage     | Measure of memory used              | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
+| process.runtime.jvm.memory.usage     | Measure of memory used              | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | `"heap"`, `"nonheap"`    |
 |                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |
 | process.runtime.jvm.memory.init      | Measure of initial memory requested | Bytes | `By`                                      | Asynchronous UpDownCounter | Int64      | type          | heap, nonheap    |
 |                                      |                                     |       |                                           |                            |            | pool          | Name of pool [1] |


### PR DESCRIPTION
## Changes

Initial draft at JVM runtime memory semantic conventions. 

Different metric names (`p.r.j.m.usage`, `p.r.j.m.init`, `p.r.j.m.comitted`, `p.r.j.m.max` so that the the aggregation across all dimensions of each metric is semantically meaningful. 

/cc @trask 
