### PR TITLE
[editorial] OT: remove non-normative table, link to OT migration page

### DIFF
--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -64,30 +64,17 @@ is not recommended for the following scenarios:
   semantics and may lead to incorrect `Context` usage and incorrect traces.
   See [Implicit and Explicit support mismatch](#implicit-and-explicit-support-mismatch).
 
-## Language version Support
+## Language version support
 
 Users are encouraged to check and update their language and runtime
 components before using the Shim layer, as the OpenTelemetry APIs and SDKs
 may have higher version requirements than their OpenTracing counterparts.
-e.g. OpenTracing Python supports Python 2.6 and higher, whereas the
-OpenTelemetry Python API supports Python 3.5 and higher.
 
-For reference see the following table, listing the OpenTracing
-and OpenTelemetry APIs minimum **language** version, as of
-January 2022:
+For details, see the [Language version support][] section of [Migrating from
+OpenTracing][].
 
-| Language   | OpenTracing API  | OpenTelemetry API |
-| ---------- | ---------------- | ----------------- |
-| Go         | 1.13             | 1.16              |
-| Java       | 7                | 8                 |
-| Python     | 2.7              | 3.6               |
-| Javascript | 6                | 8.5               |
-| DotNet     | 1.3              | 1.4               |
-| CPP        | 11               | 11                |
-
-Observe that specific OpenTracing-compliant implementations may
-already have higher language requirements, e.g. the Jaeger Python tracer
-requires Python 3.7.
+[Language version support]: https://opentelemetry.io/docs/migration/opentracing/#language-version-support
+[Migrating from OpenTracing]: https://opentelemetry.io/docs/migration/opentracing/
 
 ## Create an OpenTracing Tracer Shim
 


### PR DESCRIPTION
- Resolves https://github.com/open-telemetry/opentelemetry.io/issues/1132
- This PR removes the "Language version support" table, which is **non-normative**, and refers to the same table that is published as part of the website's [Migrating from OpenTracing] guide.

[Migrating from OpenTracing]: https://opentelemetry.io/docs/migration/opentracing/

/cc @austinlparker @tedsuo @yurishkuro @carlosalberto 