### PR TITLE
[editorial] Add space in schemas/overview

### DIFF
--- a/specification/schemas/overview.md
+++ b/specification/schemas/overview.md
@@ -239,7 +239,7 @@ field in the messages:
 - The schema_url field in the InstrumentationLibraryLogs message applies to the
   contained LogRecord messages.
 
-- If schema_url field is non-empty both in Resource\*message and in the
+- If schema_url field is non-empty both in Resource\* message and in the
   contained InstrumentationLibrary\* message then the value in
   InstrumentationLibrary\* message takes the precedence.
 


### PR DESCRIPTION
For context, see #2320 at https://github.com/open-telemetry/opentelemetry-specification/pull/2320/files#r807334158.
/cc @arminru

Btw, wouldn't be better to use code markdown (like `Resource*`) rather than having to escape `*` when used as plain text?
