### PR TITLE
Add rpc.system value for Apache Dubbo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ release.
 - Add semantic conventions for [CloudEvents](https://cloudevents.io).
   ([#1978](https://github.com/open-telemetry/opentelemetry-specification/pull/1978))
 - Add `rpc.system` value for Apache Dubbo.
-  ([#9999](https://github.com/open-telemetry/opentelemetry-specification/pull/9999))
+  ([#2453](https://github.com/open-telemetry/opentelemetry-specification/pull/2453))
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ release.
   ([#2290](https://github.com/open-telemetry/opentelemetry-specification/pull/2290))
 - Add semantic conventions for [CloudEvents](https://cloudevents.io).
   ([#1978](https://github.com/open-telemetry/opentelemetry-specification/pull/1978))
+- Add `rpc.system` value for Apache Dubbo.
+  ([#9999](https://github.com/open-telemetry/opentelemetry-specification/pull/9999))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -19,6 +19,9 @@ groups:
             - id: dotnet_wcf
               value: 'dotnet_wcf'
               brief: '.NET WCF'
+            - id: apache_dubbo
+              value: 'apache_dubbo'
+              brief: 'Apache Dubbo'
       - id: service
         type: string
         required:

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -84,6 +84,7 @@ or not they should be on the server, client or both.
 | `grpc` | gRPC |
 | `java_rmi` | Java RMI |
 | `dotnet_wcf` | .NET WCF |
+| `apache_dubbo` | Apache Dubbo |
 <!-- endsemconv -->
 
 To avoid high cardinality, implementations should prefer the most stable of `net.peer.name` or

--- a/specification/trace/semantic_conventions/rpc.md
+++ b/specification/trace/semantic_conventions/rpc.md
@@ -80,6 +80,7 @@ Examples of span names:
 | `grpc` | gRPC |
 | `java_rmi` | Java RMI |
 | `dotnet_wcf` | .NET WCF |
+| `apache_dubbo` | Apache Dubbo |
 <!-- endsemconv -->
 
 For client-side spans `net.peer.port` is required if the connection is IP-based and the port is available (it describes the server port they are connecting to).


### PR DESCRIPTION
## Changes

Adds `rpc.system` value for Apache Dubbo.

We have Java instrumentation for Apache Dubbo, and would like to "upstream" an `rpc.system` value for it.

Btw, suggesting a value of `apache_dubbo` over just `dubbo`, because as @tydhot mentioned in https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/5432:

> At present, many users' old systems in China are using Alibaba Dubbo. RPC types here need to be distinguished, otherwise there will be some confusion in observation.