### PR TITLE
Loosen requirement for a major version bump

### DIFF
--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -254,7 +254,7 @@ When a signal becomes stable, the version MUST be bumped to match the other stab
 
 ### Major version bump
 
-Major version bumps MUST occur when there is a breaking change to a stable interface, the removal of a deprecated signal, or a drop in support for a language or runtime version.
+Major version bumps MUST occur when there is a breaking change to a stable interface, the removal of a deprecated signal.
 Major version bumps SHOULD NOT occur for changes which do not result in a drop in support of some form.
 
 ### Minor version bump

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -255,7 +255,7 @@ When a signal becomes stable, the version MUST be bumped to match the other stab
 
 ### Major version bump
 
-Major version bumps MUST occur when there is a breaking change to a stable interface, the removal of a deprecated signal.
+Major version bumps MUST occur when there is a breaking change to a stable interface or a deprecated signal is removed.
 Major version bumps SHOULD NOT occur for changes which do not result in a drop in support of some form.
 
 ### Minor version bump
@@ -288,7 +288,7 @@ Each language implementation SHOULD define
 how the removal of a supported language/runtime version
 affects its versioning.
 As a rule of thumb,
-it SHOULD take the recommended approach in the given ecosystem
+it SHOULD follow the conventions in the given ecosystem.
 
 ## Long Term Support
 

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -24,6 +24,7 @@
   * [Major version bump](#major-version-bump)
   * [Minor version bump](#minor-version-bump)
   * [Patch version bump](#patch-version-bump)
+  * [Language version support](#language-version-support)
 - [Long Term Support](#long-term-support)
   * [API support](#api-support)
   * [SDK Support](#sdk-support)
@@ -280,6 +281,14 @@ The following are examples of patch fixes.
 Currently, the OpenTelemetry project does NOT have plans to backport bug and security fixes to prior minor versions of the SDK.
 Security and bug fixes MAY only be applied to the latest minor version.
 We are committed to making it feasible for end users to stay up to date with the latest version of the OpenTelemetry SDK.
+
+### Language version support
+
+Each language implementation SHOULD define
+how the removal of a supported language/runtime version
+affects its versioning.
+As a rule of thumb,
+it SHOULD take the recommended approach in the given ecosystem
 
 ## Long Term Support
 


### PR DESCRIPTION
I think a change in support for a language/runtime version should not necessarily force a major version bump.

Examples where I agree that making a version bump would be an overkill:

- https://github.com/open-telemetry/opentelemetry-dotnet/issues/3147
- https://github.com/open-telemetry/opentelemetry-dotnet/issues/2064

However, bumping a minor version in such cases makes sense.

PS. _Maybe I wrongly understand what "a drop in support" means._

FYI @open-telemetry/dotnet-maintainers 