### PR TITLE
Add semantic conventions for GraphQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ release.
   ([#2602](https://github.com/open-telemetry/opentelemetry-specification/pull/2602)).
 - Adopt attribute requirement levels in semantic conventions
   ([#2594](https://github.com/open-telemetry/opentelemetry-specification/pull/2594))
+- Add semantic conventions for GraphQL
+  ([#2456](https://github.com/open-telemetry/opentelemetry-specification/pull/2456))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -1,0 +1,20 @@
+groups:
+  - id: graphql
+    prefix: graphql
+    brief: >
+      This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL query
+      to attributes on a Span.
+    attributes:
+      - id: graphql.operation.name
+        brief: "The name of the query being executed."
+        type: string
+        examples: 'findBookById'
+      - id: graphql.operation.type
+        brief: "The name of the operation being executed."
+        type: string
+        examples: ['QUERY', 'MUTATION', 'SUBSCRIPTION']
+      - id: graphql.source
+        brief: "The GraphQL query being executed."
+        type: string
+        note: The value may be sanitized to exclude sensitive information.
+        examples: 'query findBookById { bookById(id: ?) { name } }'

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -2,8 +2,8 @@ groups:
   - id: graphql
     prefix: graphql
     brief: >
-      This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL
-      operations to attributes on a Span.
+      This document defines semantic conventions to apply when instrumenting the GraphQL implementation. They map
+      GraphQL operations to attributes on a Span.
     attributes:
       - id: operation.name
         brief: "The name of the operation being executed."

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -2,8 +2,8 @@ groups:
   - id: graphql
     prefix: graphql
     brief: >
-      This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL queries
-      to attributes on a Span.
+      This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL
+      operations to attributes on a Span.
     attributes:
       - id: operation.name
         brief: "The name of the operation being executed."
@@ -13,7 +13,7 @@ groups:
         brief: "The type of the operation being executed."
         type: string
         examples: ['QUERY', 'MUTATION', 'SUBSCRIPTION']
-      - id: query
+      - id: operation.body
         brief: "The GraphQL query being executed."
         type: string
         note: The value may be sanitized to exclude sensitive information.

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -2,18 +2,18 @@ groups:
   - id: graphql
     prefix: graphql
     brief: >
-      This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL query
+      This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL queries
       to attributes on a Span.
     attributes:
-      - id: graphql.operation.name
+      - id: operation.name
         brief: "The name of the query being executed."
         type: string
         examples: 'findBookById'
-      - id: graphql.operation.type
+      - id: operation.type
         brief: "The name of the operation being executed."
         type: string
         examples: ['QUERY', 'MUTATION', 'SUBSCRIPTION']
-      - id: graphql.source
+      - id: source
         brief: "The GraphQL query being executed."
         type: string
         note: The value may be sanitized to exclude sensitive information.

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -6,14 +6,14 @@ groups:
       to attributes on a Span.
     attributes:
       - id: operation.name
-        brief: "The name of the query being executed."
+        brief: "The name of the operation being executed."
         type: string
         examples: 'findBookById'
       - id: operation.type
-        brief: "The name of the operation being executed."
+        brief: "The type of the operation being executed."
         type: string
         examples: ['QUERY', 'MUTATION', 'SUBSCRIPTION']
-      - id: source
+      - id: query
         brief: "The GraphQL query being executed."
         type: string
         note: The value may be sanitized to exclude sensitive information.

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -24,8 +24,8 @@ groups:
               value: "subscription"
               brief: "GraphQL subscription"
         examples: ['query', 'mutation', 'subscription']
-      - id: operation.body
-        brief: "The GraphQL query being executed."
+      - id: document
+        brief: "The GraphQL document being executed."
         type: string
         note: The value may be sanitized to exclude sensitive information.
         examples: 'query findBookById { bookById(id: ?) { name } }'

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -11,8 +11,19 @@ groups:
         examples: 'findBookById'
       - id: operation.type
         brief: "The type of the operation being executed."
-        type: string
-        examples: ['QUERY', 'MUTATION', 'SUBSCRIPTION']
+        type:
+          allow_custom_values: false
+          members:
+            - id: query
+              value: "query"
+              brief: "GraphQL query"
+            - id: mutation
+              value: "mutation"
+              brief: "GraphQL mutation"
+            - id: subscription
+              value: "subscription"
+              brief: "GraphQL subscription"
+        examples: ['query', 'mutation', 'subscription']
       - id: operation.body
         brief: "The GraphQL query being executed."
         type: string

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -28,6 +28,7 @@ The following library-specific semantic conventions are defined:
 
 * [AWS Lambda](instrumentation/aws-lambda.md): For AWS Lambda spans.
 * [AWS SDK](instrumentation/aws-sdk.md): For AWS SDK spans.
+* [GraphQL](instrumentation/graphql.md): For GraphQL spans.
 
 Apart from semantic conventions for traces and [metrics](../../metrics/semantic_conventions/README.md),
 OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -11,11 +11,11 @@ span SHOULD be named `<graphql.operation.type>`. When `<graphql.operation.type>`
 MAY be used as span name.
 
 <!-- semconv graphql -->
-| Attribute  | Type | Description  | Examples  | Required |
+| Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `graphql.operation.name` | string | The name of the operation being executed. | `findBookById` | No |
-| `graphql.operation.type` | string | The type of the operation being executed. | `query`; `mutation`; `subscription` | No |
-| `graphql.document` | string | The GraphQL document being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
+| `graphql.operation.name` | string | The name of the operation being executed. | `findBookById` | Recommended |
+| `graphql.operation.type` | string | The type of the operation being executed. | `query`; `mutation`; `subscription` | Recommended |
+| `graphql.document` | string | The GraphQL document being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | Recommended |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
 

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -2,15 +2,22 @@
 
 **Status**: [Experimental](../../../document-status.md)
 
-This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL queries to
-attributes on a Span.
+This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL operations
+to attributes on a Span.
+
+**Span kind:** MUST always be `INTERNAL`.
+
+The **span name** MUST be of the format `<graphql.operation.type> <graphql.operation.name>` provided that
+`graphql.operation.type` and `graphql.operation.name` are available. If `graphql.operation.name` is not available, the
+span SHOULD be named `<graphql.operation.type>`. When `<graphql.operation.type>` is not available, `GraphQL Operation`
+MAY be used as span name.
 
 <!-- semconv graphql -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `graphql.operation.name` | string | The name of the operation being executed. | `findBookById` | No |
 | `graphql.operation.type` | string | The type of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
-| `graphql.query` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
+| `graphql.operation.body` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -8,9 +8,9 @@ attributes on a Span.
 <!-- semconv graphql -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `graphql.graphql.operation.name` | string | The name of the query being executed. | `findBookById` | No |
-| `graphql.graphql.operation.type` | string | The name of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
-| `graphql.graphql.source` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
+| `graphql.operation.name` | string | The name of the query being executed. | `findBookById` | No |
+| `graphql.operation.type` | string | The name of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
+| `graphql.source` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -14,8 +14,16 @@ MAY be used as span name.
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `graphql.operation.name` | string | The name of the operation being executed. | `findBookById` | No |
-| `graphql.operation.type` | string | The type of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
+| `graphql.operation.type` | string | The type of the operation being executed. | `query`; `mutation`; `subscription` | No |
 | `graphql.operation.body` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
+
+`graphql.operation.type` MUST be one of the following:
+
+| Value  | Description |
+|---|---|
+| `query` | GraphQL query |
+| `mutation` | GraphQL mutation |
+| `subscription` | GraphQL subscription |
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -2,10 +2,8 @@
 
 **Status**: [Experimental](../../../document-status.md)
 
-This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL operations
-to attributes on a Span.
-
-**Span kind:** MUST always be `INTERNAL`.
+This document defines semantic conventions to apply when instrumenting the GraphQL implementation. They map GraphQL
+operations to attributes on a Span.
 
 The **span name** MUST be of the format `<graphql.operation.type> <graphql.operation.name>` provided that
 `graphql.operation.type` and `graphql.operation.name` are available. If `graphql.operation.name` is not available, the

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -2,7 +2,7 @@
 
 **Status**: [Experimental](../../../document-status.md)
 
-This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL query to
+This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL queries to
 attributes on a Span.
 
 <!-- semconv graphql -->

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -8,9 +8,9 @@ attributes on a Span.
 <!-- semconv graphql -->
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
-| `graphql.operation.name` | string | The name of the query being executed. | `findBookById` | No |
-| `graphql.operation.type` | string | The name of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
-| `graphql.source` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
+| `graphql.operation.name` | string | The name of the operation being executed. | `findBookById` | No |
+| `graphql.operation.type` | string | The type of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
+| `graphql.query` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -1,0 +1,16 @@
+# Semantic conventions for GraphQL Server
+
+**Status**: [Experimental](../../../document-status.md)
+
+This document defines semantic conventions to apply when instrumenting the GraphQL Server. They map GraphQL query to
+attributes on a Span.
+
+<!-- semconv graphql -->
+| Attribute  | Type | Description  | Examples  | Required |
+|---|---|---|---|---|
+| `graphql.graphql.operation.name` | string | The name of the query being executed. | `findBookById` | No |
+| `graphql.graphql.operation.type` | string | The name of the operation being executed. | `QUERY`; `MUTATION`; `SUBSCRIPTION` | No |
+| `graphql.graphql.source` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
+
+**[1]:** The value may be sanitized to exclude sensitive information.
+<!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/graphql.md
+++ b/specification/trace/semantic_conventions/instrumentation/graphql.md
@@ -15,7 +15,7 @@ MAY be used as span name.
 |---|---|---|---|---|
 | `graphql.operation.name` | string | The name of the operation being executed. | `findBookById` | No |
 | `graphql.operation.type` | string | The type of the operation being executed. | `query`; `mutation`; `subscription` | No |
-| `graphql.operation.body` | string | The GraphQL query being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
+| `graphql.document` | string | The GraphQL document being executed. [1] | `query findBookById { bookById(id: ?) { name } }` | No |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
 


### PR DESCRIPTION
## Changes

Add semantic conventions for GraphQL span name and attributes.

Related issues #1670