### PR TITLE
Modified mongodb.md CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -938,6 +938,8 @@ New:
   ([#1154](https://github.com/open-telemetry/opentelemetry-specification/pull/1154))
 - Add OTEL_TRACE_SAMPLER_ARG env variable definition
   ([#1202](https://github.com/open-telemetry/opentelemetry-specification/pull/1202))
+- Added semantic conventions for mongodb and add specific attributes
+  ([#1027](https://github.com/open-telemetry/opentelemetry-specification/pull/1027))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -939,7 +939,7 @@ New:
 - Add OTEL_TRACE_SAMPLER_ARG env variable definition
   ([#1202](https://github.com/open-telemetry/opentelemetry-specification/pull/1202))
 - Added semantic conventions for mongodb and add specific attributes
-  ([#1027](https://github.com/open-telemetry/opentelemetry-specification/pull/1027))
+  ([#2582](https://github.com/open-telemetry/opentelemetry-specification/pull/2582))
 
 Updates:
 

--- a/specification/metrics/semantic_conventions/instrumentation/mongodb.md
+++ b/specification/metrics/semantic_conventions/instrumentation/mongodb.md
@@ -1,0 +1,32 @@
+# Instrumenting Mongodb
+
+**Status**: [Experimental](../../../document-status.md)
+
+This document defines how to apply semantic conventions when instrumenting MongoDB.
+
+<!-- toc -->
+
+- [mongodb Metrics](#mongodb-metrics)
+
+<!-- tocstop -->
+
+## Mongodb Metrics
+
+**Description:** General mongodb metrics.
+
+| Name                                | Instrument    | Value type | Unit       | Unit ([UCUM](../README.md#instrument-units)) | Description                         | Attribute Key | Attribute Values |
+|-------------------------------------| ------------- | ---------- | ---------- | -------------------------------------------- | ----------------------------------- | ------------- | ---------------- |
+| db.mongodb.cache.operation.count    | UpDownCounter | Int64      | count      | `{count}`  | The number of cache operations of the instance. | `type` | `hit`, `miss`, `misc`            |
+| db.mongodb.collection.count         | UpDownCounter | Int64      | pages      | `{pages} ` | The number of collections. | `database` | The name of a database. |
+| db.mongodb.data.size                | Counter       | Int64      | size       | `{size  }` | The size of the collection. Data compression does not affect this value. | `database` | The name of a database. |
+| db.mongodb.connection.count         | Counter       | Int64      | count      | `{count}` | The number of connections. | `database` | The name of a database. |
+|                                     |               |            |            |           |                            | `connection_type` | `active`, `available`, `current` |
+| db.mongodb.extent.count             | UpDownCounter | Int64      | count      | `{count}`  | The number of extents. | `database` | The name of a database. | 
+| db.mongodb.global_lock.time         | UpDownCounter | Int64      | usage      | `{usage}`  | The time the global lock has been held. | | |
+| db.mongodb.index.count              | Counter       | Int64      | count      | `{count}` | The number of indexes. | `database` | The name of a database. |
+| db.mongodb.index.size               | Counter       | Int64      | size       | `{size}` | Sum of the space allocated to all indexes in the database, including free index space. | `database` | The name of a database. | 
+| db.mongodb.memory.usage             | Counter       | Int64      | usage      | `usage` | The amount of memory used. | `database` | The name of a database. |
+|                                     |               |            |            |         |                            | `memory_type` | `resident`, `virtual` |
+| db.mongodb.object.count             | Counter       | Int64      | object     | `{object}` | The number of objects. | `database` | The name of a database. |
+| db.mongodb.operation.count          | Counter       | Int64      | operation  | `{operation}` | The number of operations executed. | `operation` | `insert`, `query`, `update`,`delete`,`getmore`,`command` |
+| db.mongodb.storage.size             | Counter       | Int64      | size       | `{size}` | The total amount of storage allocated to this collection. | `database` | The name of a database. | 


### PR DESCRIPTION
Added Mongodb metrics from [Mongodb Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/mongodbreceiver/metadata.yaml)

All these are the original metrics/values, with the only change of including `db` as a prefix.

## Added

- `cache.operation.count`
- `collection.count`
- `data.size`
- `connection.count`
- `extent.count`
- `global_lock.time`
- `index.count`
- `index.size`
- `memory.usage`
- `object.count`
- `operation.count`
- `storage.size`
