### PR TITLE
Allow adding links after span creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- Introduce the concept of Instrumentation Scope to replace/extend Instrumentation
+  Library. The Tracer is now associated with Instrumentation Scope
+  ([#2276](https://github.com/open-telemetry/opentelemetry-specification/pull/2276)).
 - Add documentation REQUIREMENT for adding attributes at span creation.
   ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ release.
 - Introduce the concept of Instrumentation Scope to replace/extend Instrumentation
   Library. The Tracer is now associated with Instrumentation Scope
   ([#2276](https://github.com/open-telemetry/opentelemetry-specification/pull/2276)).
-- Add documentation REQUIREMENT for adding attributes at span creation.
-  ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
+- Allow adding links after span creation, add new `AddLink` method.
+  ([#2278](https://github.com/open-telemetry/opentelemetry-specification/pull/2278))
 
 ### Metrics
 
@@ -49,6 +49,9 @@ release.
 - Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protocol
   used by the Jaeger exporter.
   ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341))
+- Add documentation REQUIREMENT for adding attributes at span creation.
+  ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
+
 ### Metrics
 
 - Initial Prometheus <-> OTLP datamodel specification
@@ -181,14 +184,9 @@ release.
   variable to point to the correct HTTP port and correct description of
   `OTEL_TRACES_EXPORTER`.
   ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333))
-<<<<<<< HEAD
-=======
 - Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protocol
   used by the Jaeger exporter.
   ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341))
-- Allow adding links after span creation, require new `AddLink` method.
-  ([#2278](https://github.com/open-telemetry/opentelemetry-specification/pull/2278))
->>>>>>> 477857e (Add changelog and adapt spec compliance matrix)
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- Add documentation REQUIREMENT for adding attributes at span creation.
+  ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
+
 ### Metrics
 
 ### Logs
@@ -43,9 +46,6 @@ release.
 - Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protocol
   used by the Jaeger exporter.
   ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341))
-- Add documentation REQUIREMENT for adding attributes at span creation.
-  ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
-
 ### Metrics
 
 - Initial Prometheus <-> OTLP datamodel specification
@@ -178,6 +178,14 @@ release.
   variable to point to the correct HTTP port and correct description of
   `OTEL_TRACES_EXPORTER`.
   ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333))
