### PR TITLE
Move metrics SDK spec to Mixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ release.
   [#2032](https://github.com/open-telemetry/opentelemetry-specification/pull/2061)
 - Changed default Prometheus Exporter host from `0.0.0.0` to `localhost`.
   ([#2282](https://github.com/open-telemetry/opentelemetry-specification/pull/2282))
+- Mark Metrics SDK spec as Stable.
+  ([#2150](https://github.com/open-telemetry/opentelemetry-specification/pull/2150))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,8 @@ release.
   [#2032](https://github.com/open-telemetry/opentelemetry-specification/pull/2061)
 - Changed default Prometheus Exporter host from `0.0.0.0` to `localhost`.
   ([#2282](https://github.com/open-telemetry/opentelemetry-specification/pull/2282))
-- Mark Metrics SDK spec as Mixed, with most compnents remaining in
-  Feature-freeze while Attribute Limits, Compatibility Requirements, and
-  Concurrency Requirements moving to Stable.
+- Mark Metrics SDK spec as Mixed, with most components moving to Stable, while
+  Exemplar remaining Feature-freeze.
   ([#2150](https://github.com/open-telemetry/opentelemetry-specification/pull/2150))
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,6 @@ release.
   [#2032](https://github.com/open-telemetry/opentelemetry-specification/pull/2061)
 - Changed default Prometheus Exporter host from `0.0.0.0` to `localhost`.
   ([#2282](https://github.com/open-telemetry/opentelemetry-specification/pull/2282))
-- Mark In-memory, OTLP and Stdout exporter specs as Stable.
-  ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
 - Mark Metrics SDK spec as Mixed, with most compnents remaining in
   Feature-freeze while Attribute Limits, Compatibility Requirements, and
   Concurrency Requirements moving to Stable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ release.
   ([#2124](https://github.com/open-telemetry/opentelemetry-specification/pull/2124))
 - Remove the concept of supported temporality, keep preferred.
   ([#2154](https://github.com/open-telemetry/opentelemetry-specification/pull/2154))
-<<<<<<< HEAD
 - Mark In-memory, OTLP and Stdout exporter specs as Stable.
   ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
 - Add to the supplemental guidelines for metric SDK authors text about implementing
@@ -42,11 +41,11 @@ release.
   [#2032](https://github.com/open-telemetry/opentelemetry-specification/pull/2061)
 - Changed default Prometheus Exporter host from `0.0.0.0` to `localhost`.
   ([#2282](https://github.com/open-telemetry/opentelemetry-specification/pull/2282))
-- Mark Metrics SDK spec as Stable.
-=======
-- Mark Metrics SDK spec as Mixed, with `MeterProvider`, `MetricReader` and
-  `MetricExporter` marked as Stable.
->>>>>>> 68952d1 (update changelog)
+- Mark In-memory, OTLP and Stdout exporter specs as Stable.
+  ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
+- Mark Metrics SDK spec as Mixed, with most compnents remaining in
+  Feature-freeze while Attribute Limits, Compatibility Requirements, and
+  Concurrency Requirements moving to Stable.
   ([#2150](https://github.com/open-telemetry/opentelemetry-specification/pull/2150))
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ release.
   ([#2124](https://github.com/open-telemetry/opentelemetry-specification/pull/2124))
 - Remove the concept of supported temporality, keep preferred.
   ([#2154](https://github.com/open-telemetry/opentelemetry-specification/pull/2154))
+<<<<<<< HEAD
 - Mark In-memory, OTLP and Stdout exporter specs as Stable.
   ([#2175](https://github.com/open-telemetry/opentelemetry-specification/pull/2175))
 - Add to the supplemental guidelines for metric SDK authors text about implementing
@@ -42,6 +43,10 @@ release.
 - Changed default Prometheus Exporter host from `0.0.0.0` to `localhost`.
   ([#2282](https://github.com/open-telemetry/opentelemetry-specification/pull/2282))
 - Mark Metrics SDK spec as Stable.
+=======
+- Mark Metrics SDK spec as Mixed, with `MeterProvider`, `MetricReader` and
+  `MetricExporter` marked as Stable.
+>>>>>>> 68952d1 (update changelog)
   ([#2150](https://github.com/open-telemetry/opentelemetry-specification/pull/2150))
 
 ### Logs

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1,6 +1,6 @@
 # Metrics SDK
 
-**Status**: [Feature-freeze](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 <details>
 <summary>Table of Contents</summary>

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -182,10 +182,10 @@ are the inputs:
     outputs metric points that use aggregation temporality (e.g. Histogram,
     Sum), the SDK SHOULD handle the aggregation temporality based on the
     temporality of each [MetricReader](#metricreader) instance.
-  * **Status**: [Feature-freeze](../document-status.md) - the `exemplar_reservoir`
-    (optional) to use for storing exemplars. This should be a factory or
-    callback similar to aggregation which allows different reservoirs to be
-    chosen by the aggregation.
+  * **Status**: [Feature-freeze](../document-status.md) - the
+    `exemplar_reservoir` (optional) to use for storing exemplars. This should be
+    a factory or callback similar to aggregation which allows different
+    reservoirs to be chosen by the aggregation.
 
 In order to avoid conflicts, views which specify a name SHOULD have an
 instrument selector that selects at most one instrument. For the registration

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -182,7 +182,7 @@ are the inputs:
     outputs metric points that use aggregation temporality (e.g. Histogram,
     Sum), the SDK SHOULD handle the aggregation temporality based on the
     temporality of each [MetricReader](#metricreader) instance.
-  * **Status**: [Experimental](../document-status.md) - the `exemplar_reservoir`
+  * **Status**: [Feature-freeze](../document-status.md) - the `exemplar_reservoir`
     (optional) to use for storing exemplars. This should be a factory or
     callback similar to aggregation which allows different reservoirs to be
     chosen by the aggregation.
@@ -428,7 +428,7 @@ series and the topic requires further analysis.
 
 ## Exemplar
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Feature-freeze](../document-status.md)
 
 Exemplars are example data points for aggregated data. They provide specific
 context to otherwise general aggregations. Exemplars allow correlation between

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -182,9 +182,10 @@ are the inputs:
     outputs metric points that use aggregation temporality (e.g. Histogram,
     Sum), the SDK SHOULD handle the aggregation temporality based on the
     temporality of each [MetricReader](#metricreader) instance.
-  * The `exemplar_reservoir` (optional) to use for storing exemplars.
-    This should be a factory or callback similar to aggregation which allows
-    different reservoirs to be chosen by the aggregation.
+  * **Status**: [Experimental](../document-status.md) - the `exemplar_reservoir`
+    (optional) to use for storing exemplars. This should be a factory or
+    callback similar to aggregation which allows different reservoirs to be
+    chosen by the aggregation.
 
 In order to avoid conflicts, views which specify a name SHOULD have an
 instrument selector that selects at most one instrument. For the registration

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1,6 +1,6 @@
 # Metrics SDK
 
-**Status**: [Stable](../document-status.md)
+**Status**: [Mixed](../document-status.md)
 
 <details>
 <summary>Table of Contents</summary>
@@ -46,6 +46,8 @@
 </details>
 
 ## MeterProvider
+
+**Status**: [Stable](../document-status.md)
 
 A `MeterProvider` MUST provide a way to allow a [Resource](../resource/sdk.md) to
 be specified. If a `Resource` is specified, it SHOULD be associated with all the
@@ -416,12 +418,16 @@ instruments that record negative measurements, e.g. `UpDownCounter` or `Observab
 
 ## Attribute limits
 
+**Status**: [Stable](../document-status.md)
+
 Attributes which belong to Metrics are exempt from the
 [common rules of attribute limits](../common/common.md#attribute-limits) at this
 time. Attribute truncation or deletion could affect identity of metric time
 series and the topic requires further analysis.
 
 ## Exemplar
+
+**Status**: [Experimental](../document-status.md)
 
 Exemplars are example data points for aggregated data. They provide specific
 context to otherwise general aggregations. Exemplars allow correlation between
@@ -587,6 +593,8 @@ measurements using the equivalent of the following naive algorithm:
 
 ## MetricReader
 
+**Status**: [Stable](../document-status.md)
+
 `MetricReader` is an interface which provides the following capabilities:
 
 * Collecting metrics from the SDK.
@@ -708,6 +716,8 @@ from `MetricReader` and start a background task which calls the inherited
   exporter.
 
 ## MetricExporter
+
+**Status**: [Stable](../document-status.md)
 
 `MetricExporter` defines the interface that protocol-specific exporters MUST
 implement so that they can be plugged into OpenTelemetry SDK and support sending
@@ -930,6 +940,8 @@ errors/exceptions are taken care of.
 
 ## Compatibility requirements
 
+**Status**: [Stable](../document-status.md)
+
 All the metrics components SHOULD allow new methods to be added to existing
 components without introducing breaking changes.
 
@@ -937,6 +949,8 @@ All the metrics SDK methods SHOULD allow optional parameter(s) to be added to
 existing methods without introducing breaking changes, if possible.
 
 ## Concurrency requirements
+
+**Status**: [Stable](../document-status.md)
 
 For languages which support concurrent execution the Metrics SDKs provide
 specific guarantees and safeties.


### PR DESCRIPTION
Supersedes #2150.

## Changes

* Mark Metrics SDK specification to Mixed, with Exemplar as Feature-freeze while other parts as Stable.

Related PR #2270 is touching the API spec post Stable release, so it might not be a blocker.
