### PR TITLE
Add documentation requirement for adding attributes at span creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ release.
 - Introduce the concept of Instrumentation Scope to replace/extend Instrumentation
   Library. The Tracer is now associated with Instrumentation Scope
   ([#2276](https://github.com/open-telemetry/opentelemetry-specification/pull/2276)).
+- Add documentation REQUIREMENT for adding attributes at span creation.
+  ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -29,7 +29,7 @@ formats is required. Implementing more than one format is optional.
 | Set active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | [Tracer](specification/trace/api.md#tracer-operations)                                           |          |     |      |     |        |      |        |     |      |     |      |       |
 | Create a new Span                                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Documentation for adding attributes at span creation                                             |          |     |      |     |        |      |        |     |      |     |      |       |
+| Documentation defines adding attributes at span creation as preferred                            |          |     |      |     |        |      |        |     |      |     |      |       |
 | Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Mark Span active                                                                                 |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -29,6 +29,7 @@ formats is required. Implementing more than one format is optional.
 | Set active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | [Tracer](specification/trace/api.md#tracer-operations)                                           |          |     |      |     |        |      |        |     |      |     |      |       |
 | Create a new Span                                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
+| Documentation for adding attributes at span creation                                             |          |     |      |     |        |      |        |     |      |     |      |       |
 | Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Mark Span active                                                                                 |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -367,8 +367,9 @@ The API MUST accept the following parameters:
   description](sdk.md#sampling). An empty collection will be assumed if
   not specified.
 
-  Whenever possible, users SHOULD set any already known attributes at span creation
-  instead of calling `SetAttribute` later.
+  Documentation MUST state that adding attributes at span creation is preferred
+  to calling `SetAttribute` later, as samplers can only consider information
+  already present during span creation.
 
 - `Link`s - an ordered sequence of Links, see API definition [here](#specifying-links).
 - `Start timestamp`, default to current time. This argument SHOULD only be set

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -367,7 +367,7 @@ The API MUST accept the following parameters:
   description](sdk.md#sampling). An empty collection will be assumed if
   not specified.
 
-  Documentation MUST state that adding attributes at span creation is preferred
+  The API documentation MUST state that adding attributes at span creation is preferred
   to calling `SetAttribute` later, as samplers can only consider information
   already present during span creation.
 


### PR DESCRIPTION
This change is prompted by @MrAlias's request in https://github.com/open-telemetry/opentelemetry-specification/pull/2278#discussion_r807426172.

The information that attributes should preferably be added at span creation rather than later by calling `SetAttribute` is relevant to users of the API and should be conveyed to them.