### PR TITLE
Update java log compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -208,22 +208,22 @@ formats is required. Implementing more than one format is optional.
 
 Disclaimer: this list of features is still a work in progress, please refer to the specification if in any doubt.
 
-| Feature                                                     | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|-------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
-| **[Logging SDK](specification/logs/logging-library-sdk.md)**| Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Get LogEmitter                                              |          |    |      |    |        |      |        |     |      |     |      |       |
-| LogEmitter.Emit(LogRecord)                                  |          |    |      |    |        |      |        |     |      |     |      |       |
-| LogEmitter.Shutdown                                         |          |    |      |    |        |      |        |     |      |     |      |       |
-| LogEmitter.ForceFlush                                       |          |    |      |    |        |      |        |     |      |     |      |       |
-| SimpleLogProcessor                                          |          |    |      |    |        |      |        |     |      |     |      |       |
-| BatchLogProcessor                                           |          |    |      |    |        |      |        |     |      |     |      |       |
-| Can plug custom log processor                               |          |    |      |    |        |      |        |     |      |     |      |       |
-| OTLP/gRPC exporter                                          |          |    |      |    |        |      |        |     |      |     |      |       |
-| OTLP/HTTP exporter                                          |          |    |      |    |        |      |        |     |      |     |      |       |
-| OTLP File exporter                                          |          |    |      |    |        |      |        |     |      |     |      |       |
-| Can plug custom log exporter                                |          |    |      |    |        |      |        |     |      |     |      |       |
-| Implicit Context Injection                                  |          |    |      |    |        |      |        |     |      |     |      |       |
-| Explicit Context                                            |          |    |      |    |        |      |        |     |      |     |      |       |
+| Feature                                                      | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+|--------------------------------------------------------------|----------|-----|------|-----|--------|------|--------|-----|------|-----|------|-------|
+| **[Logging SDK](specification/logs/logging-library-sdk.md)** | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| LogEmitterProvider.Get LogEmitter                            |          |     | +    |     |        |      |        |     |      |     |      |       |
+| LogEmitterProvider.Shutdown                                  |          |     | +    |     |        |      |        |     |      |     |      |       |
+| LogEmitterProvider.ForceFlush                                |          |     | +    |     |        |      |        |     |      |     |      |       |
+| LogEmitter.Emit(LogRecord)                                   |          |     | +    |     |        |      |        |     |      |     |      |       |
+| SimpleLogProcessor                                           |          |     | +    |     |        |      |        |     |      |     |      |       |
+| BatchLogProcessor                                            |          |     | +    |     |        |      |        |     |      |     |      |       |
+| Can plug custom log processor                                |          |     | +    |     |        |      |        |     |      |     |      |       |
+| OTLP/gRPC exporter                                           |          |     | +    |     |        |      |        |     |      |     |      |       |
+| OTLP/HTTP exporter                                           |          |     | +    |     |        |      |        |     |      |     |      |       |
+| OTLP File exporter                                           |          |     | -    |     |        |      |        |     |      |     |      |       |
+| Can plug custom log exporter                                 |          |     | +    |     |        |      |        |     |      |     |      |       |
+| Implicit Context Injection                                   |          |     | -    |     |        |      |        |     |      |     |      |       |
+| Explicit Context                                             |          |     | +    |     |        |      |        |     |      |     |      |       |
 
 ## Resource
 


### PR DESCRIPTION
Add entries for java log compliance matrix. 

Also fixes the compliance matrix, moving `Shutdown`, and `ForceFlush` methods to `LogEmitterProvider` instead of `LogEmitter`. 

Request in issue [#4349](https://github.com/open-telemetry/opentelemetry-java/issues/4349)