### PR TITLE
Clarify asynchronous instrument callback documentation and order-of-execution requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ release.
 - Introduce the concept of Instrumentation Scope to replace/extend Instrumentation
   Library. The Meter is now associated with Instrumentation Scope
   ([#2276](https://github.com/open-telemetry/opentelemetry-specification/pull/2276)).
+- Clarify that expectations for user callback behavior are documentation REQUIREMENTs.
+  ([#2361](https://github.com/open-telemetry/opentelemetry-specification/pull/2361)).
 
 ### Logs
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -356,13 +356,13 @@ being observed.
 
 Callback functions MUST be documented as follows for the end user:
 
-- Callbacks SHOULD be reentrant safe.  The SDK expects to evaluate
+- Callback functions SHOULD be reentrant safe.  The SDK expects to evaluate
   callbacks for each MetricReader independently.
-- Callbacks SHOULD NOT take an indefinite amount of time.
-- Callbacks SHOULD NOT make duplicate observations (more than one
-  `Measurement` with the same `attributes`) from asynchronous
-  instrument callbacks.
-  
+- Callback functions SHOULD NOT take an indefinite amount of time.
+- Callback functions SHOULD NOT make duplicate observations (more than one
+  `Measurement` with the same `attributes`) across all registered 
+  callbacks.
+
 The resulting behavior when a callback violates any of these
 RECOMMENDATIONS is explicitly not specified at the API level.
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -357,7 +357,7 @@ Callback functions MUST be documented as follows for the end user:
   callbacks for each MetricReader independently.
 - Callback functions SHOULD NOT take an indefinite amount of time.
 - Callback functions SHOULD NOT make duplicate observations (more than one
-  `Measurement` with the same `attributes`) across all registered 
+  `Measurement` with the same `attributes`) across all registered
   callbacks.
 
 The resulting behavior when a callback violates any of these

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -323,7 +323,7 @@ Callback functions MUST be documented as follows for the end user:
   same `attributes` in a single callback.
   
 The resulting behavior when a callback violates any of these
-RECOMMENDATIONS is explicitly not specified.
+RECOMMENDATIONS is explicitly not specified at the API level.
 
 ### Counter
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -324,9 +324,10 @@ The API to construct synchronous instruments MUST accept the following parameter
 
 #### Asynchronous Instrument API
 
-Asynchronous instruments have an associated `callback` function which
-is responsible for reporting [Measurement](#measurement)s. It will be
-called only when the Meter is being observed.
+Asynchronous instruments have associated `callback` functions which
+are responsible for reporting [Measurement](#measurement)s. Callback
+functions will be called only when the Meter is being observed.  The
+order of callback execution is unspecified.
 
 The API to construct asynchronous instruments MUST accept the following parameters:
 
@@ -349,10 +350,6 @@ Where the API supports registration of callback functions after
 asynchronous instrumentation creation, it MUST return something (e.g.,
 a registration handle, receipt or token) to the user that supports
 undoing the effect of callback registation.
-
-The `callback` function is responsible for reporting
-[Measurement](#measurement)s. It will only be called when the Meter is
-being observed.
 
 Callback functions MUST be documented as follows for the end user:
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -327,7 +327,7 @@ The API to construct synchronous instruments MUST accept the following parameter
 Asynchronous instruments have associated `callback` functions which
 are responsible for reporting [Measurement](#measurement)s. Callback
 functions will be called only when the Meter is being observed.  The
-order of callback execution is unspecified.
+order of callback execution is not specified.
 
 The API to construct asynchronous instruments MUST accept the following parameters:
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -314,12 +314,16 @@ asynchronous instrumentation creation, it MUST return something (e.g.,
 a registration handle, receipt or token) to the user that supports
 undoing the effect of callback registation.
 
-Callback functions SHOULD NOT take an indefinite amount of time.
+Callback functions MUST be documented as follows for the end user:
 
-Callback functions SHOULD NOT make duplicate observations from asynchronous
-instrument callbacks.  The resulting behavior when a callback observes
-multiple values for identical instrument and attributes is explicitly
-not specified.
+- Callbacks SHOULD be reentrant safe.  The SDK expects to evaluate
+  callbacks for each MetricReader independently.
+- Callbacks SHOULD NOT take an indefinite amount of time.
+- Callbacks SHOULD NOT provide more than one `Measurement` with the
+  same `attributes` in a single callback.
+  
+The resulting behavior when a callback violates any of these
+RECOMMENDATIONS is explicitly not specified.
 
 ### Counter
 


### PR DESCRIPTION
Part of #2350

## Changes

As noted in #2350 (and a comment in #2317 by @anuraaga), the requirements for callbacks to behave a certain way apply to the user, not the implementation or the API designer. Therefore, specify these as documentation requirements.
