### PR TITLE
Handle instrumentation scope in the Prometheus conversion spec

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -173,7 +173,7 @@ The instrumentation scope is used to obtain a
 
 ### Tracer Name / Meter Name
 
-This refers to the `name` and (optional) `version` arguments specified when
+This refers to the `name`, (optional) `short_name`, (optional) `version` arguments specified when
 creating a new `Tracer` or `Meter` (see
 [Obtaining a Tracer](trace/api.md#tracerprovider)/[Obtaining a Meter](metrics/api.md#meterprovider)).
 The name/version pair identifies the

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -440,7 +440,7 @@ This field is optional.
 
 ### Field: `InstrumentationScope`
 
-Type: (Name,Version) tuple of strings.
+Type: (Name,ShortName,Version) tuple of strings.
 
 Description: the [instrumentation scope](../glossary.md#instrumentation-scope).
 Multiple occurrences of events coming from the same scope can happen across time and
@@ -449,7 +449,7 @@ a logger name (e.g. Java
 [Logger Name](https://docs.oracle.com/javase/7/docs/api/java/util/logging/Logger.html#getLogger(java.lang.String)))
 the Logger Name SHOULD be recorded as the Instrumentation Scope name.
 
-Version is optional. Name SHOULD be specified if version is specified, otherwise Name
+ShortName and Version are optional. Name SHOULD be specified if version or short name is specified, otherwise Name
 is optional.
 
 ### Field: `Attributes`

--- a/specification/metrics/datamodel.md
+++ b/specification/metrics/datamodel.md
@@ -1325,7 +1325,7 @@ OpenMetrics exemplar unless they would exceed the OpenMetrics
 
 The OpenMetrics prevents naming collisions for metrics from different libraries
 by adding a [metric namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces),
-which is a single-word prefix, to metrics. The [Instrumentation Scope Short Name](TODO)
+which is a single-word prefix, to metrics. The [Instrumentation Scope Short Name](../glossary.md#instrumentation-scope)
 is the equivalent in OpenTelemetry, and MUST be attached as a prefix to all
 metrics from an Instrumentation Scope, if the short name is present. The full
 format of metrics is `<instrumentation scope short_name>_<metric_name>`.

--- a/specification/metrics/datamodel.md
+++ b/specification/metrics/datamodel.md
@@ -60,6 +60,7 @@
     + [Dropped Types](#dropped-types)
     + [Start Time](#start-time)
     + [Exemplars](#exemplars-1)
+    + [Instrumentation Scope](#instrumentation-scope)
     + [Resource Attributes](#resource-attributes)
   * [OTLP Metric points to Prometheus](#otlp-metric-points-to-prometheus)
     + [Gauges](#gauges-1)
@@ -69,6 +70,7 @@
     + [Dropped Data Points](#dropped-data-points)
     + [Metric Attributes](#metric-attributes)
     + [Exemplars](#exemplars-2)
+    + [Instrumentation Scope](#instrumentation-scope-1)
     + [Resource Attributes](#resource-attributes-1)
 - [Footnotes](#footnotes)
 
@@ -1182,6 +1184,11 @@ retrieved from the `trace_id` and `span_id` label keys, respectively.  All
 labels not used for the trace and span ids MUST be added to the OpenTelemetry
 exemplar as attributes.
 
+#### Instrumentation Scope
+
+Instrumentation Scope MUST be left unset for metrics scraped from Prometheus
+endpoints.
+
 #### Resource Attributes
 
 When scraping a Prometheus endpoint, resource attributes MUST be added to the
@@ -1283,6 +1290,17 @@ and span IDs, respectively. Timestamps MUST be added as timestamps on the
 OpenMetrics exemplar, and `filtered_attributes` MUST be added as labels on the
 OpenMetrics exemplar unless they would exceed the OpenMetrics
 [limit on characters](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars).
+
+#### Instrumentation Scope
+
+The OpenMetrics equivalent of Instrumentation Scope is the
+[metric namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces),
+which is a single-word prefix for metrics which identifies the source of the
+metric. However, the Instrumentation Scope Name in OpenTelemetry isn't
+generally suitable to use as a prefix because of how verbose it is.  Exporters
+MUST not attach the instrumentation scope name as a prefix or label to metrics.
+The Instrumentation Scope MAY be added as an info-type metric family with the
+name "opentelemetry_instrumentation_scope", and labels "name" and "version".
 
 #### Resource Attributes
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -55,7 +55,7 @@
 ### Tracer Creation
 
 New `Tracer` instances are always created through a `TracerProvider` (see
-[API](api.md#tracerprovider)). The `name` and `version` arguments supplied to
+[API](api.md#tracerprovider)). The `name`, `short_name`, and `version` arguments supplied to
 the `TracerProvider` must be used to create an
 [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which is
 stored on the created `Tracer`.


### PR DESCRIPTION
Related: https://github.com/open-telemetry/opentelemetry-specification/issues/1906

## Background

[OpenMetrics Naming+Namespacing](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces)

## Changes

This adds "short_name" to the instrumentation scope, which would be an optional, single-word name for the scope. If present, it would be used as the metric prefix in Prometheus exporters. In prometheus receivers, the `opentelemetry_instrumentation_scope` metric would identify prefixes that can be removed from metrics, and used to reconstruct the Instrumentation scope in OTLP.

Alternatives:

* Turn the library name into the single-word metric prefix.  E.g. `goopentelemetryiocontribinstrumentationnethttpotelhttp_http_server_duration`
  * Downside: This is ugly
* Add it as a label to all metrics within the scope: {"instrumentation_scope": "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"}
  * Downside: This isn't how OpenMetrics is designed to namespace metrics. Removing this later would be breaking for users.

cc @jmacd @Aneurysm9 @jsuereth 