### PR TITLE
Clarify that instrument name conflict only happens within a Meter

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -192,7 +192,7 @@ In order to avoid conflicts, views which specify a name SHOULD have an
 instrument selector that selects at most one instrument. For the registration
 mechanism described above, where selection is provided via configuration, the
 SDK SHOULD NOT allow Views with a specified name to be declared with instrument
-selectors that select more than one instrument (e.g. wild card instrument name)
+selectors that may select more than one instrument (e.g. wild card instrument name)
 in the same Meter.
 
 The SDK SHOULD use the following logic to determine how to process Measurements

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -191,8 +191,9 @@ are the inputs:
 In order to avoid conflicts, views which specify a name SHOULD have an
 instrument selector that selects at most one instrument. For the registration
 mechanism described above, where selection is provided via configuration, the
-SDK MUST NOT allow Views with a specified name to be declared with instrument
-selectors that select more than one instrument (e.g. wild card instrument name).
+SDK SHOULD NOT allow Views with a specified name to be declared with instrument
+selectors that select more than one instrument (e.g. wild card instrument name)
+in the same Meter.
 
 The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:


### PR DESCRIPTION
Fixes #2337.

Based on the [2/15/2022 Spec SIG Meeting](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit?pli=1#heading=h.ixd3fm5gwjy1) discussion and reading through [RFC2119](https://www.rfc-editor.org/rfc/rfc2119.html).