### PR TITLE
OTEL_EXPORTER_OTLP_PROTOCOL value MUST be one of

### DIFF
--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -36,7 +36,8 @@ The following configuration options MUST be available to configure the OTLP expo
   - Default: 10s
   - Env vars: `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT`
 
-- **Protocol**: The transport protocol. Options MAY include `grpc`, `http/protobuf`, and `http/json`. See [Specify Protocol](./exporter.md#specify-protocol) for more details.
+- **Protocol**: The transport protocol. Options MUST be one of: `grpc`, `http/protobuf`, `http/json`.
+  See [Specify Protocol](./exporter.md#specify-protocol) for more details.
   - Default: `http/protobuf` [3]
   - Env vars: `OTEL_EXPORTER_OTLP_PROTOCOL` `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` `OTEL_EXPORTER_OTLP_METRICS_PROTOCOL`
 


### PR DESCRIPTION
Based on https://github.com/open-telemetry/opentelemetry-specification/pull/2341#discussion_r806960073

By @tigrannajaryan 

> Why does this say `MAY`? This is not a recommendation, it is a strict list. Should it say: `MUST be one of ...` instead?

As far as I checked, only the OTel Erlang SDK would violate this rule. See: https://github.com/open-telemetry/opentelemetry-erlang/search?q=OTEL_EXPORTER_OTLP_PROTOCOL

@tsloughter WDYT? Is it a blocker from your perspective? 