### PR TITLE
Map SunOS to `solaris` for `os.type` resource attribute

### DIFF
--- a/semantic_conventions/resource/os.yaml
+++ b/semantic_conventions/resource/os.yaml
@@ -40,7 +40,7 @@ groups:
               brief: "AIX (Advanced Interactive eXecutive)"
             - id: solaris
               value: 'solaris'
-              brief: "Oracle Solaris"
+              brief: "SunOS, Oracle Solaris"
             - id: z_os
               value: 'z_os'
               brief: "IBM z/OS"

--- a/specification/resource/semantic_conventions/os.md
+++ b/specification/resource/semantic_conventions/os.md
@@ -29,6 +29,6 @@ In case of virtualized environments, this is the operating system as it is obser
 | `dragonflybsd` | DragonFly BSD |
 | `hpux` | HP-UX (Hewlett Packard Unix) |
 | `aix` | AIX (Advanced Interactive eXecutive) |
-| `solaris` | Oracle Solaris |
+| `solaris` | SunOS, Oracle Solaris |
 | `z_os` | IBM z/OS |
 <!-- endsemconv -->


### PR DESCRIPTION
## Changes

Both Solaris and SunOS are unfamiliar for me, but some runtimes([Node.js](https://nodejs.org/api/os.html#osplatform)) might have a value `sunos` or similar for Solaris platform which might confuse implementors whether this falls under a well-known value or not. I suggest adding "SunOS" next to "Oracle Solaris" to make that clear.

Trivial change - didn't update the changelog.
