### PR TITLE
Specify how to obtain a Ruby thread's id

### DIFF
--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -203,7 +203,7 @@ Examples of where `thread.id` and `thread.name` can be extracted from:
 | JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()` |
 | .NET                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |
 | Python                | `threading.current_thread().ident`     | `threading.current_thread().name`  |
-| Ruby                  |                                        | `Thread.current.name`              |
+| Ruby                  | `Thread.current.object_id`             | `Thread.current.name`              |
 | C++                   | `std::this_thread::get_id()`             |                                    |
 | Erlang               | `erlang:system_info(scheduler_id)` |                                  |
 


### PR DESCRIPTION
Update the span-general.md#source-code-attributes table for obtaining
thread ids and names across languages to explain how to obtain a
thread's id for Ruby.