### PR TITLE
[editorial] compatibility/opentracing.md: fix anchor, `##` -> `#`

### DIFF
--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -501,7 +501,7 @@ OpenTracing defines two types of references:
 
 OpenTelemetry does not define strict equivalent semantics for these
 references. These reference types must not be confused with the
-[Link](../trace/api.md##specifying-links) functionality. This information
+[Link](../trace/api.md#specifying-links) functionality. This information
 is however preserved as the `opentracing.ref_type` attribute.
 
 ## In process Propagation exceptions


### PR DESCRIPTION
There's an extra `#` in an anchor:

```console
$ GET="no" npm run check-links # from the opentelemetry.io repo
========================================================================
docs/reference/specification/compatibility/opentracing/index.html
  hash does not exist --- docs/reference/specification/compatibility/opentracing/index.html --> /docs/reference/specification/trace/api/##specifying-links
========================================================================
✘✘✘ failed in 536.869273ms
1 errors in 541 documents
```

/cc @tedsuo @austinlparker 