### PR TITLE
Remove the "MUST" wording which requires exemplar to be on-by-default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ release.
   ([#2282](https://github.com/open-telemetry/opentelemetry-specification/pull/2282))
 - Clarified wildcard and predicate support in metrics SDK View API.
   ([#2325](https://github.com/open-telemetry/opentelemetry-specification/pull/2325))
+- Changed the Exemplar wording, exemplar should be turned off by default.
+  ([#2414](https://github.com/open-telemetry/opentelemetry-specification/pull/2414))
 
 ### Logs
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -519,11 +519,8 @@ While the metric data point for the counter would carry the attributes `X` and
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements
 via the `ExemplarFilter` and `ExemplarReservoir` hooks.
 
-A Metric SDK MUST allow `Exemplar` sampling to be disabled. In this instance
-the SDK SHOULD not have overhead related to exemplar sampling.
-
-A Metric SDK MUST sample `Exemplar`s only from measurements within the context
-of a sampled trace BY DEFAULT.
+`Exemplar` sampling SHOULD be turned off by default. If `Exemplar` sampling is
+off, the SDK MUST NOT have overhead related to exemplar sampling.
 
 A Metric SDK MUST allow exemplar sampling to leverage the configuration of
 metric aggregation. For example, Exemplar sampling of histograms should be able


### PR DESCRIPTION
Fixes #2118, which is considered as a blocking issue for metrics SDK spec stable release.

## Changes

We've discussed this during the [3/11/2022 metrics issue triage meeting](https://docs.google.com/document/d/1BHK8OgvInms5hDt8yG97kt_l1zgBKdnl94tOA-d4udc/edit?pli=1#).

The priority is to ship the stable version of the Metrics SDK spec, however the Exemplar part still has many open questions and there are not sufficient prototype from language SIGs. Here are some decisions we've made in order to move the needles:

* Instead of being blocked by the Exemplar spec, we will focus on shipping the SDK spec as Mixed, by moving most parts to Stable but leave Exemplar as "Feature-freeze" (PR #2304).
* Weaken the wording in the Exemplar spec, so it won't cause conflict or introduce breaking change to the spec.

This PR removed the "exemplar must be on by default" wording, and used "should be turned off by default" instead. This gives the spec certain room, so later we can change it to "may be turned on by default" or "should be turned on by default" without having to bump the major version of the spec.
