### PR TITLE
nit: Pluralize "measures"

### DIFF
--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -28,7 +28,7 @@ Below is a table of HTTP client metric instruments.
 
 | Name                   | Instrument | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
 |------------------------|------------|--------------|-------------------------------------------|-------------|
-| `http.client.duration` | Histogram  | milliseconds | `ms`                                      | measure the duration of the outbound HTTP request |
+| `http.client.duration` | Histogram  | milliseconds | `ms`                                      | measures the duration of the outbound HTTP request |
 
 ## Attributes
 


### PR DESCRIPTION
Super minor...

The description of the `http.server.duration` metric is: `measures the duration of the inbound HTTP request`. This just makes `http.client.duration` the same.