### PR TITLE
Correct description of OTEL_EXPORTER_JAEGER_ENDPOINT and OTEL_TRACES_EXPORTER

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ release.
   add optional specification for consistent probability sampling.
   ([#2047](https://github.com/open-telemetry/opentelemetry-specification/pull/2047))
 - Change description and default value of OTEL_EXPORTER_JAEGER_ENDPOINT env var
-  to point to the correct HTTP port.
+  to point to the correct HTTP port
+  ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333)).
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
 - Add support for probability sampling in the OpenTelemetry `tracestate` entry and
   add optional specification for consistent probability sampling.
   ([#2047](https://github.com/open-telemetry/opentelemetry-specification/pull/2047))
+- Change description and default value of OTEL_EXPORTER_JAEGER_ENDPOINT env var
+  to point to the correct HTTP port.
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ release.
   add optional specification for consistent probability sampling.
   ([#2047](https://github.com/open-telemetry/opentelemetry-specification/pull/2047))
 - Change description and default value of OTEL_EXPORTER_JAEGER_ENDPOINT env var
-  to point to the correct HTTP port
+  to point to the correct HTTP port and correct description of OTEL_TRACES_EXPORTER
   ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333)).
 
 ### Metrics

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -126,14 +126,16 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 | Name                            | Description                                                      | Default                                                                                          |
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                                    | "localhost"                                                                                      |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent (1)                                | "localhost"                                                                                      |
 | OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent `compact` Thrift protocol              | 6831                                                                                             |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][[jaeger_http]] endpoint for Jaeger traces | <!-- markdown-link-check-disable --> "http://localhost:14268/api/traces"<!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][[jaeger_http]] endpoint for Jaeger traces (2) | <!-- markdown-link-check-disable --> "http://localhost:14268/api/traces"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |
 
-See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
+(1) See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
+
+(2) If SDK defaults to using gRPC, then OTEL_EXPORTER_JAEGER_ENDPOINT refers to gRPC endpoint, e.g. `http://localhost:14250`.
 
 ## Zipkin Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -128,7 +128,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent                                    | "localhost"                                                                                      |
 | OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent `compact` Thrift protocol              | 6831                                                                                             |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | HTTP endpoint for Jaeger traces                                  | <!-- markdown-link-check-disable --> "http://localhost:14250"<!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][[jaeger_http]] endpoint for Jaeger traces | <!-- markdown-link-check-disable --> "http://localhost:14268/api/traces"<!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |
@@ -222,3 +222,5 @@ To ensure consistent naming across projects, this specification recommends that 
 ```
 OTEL_{LANGUAGE}_{FEATURE}
 ```
+
+[jaeger_http]: https://www.jaegertracing.io/docs/latest/apis/#thrift-over-http-stable

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -183,7 +183,7 @@ Known values for `OTEL_TRACES_EXPORTER` are:
 - `"otlp"`: [OTLP](./protocol/otlp.md)
 - `"jaeger"`: export in Jaeger data model. If no additional configuration is
   provided the default protocol SHOULD be [Thrift over HTTP][jaeger_http] unless
-  SDKs have good reasons to choose [Protobuf/gRPC][jaeger_grpc] as the default
+  SDKs have good reasons to choose [gRPC][jaeger_grpc] as the default
   (e.g. for backward compatibility reasons when gRPC was already the default
   in a stable SDK release).
 - `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -128,7 +128,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent [1]                                | "localhost"                                                                                      |
 | OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent `compact` Thrift protocol              | 6831                                                                                             |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][[jaeger_http]] endpoint for Jaeger traces [2] | <!-- markdown-link-check-disable --> `"http://localhost:14268/api/traces"` <!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][jaeger_http] endpoint for Jaeger traces [2] | <!-- markdown-link-check-disable --> `"http://localhost:14268/api/traces"` <!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -126,16 +126,16 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 | Name                            | Description                                                      | Default                                                                                          |
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent (1)                                | "localhost"                                                                                      |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent [1]                                | "localhost"                                                                                      |
 | OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent `compact` Thrift protocol              | 6831                                                                                             |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][[jaeger_http]] endpoint for Jaeger traces (2) | <!-- markdown-link-check-disable --> "http://localhost:14268/api/traces"<!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][[jaeger_http]] endpoint for Jaeger traces [2] | <!-- markdown-link-check-disable --> `"http://localhost:14268/api/traces"` <!-- markdown-link-check-enable --> |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |
 
-(1) See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
+[1] See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
 
-(2) If SDK defaults to using gRPC, then OTEL_EXPORTER_JAEGER_ENDPOINT refers to gRPC endpoint, e.g. `http://localhost:14250`.
+[2] If SDK defaults to using gRPC, then OTEL_EXPORTER_JAEGER_ENDPOINT refers to gRPC endpoint, e.g. `http://localhost:14250`.
 
 ## Zipkin Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -135,7 +135,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 [1] See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
 
-[2] If SDK defaults to using gRPC, then OTEL_EXPORTER_JAEGER_ENDPOINT refers to gRPC endpoint, e.g. `http://localhost:14250`.
+[2] When the exporter uses the gRPC protocol, the environment variable refers to the gRPC endpoint and the default value should be `http://localhost:14250`.
 
 ## Zipkin Exporter
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -179,7 +179,11 @@ The SDK MAY accept a comma-separated list to enable setting multiple exporters.
 Known values for `OTEL_TRACES_EXPORTER` are:
 
 - `"otlp"`: [OTLP](./protocol/otlp.md)
-- `"jaeger"`: [Jaeger gRPC](https://www.jaegertracing.io/docs/1.21/apis/#protobuf-via-grpc-stable)
+- `"jaeger"`: export in Jaeger data model. If no additional configuration is
+  provided the default protocol SHOULD be [Thrift over HTTP][jaeger_http] unless
+  SDKs have good reasons to choose [Protobuf/gRPC][jaeger_grpc] as the default
+  (e.g. for backward compatibility reasons when gRPC was already the default
+  in a stable SDK release).
 - `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
 - `"none"`: No automatically configured exporter for traces.
 
@@ -224,3 +228,4 @@ OTEL_{LANGUAGE}_{FEATURE}
 ```
 
 [jaeger_http]: https://www.jaegertracing.io/docs/latest/apis/#thrift-over-http-stable
+[jaeger_grpc]: https://www.jaegertracing.io/docs/latest/apis/#protobuf-via-grpc-stable


### PR DESCRIPTION
Fixes #2331

## Changes

The OTEL_EXPORTER_JAEGER_ENDPOINT env var description is updated:
  * clarify that it refers to Thrift over HTTP endpoint, provide a link to Jaeger API spec
  * change the default value to point to the correct HTTP port, not the gRPC port
  * clarify that the path (`/api/traces`) must be included in the value, to support installations running at remapped URLs

The OTEL_TRACES_EXPORTER env var description updated to reflect state of the world where all but Java SDKs implement http/thrift protocol, not gRPC as was stated in the description.

