### PR TITLE
Add OTEL_EXPORTER_JAEGER_PROTOCOL and improve description of other OTEL_EXPORTER_JAEGER_* env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ release.
   variable to point to the correct HTTP port and correct description of
   `OTEL_TRACES_EXPORTER`.
   ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333))
-- Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protcol used
-  by the Jaeger exporter.
+- Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protocol
+  used by the Jaeger exporter.
   ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341))
 
 ### Metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,18 @@ release.
 ### Traces
 
 - Clarify `StartSpan` returning the parent as a non-recording Span when no SDK
-  is in use
+  is in use.
   ([#2121](https://github.com/open-telemetry/opentelemetry-specification/pull/2121))
 - Add support for probability sampling in the OpenTelemetry `tracestate` entry and
   add optional specification for consistent probability sampling.
   ([#2047](https://github.com/open-telemetry/opentelemetry-specification/pull/2047))
-- Change description and default value of OTEL_EXPORTER_JAEGER_ENDPOINT env var
-  to point to the correct HTTP port and correct description of OTEL_TRACES_EXPORTER
+- Change description and default value of `OTEL_EXPORTER_JAEGER_ENDPOINT` environment
+  variable to point to the correct HTTP port and correct description of
+  `OTEL_TRACES_EXPORTER`.
   ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333)).
+- Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protcol used
+  by the Jaeger exporter.
+  ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341)).
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ release.
 - Change description and default value of `OTEL_EXPORTER_JAEGER_ENDPOINT` environment
   variable to point to the correct HTTP port and correct description of
   `OTEL_TRACES_EXPORTER`.
