### PR TITLE
Remove spec status=Experimental from compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -93,8 +93,6 @@ formats is required. Implementing more than one format is optional.
 
 ## Metrics
 
-Disclaimer: this list of features is still a work in progress, please refer to the specification if in any doubt.
-
 | Feature                                                                                                                                                                      | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 |------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | The API provides a way to set and get a global default `MeterProvider`.                                                                                                      | X        | +  |  +   |    |    +   |      |        |     |      |     |   -  |       |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -93,8 +93,6 @@ formats is required. Implementing more than one format is optional.
 
 ## Metrics
 
-**Status**: [Experimental](./specification/document-status.md)
-
 Disclaimer: this list of features is still a work in progress, please refer to the specification if in any doubt.
 
 | Feature                                                                                                                                                                      | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |


### PR DESCRIPTION
Remove the spec status since the compliance matrix doc is not a spec.

Related to https://github.com/open-telemetry/opentelemetry-specification/pull/2473#discussion_r844411696