### PR TITLE
Semantic conventions for Summary metrics

### DIFF
--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -170,7 +170,7 @@ use `{packets}`, `{errors}`, `{faults}`, etc.
 
 ### Instrument Conventions
 
-Metrics semantic conventions are specificatied using the names of the synchronous instrument types,
+Metrics semantic conventions are specified using the names of the synchronous instrument types,
 like `Counter` or `UpDownCounter`.  Implementations MAY use the asynchronous equivalent instead,
 like `Asynchronous Counter` or `Asynchronous UpDownCounter`.
 Whether implementations choose the synchronous type or the asynchronous equivalent is considered to be an

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -213,11 +213,11 @@ precalculated information about a distribution of measurements named
 - **H.avg** - A Gauge conveying the average-value measurement in the distribution (original units)
 - **H.min** - A Gauge conveying the minimum-value measurement in the distribution (original units)
 - **H.max** - A Gauge conveying the maximum-value measurement in the distribution (original units)
-- **H.pXY** - A Gauge calculated value of the percentile described by two decimal digits XY expressing quantile `(10X+Y)/100` in the distribution, used for percentiles 1% through 99% (unitless)
+- **H.XYp** - A Gauge calculated value of the percentile described by two decimal digits XY expressing quantile `(10X+Y)/100` in the distribution, used for percentiles 1% through 99% (unitless)
 
 For example, the median of the distribution with name `H` SHOULD be
-named `H.p50`, and the 99th percentile of the distribution with name
-`H` SHOULD be named `H.p99`.
+named `H.50p`, and the 99th percentile of the distribution with name
+`H` SHOULD be named `H.99p`.
 
 The expanded form specified here SHOULD be used as a normative
 reference when deriving metric names using standard aggregations over


### PR DESCRIPTION
Part of #2485 

## Changes

#2485 deals in specifying conventional names for metrics that have been traditionally pre-calculated about a distribution of measurements. When these measurements originate in Prometheus/OpenMetrics, we have a purpose-defined data point that can be used. When these measurements originate in a system with delta temporality or outside of Prometheus, they may exist in an "expanded form" as individual counter and gauge series.

This PR establishes semantic-conventional defaults for such pre-calculated summary metrics. Using these conventions, the semantic conventions for Kafka measurements can be written as "Histogram" while existing instrumentation may still output pre-calculated metrics in one of several ways. They can be expressed using the OTLP Summary point (if cumulative temporality), the OTLP Histogram data point (if delta temporality and no percentiles), or the expanded form (multiple metrics).
