### PR TITLE
Remove `flush` method on LogEmitter

### DIFF
--- a/specification/logs/logging-library-sdk.md
+++ b/specification/logs/logging-library-sdk.md
@@ -63,7 +63,6 @@ Methods:
   e.g.
   [Java discussion](https://github.com/open-telemetry/opentelemetry-java/pull/3759#discussion_r738019425))
 
-- Flush.
 
 ### LogRecord
 


### PR DESCRIPTION
Fixes #2342 

## Changes

This change proposes to remove the `flush` on Emitter for the consistency. There is no `flush` on Tracer/Meter specification. Language sdk implementations may choose the idiomatic way to provide the appender/handler ability to call flush on the `LogEmitterProvider` (ex: setter in [java](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/main/instrumentation/log4j/log4j-appender-2.16/library/src/main/java/io/opentelemetry/instrumentation/log4j/appender/v2_16/OpenTelemetryAppender.java#L86-L95), `init` arg in py, or possibly a global accessor for provider etc...)