### PR TITLE
minor: fix heading size in MetricReader operations

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -662,7 +662,7 @@ Note: it is expected that the `MetricReader.Collect` implementations will be
 provided by the SDK, so it is RECOMMENDED to prevent the user from accidentally
 overriding it, if possible (e.g. `final` in C++ and Java, `sealed` in C#).
 
-### Shutdown
+#### Shutdown
 
 This method provides a way for the `MetricReader` to do any cleanup required.
 


### PR DESCRIPTION
Small correction: the heading font was incorrect for the `Shutdown` operation under `MetricReader`