### PR TITLE
Add thread semantic attributes for logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ release.
 
 ### Semantic Conventions
 
+- Add thread semantic attributes for logs.
+  ([#2389](https://github.com/open-telemetry/opentelemetry-specification/pull/2389))
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/specification/logs/semantic_conventions/README.md
+++ b/specification/logs/semantic_conventions/README.md
@@ -5,6 +5,7 @@
 The following semantic conventions for logs are defined:
 
 * [Log Media](media.md): Semantic attributes that may be used in describing the source of a log.
+* [Thread](thread.md): Semantic attributes that may be used in describing the thread that emitted a log.
 
 Apart from semantic conventions for logs, [traces](../../trace/semantic_conventions/README.md), and [metrics](../../metrics/semantic_conventions/README.md),
 OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own

--- a/specification/logs/semantic_conventions/thread.md
+++ b/specification/logs/semantic_conventions/thread.md
@@ -1,0 +1,21 @@
+# Thread attributes
+
+**Status**: [Experimental](../../document-status.md)
+
+These attributes may be used to store information about a thread that emitted a log.
+
+| Attribute     | Type   | Description                                               | Examples | Required |
+|---------------|--------|-----------------------------------------------------------|----------|----------|
+| `thread.id`   | int    | Current "managed" thread ID (as opposed to OS thread ID). | `42`     | No       |
+| `thread.name` | string | Current thread name.                                      | `main`   | No       |
+
+Examples of where `thread.id` and `thread.name` can be extracted from:
+
+| Launguage or platform | `thread.id`                            | `thread.name`                      |
+|-----------------------|----------------------------------------|------------------------------------|
+| JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()` |
+| .NET                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
+| Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
+| Ruby                  |                                        | `Thread.current.name`              |
+| C++                   | `std::this_thread::get_id()`           |                                    |
+| Erlang                | `erlang:system_info(scheduler_id)`     |                                    |


### PR DESCRIPTION
## Changes

Adds thread semantic attributes for logs, copied from the thread semantic attributes for spans.