### PR TITLE
View aggregation examples modified to remove unsupported things

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -251,19 +251,19 @@ meter_provider
 ```
 
 ```python
-# Counter X will be exported as sum
+# Counter X will be exported as cumulative sum
 meter_provider
     .add_view("X", aggregation=SumAggregation())
-    .add_metric_reader(PeriodicExportingMetricReader(ConsoleExporter()))
+    .add_metric_reader(PeriodicExportingMetricReader(AggregationTemporality.CUMULATIVE, ConsoleExporter()))
 ```
 
 ```python
-# Counter X will be exported as sum
+# Counter X will be exported as delta sum
 # Histogram Y and Gauge Z will be exported with 2 attributes (a and b)
 meter_provider
     .add_view("X", aggregation=SumAggregation())
     .add_view("*", attribute_keys=["a", "b"])
-    .add_metric_reader(PeriodicExportingMetricReader(ConsoleExporter()))
+    .add_metric_reader(PeriodicExportingMetricReader(AggregationTemporality.DELTA, ConsoleExporter()))
 ```
 
 ### Aggregation

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -251,17 +251,17 @@ meter_provider
 ```
 
 ```python
-# Counter X will be exported as cumulative sum
+# Counter X will be exported as sum
 meter_provider
-    .add_view("X", aggregation=SumAggregation(CUMULATIVE))
+    .add_view("X", aggregation=SumAggregation())
     .add_metric_reader(PeriodicExportingMetricReader(ConsoleExporter()))
 ```
 
 ```python
-# Counter X will be exported as delta sum
+# Counter X will be exported as sum
 # Histogram Y and Gauge Z will be exported with 2 attributes (a and b)
 meter_provider
-    .add_view("X", aggregation=SumAggregation(DELTA))
+    .add_view("X", aggregation=SumAggregation())
     .add_view("*", attribute_keys=["a", "b"])
     .add_metric_reader(PeriodicExportingMetricReader(ConsoleExporter()))
 ```


### PR DESCRIPTION
The current spec for View does not allow specifying temporality (cumulative/delta) on aggregation, and it is only allowed along with MetricReader. This PR is modifying the examples to remove the unsupported capabilities, to avoid confusion.