### PR TITLE
Add `make all` target to test changes locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ MARKDOWN_TOC=./node_modules/.bin/markdown-toc
 # Keep links in semantic_conventions/README.md and .vscode/settings.json in sync!
 SEMCONVGEN_VERSION=0.8.0
 
+# TODO: add `yamllint` step to `all` after making sure it works on Mac.
+.PHONY: all
+all: markdownlint markdown-link-check misspell table-check schema-check
+
 $(MISSPELL):
 	cd $(TOOLS_DIR) && go build -o $(MISSPELL_BINARY) github.com/client9/misspell/cmd/misspell
 


### PR DESCRIPTION
Make all performs roughly the same steps as the already existing github actions. The only
exception is yamllint which I was not able to make work on my Mac after quite some time
and had to skip. If anyone knows how to make it work on a Mac please submit a follow-up PR.

Note that the checks can run in parallel to speed up, e.g. `make -j4`.
