### PR TITLE
Correct default value of OTEL_PROPAGATORS to align with API requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ release.
 
 ### SDK Configuration
 
+- Correct default value of OTEL_PROPAGATORS to align with API requirements. (#TBD)
+
 ### Telemetry Schemas
 
 ## v1.9.0 (2021-02-10)

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -42,7 +42,7 @@ For example, the value `12000` indicates 12000 milliseconds, i.e., 12 seconds.
 | OTEL_RESOURCE_ATTRIBUTES | Key-value pairs to be used as resource attributes | See [Resource semantic conventions](resource/semantic_conventions/README.md#semantic-attributes-with-sdk-provided-default-value) for details. | See [Resource SDK](./resource/sdk.md#specifying-resource-information-via-an-environment-variable) for more details. |
 | OTEL_SERVICE_NAME        | Sets the value of the [`service.name`](./resource/semantic_conventions/README.md#service) resource attribute | | If `service.name` is also provided in `OTEL_RESOURCE_ATTRIBUTES`, then `OTEL_SERVICE_NAME` takes precedence. |
 | OTEL_LOG_LEVEL           | Log level used by the SDK logger                  | "info"                            |                                     |
-| OTEL_PROPAGATORS         | Propagators to be used as a comma-separated list  | "tracecontext,baggage"            | Values MUST be deduplicated in order to register a `Propagator` only once. |
+| OTEL_PROPAGATORS         | Propagators to be used as a comma-separated list  | "none"            | Values MUST be deduplicated in order to register a `Propagator` only once. |
 | OTEL_TRACES_SAMPLER       | Sampler to be used for traces                     | "parentbased_always_on"                       | See [Sampling](./trace/sdk.md#sampling) |
 | OTEL_TRACES_SAMPLER_ARG   | String value to be used as the sampler argument   |                                   | The specified value will only be used if OTEL_TRACES_SAMPLER is set. Each Sampler type defines its own expected input, if any. Invalid or unrecognized input MUST be logged and MUST be otherwise ignored, i.e. the SDK MUST behave as if OTEL_TRACES_SAMPLER_ARG is not set.  |
 


### PR DESCRIPTION
## Changes

The default value for `OTEL_PROPAGATORS` is currently "tracecontext,baggage".  This conflicts with [the API's requirement](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/context/api-propagators.md#global-propagators) that "[t]he OpenTelemetry API MUST use no-op propagators unless explicitly configured otherwise."  

It is not possible to have both a default set of propagators in the absence of a value in `OTEL_PROPAGATORS` in the environment and have no-op propagators unless explicitly configured otherwise.  Because the default for `OTEL_PROPAGATORS` predates the [change to require a no-op default](https://github.com/open-telemetry/opentelemetry-specification/pull/930), I assume that it was an oversight and should be brought in line with the current requirements.
