### PR TITLE
Update spec-compliance-matrix 

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -286,7 +286,7 @@ Note: Support for environment variables is optional.
 |OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                 | + |    |   |      |    | -    |   |    |   | -  |     |
 |OTEL_ATTRIBUTE_COUNT_LIMIT                        | + |    |   |      |    | -    |   |    |   | -  |     |
 |OTEL_METRICS_EXEMPLAR_FILTER                      | - |    |   |      |    |      |   |    |   | -  |     |
-|OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | - |    |   |      |    |      |   |    |   | -  |     |
+|OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | - | +  |   |      |    |      |   |    |   | -  |     |
 
 ## Exporters
 


### PR DESCRIPTION
## Fixes
Inconsistencies in the spec compliance matrix related to the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable

## Changes
According to [this PR](https://github.com/open-telemetry/opentelemetry-java/pull/4288) that was merged and released as part of the Java SDK Version v1.14.0, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` is now a supported environment variable and the spec compliance matrix should reflect this.

## Related Issues
None

## Related PRs
* https://github.com/open-telemetry/opentelemetry-java/pull/4288