-  ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333)).
+  ([#2333](https://github.com/open-telemetry/opentelemetry-specification/pull/2333))
 - Add `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protcol used
   by the Jaeger exporter.
-  ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341)).
+  ([#2341](https://github.com/open-telemetry/opentelemetry-specification/pull/2341))
 
 ### Metrics
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -126,7 +126,7 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 | Name                            | Description                                                      | Default                                                                                          |
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. Options MAY include [`http/thrift.binary`][jaeger_http], [`grpc`][jaeger_grpc], [`udp/thrift.compact`][jaeger_udp], [`udp/thrift.binary`][jaeger_udp] | `http/thrift.binary` [1] |
+| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. The value MUST be one of: [`http/thrift.binary`][jaeger_http], [`grpc`][jaeger_grpc], [`udp/thrift.compact`][jaeger_udp], [`udp/thrift.binary`][jaeger_udp] | `http/thrift.binary` [1] |
 | OTEL_EXPORTER_JAEGER_ENDPOINT (`http/thrift.binary` protocol) | Full URL of the [Jaeger HTTP endpoint][jaeger_collector] | `http://localhost:14268/api/traces`                                        |
 | OTEL_EXPORTER_JAEGER_ENDPOINT (`grpc` protocol) | URL of the [Jaeger gRPC endpoint][jaeger_collector] | `http://localhost:14250`                                                                      |
 | OTEL_EXPORTER_JAEGER_TIMEOUT (`http/thrift.binary`, `grpc` protocols) | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                        |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -127,15 +127,21 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 | Name                            | Description                                                      | Default                                                                                          |
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent [1]                                | "localhost"                                                                                      |
-| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent `compact` Thrift protocol              | 6831                                                                                             |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of [Thrift over HTTP][jaeger_http] endpoint for Jaeger traces [2] | <!-- markdown-link-check-disable --> `"http://localhost:14268/api/traces"` <!-- markdown-link-check-enable --> |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent [1]                                    | 6831                                                                                              |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of endpoint for Jaeger traces [2] | `http://localhost:14268/api/traces` for `http/thrift.binary` protocol, `http://localhost:14250` for `grpc` protocol |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |
+| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. Options MAY include `http/thrift.binary`, `grpc`, `udp/thrift.compact` | `http/thrift.binary` [3]                                                       |
 
-[1] See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
+[1] Used when `udp/thrift.compact` protocol is used.
+  See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
 
-[2] When the exporter uses the gRPC protocol, the environment variable refers to the gRPC endpoint and the default value should be `http://localhost:14250`.
+[2] Used when `http/thrift.binary` or `grpc` protocol is used.
+
+[3] The default transport SHOULD be [Thrift over HTTP][jaeger_http] unless
+  SDKs have good reasons to choose other as the default
+  (e.g. for backward compatibility reasons).
 
 ## Zipkin Exporter
 
@@ -181,11 +187,7 @@ The SDK MAY accept a comma-separated list to enable setting multiple exporters.
 Known values for `OTEL_TRACES_EXPORTER` are:
 
 - `"otlp"`: [OTLP](./protocol/otlp.md)
-- `"jaeger"`: export in Jaeger data model. If no additional configuration is
-  provided the default protocol SHOULD be [Thrift over HTTP][jaeger_http] unless
-  SDKs have good reasons to choose [gRPC][jaeger_grpc] as the default
-  (e.g. for backward compatibility reasons when gRPC was already the default
-  in a stable SDK release).
+- `"jaeger"`: export in Jaeger data model
 - `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
 - `"none"`: No automatically configured exporter for traces.
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -126,22 +126,25 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 
 | Name                            | Description                                                      | Default                                                                                          |
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent [1]                                | "localhost"                                                                                      |
-| OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent [1]                                    | 6831                                                                                              |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of endpoint for Jaeger traces [2] | `http://localhost:14268/api/traces` for `http/thrift.binary` protocol, `http://localhost:14250` for `grpc` protocol    |
-| OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
-| OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
-| OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |
-| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. Options MAY include `http/thrift.binary`, `grpc`, `udp/thrift.compact` | `http/thrift.binary` [3]                                            |
+| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. Options MAY include [`http/thrift.binary`][jaeger_http], [`grpc`][jaeger_grpc], [`udp/thrift.compact`][jaeger_udp], [`udp/thrift.binary`][jaeger_udp] | `http/thrift.binary` [1] |
+| OTEL_EXPORTER_JAEGER_ENDPOINT (`http/thrift.binary` protocol) | Full URL of the [Jaeger HTTP endpoint][jaeger_collector] | `http://localhost:14268/api/traces`                                        |
+| OTEL_EXPORTER_JAEGER_ENDPOINT (`grpc` protocol) | URL of the [Jaeger gRPC endpoint][jaeger_collector] | `http://localhost:14250`                                                                      |
+| OTEL_EXPORTER_JAEGER_TIMEOUT (`http/thrift.binary`, `grpc` protocols) | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                        |
+| OTEL_EXPORTER_JAEGER_USER (`http/thrift.binary`, `grpc` protocols) | Username to be used for HTTP basic authentication |                                                                              |
+| OTEL_EXPORTER_JAEGER_PASSWORD (`http/thrift.binary`, `grpc` protocols) | Password to be used for HTTP basic authentication |                                                                          |
+| OTEL_EXPORTER_JAEGER_AGENT_HOST (`udp/thrift.*` protocols) | Hostname of the [Jaeger agent][jaeger_agent] | `localhost`                                                                               |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT (`udp/thrift.compact` protocol) | `udp/thrift.compact` port of the [Jaeger agent][jaeger_agent] | `6831`                                                              |
+| OTEL_EXPORTER_JAEGER_AGENT_PORT (`udp/thrift.binary` protocol) | `udp/thrift.binary` port of the [Jaeger agent][jaeger_agent] | `6832`                                                                |
 
-[1] Used when `udp/thrift.compact` protocol is selected.
-  See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
-
-[2] Used when `http/thrift.binary` or `grpc` protocol is selected.
-
-[3] The default transport SHOULD be [Thrift over HTTP][jaeger_http] unless
+[1] The default transport SHOULD be `http/thrift.binary` unless
   SDKs have good reasons to choose other as the default
   (e.g. for backward compatibility reasons).
+
+[jaeger_http]: https://www.jaegertracing.io/docs/latest/apis/#thrift-over-http-stable
+[jaeger_grpc]: https://www.jaegertracing.io/docs/latest/apis/#protobuf-via-grpc-stable
+[jaeger_udp]: https://www.jaegertracing.io/docs/latest/apis/#thrift-over-udp-stable
+[jaeger_collector]: https://www.jaegertracing.io/docs/latest/deployment/#collector
+[jaeger_agent]: https://www.jaegertracing.io/docs/latest/deployment/#agent
 
 ## Zipkin Exporter
 
@@ -230,6 +233,3 @@ To ensure consistent naming across projects, this specification recommends that 
 ```
 OTEL_{LANGUAGE}_{FEATURE}
 ```
-
-[jaeger_http]: https://www.jaegertracing.io/docs/latest/apis/#thrift-over-http-stable
-[jaeger_grpc]: https://www.jaegertracing.io/docs/latest/apis/#protobuf-via-grpc-stable

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -128,16 +128,16 @@ See [OpenTelemetry Protocol Exporter Configuration Options](./protocol/exporter.
 |---------------------------------|------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
 | OTEL_EXPORTER_JAEGER_AGENT_HOST | Hostname for the Jaeger agent [1]                                | "localhost"                                                                                      |
 | OTEL_EXPORTER_JAEGER_AGENT_PORT | Port for the Jaeger agent [1]                                    | 6831                                                                                              |
-| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of endpoint for Jaeger traces [2] | `http://localhost:14268/api/traces` for `http/thrift.binary` protocol, `http://localhost:14250` for `grpc` protocol |
+| OTEL_EXPORTER_JAEGER_ENDPOINT   | Full URL of endpoint for Jaeger traces [2] | `http://localhost:14268/api/traces` for `http/thrift.binary` protocol, `http://localhost:14250` for `grpc` protocol    |
 | OTEL_EXPORTER_JAEGER_TIMEOUT    | Maximum time the Jaeger exporter will wait for each batch export | 10s                                                                                              |
 | OTEL_EXPORTER_JAEGER_USER       | Username to be used for HTTP basic authentication                |                                                                                                  |
 | OTEL_EXPORTER_JAEGER_PASSWORD   | Password to be used for HTTP basic authentication                |                                                                                                  |
-| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. Options MAY include `http/thrift.binary`, `grpc`, `udp/thrift.compact` | `http/thrift.binary` [3]                                                       |
+| OTEL_EXPORTER_JAEGER_PROTOCOL   | The transport protocol. Options MAY include `http/thrift.binary`, `grpc`, `udp/thrift.compact` | `http/thrift.binary` [3]                                            |
 
-[1] Used when `udp/thrift.compact` protocol is used.
+[1] Used when `udp/thrift.compact` protocol is selected.
   See [Jaeger Agent](https://www.jaegertracing.io/docs/latest/deployment/#agent) documentation.
 
-[2] Used when `http/thrift.binary` or `grpc` protocol is used.
+[2] Used when `http/thrift.binary` or `grpc` protocol is selected.
 
 [3] The default transport SHOULD be [Thrift over HTTP][jaeger_http] unless
   SDKs have good reasons to choose other as the default


### PR DESCRIPTION
Follow-up of #2333

## Changes

Preview [here](https://github.com/pellared/opentelemetry-specification/blob/patch-2/specification/sdk-environment-variables.md#jaeger-exporter)

- Add the `OTEL_EXPORTER_JAEGER_PROTOCOL` environment variable to select the protocol used
  by the Jaeger exporter.
- More explicit description of the rest of the  `OTEL_EXPORTER_JAEGER_*` environment variables (e.g. when they are applicable - it also represents the current state of SDKs)

Here are the following reasons for this change

1. Enable the possibility of selecting the protocol when the Jaeger exporter is set via env var `OTEL_TRACES_EXPORTER=jaeger` (instead of supporting values like `OTEL_TRACES_EXPORTER=jaeger-udp`). 
2. This resembles [the configuration of the OTLP exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md) which has `OTEL_EXPORTER_OTLP_PROTOCOL`
3. The newest OTel .NET SDK RC version supports this env var. See [here](https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.Jaeger). I feel that it is safer to standardize it (especially the supported values) before it is released
4. We want to take advantage of it in [OTel .NET AutoInstrumentation](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation). However, I believe this could be useful in other places as well.
5. Node.js SDK uses `6832` as the default Agent port because it uses a different protocol

Related issues:
- https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/issues/355

FYI (all SIG maintainers where I see that `OTEL_EXPORTER_JAEGER_ENDPOINT` is used) @open-telemetry/dotnet-maintainers @open-telemetry/dotnet-instrumentation-maintainers @open-telemetry/java-instrumentation-maintainers @open-telemetry/python-maintainers @open-telemetry/go-maintainers @open-telemetry/php-maintainers  @open-telemetry/java-maintainers @open-telemetry/ruby-maintainers @open-telemetry/rust-maintainers 

## Alternative

Instead of adding `OTEL_EXPORTER_JAEGER_PROTOCOL` we can specify more specific values for `OTEL_TRACES_EXPORTER` like `jaeger/http/thrift.binary` but this would be inconsistent with the OTLP exporter configuration.

## TODO in next PR

- reformatting the table to make it more readable
  - https://github.com/open-telemetry/opentelemetry-specification/pull/2341#discussion_r806627129
  - https://github.com/open-telemetry/opentelemetry-specification/pull/2341#discussion_r806965306
  - https://github.com/open-telemetry/opentelemetry-specification/pull/2341#discussion_r808263460