### PR TITLE
Add example log SeverityNumber mapping for .NET

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -1335,19 +1335,19 @@ for an exhaustive list.
 
 ## Appendix B: `SeverityNumber` example mappings
 
-|Syslog       |WinEvtLog  |Log4j |Zap   |java.util.logging|SeverityNumber|
-|-------------|-----------|------|------|-----------------|--------------|
-|             |           |TRACE |      | FINEST          |TRACE         |
-|Debug        |Verbose    |DEBUG |Debug | FINER           |DEBUG         |
-|             |           |      |      | FINE            |DEBUG2        |
-|             |           |      |      | CONFIG          |DEBUG3        |
-|Informational|Information|INFO  |Info  | INFO            |INFO          |
-|Notice       |           |      |      |                 |INFO2         |
-|Warning      |Warning    |WARN  |Warn  | WARNING         |WARN          |
-|Error        |Error      |ERROR |Error | SEVERE          |ERROR         |
-|Critical     |Critical   |      |Dpanic|                 |ERROR2        |
-|Alert        |           |      |Panic |                 |ERROR3        |
-|Emergency    |           |FATAL |Fatal |                 |FATAL         |
+|Syslog       |WinEvtLog  |Log4j |Zap   |java.util.logging|.NET (Microsoft.Extensions.Logging)|SeverityNumber|
+|-------------|-----------|------|------|-----------------|-----------------------------------|--------------|
+|             |           |TRACE |      | FINEST          |LogLeve.Trace                      |TRACE         |
+|Debug        |Verbose    |DEBUG |Debug | FINER           |LogLeve.Debug                      |DEBUG         |
+|             |           |      |      | FINE            |                                   |DEBUG2        |
+|             |           |      |      | CONFIG          |                                   |DEBUG3        |
+|Informational|Information|INFO  |Info  | INFO            |LogLeve.Information                |INFO          |
+|Notice       |           |      |      |                 |                                   |INFO2         |
+|Warning      |Warning    |WARN  |Warn  | WARNING         |LogLeve.Warning                    |WARN          |
+|Error        |Error      |ERROR |Error | SEVERE          |LogLeve.Error                      |ERROR         |
+|Critical     |Critical   |      |Dpanic|                 |                                   |ERROR2        |
+|Alert        |           |      |Panic |                 |                                   |ERROR3        |
+|Emergency    |           |FATAL |Fatal |                 |LogLeve.Critical                   |FATAL         |
 
 ## References
 


### PR DESCRIPTION
## Changes

Added log SeverityNumber mapping for .NET [Microsoft.Extensions.Logging.LogLeval](https://docs.microsoft.com/dotnet/api/microsoft.extensions.logging.loglevel). Probably no need to update changelog because the table is provided as an example?