### PR TITLE
Fix sporadic markdown link check failures

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -1,7 +1,12 @@
 {
   "ignorePatterns": [
-      {
-          "pattern": "^https://github\\.com"
-      }
+    {
+      "pattern": "^https://github\\.com/open-telemetry/opentelemetry-specification/(issues|pull)"
+    }
+  ],
+  "retryOn429": true,
+  "aliveStatusCodes": [
+    200,
+    403
   ]
 }

--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -365,7 +365,7 @@ The `Add Event`'s `name` parameter MUST be the value with the `event` key in
 the pair set, or else fallback to use the `log` literal string.
 
 If pair set contains an `event=error` entry, the values MUST be
-[mapped](https://github.com/opentracing/specification/blob/master/semantic_conventionsmd#log-fields-table)
+[mapped](https://github.com/opentracing/specification/blob/master/semantic_conventions.md#log-fields-table)
 to an `Event` with the conventions outlined in the
 [Exception semantic conventions](../trace/semantic_conventions/exceptions.md) document:
 

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -15,7 +15,7 @@ Jaeger accepts spans in two formats:
 See also:
 
 * [Jaeger APIs](https://www.jaegertracing.io/docs/latest/apis/)
-* [Reference implementation of this translation in the OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector/blob/master/translator/trace/jaeger/traces_to_jaegerproto.go)
+* [Reference implementation of this translation in the OpenTelemetry Collector Contrib repository](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/translator/jaeger/traces_to_jaegerproto.go)
 
 ## Summary
 


### PR DESCRIPTION
We've also noticed https://docs.github.com returning 403s to the link checker bot lately in the Java repos.

This PR also reduces the scope of the `ignorePatterns`, which caught two broken links.

`retryOn429` helps with github throttling.