### PR TITLE
Fix a typo

### DIFF
--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -198,7 +198,7 @@ a thread that started a span.
 
 Examples of where `thread.id` and `thread.name` can be extracted from:
 
-| Launguage or platform | `thread.id`                            | `thread.name`                      |
+| Language or platform | `thread.id`                            | `thread.name`                      |
 |-----------------------|----------------------------------------|------------------------------------|
 | JVM                   | `Thread.currentThread().getId()`       | `Thread.currentThread().getName()` |
 | .NET                  | `Thread.CurrentThread.ManagedThreadId` | `Thread.CurrentThread.Name`        |


### PR DESCRIPTION
Hi :wave: 
Just a small typo that I spotted while reading the documentation :slightly_smiling_face: 
:bow: 