### PR TITLE
Database connection pool metrics semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ release.
 
 - Clarify SDK behavior when view conflicts are present
   ([#2462](https://github.com/open-telemetry/opentelemetry-specification/pull/2462)).
+- Add database connection pool metrics semantic conventions
+  ([#2273](https://github.com/open-telemetry/opentelemetry-specification/pull/2273)).
 
 ### Logs
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -20,6 +20,7 @@
 The following semantic conventions surrounding metrics are defined:
 
 * [HTTP](http-metrics.md): For HTTP client and server metrics.
+* [Database](database-metrics.md): For SQL and NoSQL client metrics.
 * [System](system-metrics.md): For standard system metrics.
 * [Process](process-metrics.md): For standard process metrics.
 * [Runtime Environment](runtime-environment-metrics.md): For runtime environment metrics.

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -46,13 +46,9 @@ MUST NOT be used.
 | `db.client.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                   |
 | `db.client.connections.pending_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.            |
 | `db.client.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have occurred trying to obtain a connection from the pool. |
-| `db.client.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.                    |
-
-All `db.client.connections.time` measurements MUST include the following attribute:
-
-| Name        | Type   | Description                                                                                                                                                                                                                                | Examples | Required |
-|-------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
-| `operation` | string | The type of operation applied to a connection. Valid values include: `create` (time it took to create a new connection), `use` (time spent using a connection obtained from the pool), `wait` (time spent waiting for an open connection). | `create` | Yes      |
+| `db.client.connections.create_time`      | Histogram                  | milliseconds | `ms`                                      | The time it took to create a new connection.                                                      |
+| `db.client.connections.wait_time`        | Histogram                  | milliseconds | `ms`                                      | The time it took to obtain an open connection from the pool.                                      |
+| `db.client.connections.use_time`         | Histogram                  | milliseconds | `ms`                                      | The time between borrowing a connection and returning it to the pool.                             |
 
 Below is a table of the attributes that MUST be included on all connection pool measurements:
 

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -39,16 +39,16 @@ Instrumentation libraries for database client connection pools that collect data
 following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments
 MUST NOT be used.
 
-| Name                                     | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                                                                       |
-|------------------------------------------|----------------------------|--------------|-------------------------------------------|---------------------------------------------------------------------------------------------------|
-| `db.client.connections.idle.max`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.                                              |
-| `db.client.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.                                              |
-| `db.client.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                   |
-| `db.client.connections.pending_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.            |
-| `db.client.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have occurred trying to obtain a connection from the pool. |
-| `db.client.connections.create_time`      | Histogram                  | milliseconds | `ms`                                      | The time it took to create a new connection.                                                      |
-| `db.client.connections.wait_time`        | Histogram                  | milliseconds | `ms`                                      | The time it took to obtain an open connection from the pool.                                      |
-| `db.client.connections.use_time`         | Histogram                  | milliseconds | `ms`                                      | The time between borrowing a connection and returning it to the pool.                             |
+| Name                                     | Instrument ([*](README.md#instrument-types)) | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                                                                       |
+|------------------------------------------|----------------------------------------------|--------------|-------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `db.client.connections.idle.max`         | UpDownCounter                                | connections  | `{connections}`                           | The maximum number of idle open connections allowed.                                              |
+| `db.client.connections.idle.min`         | UpDownCounter                                | connections  | `{connections}`                           | The minimum number of idle open connections allowed.                                              |
+| `db.client.connections.max`              | UpDownCounter                                | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                   |
+| `db.client.connections.pending_requests` | UpDownCounter                                | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.            |
+| `db.client.connections.timeouts`         | Counter                                      | timeouts     | `{timeouts}`                              | The number of connection timeouts that have occurred trying to obtain a connection from the pool. |
+| `db.client.connections.create_time`      | Histogram                                    | milliseconds | `ms`                                      | The time it took to create a new connection.                                                      |
+| `db.client.connections.wait_time`        | Histogram                                    | milliseconds | `ms`                                      | The time it took to obtain an open connection from the pool.                                      |
+| `db.client.connections.use_time`         | Histogram                                    | milliseconds | `ms`                                      | The time between borrowing a connection and returning it to the pool.                             |
 
 Below is a table of the attributes that MUST be included on all connection pool measurements:
 

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -45,7 +45,7 @@ MUST NOT be used.
 | `db.client.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.                                                                                         |
 | `db.client.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                                                              |
 | `db.client.connections.waiting_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.                                                       |
-| `db.client.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts happened when trying to obtaing a connection from the pool that have happened since the application start. |
+| `db.client.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have occurred trying to obtain a connection from the pool. |
 | `db.client.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.                                                               |
 
 All `db.client.connections.time` measurements MUST include the following attribute:

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -25,33 +25,37 @@ and units.
 Below is a table of database client connection pool metric instruments that MUST be used by connection pool
 instrumentations:
 
-| Name                    | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
-|-------------------------|----------------------------|--------------|-------------------------------------------|-------------|
-| `db.connections.total`  | Asynchronous UpDownCounter | connections  | `{connections}`                           | The total number of open connections.
-| `db.connections.active` | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently in use.
-| `db.connections.idle`   | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently idle.
+| Name                   | Instrument                 | Unit        | Unit ([UCUM](README.md#instrument-units)) | Description |
+|------------------------|----------------------------|-------------|-------------------------------------------|-------------|
+| `db.connections.usage` | Asynchronous UpDownCounter | connections | `{connections}`                           | The number of connections that are currently in state described by the `state` attribute.
+
+The `db.connections.usage` metric events MUST include the following attribute:
+
+| Name    | Type   | Description                                                                  | Examples | Required |
+|---------|--------|------------------------------------------------------------------------------|----------|----------|
+| `state` | string | The state of a connection in the pool. Valid values include: `idle`, `used`. | `idle`   | Yes      |
 
 Instrumentation libraries for database server connection pools that collect data for the following data MUST use the
 following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments
 MUST NOT be used.
 
-| Name                             | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
-|----------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
-| `db.connections.idle.max`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.
-| `db.connections.idle.min`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.
-| `db.connections.max`             | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.
-| `db.connections.pending_threads` | Asynchronous UpDownCounter | threads      | `{threads}`                               | The number of threads that are currently waiting for an open connection.
-| `db.connections.timeouts`        | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
-| `db.connections.time`            | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.
+| Name                              | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|-----------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
+| `db.connections.idle.max`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.
+| `db.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.
+| `db.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.
+| `db.connections.waiting_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection.
+| `db.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
+| `db.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.
 
-Below is a table of the attributes that MUST be included on connection pool metric events:
+The `db.connections.time` metric events MUST include the following attribute:
+
+| Name        | Type   | Description                                                                                   | Examples | Required |
+|-------------|--------|-----------------------------------------------------------------------------------------------|----------|----------|
+| `operation` | string | The type of operation applied to a connection. Valid values include: `create`, `use`, `wait`. | `create` | Yes      |
+
+Below is a table of the attributes that MUST be included on all connection pool metric events:
 
 | Name        | Type   | Description                                                                  | Examples       | Required |
 |-------------|--------|------------------------------------------------------------------------------|----------------|----------|
 | `pool.name` | string | The name of the connection pool; unique within the instrumented application. | `myDataSource` | Yes      |
-
-The `db.connections.time` metric events MUST include the following attribute:
-
-| Name        | Type   | Description                                                                                   | Examples       | Required |
-|-------------|--------|-----------------------------------------------------------------------------------------------|----------------|----------|
-| `operation` | string | The type of operation applied to a connection. Valid values include: `create`, `use`, `wait`. | `create` | Yes      |

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -1,0 +1,51 @@
+# General
+
+**Status**: [Experimental](../../document-status.md)
+
+The conventions described in this section are specific to SQL and NoSQL clients.
+
+**Disclaimer:** These are initial database client metric instruments and attributes but more may be added in the future.
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+- [Metric Instruments](#metric-instruments)
+  * [Connection pools](#connection-pools)
+
+<!-- tocstop -->
+
+## Metric Instruments
+
+The following metric instruments MUST be used to describe database client operations. They MUST be of the specified type
+and units.
+
+### Connection pools
+
+Below is a table of database connection pool server metric instruments that MUST be used by connection pool
+instrumentations:
+
+| Name                        | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|-----------------------------|----------------------------|--------------|-------------------------------------------|-------------|
+| `db.connection_pool.total`  | Asynchronous UpDownCounter | connections  | `{connections}`                           | The total number of open connections.
+| `db.connection_pool.active` | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently in use.
+| `db.connection_pool.idle`   | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently idle.
+
+Connection pool instrumentations SHOULD use the following metric instruments, if applicable:
+
+| Name                                 | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|--------------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
+| `db.connection_pool.idle.max`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.
+| `db.connection_pool.idle.min`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.
+| `db.connection_pool.max`             | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.
+| `db.connection_pool.pending_threads` | Asynchronous UpDownCounter | threads      | `{threads}`                               | The number of threads that are currently waiting for an open connection.
+| `db.connection_pool.timeouts`        | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
+| `db.connection_pool.create_time`     | Histogram                  | milliseconds | `ms`                                      | The time it took to create a new connection.
+| `db.connection_pool.wait_time`       | Histogram                  | milliseconds | `ms`                                      | The time it took to get an open connection from the pool.
+| `db.connection_pool.use_time`        | Histogram                  | milliseconds | `ms`                                      | The time between borrowing a connection and returning it to the pool.
+
+Below is a table of the attributes that are to be included on connection pool metric events:
+
+| Name   | Type   | Description                                                                  | Examples       | Required |
+|--------|--------|------------------------------------------------------------------------------|----------------|----------|
+| `name` | string | The name of the connection pool; unique within the instrumented application. | `myDataSource` | Yes      |

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -29,7 +29,7 @@ instrumentations:
 |------------------------|----------------------------|-------------|-------------------------------------------|-------------|
 | `db.connections.usage` | Asynchronous UpDownCounter | connections | `{connections}`                           | The number of connections that are currently in state described by the `state` attribute.
 
-The `db.connections.usage` metric events MUST include the following attribute:
+All `db.connections.usage` measurements MUST include the following attribute:
 
 | Name    | Type   | Description                                                                  | Examples | Required |
 |---------|--------|------------------------------------------------------------------------------|----------|----------|
@@ -48,13 +48,13 @@ MUST NOT be used.
 | `db.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
 | `db.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.
 
-The `db.connections.time` metric events MUST include the following attribute:
+All `db.connections.time` measurements MUST include the following attribute:
 
 | Name        | Type   | Description                                                                                   | Examples | Required |
 |-------------|--------|-----------------------------------------------------------------------------------------------|----------|----------|
 | `operation` | string | The type of operation applied to a connection. Valid values include: `create`, `use`, `wait`. | `create` | Yes      |
 
-Below is a table of the attributes that MUST be included on all connection pool metric events:
+Below is a table of the attributes that MUST be included on all connection pool measurements:
 
 | Name        | Type   | Description                                                                  | Examples       | Required |
 |-------------|--------|------------------------------------------------------------------------------|----------------|----------|

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -22,30 +22,36 @@ and units.
 
 ### Connection pools
 
-Below is a table of database connection pool server metric instruments that MUST be used by connection pool
+Below is a table of database client connection pool metric instruments that MUST be used by connection pool
 instrumentations:
 
-| Name                        | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
-|-----------------------------|----------------------------|--------------|-------------------------------------------|-------------|
-| `db.connection_pool.total`  | Asynchronous UpDownCounter | connections  | `{connections}`                           | The total number of open connections.
-| `db.connection_pool.active` | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently in use.
-| `db.connection_pool.idle`   | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently idle.
+| Name                    | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|-------------------------|----------------------------|--------------|-------------------------------------------|-------------|
+| `db.connections.total`  | Asynchronous UpDownCounter | connections  | `{connections}`                           | The total number of open connections.
+| `db.connections.active` | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently in use.
+| `db.connections.idle`   | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently idle.
 
-Instrumentation libraries for database server connection pools that collect data for the following data MUST use the following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments MUST NOT be used.
+Instrumentation libraries for database server connection pools that collect data for the following data MUST use the
+following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments
+MUST NOT be used.
 
-| Name                                 | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
-|--------------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
-| `db.connection_pool.idle.max`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.
-| `db.connection_pool.idle.min`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.
-| `db.connection_pool.max`             | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.
-| `db.connection_pool.pending_threads` | Asynchronous UpDownCounter | threads      | `{threads}`                               | The number of threads that are currently waiting for an open connection.
-| `db.connection_pool.timeouts`        | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
-| `db.connection_pool.create_time`     | Histogram                  | milliseconds | `ms`                                      | The time it took to create a new connection.
-| `db.connection_pool.wait_time`       | Histogram                  | milliseconds | `ms`                                      | The time it took to get an open connection from the pool.
-| `db.connection_pool.use_time`        | Histogram                  | milliseconds | `ms`                                      | The time between borrowing a connection and returning it to the pool.
+| Name                             | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|----------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
+| `db.connections.idle.max`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.
+| `db.connections.idle.min`        | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.
+| `db.connections.max`             | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.
+| `db.connections.pending_threads` | Asynchronous UpDownCounter | threads      | `{threads}`                               | The number of threads that are currently waiting for an open connection.
+| `db.connections.timeouts`        | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
+| `db.connections.time`            | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.
 
 Below is a table of the attributes that MUST be included on connection pool metric events:
 
-| Name   | Type   | Description                                                                  | Examples       | Required |
-|--------|--------|------------------------------------------------------------------------------|----------------|----------|
-| `name` | string | The name of the connection pool; unique within the instrumented application. | `myDataSource` | Yes      |
+| Name        | Type   | Description                                                                  | Examples       | Required |
+|-------------|--------|------------------------------------------------------------------------------|----------------|----------|
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. | `myDataSource` | Yes      |
+
+The `db.connections.time` metric events MUST include the following attribute:
+
+| Name        | Type   | Description                                                                                   | Examples       | Required |
+|-------------|--------|-----------------------------------------------------------------------------------------------|----------------|----------|
+| `operation` | string | The type of operation applied to a connection. Valid values include: `create`, `use`, `wait`. | `create` | Yes      |

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -25,34 +25,34 @@ and units.
 Below is a table of database client connection pool metric instruments that MUST be used by connection pool
 instrumentations:
 
-| Name                   | Instrument                 | Unit        | Unit ([UCUM](README.md#instrument-units)) | Description |
-|------------------------|----------------------------|-------------|-------------------------------------------|-------------|
-| `db.connections.usage` | Asynchronous UpDownCounter | connections | `{connections}`                           | The number of connections that are currently in state described by the `state` attribute.
+| Name                          | Instrument                 | Unit        | Unit ([UCUM](README.md#instrument-units)) | Description                                                                               |
+|-------------------------------|----------------------------|-------------|-------------------------------------------|-------------------------------------------------------------------------------------------|
+| `db.client.connections.usage` | Asynchronous UpDownCounter | connections | `{connections}`                           | The number of connections that are currently in state described by the `state` attribute. |
 
-All `db.connections.usage` measurements MUST include the following attribute:
+All `db.client.connections.usage` measurements MUST include the following attribute:
 
 | Name    | Type   | Description                                                                  | Examples | Required |
 |---------|--------|------------------------------------------------------------------------------|----------|----------|
 | `state` | string | The state of a connection in the pool. Valid values include: `idle`, `used`. | `idle`   | Yes      |
 
-Instrumentation libraries for database server connection pools that collect data for the following data MUST use the
+Instrumentation libraries for database client connection pools that collect data for the following data MUST use the
 following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments
 MUST NOT be used.
 
-| Name                              | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
-|-----------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
-| `db.connections.idle.max`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.
-| `db.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.
-| `db.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.
-| `db.connections.waiting_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection.
-| `db.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have happened since the application start.
-| `db.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.
+| Name                                     | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                                                                                                                  |
+|------------------------------------------|----------------------------|--------------|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| `db.client.connections.idle.max`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.                                                                                         |
+| `db.client.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.                                                                                         |
+| `db.client.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                                                              |
+| `db.client.connections.waiting_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.                                                       |
+| `db.client.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts happened when trying to obtaing a connection from the pool that have happened since the application start. |
+| `db.client.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.                                                               |
 
-All `db.connections.time` measurements MUST include the following attribute:
+All `db.client.connections.time` measurements MUST include the following attribute:
 
-| Name        | Type   | Description                                                                                   | Examples | Required |
-|-------------|--------|-----------------------------------------------------------------------------------------------|----------|----------|
-| `operation` | string | The type of operation applied to a connection. Valid values include: `create`, `use`, `wait`. | `create` | Yes      |
+| Name        | Type   | Description                                                                                                                                                                                                                                | Examples | Required |
+|-------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
+| `operation` | string | The type of operation applied to a connection. Valid values include: `create` (time it took to create a new connection), `use` (time spent using a connection obtained from the pool), `wait` (time spent waiting for an open connection). | `create` | Yes      |
 
 Below is a table of the attributes that MUST be included on all connection pool measurements:
 

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -39,14 +39,14 @@ Instrumentation libraries for database client connection pools that collect data
 following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments
 MUST NOT be used.
 
-| Name                                     | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                                                                                                                  |
-|------------------------------------------|----------------------------|--------------|-------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
-| `db.client.connections.idle.max`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.                                                                                         |
-| `db.client.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.                                                                                         |
-| `db.client.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                                                              |
-| `db.client.connections.waiting_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.                                                       |
+| Name                                     | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                                                                       |
+|------------------------------------------|----------------------------|--------------|-------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `db.client.connections.idle.max`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of idle open connections allowed.                                              |
+| `db.client.connections.idle.min`         | Asynchronous UpDownCounter | connections  | `{connections}`                           | The minimum number of idle open connections allowed.                                              |
+| `db.client.connections.max`              | Asynchronous UpDownCounter | connections  | `{connections}`                           | The maximum number of open connections allowed.                                                   |
+| `db.client.connections.pending_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | The number of pending requests for an open connection, cumulative for the entire pool.            |
 | `db.client.connections.timeouts`         | Counter                    | timeouts     | `{timeouts}`                              | The number of connection timeouts that have occurred trying to obtain a connection from the pool. |
-| `db.client.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.                                                               |
+| `db.client.connections.time`             | Histogram                  | milliseconds | `ms`                                      | The time it took to apply an operation described by the `operation` attribute.                    |
 
 All `db.client.connections.time` measurements MUST include the following attribute:
 

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -31,7 +31,7 @@ instrumentations:
 | `db.connection_pool.active` | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently in use.
 | `db.connection_pool.idle`   | Asynchronous UpDownCounter | connections  | `{connections}`                           | The number of open connections that are currently idle.
 
-Connection pool instrumentations SHOULD use the following metric instruments, if applicable:
+Instrumentation libraries for database server connection pools that collect data for the following data MUST use the following metric instruments. Otherwise, if the instrumentation library does not collect this data, these instruments MUST NOT be used.
 
 | Name                                 | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
 |--------------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
@@ -44,7 +44,7 @@ Connection pool instrumentations SHOULD use the following metric instruments, if
 | `db.connection_pool.wait_time`       | Histogram                  | milliseconds | `ms`                                      | The time it took to get an open connection from the pool.
 | `db.connection_pool.use_time`        | Histogram                  | milliseconds | `ms`                                      | The time between borrowing a connection and returning it to the pool.
 
-Below is a table of the attributes that are to be included on connection pool metric events:
+Below is a table of the attributes that MUST be included on connection pool metric events:
 
 | Name   | Type   | Description                                                                  | Examples       | Required |
 |--------|--------|------------------------------------------------------------------------------|----------------|----------|

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -27,7 +27,7 @@ instrumentations:
 
 | Name                          | Instrument                 | Unit        | Unit ([UCUM](README.md#instrument-units)) | Description                                                                               |
 |-------------------------------|----------------------------|-------------|-------------------------------------------|-------------------------------------------------------------------------------------------|
-| `db.client.connections.usage` | Asynchronous UpDownCounter | connections | `{connections}`                           | The number of connections that are currently in state described by the `state` attribute. |
+| `db.client.connections.usage` | UpDownCounter | connections | `{connections}`                           | The number of connections that are currently in state described by the `state` attribute. |
 
 All `db.client.connections.usage` measurements MUST include the following attribute:
 


### PR DESCRIPTION
Fixes #2263

## Changes

Adds database connection pool metrics semantic conventions.

This PR is based on the DB connection pool metrics implemented in the Splunk Java instrumentation distro:
*  https://github.com/signalfx/splunk-otel-java/blob/main/docs/metrics.md#connection-pool-metrics
* https://github.com/signalfx/splunk-otel-java/blob/main/bootstrap/src/main/java/com/splunk/opentelemetry/javaagent/bootstrap/metrics/DataSourceSemanticConventions.java
