### PR TITLE
Change http.server.active_requests from asynchronous to synchronous UpDownCounter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ release.
   ([#2290](https://github.com/open-telemetry/opentelemetry-specification/pull/2290))
 - Add semantic conventions for [CloudEvents](https://cloudevents.io).
   ([#1978](https://github.com/open-telemetry/opentelemetry-specification/pull/1978))
+- Change `http.server.active_requests` from asynchronous to synchronous UpDownCounter
+  ([#2451](https://github.com/open-telemetry/opentelemetry-specification/pull/2451))
 
 ### Compatibility
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -17,10 +17,10 @@ type and units.
 
 Below is a table of HTTP server metric instruments.
 
-| Name                          | Instrument                 | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
-|-------------------------------|----------------------------|--------------|-------------------------------------------|-------------|
-| `http.server.duration`        | Histogram                  | milliseconds | `ms`                                      | measures the duration of the inbound HTTP request |
-| `http.server.active_requests` | Asynchronous UpDownCounter | requests     | `{requests}`                              | measures the number of concurrent HTTP requests that are currently in-flight |
+| Name                          | Instrument    | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description |
+|-------------------------------|---------------|--------------|-------------------------------------------|-------------|
+| `http.server.duration`        | Histogram     | milliseconds | `ms`                                      | measures the duration of the inbound HTTP request |
+| `http.server.active_requests` | UpDownCounter | requests     | `{requests}`                              | measures the number of concurrent HTTP requests that are currently in-flight |
 
 ### HTTP Client
 


### PR DESCRIPTION
## Changes

Changes `http.server.active_requests` from an asynchronous UpDownCounter to a synchronous UpDownCounter.

Since instrumentation will typically increment/decrement this metric for each request (especially important in order to record its attributes), as opposed to reading the value from an underlying component.