### PR TITLE
Minor clarification in Metric View registration spec

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -188,7 +188,7 @@ In order to avoid conflicts, views which specify a name SHOULD have an
 instrument selector that selects at most one instrument. For the registration
 mechanism described above, where selection is provided via configuration, the
 SDK MUST NOT allow Views with a specified name to be declared with instrument
-selectors that select by instrument type or wildcard.
+selectors that select more than one instrument (e.g. wild card instrument name).
 
 The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:


### PR DESCRIPTION
The current wording incorrectly implies that "instrument selectors that select by instrument type or wildcard" can select multiple-instruments. However, as instrument selection criteria contains things like name, version etc of the `Meter`, they can also select multiple instruments. This PR slightly adjusts the wording to fix this.