### PR TITLE
Add semantic conventions for k8sobjects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ release.
 
 ### Resource
 
+- Add the Kubernetes Object related semantic conventions
+  ([#2300](https://github.com/open-telemetry/opentelemetry-specification/pull/2300))
+
 ### Semantic Conventions
 
 - Prohibit usage of retired names in semantic conventions.

--- a/semantic_conventions/resource/k8s.yaml
+++ b/semantic_conventions/resource/k8s.yaml
@@ -168,3 +168,30 @@ groups:
         brief: >
           The name of the CronJob.
         examples: ['opentelemetry']
+
+  - id: k8s.object
+    prefix: k8s.object
+    brief: >
+      A generic way to represent any Kubernetes objects including any
+      [Custom Objects](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-custom-objects).
+    attributes:
+      - id: uid
+        type: string
+        brief: >
+          The UID of the Object.
+        examples: ['275ecb36-5aa8-4c2a-9c47-d8bb681b9aff']
+      - id: name
+        type: string
+        brief: >
+          The name of the Object.
+        examples: ['opentelemetry-pod-autoconf']
+      - id: kind
+        type: string
+        brief: >
+          A value representing kind of the Object.
+        examples: ['pod', 'replicaset']
+      - id: fieldpath
+        type: string
+        brief: >
+          A value referring to a piece of an object instead of an entire Object.
+        examples: ['spec.containers{nginx}']

--- a/specification/resource/semantic_conventions/k8s.md
+++ b/specification/resource/semantic_conventions/k8s.md
@@ -185,3 +185,20 @@ A CronJob creates Jobs on a repeating schedule.
 | `k8s.cronjob.uid` | string | The UID of the CronJob. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | No |
 | `k8s.cronjob.name` | string | The name of the CronJob. | `opentelemetry` | No |
 <!-- endsemconv -->
+
+## Object
+
+A Kubernetes Object created from any Kubernetes Resources including any [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions).
+
+**type:** `k8s.object`
+
+**Description:** A generic way to represent any Kubernetes objects including any [Custom Objects](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-custom-objects).
+
+<!-- semconv k8s.object -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `k8s.object.uid` | string | The UID of the Object. | `275ecb36-5aa8-4c2a-9c47-d8bb681b9aff` | No |
+| `k8s.object.name` | string | The name of the Object. | `opentelemetry-pod-autoconf` | No |
+| `k8s.object.kind` | string | A value representing kind of the Object. | `pod`; `replicaset` | No |
+| `k8s.object.fieldpath` | string | A value referring to a piece of an object instead of an entire Object. | `spec.containers{nginx}` | No |
+<!-- endsemconv -->


### PR DESCRIPTION
## Changes

- Added k8s resource object-related attributes as there can be objects of [CRD](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions), so to make generic semantics to represent any type of k8s objects (CRD or defaults like a pod, node, etc).