### PR TITLE
Define attribute requirement levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ release.
 
 ### Semantic Conventions
 
+- Define attribute requirement levels
+  ([#2522](https://github.com/open-telemetry/opentelemetry-specification/pull/2522)).
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -15,7 +15,7 @@ i.e.:
 ## Writing semantic conventions
 
 Semantic conventions for the spec MUST adhere to the
-[attribute naming conventions](../specification/common/attribute-naming.md).
+[attribute naming](../specification/common/attribute-naming.md) and [requirement level](../specification/common/attribute-requirement-level.md) conventions.
 
 Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.11.0/semantic-conventions/syntax.md)
 for how to write the YAML files for semantic conventions and what the YAML properties mean.

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -51,6 +51,8 @@ both containing an array of strings to represent a mapping
 
 See [Attribute Naming](attribute-naming.md) for naming guidelines.
 
+See [Requirement Level](attribute-requirement-level.md) for requirement levels guidelines.
+
 See [this document](attribute-type-mapping.md) to find out how to map values obtained
 outside OpenTelemetry into OpenTelemetry attribute values.
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -18,11 +18,10 @@ _This section applies to Log, and Metric, Resource, and Span describes requireme
 Following attribute requirement levels are specified:
 
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
+_Note: Consumers of the telemetry may use `Required` attributes to identify specific semantic convention(s) the given telemetry item follows._
 
-- **Conditional**. All instrumentations SHOULD add the attribute when instrumented entity supports corresponding feature and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention assigning `Conditional` level on an attribute, SHOULD clarify when attribute is expected to be populated.
-`http.route` is an example of a conditional attribute: is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
-_Note: For producers of telemetry `Required` and `Conditional` levels are semantically the same (under the assumption that `Required` attributes are always available). However, consumers may use this distinction to identify conventions or validate telemetry._
-< TODO need a better name, took 'conditional' from schema definition>
+- **Conditionally required**. All instrumentations MUST add the attribute when given condition is satisfied and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention of a `Conditionally required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
+`http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't provide the attribute.
 
 - **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY allow explicit configuration to disable recommended attributes.
 
@@ -30,15 +29,14 @@ _Note: For producers of telemetry `Required` and `Conditional` levels are semant
 
 The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Opt-in** level.
 
-Semantic convention that refers to an attribute from another (e.g. general) semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
+Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
+For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally required` level on it.
 
-Instrumentations that decide not to populate `Conditional` or `Recommended` attributes due to performance, security, privacy, or other consideration by default, SHOULD use the **Opt-in** requirement level on them if the attributes are logically applicable.
+Instrumentations that decide not to populate `Conditionally required` or `Recommended` attributes due to performance, security, privacy, or other consideration by default, SHOULD use the **Opt-in** requirement level on them if the attributes are logically applicable.
 
 ## Performance suggestions
 
-In some cases instrumented entities do not have `Conditional` or `Recommended` attribute value readily available and retrieval can be expensive. Instrumentations SHOULD NOT perform expensive resource-consuming operation to obtain attribute values. Corresponding attributes SHOULD NOT be populated by default.
-
-Here are several examples of expensive operations:
+Here are several examples of expensive operations to be avoided by default:
 
 - DNS lookup to populate `net.peer.name` if only IP address is available to the instrumentation.
 - forcing `http.route` calculation before HTTP framework calculates it

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -18,7 +18,7 @@ _This section applies to Log, and Metric, Resource, and Span describes requireme
 Following attribute requirement levels are specified:
 
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
-_Note: Consumers of telemetry may want to know if telemetry item follows specific semantic convention. They can rely on presence of `Required` attribute defined by such convention. For example, `db.system` attribute on a span can be used as an indication that span follows database semantics._
+_Note: Consumers of telemetry can detect if telemetry item follows specific semantic convention by checking presence of a `Required` attribute defined by such convention. For example, `db.system` attribute on a span can be used as an indication that span follows database semantics._
 
 - **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
 `http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -1,0 +1,43 @@
+# Attribute Requirement Level
+
+**Status**: [Experimental](../document-status.md)
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- toc -->
+
+- [Performance considerations](#performance-considerations)
+
+<!-- tocstop -->
+
+</details>
+
+_This section applies to Resource, Span, Log, and Metric and describes requirement levels for attributes._
+
+Following attribute requirement levels are specified:
+
+- **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of required attribute.
+
+- **Conditional**. All instrumentations MUST add the attribute when instrumented entity supports corresponding feature and the attribute value can be efficiently retrieved and populated (see [Performance Considerations](#performance-considerations)).
+For example, `http.route` is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
+_Note: For producers of telemetry `Required` and `Conditional` levels are semantically the same (under the assumption that `Required` attributes are always available). However, consumers may use this distinction to identify conventions or validate telemetry._
+< TODO need a better name, took 'conditional' from schema definition>
+
+- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be efficiently populated. Instrumentation MAY allow explicit configuration to disable recommended attributes.
+
+- **Opt-in**. Instrumentations SHOULD NOT add the attribute by default. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Opt-in** attributes.
+
+The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Opt-in** level.
+
+Semantic convention that refers to attribute from another (e.g. general) semantic convention defaults to initial requirement level and MAY modify the requirement level in scope of a child convention.
+
+Instrumentation that cannot populate attribute according to defined requirement level due to performance, security, privacy, or other consideration, MUST use **Opt-in** requirement level on it.
+
+## Performance considerations
+
+In some cases instrumented entities do not have attribute value readily available and retrieval can be expensive. For example, `net.peer.name` may require DNS lookup if only IP address is available to the instrumentation.
+
+Instrumentations MUST NOT perform expensive resource-consuming operation to obtain attribute values. Corresponding attributes MUST NOT be populated by default.
+
+Basic local operations such as string formatting, escaping or arithmetic operations are allowed.

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -19,25 +19,27 @@ Following attribute requirement levels are specified:
 
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of required attribute.
 
-- **Conditional**. All instrumentations MUST add the attribute when instrumented entity supports corresponding feature and the attribute value can be efficiently retrieved and populated (see [Performance Considerations](#performance-suggestions)).
+- **Conditional**. All instrumentations SHOULD add the attribute when instrumented entity supports corresponding feature and the attribute value can be [efficiently retrieved and populated](#performance-suggestions).
 For example, `http.route` is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
 _Note: For producers of telemetry `Required` and `Conditional` levels are semantically the same (under the assumption that `Required` attributes are always available). However, consumers may use this distinction to identify conventions or validate telemetry._
 < TODO need a better name, took 'conditional' from schema definition>
 
-- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be efficiently populated. Instrumentation MAY allow explicit configuration to disable recommended attributes.
+- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY allow explicit configuration to disable recommended attributes.
 
 - **Opt-in**. Instrumentations SHOULD NOT add the attribute by default. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Opt-in** attributes.
 
 The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Opt-in** level.
 
-Semantic convention that refers to attribute from another (e.g. general) semantic convention defaults to initial requirement level and MAY modify the requirement level in scope of a child convention.
+Semantic convention that refers to an attribute from another (e.g. general) semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
 
-Instrumentation that cannot populate attribute according to defined requirement level due to performance, security, privacy, or other consideration, MUST use **Opt-in** requirement level on it.
+Instrumentation that cannot populate `Conditional` or `Recommended` attribute due to performance, security, privacy, or other consideration, MUST use **Opt-in** requirement level on it.
 
 ## Performance suggestions
 
-In some cases instrumented entities do not have attribute value readily available and retrieval can be expensive. For example, `net.peer.name` may require DNS lookup if only IP address is available to the instrumentation.
+In some cases instrumented entities do not have `Conditional` or `Recommended` attribute value readily available and retrieval can be expensive. Instrumentations SHOULD NOT perform expensive resource-consuming operation to obtain attribute values. Corresponding attributes SHOULD NOT be populated by default.
 
-Instrumentations SHOULD NOT perform expensive resource-consuming operation to obtain attribute values. Corresponding attributes SHOULD NOT be populated by default.
+Here are several examples of expensive operations:
 
-Basic local operations such as string formatting, escaping or arithmetic operations are allowed.
+- DNS lookup to populate `net.peer.name` if only IP address is available to the instrumentation.
+- forcing `http.route` calculation before HTTP framework calculates it
+- reading response stream to find `http.response_content_length` when `Content-Length` header is not available

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -20,7 +20,7 @@ Following attribute requirement levels are specified:
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
 _Note: Consumers of telemetry can detect if telemetry item follows specific semantic convention by checking presence of a `Required` attribute defined by such convention. For example, `db.system` attribute on a span can be used as an indication that span follows database semantics._
 
-- **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
+- **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied. Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
 `http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.
 
 - **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY offer a configuration option to disable recommended attributes.
@@ -32,7 +32,7 @@ The requirement level for attribute is defined by semantic conventions depending
 Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
 For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
-Instrumentations that decide not to populate `Conditionally Required` or `Recommended` attributes due to performance, security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
+Instrumentations that decide not to populate `Conditionally Required` or `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
 
 ## Performance suggestions
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -17,9 +17,9 @@ _This section applies to Log, and Metric, Resource, and Span describes requireme
 
 Following attribute requirement levels are specified:
 
-- **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of required attribute.
+- **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
 
-- **Conditional**. All instrumentations SHOULD add the attribute when instrumented entity supports corresponding feature and the attribute value can be [efficiently retrieved and populated](#performance-suggestions).
+- **Conditional**. All instrumentations SHOULD add the attribute when instrumented entity supports corresponding feature and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention assigning `conditional` level on an attribute, SHOULD clarify when attribute is expected to be populated.
 For example, `http.route` is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
 _Note: For producers of telemetry `Required` and `Conditional` levels are semantically the same (under the assumption that `Required` attributes are always available). However, consumers may use this distinction to identify conventions or validate telemetry._
 < TODO need a better name, took 'conditional' from schema definition>
@@ -32,7 +32,7 @@ The requirement level for attribute is defined by semantic conventions depending
 
 Semantic convention that refers to an attribute from another (e.g. general) semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
 
-Instrumentation that cannot populate `Conditional` or `Recommended` attribute due to performance, security, privacy, or other consideration, MUST use **Opt-in** requirement level on it.
+Instrumentations that decide not to populate `Conditional` or `Recommended` attributes due to performance, security, privacy, or other consideration by default, SHOULD use the **Opt-in** requirement level on them if the attributes are logically applicable.
 
 ## Performance suggestions
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -1,4 +1,4 @@
-# Attribute Requirement Level
+# Attribute Requirement Levels for Semantic Conventions
 
 **Status**: [Experimental](../document-status.md)
 
@@ -13,7 +13,7 @@
 
 </details>
 
-_This section applies to Log, Metric, Resource, and Span, and describes requirement levels for attributes._
+_This section applies to Log, Metric, Resource, and Span, and describes requirement levels for attributes defined in semantic conventions._
 
 The following attribute requirement levels are specified:
 
@@ -33,7 +33,7 @@ Semantic convention that refers to an attribute from another semantic convention
 For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
 When the condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the **Optional** requirement level on the attribute.
-For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do a DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so considering performance issues the DNS lookup introduces.
+For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do a DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so, considering performance issues the DNS lookup introduces.
 
 Instrumentations that decide not to populate `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -7,19 +7,19 @@
 
 <!-- toc -->
 
-- [Performance considerations](#performance-considerations)
+- [Performance suggestions](#performance-suggestions)
 
 <!-- tocstop -->
 
 </details>
 
-_This section applies to Resource, Span, Log, and Metric and describes requirement levels for attributes._
+_This section applies to Log, and Metric, Resource, and Span describes requirement levels for attributes._
 
 Following attribute requirement levels are specified:
 
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of required attribute.
 
-- **Conditional**. All instrumentations MUST add the attribute when instrumented entity supports corresponding feature and the attribute value can be efficiently retrieved and populated (see [Performance Considerations](#performance-considerations)).
+- **Conditional**. All instrumentations MUST add the attribute when instrumented entity supports corresponding feature and the attribute value can be efficiently retrieved and populated (see [Performance Considerations](#performance-suggestions)).
 For example, `http.route` is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
 _Note: For producers of telemetry `Required` and `Conditional` levels are semantically the same (under the assumption that `Required` attributes are always available). However, consumers may use this distinction to identify conventions or validate telemetry._
 < TODO need a better name, took 'conditional' from schema definition>
@@ -34,10 +34,10 @@ Semantic convention that refers to attribute from another (e.g. general) semanti
 
 Instrumentation that cannot populate attribute according to defined requirement level due to performance, security, privacy, or other consideration, MUST use **Opt-in** requirement level on it.
 
-## Performance considerations
+## Performance suggestions
 
 In some cases instrumented entities do not have attribute value readily available and retrieval can be expensive. For example, `net.peer.name` may require DNS lookup if only IP address is available to the instrumentation.
 
-Instrumentations MUST NOT perform expensive resource-consuming operation to obtain attribute values. Corresponding attributes MUST NOT be populated by default.
+Instrumentations SHOULD NOT perform expensive resource-consuming operation to obtain attribute values. Corresponding attributes SHOULD NOT be populated by default.
 
 Basic local operations such as string formatting, escaping or arithmetic operations are allowed.

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -25,7 +25,7 @@ _Note: Consumers of telemetry may want to know if telemetry item follows specifi
 
 - **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY offer a configuration option to disable recommended attributes.
 
-- **Optional**. Instrumentations MAY populate the attribute. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Optional** attributes.
+- **Optional**. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Optional** attributes.
 
 The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Optional** level.
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -18,7 +18,7 @@ _This section applies to Log, and Metric, Resource, and Span describes requireme
 Following attribute requirement levels are specified:
 
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
-_Note: Consumers of the telemetry may use `Required` attributes to identify specific semantic convention(s) the given telemetry item follows._
+_Note: Consumers of telemetry may want to know if telemetry item follows specific semantic convention. They can rely on presence of `Required` attribute defined by such convention. For example, `db.system` attribute on a span can be used as an indication that span follows database semantics._
 
 - **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
 `http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -13,27 +13,27 @@
 
 </details>
 
-_This section applies to Log, and Metric, Resource, and Span describes requirement levels for attributes._
+_This section applies to Log, Metric, Resource, and Span, and describes requirement levels for attributes._
 
-Following attribute requirement levels are specified:
+The following attribute requirement levels are specified:
 
-- **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
-_Note: Consumers of telemetry can detect if telemetry item follows specific semantic convention by checking presence of a `Required` attribute defined by such convention. For example, `db.system` attribute on a span can be used as an indication that span follows database semantics._
+- **Required**. All instrumentations MUST populate the attribute. Semantic convention defining a Required attribute expects that an absolute majority of instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a Required attribute.
+_Note: Consumers of telemetry can detect if telemetry item follows a specific semantic convention by checking the presence of a `Required` attribute defined by such convention. For example, the presence of `db.system` attribute on a span can be used as an indication that the span follows database semantics._
 
 - **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied. Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
 `http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.
 
-- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY offer a configuration option to disable recommended attributes.
+- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentations MAY offer a configuration option to disable Recommended attributes.
 
-- **Optional**. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Optional** attributes.
+- **Optional**. Instrumentations SHOULD populate the attribute if and only if the user configures the instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Optional** attributes.
 
 The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Optional** level.
 
-Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
+Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from the referred semantic convention applies.
 For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
-When condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the **Optional** requirement level on the attribute.
-For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so considering performance issues DNS lookup introduces.
+When the condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the **Optional** requirement level on the attribute.
+For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do a DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so considering performance issues the DNS lookup introduces.
 
 Instrumentations that decide not to populate `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -26,22 +26,28 @@ The following attribute requirement levels are specified:
 - [Recommended](#recommended)
 - [Optional](#optional)
 
-The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with `Optional` level.
+The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements.
+
+For example, Metric attributes that may have high cardinality can only be defined with `Optional` level.
 
 Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from the referred semantic convention applies.
+
 For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
 ## Required
 
 All instrumentations MUST populate the attribute. Semantic convention defining a Required attribute expects that an absolute majority of instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a Required attribute.
+
 _Note: Consumers of telemetry can detect if telemetry item follows a specific semantic convention by checking the presence of a `Required` attribute defined by such convention. For example, the presence of `db.system` attribute on a span can be used as an indication that the span follows database semantics._
 
 ## Conditionally Required
 
 All instrumentations MUST add the attribute when given condition is satisfied. Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
+
 `http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.
 
 When the condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the `Optional` requirement level on the attribute.
+
 For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do a DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so, considering performance issues the DNS lookup introduces.
 
 ## Recommended

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -20,19 +20,19 @@ Following attribute requirement levels are specified:
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
 _Note: Consumers of the telemetry may use `Required` attributes to identify specific semantic convention(s) the given telemetry item follows._
 
-- **Conditionally required**. All instrumentations MUST add the attribute when given condition is satisfied and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention of a `Conditionally required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
-`http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't provide the attribute.
+- **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
+`http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.
 
-- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY allow explicit configuration to disable recommended attributes.
+- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentation MAY offer a configuration option to disable recommended attributes.
 
-- **Opt-in**. Instrumentations SHOULD NOT add the attribute by default. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Opt-in** attributes.
+- **Optional**. Instrumentations MAY populate the attribute. Instrumentation SHOULD populate the attribute if and only if user configures instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Optional** attributes.
 
-The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Opt-in** level.
+The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Optional** level.
 
 Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
-For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally required` level on it.
+For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
-Instrumentations that decide not to populate `Conditionally required` or `Recommended` attributes due to performance, security, privacy, or other consideration by default, SHOULD use the **Opt-in** requirement level on them if the attributes are logically applicable.
+Instrumentations that decide not to populate `Conditionally Required` or `Recommended` attributes due to performance, security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
 
 ## Performance suggestions
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -7,6 +7,10 @@
 
 <!-- toc -->
 
+- [Required](#required)
+- [Conditionally Required](#conditionally-required)
+- [Recommended](#recommended)
+- [Optional](#optional)
 - [Performance suggestions](#performance-suggestions)
 
 <!-- tocstop -->
@@ -17,25 +21,38 @@ _This section applies to Log, Metric, Resource, and Span, and describes requirem
 
 The following attribute requirement levels are specified:
 
-- **Required**. All instrumentations MUST populate the attribute. Semantic convention defining a Required attribute expects that an absolute majority of instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a Required attribute.
-_Note: Consumers of telemetry can detect if telemetry item follows a specific semantic convention by checking the presence of a `Required` attribute defined by such convention. For example, the presence of `db.system` attribute on a span can be used as an indication that the span follows database semantics._
+- [Required](#required)
+- [Conditionally Required](#conditionally-required)
+- [Recommended](#recommended)
+- [Optional](#optional)
 
-- **Conditionally Required**. All instrumentations MUST add the attribute when given condition is satisfied. Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
-`http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.
-
-- **Recommended**. Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentations MAY offer a configuration option to disable Recommended attributes.
-
-- **Optional**. Instrumentations SHOULD populate the attribute if and only if the user configures the instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate **Optional** attributes.
-
-The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with **Optional** level.
+The requirement level for attribute is defined by semantic conventions depending on attribute availability across instrumented entities, performance, security, and other factors. When defining requirement levels, semantic conventions MUST take into account signal-specific requirements. For example, Metric attributes that may have high cardinality can only be defined with `Optional` level.
 
 Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from the referred semantic convention applies.
 For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
-When the condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the **Optional** requirement level on the attribute.
+## Required
+
+All instrumentations MUST populate the attribute. Semantic convention defining a Required attribute expects that an absolute majority of instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a Required attribute.
+_Note: Consumers of telemetry can detect if telemetry item follows a specific semantic convention by checking the presence of a `Required` attribute defined by such convention. For example, the presence of `db.system` attribute on a span can be used as an indication that the span follows database semantics._
+
+## Conditionally Required
+
+All instrumentations MUST add the attribute when given condition is satisfied. Semantic convention of a `Conditionally Required` level of an attribute MUST clarify the condition under which the attribute is expected to be populated.
+`http.route` is an example of a conditionally required attribute to be populated when instrumented HTTP framework provides route information for the instrumented request. Some low-level HTTP server implementations do not support routing and corresponding instrumentations can't populate the attribute.
+
+When the condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the `Optional` requirement level on the attribute.
 For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do a DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so, considering performance issues the DNS lookup introduces.
 
-Instrumentations that decide not to populate `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
+## Recommended
+
+Instrumentations SHOULD add the attribute by default if it's readily available and can be [efficiently populated](#performance-suggestions). Instrumentations MAY offer a configuration option to disable Recommended attributes.
+
+Instrumentations that decide not to populate `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the `Optional` requirement level on them if the attributes are logically applicable.
+
+## Optional
+
+Instrumentations SHOULD populate the attribute if and only if the user configures the instrumentation to do so. Instrumentation that doesn't support configuration MUST NOT populate `Optional` attributes.
 
 ## Performance suggestions
 

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -32,12 +32,15 @@ The requirement level for attribute is defined by semantic conventions depending
 Semantic convention that refers to an attribute from another semantic convention MAY modify the requirement level within its own scope. Otherwise, requirement level from referred semantic convention applies.
 For example, [Database semantic convention](../trace/semantic_conventions/database.md) references `net.transport` attribute defined in [General attributes](../trace/semantic_conventions/span-general.md) with `Conditionally Required` level on it.
 
-Instrumentations that decide not to populate `Conditionally Required` or `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
+When condition on `Conditionally Required` attribute is not satisfied and there is no requirement to populate attribute, semantic conventions MAY provide special instructions on how to handle it. If no instructions are given and if instrumentation can populate the attribute, instrumentation SHOULD use the **Optional** requirement level on the attribute.
+For example, `net.peer.name` is `Conditionally Required` by [Database convention](../trace/semantic_conventions/database.md) when available. When only `net.peer.ip` is available,  instrumentation can do DNS lookup, cache and populate `net.peer.name` but only if user explicitly enables instrumentation to do so considering performance issues DNS lookup introduces.
+
+Instrumentations that decide not to populate `Recommended` attributes due to [performance](#performance-suggestions), security, privacy, or other consideration by default, SHOULD use the **Optional** requirement level on them if the attributes are logically applicable.
 
 ## Performance suggestions
 
 Here are several examples of expensive operations to be avoided by default:
 
-- DNS lookup to populate `net.peer.name` if only IP address is available to the instrumentation.
+- DNS lookup to populate `net.peer.name` if only IP address is available to the instrumentation. Caching lookup results does not solve the issue for all possible cases and should be avoided by default too.
 - forcing `http.route` calculation before HTTP framework calculates it
 - reading response stream to find `http.response_content_length` when `Content-Length` header is not available

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -19,8 +19,8 @@ Following attribute requirement levels are specified:
 
 - **Required**. All instrumentations MUST populate the attribute. Semantic convention defining required attribute expects that an absolute majority instrumentation libraries and applications are able to efficiently retrieve and populate it, can ensure cardinality, security, and other requirements specific to signal defined by the convention. `http.method` is an example of a required attribute.
 
-- **Conditional**. All instrumentations SHOULD add the attribute when instrumented entity supports corresponding feature and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention assigning `conditional` level on an attribute, SHOULD clarify when attribute is expected to be populated.
-For example, `http.route` is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
+- **Conditional**. All instrumentations SHOULD add the attribute when instrumented entity supports corresponding feature and the attribute value can be [efficiently retrieved and populated](#performance-suggestions). Semantic convention assigning `Conditional` level on an attribute, SHOULD clarify when attribute is expected to be populated.
+`http.route` is an example of a conditional attribute: is widely supported by HTTP web frameworks, but some low-level HTTP server implementations do not support it.
 _Note: For producers of telemetry `Required` and `Conditional` levels are semantically the same (under the assumption that `Required` attributes are always available). However, consumers may use this distinction to identify conventions or validate telemetry._
 < TODO need a better name, took 'conditional' from schema definition>
 


### PR DESCRIPTION
Extracted general attribute requirement level from  https://github.com/open-telemetry/opentelemetry-specification/pull/2469

## Changes

Adds terminology to be used by semantic convention to declare attribute presence requirements.

We currently have 4 vaguely defined levels across semantic conventions:
- `always` - all instrumentations MUST provide
- `conditional` which we use to specify when an attribute should be provided (but we use it inconsistently on optional and required attributes)
  e.g. [rpc.service](
https://github.com/open-telemetry/opentelemetry-specification/blob/031630c818c60666b27764a5b7a0e4ed435f55c4/semantic_conventions/trace/rpc.yaml#L27-20) is recommended (but not required?)     
  ```yml
     required:
       conditional: "No, but recommended"
  ```
  or [http.retry_count](https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/http.yaml#L114) that is optional and conditional
  ```yml
     required:
       conditional: If and only if a request was retried.
  ```

  or [db.name](https://github.com/open-telemetry/opentelemetry-specification/blob/main/semantic_conventions/trace/database.yaml#L179) which is required if available
  ```yml
     required:
       conditional: Required, if applicable.
  ```
- none, which means optional
- requires explicit enablement (e.g. [HTTP headers](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/http.md#http-request-and-response-headers))

**This PR adds and clarifies the terminology:** 
- `required` - MUST provide
-  ~~`conditional` (naming suggestions are welcome)~~ `conditionally required` - MUST IF \<condition\>
- `recommended` - SHOULD provide
- ~~`opt-in`~~ `optional` - MAY provide (when enabled)

Here's the corresponding tooling change: https://github.com/open-telemetry/build-tools/pull/92

Related issues #2114.

