### PR TITLE
[editorial] Generate ALL_DOCS using find only, no grep -v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # All documents to be used in spell check.
-ALL_DOCS := $(shell find . -name '*.md' -not -path './.github/*' -type f | grep -v ^./node_modules | sort)
+ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)
 PWD := $(shell pwd)
 
 TOOLS_DIR := ./internal/tools


### PR DESCRIPTION
For computing `ALL_DOCS`, we don't need to use `grep -v`.

This PR adjusts the `find` arguments to get the same result, as tested by diffing the `ALL_DOCS` output with both versions:

```makefile
ALL_DOCS:
  @echo $(ALL_DOCS) | tr ' ' "\n"
```