### PR TITLE
Clarify how to propose changes and resolve stuck pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -242,18 +242,29 @@ Any [spec
 maintainer](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto) can
 merge the PR once it is **ready to merge**.
 
-If a PR has been stuck (e.g. there are lots of debates and people couldn't agree
-on each other), the owner should try to get people aligned by:
+## What happens when an Issue or Pull Request becomes stuck?
 
+If a PR is stuck because a code owner has requested changes, but has not responded
+to further discussion, please do the following:
+
+* On GitHub, ping the code owner in question and the person assigned to the Issue/PR.
+* Contact your sponsor, if you have one.
+* Reaching out to the above people on the [#otel-specification Slack channel](https://cloud-native.slack.com/archives/C01N7PP1THC). If you are new, you can create a CNCF Slack account [here](http://slack.cncf.io/).
+
+If a PR is stuck because there are lots of debates and people couldn't agree
+on each other, the owner should try to get people aligned by:
+
+* Working with your sponsor to resolve the issue.
 * Consolidating the perspectives and putting a summary in the PR. It is
   recommended to add a link into the PR description, which points to a comment
   with a summary in the PR conversation.
 * Tagging subdomain experts (by looking at the change history) in the PR asking
   for suggestion.
-* Reaching out to more people on the [CNCF OpenTelemetry Slack channel](https://cloud-native.slack.com/archives/C01N7PP1THC). If you are new, you can create a CNCF Slack account [here](http://slack.cncf.io/).
+* Reaching out to more people on the [#otel-specification Slack channel](https://cloud-native.slack.com/archives/C01N7PP1THC). If you are new, you can create a CNCF Slack account [here](http://slack.cncf.io/).
 * Stepping back to see if it makes sense to narrow down the scope of the PR or
   split it up.
-
-If none of the above worked and the PR has been stuck for more than 2 weeks, the
-owner should bring it to the [OpenTelemetry Specification SIG
+* Bring the PR/Issue to the [OpenTelemetry Specification SIG
 meeting](https://github.com/open-telemetry/community#cross-language-specification).
+
+If none of the above worked, the owner should ask the person assigned to the Issue/PR
+to make a decision as to how to move forwards.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,31 @@ Agreement](https://identity.linuxfoundation.org/projects/cncf).
 
 ## Proposing a change
 
-Significant changes should go through the [OpenTelemetry Enhancement
-Proposal](https://github.com/open-telemetry/oteps) process.
+OpenTelemetry is designed to work across many programming languages and 
+operational environments. Once stable, backwards compatibility is a strict 
+requirement for every component. Because of this, specification proposals need
+to be well researched and have broad community support in order to be accepted. 
+
+For small changes which do not intend to alter the meaning of the specification,
+a Pull Request is sufficient.
+
+However, we ask that proposals be taken to the community before significant work 
+is done on them, in order to ensure that there is alignment and that they have a 
+good chance of being accepted.
+
+### Get a sponsor before you start an OTEP
+For proposals that represent a significant addition to the spec, an 
+[OTEP](https://github.com/open-telemetry/oteps) (OpenTelemetry Enhancement 
+Proposal) needs to be written and approved before the spec can be changed.
+it is recommended that you first propose the change as an issue, and ideally come to a spec meeting
+to discuss it. If there is interest in the community in pursuing the proposal, a
+sponsor can be assigned to guide you through creating an OTEP.
+
+### Create a Spec SIG
+For large, wide ranging changes which will require a sustained effort in order 
+to be completed, we suggest proposing a SIG (Special Interest Group) and 
+developing a proposal with a broad group of relevant experts and community 
+members.
 
 ## Writing specs
 


### PR DESCRIPTION
This PR adds clarity to the spec writing process, by defining the role of "Sponsor." A sponsor is a TC member or equivalent who is assigned to help shepherd large or complex proposals through the specification process.

In particular, sponsors should be assigned in the following cases:
* When an issue leads to a request for an OTEP, a sponsor should be assigned to the contributor(s) who are going to draft the OTEP.
* All spec SIGs should have a sponsor.

The concept of Sponsors have been brought up to help resolve two related issues:
* Our project is complex, and contributors who get stuck are often confused about who to talk to and how to move forward.
* Help prevent Spec SIGs and OTEP authors doing a significant amount of work before receiving feedback.

This PR also clarifies what to do when an issue is stuck due to a code owner not responding to further discussion on changes they have requested.