### PR TITLE
Add instr-wg as code owers for semantic conventions.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@ experimental/logs/      @open-telemetry/technical-committee @open-telemetry/spec
 specification/logs/     @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers
 
 # Semantic Conventions owners (global + trace/metrics/logs + instr-wg)
+semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/instr-wg
 specification/trace/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers @open-telemetry/instr-wg
 specification/metrics/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers @open-telemetry/instr-wg
 specification/logs/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers @open-telemetry/instr-wg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,9 @@ specification/metrics/  @open-telemetry/technical-committee @open-telemetry/spec
 # Logs owners (global + logs)
 experimental/logs/      @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers
 specification/logs/     @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers
+
+# Semantic Conventions owners (global + trace/metrics/logs + instr-wg)
+specification/trace/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers @open-telemetry/instr-wg
+specification/metrics/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers @open-telemetry/instr-wg
+specification/logs/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers @open-telemetry/instr-wg
+specification/resource/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/instr-wg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,8 +28,8 @@ experimental/logs/      @open-telemetry/technical-committee @open-telemetry/spec
 specification/logs/     @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers
 
 # Semantic Conventions owners (global + trace/metrics/logs + instr-wg)
-semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/instr-wg
-specification/trace/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers @open-telemetry/instr-wg
-specification/metrics/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers @open-telemetry/instr-wg
-specification/logs/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers @open-telemetry/instr-wg
-specification/resource/semantic_conventions @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/instr-wg
+semantic_conventions/ @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/instr-wg
+specification/trace/semantic_conventions/ @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-trace-approvers @open-telemetry/instr-wg
+specification/metrics/semantic_conventions/ @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-metrics-approvers @open-telemetry/instr-wg
+specification/logs/semantic_conventions/ @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/specs-logs-approvers @open-telemetry/instr-wg
+specification/resource/semantic_conventions/ @open-telemetry/technical-committee @open-telemetry/specs-approvers @open-telemetry/instr-wg


### PR DESCRIPTION
This change adds the https://github.com/orgs/open-telemetry/teams/instr-wg team as a code owner for semantic conventions. This group represents members of the instrumentation SIG who are willing to review changes to semantic conventions, and to ensure that subject matter experts are included as part of the review process.