### PR TITLE
Add system metrics clarification around containers

### DIFF
--- a/specification/metrics/semantic_conventions/system-metrics.md
+++ b/specification/metrics/semantic_conventions/system-metrics.md
@@ -8,7 +8,7 @@ conventions](README.md#general-metric-semantic-conventions) when creating
 instruments not explicitly defined in the specification.
 
 When reporting `system.*` metrics from inside a container, they SHOULD be
-container metrics and not host metrics, unless the resource attributes
+reported for the container and not the host, unless the resource attributes
 specifically describe the host.
 
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->

--- a/specification/metrics/semantic_conventions/system-metrics.md
+++ b/specification/metrics/semantic_conventions/system-metrics.md
@@ -7,6 +7,10 @@ metrics in OpenTelemetry. Consider the [general metric semantic
 conventions](README.md#general-metric-semantic-conventions) when creating
 instruments not explicitly defined in the specification.
 
+When reporting `system.*` metrics from inside a container, they SHOULD be
+container metrics and not host metrics, unless the resource attributes
+specifically describe the host.
+
 <!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 
 <!-- toc -->


### PR DESCRIPTION
The JVM Metrics working group would like to emit a couple key system metrics from inside the JVM (e.g. for users who aren't using the collector/agent/other mechanism), and we'd like to add clarification somewhere that these metrics should be interpreted as container-level metrics and not host-level metrics.

cc: @jonatan-ivanov @jack-berg @kittylyst