### PR TITLE
Add trace semantic conventions attributes for capturing application layer protocols

### DIFF
--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -33,6 +33,14 @@ groups:
               brief: 'Something else (non IP-based).'
         brief: >
           Transport protocol used. See note below.
+      - id: protocol.name
+        type: string
+        brief: 'Application layer protocol used. The value SHOULD be normalized to lowercase.'
+        examples: ['amqp', 'http', 'nntp']
+      - id: protocol.version
+        type: string
+        brief: 'Version of the application layer protocol used.'
+        examples: '0.9.1'
       - id: peer.ip
         type: string
         brief: >

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -35,6 +35,8 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `net.transport` | string | Transport protocol used. See note below. | `ip_tcp` | No |
+| `net.protocol.name` | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `nntp` | No |
+| `net.protocol.version` | string | Version of the application layer protocol used. | `0.9.1` | No |
 | `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
 | `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | No |
 | `net.peer.name` | string | Remote hostname or similar, see note below. [1] | `example.com` | No |


### PR DESCRIPTION
Fixes #2548

## Changes

This PR proposed the two additional attributes `net.procol.name` and `net.protocol.version`. These allow capturing the name and version of the application layer protocol used (in addition to the name of the transport protocol captured in `net.transport`). The naming is consistent with ECS, where [network.protocol](https://www.elastic.co/guide/en/ecs/current/ecs-network.html#field-network-protocol) is used.

Those general attributes could be used to replace the existing attributes `messaging.protocol` and `messaging.protocol_version` by the proposed generic attributes, which can also be reused for other use cases.