+<<<<<<< HEAD
+=======
+- Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protocol
+  used by the Jaeger exporter.
+  ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341))
+- Allow adding links after span creation, require new `AddLink` method.
+  ([#2278](https://github.com/open-telemetry/opentelemetry-specification/pull/2278))
+>>>>>>> 477857e (Add changelog and adapt spec compliance matrix)
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -64,11 +64,9 @@ formats is required. Implementing more than one format is optional.
 | Array of primitives (homogeneous)                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | `null` values documented as invalid/undefined                                                    |          | +   | +    | +   | +      | +    | N/A    | +   |      | +   |      | N/A   |
 | Unicode support for keys and string values                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
+| [AddLink](specification/trace/api.md#add-links)                                                  |          |     |      |     |        |      |        |     |      |     |      |       |
 | Links can be recorded on span creation                                                           |          | +   | +    |     |        | +    | +      | +   | +    | +   | +    |       |
 | Links order is preserved                                                                         |          | +   | +    |     |        | +    | +      | +   | +    | +   | +    |       |
-| [AddLink](specification/trace/api.md#add-links)                                                  |          |    |      |    |        |      |        |     |      |     |      |       |
-| Links can be recorded on span creation                                                           |          | +   | +    |     |        | +    | +      | +   | +    | +   |      |       |
-| Links order is preserved                                                                         |          | +   | +    |     |        | +    | +      | +   | +    | +   |      |       |
 | [Span events](specification/trace/api.md#add-events)                                             |          |     |      |     |        |      |        |     |      |     |      |       |
 | AddEvent                                                                                         |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Add order preserved                                                                              |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -29,7 +29,7 @@ formats is required. Implementing more than one format is optional.
 | Set active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | [Tracer](specification/trace/api.md#tracer-operations)                                           |          |     |      |     |        |      |        |     |      |     |      |       |
 | Create a new Span                                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Documentation defines adding attributes at span creation as preferred                            |          |     |      |     |        |      |        |     |      |     | +    |       |
+| Documentation defines adding attributes and links at span creation as preferred                  |          |     |      |     |        |      |        |     |      |     |      |       |
 | Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Mark Span active                                                                                 |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -64,9 +64,11 @@ formats is required. Implementing more than one format is optional.
 | Array of primitives (homogeneous)                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | `null` values documented as invalid/undefined                                                    |          | +   | +    | +   | +      | +    | N/A    | +   |      | +   |      | N/A   |
 | Unicode support for keys and string values                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Span linking](specification/trace/api.md#specifying-links)                                      |          |     |      |     |        |      |        |     |      |     |      |       |
 | Links can be recorded on span creation                                                           |          | +   | +    |     |        | +    | +      | +   | +    | +   | +    |       |
 | Links order is preserved                                                                         |          | +   | +    |     |        | +    | +      | +   | +    | +   | +    |       |
+| [AddLink](specification/trace/api.md#add-links)                                                  |          |    |      |    |        |      |        |     |      |     |      |       |
+| Links can be recorded on span creation                                                           |          | +   | +    |     |        | +    | +      | +   | +    | +   |      |       |
+| Links order is preserved                                                                         |          | +   | +    |     |        | +    | +      | +   | +    | +   |      |       |
 | [Span events](specification/trace/api.md#add-events)                                             |          |     |      |     |        |      |        |     |      |     |      |       |
 | AddEvent                                                                                         |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Add order preserved                                                                              |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/specification/common/common.md
+++ b/specification/common/common.md
@@ -117,7 +117,7 @@ at this time, as discussed in
 [data points](../metrics/datamodel.md#metric-points),
 [Spans](../trace/api.md#set-attributes), Span
 [Events](../trace/api.md#add-events), Span
-[Links](../trace/api.md#specifying-links) and
+[Links](../trace/api.md#add-links) and
 [Log Records](../logs/data-model.md) may contain a collection of attributes. The
 keys in each such collection are unique, i.e. there MUST NOT exist more than one
 key-value pair with the same key. The enforcement of uniqueness may be performed

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -118,7 +118,7 @@ using the OpenCensus <-> OpenTelemetry bridge.
    This leads to some issues with OpenCensus APIs that allowed flexible
    specification of parent spans post-initialization.
 2. Links added to spans after the spans are created. This is [not supported in
-   OpenTelemetry](../trace/api.md#specifying-links), therefore OpenCensus spans
+   OpenTelemetry](../trace/api.md#add-links), therefore OpenCensus spans
    that have links added to them after creation will be mapped to OpenTelemetry
    spans without the links.
 3. OpenTelemetry specifies that samplers are

--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -515,7 +515,7 @@ OpenTracing defines two types of references:
 
 OpenTelemetry does not define strict equivalent semantics for these
 references. These reference types must not be confused with the
-[Link](../trace/api.md#specifying-links) functionality. This information
+[Link](../trace/api.md##add-links) functionality. This information
 is however preserved as the `opentracing.ref_type` attribute.
 
 ## In process Propagation exceptions

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -481,7 +481,7 @@ attributes, cannot change their decisions.
 
 #### Add Links
 
-A `Span` MUST have the ability to add `Link`s associated with it. Linked
+A `Span` SHOULD have the ability to add `Link`s associated with it. Linked
 `Span`s can be from the same or a different trace (see
 [Links between spans](../overview.md#links-between-spans)).
 
@@ -491,7 +491,7 @@ A `Link` is structurally defined by the following properties:
 - Zero or more [`Attributes`](../common/common.md#attributes) further describing
   the link.
 
-The Span interface MUST provide:
+The Span interface SHOULD provide:
 
 - An API to record a single `Link` where the `Link` properties are passed as
   arguments. This MAY be called `AddLink`. This API takes the `SpanContext` of

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -505,7 +505,7 @@ The Span interface MAY provide:
 - An API to set multiple `Link`s at once, where the `Link`s are passed in a
   single method call.
 
-Links SHOULD preserve the order in which they're set.
+Spans SHOULD preserve the order in which Links are set.
 
 Note that [Samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any `Link`s added later cannot change their


### PR DESCRIPTION
Fixes #454

In a discussion in the specification SIG, it was deemed feasible to revise a further decision about not allowing adding links to spans after span creation.

Adding links after span creation allows to create more meaningful traces in certain scenarios (several of those scenarios were identified by the messaging workgroup). Best-effort sampling based on links is still possible, only based on links added at creation time (similar to attributes).

## Changes

This moves the section about adding span links from "Span creation" to "Span operations", removing mentions of the limitation that links can only be added at creation time. The name `AddLink` is proposed, wording is kept consistent with the corresponding section for adding attributes.