### PR TITLE
Add system.cpu.count metric

### DIFF
--- a/specification/metrics/semantic_conventions/system-metrics.md
+++ b/specification/metrics/semantic_conventions/system-metrics.md
@@ -35,6 +35,7 @@ instruments not explicitly defined in the specification.
 |                        |             |       |                      |            | cpu              | CPU number [0..n-1]                 |
 | system.cpu.utilization |             | 1     | Asynchronous Gauge   | Double     | state            | idle, user, system, interrupt, etc. |
 |                        |             |       |                      |            | cpu              | CPU number (0..n)                   |
+| system.cpu.count       |             | 1     | Asynchronous UpDownCounter | Int64 |                 |                                     |
 
 ### `system.memory.` - Memory metrics
 


### PR DESCRIPTION
I wasn't sure if this should be a resource attribute or metric, but I was able to test that cpu count can change at runtime, e.g. `docker update --cpuset-cpus`, and `nproc` and Java `Runtime.availableProcessors()` pick up the change at runtime, so seems like it should be a metric.

## Changes

Adds a new metric `system.cpu.count` to capture the number of CPUs available.