### PR TITLE
4xx client errors to be left unset

### DIFF
--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -45,8 +45,8 @@ default span name.
 the response body; or 3xx codes with max redirects exceeded), in which case status
 MUST be set to `Error`.
 
-For HTTP status codes in the 4xx range span status MUST be left unset in case of `SpanKind.SERVER`
-and MUST be set to `Error` in case of `SpanKind.CLIENT`.
+For HTTP status codes in the 4xx range span status MUST be left unset regardless of
+`SpanKind`. 
 
 For HTTP status codes in the 5xx range, as well as any other code the client
 failed to interpret, span status MUST be set to `Error`.


### PR DESCRIPTION
Fixes part of [OTEP-174](https://github.com/open-telemetry/oteps/pull/174)

## Changes

As part of [OTEP-174](https://github.com/open-telemetry/oteps/pull/174) it was suggested that span error statuses should be left unset for client 4xx spans. The reason being, a 4xx on the client does not necessarily indicate an error. For example, a 429 might not be considered an error on the client side. 

Related [oteps](https://github.com/open-telemetry/oteps) #

- [OTEP-174](https://github.com/open-telemetry/oteps/pull/174)
