### PR TITLE
Add table for well-known rpc.system values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ release.
 
 ### Semantic Conventions
 
+- Changed `rpc.system` to an enum (allowing custom values), and changed the
+  `rpc.system` value for .NET WCF from `wcf` to `dotnet_wcf`.
+  ([#2377](https://github.com/open-telemetry/opentelemetry-specification/pull/2377))
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -5,10 +5,20 @@ groups:
     events: [rpc.message]
     attributes:
       - id: system
-        type: string
         required: always
-        brief: 'A string identifying the remoting system.'
-        examples: ["grpc", "java_rmi", "wcf"]
+        brief: 'A string identifying the remoting system. See below for a list of well-known identifiers.'
+        type:
+          allow_custom_values: true
+          members:
+            - id: grpc
+              value: 'grpc'
+              brief: 'gRPC'
+            - id: java_rmi
+              value: 'java_rmi'
+              brief: 'Java RMI'
+            - id: wcf
+              value: 'wcf'
+              brief: 'WCF'
       - id: service
         type: string
         required:

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -16,9 +16,9 @@ groups:
             - id: java_rmi
               value: 'java_rmi'
               brief: 'Java RMI'
-            - id: wcf
-              value: 'wcf'
-              brief: 'WCF'
+            - id: dotnet_wcf
+              value: 'dotnet_wcf'
+              brief: '.NET WCF'
       - id: service
         type: string
         required:

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -83,7 +83,7 @@ or not they should be on the server, client or both.
 |---|---|
 | `grpc` | gRPC |
 | `java_rmi` | Java RMI |
-| `wcf` | WCF |
+| `dotnet_wcf` | .NET WCF |
 <!-- endsemconv -->
 
 To avoid high cardinality, implementations should prefer the most stable of `net.peer.name` or

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -60,7 +60,7 @@ or not they should be on the server, client or both.
 <!-- semconv rpc -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| [`rpc.system`](../../trace/semantic_conventions/rpc.md) | string | A string identifying the remoting system. | `grpc`; `java_rmi`; `wcf` | Yes |
+| [`rpc.system`](../../trace/semantic_conventions/rpc.md) | string | A string identifying the remoting system. See below for a list of well-known identifiers. | `grpc` | Yes |
 | [`rpc.service`](../../trace/semantic_conventions/rpc.md) | string | The full (logical) name of the service being called, including its package name, if applicable. [1] | `myservice.EchoService` | No, but recommended |
 | [`rpc.method`](../../trace/semantic_conventions/rpc.md) | string | The name of the (logical) method being called, must be equal to the $method part in the span name. [2] | `exampleMethod` | No, but recommended |
 | [`net.peer.ip`](../../trace/semantic_conventions/span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below |
@@ -76,6 +76,14 @@ or not they should be on the server, client or both.
 
 * [`net.peer.ip`](../../trace/semantic_conventions/span-general.md)
 * [`net.peer.name`](../../trace/semantic_conventions/span-general.md)
+
+`rpc.system` MUST be one of the following or, if none of the listed values apply, a custom value:
+
+| Value  | Description |
+|---|---|
+| `grpc` | gRPC |
+| `java_rmi` | Java RMI |
+| `wcf` | WCF |
 <!-- endsemconv -->
 
 To avoid high cardinality, implementations should prefer the most stable of `net.peer.name` or

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -79,7 +79,7 @@ Examples of span names:
 |---|---|
 | `grpc` | gRPC |
 | `java_rmi` | Java RMI |
-| `wcf` | WCF |
+| `dotnet_wcf` | .NET WCF |
 <!-- endsemconv -->
 
 For client-side spans `net.peer.port` is required if the connection is IP-based and the port is available (it describes the server port they are connecting to).

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -56,7 +56,7 @@ Examples of span names:
 <!-- semconv rpc -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `rpc.system` | string | A string identifying the remoting system. | `grpc`; `java_rmi`; `wcf` | Yes |
+| `rpc.system` | string | A string identifying the remoting system. See below for a list of well-known identifiers. | `grpc` | Yes |
 | `rpc.service` | string | The full (logical) name of the service being called, including its package name, if applicable. [1] | `myservice.EchoService` | No, but recommended |
 | `rpc.method` | string | The name of the (logical) method being called, must be equal to the $method part in the span name. [2] | `exampleMethod` | No, but recommended |
 | [`net.peer.ip`](span-general.md) | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | See below |
@@ -72,6 +72,14 @@ Examples of span names:
 
 * [`net.peer.ip`](span-general.md)
 * [`net.peer.name`](span-general.md)
+
+`rpc.system` MUST be one of the following or, if none of the listed values apply, a custom value:
+
+| Value  | Description |
+|---|---|
+| `grpc` | gRPC |
+| `java_rmi` | Java RMI |
+| `wcf` | WCF |
 <!-- endsemconv -->
 
 For client-side spans `net.peer.port` is required if the connection is IP-based and the port is available (it describes the server port they are connecting to).


### PR DESCRIPTION
## Changes

Adds a table for well-known `rpc.system` values, similar to what is done already for `db.system`.

This will make it easier to propose new `rpc.system` values, and it will also enable auto-generation of `rpc.system` constants similar to what is done already for `db.system` in some languages.
