### PR TITLE
remove confusing async updowncounter example from sync section

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -818,23 +818,6 @@ pre-calculated value is already available or fetching the snapshot of the
 "current value" is straightforward, use [Asynchronous
 UpDownCounter](#asynchronous-updowncounter) instead.
 
-Taking the **the size of a collection** as an example, almost all the language
-runtimes would provide APIs for retrieving the size of a collection, whether the
-size is internally maintained or calculated on the fly. If the intention is to
-report the size that can be retrieved from these APIs, use [Asynchronous
-UpDownCounter](#asynchronous-updowncounter).
-
-```python
-# Python
-
-items = []
-
-meter.create_observable_up_down_counter(
-    name="store.inventory",
-    description="the number of the items available",
-    callback=lambda result: result.Observe(len(items)))
-```
-
 There are cases when the runtime APIs won't provide sufficient information, e.g.
 reporting the number of items in a concurrent bag by the "color" and "material"
 properties.


### PR DESCRIPTION
## Changes

I found including an example for the async up down counter in the sync section to be a bit odd. At the very least it should be changed to match the other examples by using `meter.create_observable_updowncounter` like the examples in the async section. I can close this and open a separate PR to just change the method name if the example should stay as is.