### PR TITLE
Include OTLP version header in OTLP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ content of "Unreleased" section content will generate release notes for the
 release.
 
 ## Unreleased
+- Add otlp-version identifier metadata/header to requests
 
 ### Context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ content of "Unreleased" section content will generate release notes for the
 release.
 
 ## Unreleased
-- Add otlp-version identifier metadata/header to requests
+- Include OTLP version header in OTLP requests
 
 ### Context
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -323,6 +323,13 @@ some in beta.
 
 The default network port for OTLP/gRPC is 4317.
 
+### OTLP/gRPC Metadata
+
+The client MUST set the "x-otlp-version: {otlp version}" metadata entry.
+Where {otlp version} is the OTLP proto version used to encode the payload.
+
+For example: "x-otlp-version: 0.17.0"
+
 ### OTLP/HTTP
 
 **Status**: Binary format is [Stable](../document-status.md),
@@ -353,6 +360,11 @@ the request body is a Protobuf-encoded `ExportMetricsServiceRequest` message.
 
 The default URL path for requests that carry log data is `/v1/logs` and the
 request body is a Protobuf-encoded `ExportLogsServiceRequest` message.
+
+The client MUST set the "x-otlp-version: {otlp version}" request header.
+Where {otlp version} is the OTLP proto version used to encode the payload.
+
+For example: "x-otlp-version: 0.17.0"
 
 The client MUST set "Content-Type: application/x-protobuf" request header when
 sending binary-encoded Protobuf or "Content-Type: application/json" request


### PR DESCRIPTION
## Changes

It is useful to know the version of the OTLP protobuf definition used to create the binary or JSON. This can aid in routing to different services that can handle different proto versions or informing behaviour based on proto version changes.

Please provide a brief description of the changes here. Update the
`CHANGELOG.md` for non-trivial changes. If `CHANGELOG.md` is updated,
also be sure to update `spec-compliance-matrix.md` if necessary.

Related issues #

Related [oteps](https://github.com/open-telemetry/oteps) #
