### PR TITLE
Add environment variables for capturing Http headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ release.
   ([#2276](https://github.com/open-telemetry/opentelemetry-specification/pull/2276)).
 - Add documentation REQUIREMENT for adding attributes at span creation.
   ([#2383](https://github.com/open-telemetry/opentelemetry-specification/pull/2383)).
+- Add environment variables for capturing Http headers.
+  ([#2461](https://github.com/open-telemetry/opentelemetry-specification/pull/2461)).
 
 ### Metrics
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -263,3 +263,19 @@ To ensure consistent naming across projects, this specification recommends that 
 ```
 OTEL_{LANGUAGE}_{FEATURE}
 ```
+
+## HTTP request and response headers
+
+See [HTTP request and response headers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers)
+
+Environment variables for capturing http request and response headers:
+
+| Name                                                      | Description                                                                                                                                         |
+|-----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST  | A comma-separated list of HTTP header names. HTTP server instrumentations will capture HTTP request header values for all configured header names.  |
+| OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE | A comma-separated list of HTTP header names. HTTP server instrumentations will capture HTTP response header values for all configured header names. |
+| OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_CLIENT_REQUEST  | A comma-separated list of HTTP header names. HTTP client instrumentations will capture HTTP request header values for all configured header names.  |
+| OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_CLIENT_RESPONSE | A comma-separated list of HTTP header names. HTTP client instrumentations will capture HTTP response header values for all configured header names. |
+
+For example,
+``OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="Custom-Header-1,Content-Type"`` will capture ``Custom-Header-1`` and ``Content-Type`` headers from request headers and add them as span attributes. The names of the added span attributes will be normalised to ``http.request.header.custom_header_1`` and ``http.request.header.content_type`` as per the [semantic convention](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers).


### PR DESCRIPTION
## Changes
Add environment variables to be configured for capturing http headers. 
This [spec (HTTP request and response headers)](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers) describes  how to capture the http request/response header and add them in the span. It does not specify the environment variables need to be configured to capture the headers. This change specifies these environment variables.

Env vars proposed in the PR are already supported in [Java](https://github.com/open-telemetry/opentelemetry.io/blob/b04b753c9a5c9d14899053b78bbd46bb51dfa97e/content/en/docs/instrumentation/java/automatic/agent-config.md#capturing-http-request-and-response-headers) and [Python](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/util/opentelemetry-util-http/src/opentelemetry/util/http/__init__.py#L21) sdks. 

Related PR: https://github.com/open-telemetry/opentelemetry-specification/pull/1898  

Additional info: 
One thing that I have seen in python is that headers provided by some frameworks/libraries (e.g. wsgi based frameworks like flask) are lowercase and `-` is replaced with `_` which would mean user who configures
`OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST="CusTOM_HEAder-1"`
will be able to capture ``custom-header-1`` from request headers for some frameworks/libraries whereas for some other frameworks he won't be able to capture this header as it does not change `-` to `_`.
(All python frameworks/libraries I saw provides case-insensitive headers but only some of them replace `-` with `_`)
Mentioning this info here as I am not sure if it might affect this spec or not. 