### PR TITLE
Mark OTLP Logs Stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ release.
 
 ### Logs
 
+- OTLP Logs are now Stable
+  ([#2565](https://github.com/open-telemetry/opentelemetry-specification/pull/2565))
+
 ### Resource
 
 ### Semantic Conventions

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -54,7 +54,7 @@ own maturity level, which in turn applies to **all** the OTLP Transports listed 
 
 * Tracing: **Stable**
 * Metrics: **Stable**
-* Logs: **Beta**
+* Logs: **Stable**
 
 See [OTLP Maturity Level](https://github.com/open-telemetry/opentelemetry-proto#maturity-level).
 


### PR DESCRIPTION
The proto is already declared Stable: https://github.com/open-telemetry/opentelemetry-proto/pull/376
