### PR TITLE
Update dotnet compliance to add OTLP Log export over http

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -219,7 +219,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | BatchLogProcessor                                            |          |     | +    |     |   +    |      |        |     |      |     | +    |       |
 | Can plug custom log processor                                |          |     | +    |     |   +    |      |        |     |      |     | +    |       |
 | OTLP/gRPC exporter                                           |          |     | +    |     |   +    |      |        |     |      |     | +    |       |
-| OTLP/HTTP exporter                                           |          |     | +    |     |   -    |      |        |     |      |     | -    |       |
+| OTLP/HTTP exporter                                           |          |     | +    |     |   -    |      |        |     |      |     | +    |       |
 | OTLP File exporter                                           |          |     | -    |     |   -    |      |        |     |      |     | -    |       |
 | Can plug custom log exporter                                 |          |     | +    |     |   +    |      |        |     |      |     | +    |       |
 | Implicit Context Injection                                   |          |     | -    |     |   +    |      |        |     |      |     | +    |       |


### PR DESCRIPTION
Add OTLP Log Exporter with HTTP
https://github.com/open-telemetry/opentelemetry-dotnet/pull/3225