### PR TITLE
[linters] Install tools based on versions in package.json

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,7 +14,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: run markdownlint
-      run: make markdownlint
+      run: |
+        npm install
+        make markdownlint
 
   yamllint:
     runs-on: ubuntu-latest
@@ -37,7 +39,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: run markdown-link-check
-      run: make markdown-link-check
+      run: |
+        npm install
+        make markdown-link-check
 
   markdown-toc-check:
     runs-on: ubuntu-latest
@@ -46,7 +50,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: run markdown-toc
-      run: make markdown-toc
+      run: |
+        npm install
+        make markdown-toc
 
     - name: validate markdown-toc
       run: git diff --exit-code ':*.md' || (echo 'Generated markdown Table of Contents is out of date, please run "make markdown-toc" and commit the changes in this PR.' && exit 1)

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: check out code
       uses: actions/checkout@v2
 
-    - name: npm install
+    - name: install dependencies
       run: npm install
 
     - name: run markdownlint
@@ -39,7 +39,7 @@ jobs:
     - name: check out code
       uses: actions/checkout@v2
 
-    - name: npm install
+    - name: install dependencies
       run: npm install
 
     - name: run markdown-link-check
@@ -51,7 +51,7 @@ jobs:
     - name: check out code
       uses: actions/checkout@v2
 
-    - name: npm install
+    - name: install dependencies
       run: npm install
 
     - name: run markdown-toc

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,10 +13,11 @@ jobs:
     - name: check out code
       uses: actions/checkout@v2
 
+    - name: npm install
+      run: npm install
+
     - name: run markdownlint
-      run: |
-        npm install
-        make markdownlint
+      run: make markdownlint
 
   yamllint:
     runs-on: ubuntu-latest
@@ -38,10 +39,11 @@ jobs:
     - name: check out code
       uses: actions/checkout@v2
 
+    - name: npm install
+      run: npm install
+
     - name: run markdown-link-check
-      run: |
-        npm install
-        make markdown-link-check
+      run: make markdown-link-check
 
   markdown-toc-check:
     runs-on: ubuntu-latest
@@ -49,10 +51,11 @@ jobs:
     - name: check out code
       uses: actions/checkout@v2
 
+    - name: npm install
+      run: npm install
+
     - name: run markdown-toc
-      run: |
-        npm install
-        make markdown-toc
+      run: make markdown-toc
 
     - name: validate markdown-toc
       run: git diff --exit-code ':*.md' || (echo 'Generated markdown Table of Contents is out of date, please run "make markdown-toc" and commit the changes in this PR.' && exit 1)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,11 +42,16 @@ one that is needlessly restrictive and complex.
 ### Consistency Checks
 
 The Specification has a number of tools it uses to check things like style,
-spelling and link validity. You can run all of these locally via:
+spelling and link validity. Before using the tools, run:
 
 ```bash
-npm install # get the tools
-make check  # run all checks
+npm install
+```
+
+You can perform all checks locally using this command:
+
+```bash
+make check
 ```
 
 Note: This can take a long time as it checks all links. You should use this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ The Specification has a number of tools it uses to check things like style,
 spelling and link validity. You can run all of these locally via:
 
 ```bash
-make check
+npm install # get the tools
+make check  # run all checks
 ```
 
 Note: This can take a long time as it checks all links. You should use this
@@ -92,11 +93,10 @@ wide. There are tools that can do it for you effectively. Please submit proposal
 to include your editor settings required to enable this behavior so the out of
 the box settings for this repository will be consistent.
 
-To check for style violations, use
+To check for style violations, run:
 
 ```bash
-make install-markdownlint # install markdownlint if not installed
-make markdownlint # run at the root of the repo
+make markdownlint
 ```
 
 To fix style violations, follow the
@@ -109,13 +109,14 @@ you can also use the `fixAll` command of the
 
 In addition, please make sure to clean up typos before you submit the change.
 
-To check for typos, use
+To check for typos, run the following command:
 
 ```bash
-# Golang is needed for the misspell tool.
-make install-misspell
 make misspell
 ```
+
+> **NOTE**: The `misspell` make target will also fetch and build the tool if
+> necessary. You'll need [Go](https://go.dev) to build the spellchecker.
 
 To quickly fix typos, use
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,10 @@ misspell-correction:	$(MISSPELL)
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	@for f in $(ALL_DOCS); do npx markdown-link-check --quiet --config .markdown_link_check_config.json $$f; done
+	@for f in $(ALL_DOCS); do \
+		npx --no -- markdown-link-check --quiet --config .markdown_link_check_config.json $$f \
+			|| exit 1; \
+	done
 
 # This target runs markdown-toc on all files that contain
 # a comment <!-- tocstop -->.
