### PR TITLE
For prometheus metrics without sums, use a sum of 0

### DIFF
--- a/specification/metrics/datamodel.md
+++ b/specification/metrics/datamodel.md
@@ -1141,7 +1141,7 @@ Multiple Prometheus histogram metrics MUST be merged together into a single OTLP
 * The `le` label on non-suffixed metrics is used to identify and order histogram bucket boundaries. Each Prometheus line produces one bucket count on the resulting histogram. Each value for the `le` label except `+Inf` produces one bucket boundary.
 * Lines with `_count` and `_sum` suffixes are used to determine the histogram's count and sum.
 * If `_count` is not present, the metric MUST be dropped.
-* If `_sum` is not present, it MUST be computed from the buckets.
+* If `_sum` is not present, the histogram's sum MUST be set to 0.
 
 #### Summaries
 


### PR DESCRIPTION
Related issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7546

## Changes

It is not possible to implement the spec as it is currently written, since the sum cannot be computed from buckets.

The [OpenMetrics histogram spec](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram) says: 

> Negative threshold buckets MAY be used, but then the Histogram MetricPoint MUST NOT contain a sum value as it would no longer be a counter semantically.

We have two options for how to handle histograms without sums:

* Leave the sum as 0
* Drop the Histogram entirely.

Leaving the sum as 0 seems like the better option, even if it can be surprising in some cases.

cc @Aneurysm9 @jmacd 
