### PR TITLE
Update com.google.* to gcp.* in logs data model

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -1007,7 +1007,7 @@ Field            | Type               | Description                             
 -----------------|--------------------| ------------------------------------------------------- | ---------------------------
 timestamp        | string             | The time the event described by the log entry occurred. | Timestamp
 resource         | MonitoredResource  | The monitored resource that produced this log entry.    | Resource
-log_name         | string             | The URL-encoded LOG_ID suffix of the log_name field identifies which log stream this entry belongs to. | Attributes["com.google.log_name"]
+log_name         | string             | The URL-encoded LOG_ID suffix of the log_name field identifies which log stream this entry belongs to. | Attributes["gcp.log_name"]
 json_payload     | google.protobuf.Struct | The log entry payload, represented as a structure that is expressed as a JSON object. | Body
 proto_payload    | google.protobuf.Any | The log entry payload, represented as a protocol buffer. | Body
 text_payload     | string             | The log entry payload, represented as a Unicode string (UTF-8). | Body
@@ -1015,8 +1015,8 @@ severity         | LogSeverity        | The severity of the log entry.          
 trace            | string             | The trace associated with the log entry, if any.        | TraceId
 span_id          | string             | The span ID within the trace associated with the log entry. | SpanId
 labels           | map<string,string> | A set of user-defined (key, value) data that provides additional information about the log entry. | Attributes
-http_request     | HttpRequest        | The HTTP request associated with the log entry, if any. | Attributes["com.google.httpRequest"]
-All other fields |                    |                                                         | Attributes["com.google.*"]
+http_request     | HttpRequest        | The HTTP request associated with the log entry, if any. | Attributes["gcp.http_request"]
+All other fields |                    |                                                         | Attributes["gcp.*"]
 
 ## Elastic Common Schema
 


### PR DESCRIPTION
Fixes #2503 

## Changes

Updates GCP attributes in the logs data model to use an abbreviated `gcp.` rather than the full `com.google.`. This format is allowed in the [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md#cloud-provider-specific-attributes) and provides consistency with other cloud provider usages throughout the specification.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