@@ -42,7 +45,7 @@ markdown-toc:
 	@for f in $(ALL_DOCS); do \
 		if grep -q '<!-- tocstop -->' $$f; then \
 			echo markdown-toc: processing $$f; \
-			npx markdown-toc --no-first-h1 --no-stripHeadingTags -i $$f; \
+			npx --no -- markdown-toc --no-first-h1 --no-stripHeadingTags -i $$f || exit 1; \
 		else \
 			echo markdown-toc: no TOC markers, skipping $$f; \
 		fi; \
@@ -50,8 +53,11 @@ markdown-toc:
 
 .PHONY: markdownlint
 markdownlint:
-	@if ! npm ls markdownlint; then npm install; fi
-	@for f in $(ALL_DOCS); do echo $$f; npx markdownlint -c .markdownlint.yaml $$f || exit 1;	done
+	@for f in $(ALL_DOCS); do \
+		echo $$f; \
+		npx --no -p markdownlint-cli markdownlint -c .markdownlint.yaml $$f \
+			|| exit 1; \
+	done
 
 .PHONY: install-yamllint
 install-yamllint:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ misspell-correction:	$(MISSPELL)
 
 .PHONY: markdown-link-check
 markdown-link-check:
-	@if ! npm ls markdown-link-check; then npm install; fi
 	@for f in $(ALL_DOCS); do npx markdown-link-check --quiet --config .markdown_link_check_config.json $$f; done
 
 # This target runs markdown-toc on all files that contain
@@ -40,7 +39,6 @@ markdown-link-check:
 #   <!-- tocstop -->
 .PHONY: markdown-toc
 markdown-toc:
-	@if ! npm ls markdown-toc; then npm install; fi
 	@for f in $(ALL_DOCS); do \
 		if grep -q '<!-- tocstop -->' $$f; then \
 			echo markdown-toc: processing $$f; \
@@ -90,7 +88,7 @@ check: misspell markdownlint markdown-link-check
 fix: table-generation misspell-correction
 	@echo "All autofixes complete"
 
-# Attempt to install all the tools
 .PHONY: install-tools
-install-tools: $(MISSPELL) markdownlint markdown-link-check markdown-toc
+install-tools: $(MISSPELL)
+	npm install
 	@echo "All tools installed"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ misspell-correction:	$(MISSPELL)
 
 .PHONY: markdown-link-check
 markdown-link-check:
+	@if ! npm ls markdown-link-check; then npm install; fi
 	@for f in $(ALL_DOCS); do \
 		npx --no -- markdown-link-check --quiet --config .markdown_link_check_config.json $$f \
 			|| exit 1; \
@@ -42,6 +43,7 @@ markdown-link-check:
 #   <!-- tocstop -->
 .PHONY: markdown-toc
 markdown-toc:
+	@if ! npm ls markdown-toc; then npm install; fi
 	@for f in $(ALL_DOCS); do \
 		if grep -q '<!-- tocstop -->' $$f; then \
 			echo markdown-toc: processing $$f; \
@@ -53,6 +55,7 @@ markdown-toc:
 
 .PHONY: markdownlint
 markdownlint:
+	@if ! npm ls markdownlint; then npm install; fi
 	@for f in $(ALL_DOCS); do \
 		echo $$f; \
 		npx --no -p markdownlint-cli markdownlint -c .markdownlint.yaml $$f \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SEMCONVGEN_VERSION=0.8.0
 
 # TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all
-all: markdownlint markdown-link-check misspell table-check schema-check
+all: install-tools markdownlint markdown-link-check misspell table-check schema-check
 
 $(MISSPELL):
 	cd $(TOOLS_DIR) && go build -o $(MISSPELL_BINARY) github.com/client9/misspell/cmd/misspell

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "devDependencies": {
+    "markdown-link-check": "^3.9.3",
+    "markdown-toc": "^1.2.0",
+    "markdownlint-cli": "0.31.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "devDependencies": {
     "markdown-link-check": "^3.9.3",
     "markdown-toc": "^1.2.0",
-    "markdownlint-cli": "^0.31.0"
+    "markdownlint-cli": "0.31.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "devDependencies": {
     "markdown-link-check": "^3.9.3",
     "markdown-toc": "^1.2.0",
-    "markdownlint-cli": "0.31.0"
+    "markdownlint-cli": "^0.31.0"
   }
 }


### PR DESCRIPTION
I'm having issues running certain spec checks from the website because it's working from a spec submodule. This PR:

- Switches to using `npx` to run npm commands rather than hardcoded paths
- Uses `npm install` to install all necessary NPM-based tools
  - Adds a `package.json` file for this purpose -- with `markdownlint-cli` pinned to `v0.31.0` as was done in #2320

IMHO, this is a clean and conventional way to deal with NPM packages. WDYT?

/cc @austinlparker 