### PR TITLE
Added couchdb metrics addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -938,6 +938,8 @@ New:
   ([#1154](https://github.com/open-telemetry/opentelemetry-specification/pull/1154))
 - Add OTEL_TRACE_SAMPLER_ARG env variable definition
   ([#1202](https://github.com/open-telemetry/opentelemetry-specification/pull/1202))
+- Add semantic conventions for Mongodb and add specific attributes.
+  ([#2582](https://github.com/open-telemetry/opentelemetry-specification/pull/2582))
 
 Updates:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -938,8 +938,8 @@ New:
   ([#1154](https://github.com/open-telemetry/opentelemetry-specification/pull/1154))
 - Add OTEL_TRACE_SAMPLER_ARG env variable definition
   ([#1202](https://github.com/open-telemetry/opentelemetry-specification/pull/1202))
-- Add semantic conventions for Mongodb and add specific attributes.
-  ([#2582](https://github.com/open-telemetry/opentelemetry-specification/pull/2582))
+- Add semantic conventions for Couchdb and add specific attributes.
+  ([#2582](https://github.com/open-telemetry/opentelemetry-specification/pull/2585))
 
 Updates:
 

--- a/specification/metrics/semantic_conventions/instrumentation/couchdb.md
+++ b/specification/metrics/semantic_conventions/instrumentation/couchdb.md
@@ -1,0 +1,26 @@
+# Instrumenting Couchdb
+
+**Status**: [Experimental](../../../document-status.md)
+
+This document defines how to apply semantic conventions when instrumenting Couchdb.
+
+<!-- toc -->
+
+- [couchdb Metrics](#couchdb-metrics)
+
+<!-- tocstop -->
+
+## Couchdb Metrics
+
+**Description:** General Couchdb metrics.
+
+| Name                                | Instrument    | Value type | Unit       | Unit ([UCUM](../README.md#instrument-units)) | Description                         | Attribute Key | Attribute Values |
+|-------------------------------------| ------------- | ---------- | ---------- | -------------------------------------------- | ----------------------------------- | ------------- | ---------------- |
+| db.couchdb.average.request.time     | Gauge         | Double     | average    | `{average}`  | The average duration of a served request. | | |
+| db.couchdb.httpd.bulk.request.count | UpDownCounter | Int64      | count      | `{count} ` |The number of bulk requests. | | |
+| db.couchdb.httpd.request.count      | Counter       | Int64      | size       | `{count}` | The number of HTTP requests by method. | `http.method` | `COPY`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT` |
+| db.couchdb.httpd.response.count     | Counter       | Int64      | count      | `{count}` | The number of connections. | ` http.status_code` | An HTTP status code. |
+| db.couchdb.httpd.view.count         | Counter       | Int64      | count      | `{count}` | The number of views read. | `view` | `temporary_view_reads`, `view_reads` | 
+| db.couchdb.database.open            | UpDownCounter | Int64      | open       | `{open}`  | The number of open databases. | | |
+| db.couchdb.file.descriptor.open     | UpDownCounter | Int64      | count      | `{count}` | The number of open file descriptors. | | |
+| db.couchdb.database.operation.count | Counter       | Int64      | count      | `{count}` | The number of database operations. | `operation` | `writes`, `reads` | 

--- a/specification/metrics/semantic_conventions/instrumentation/couchdb.md
+++ b/specification/metrics/semantic_conventions/instrumentation/couchdb.md
@@ -17,7 +17,7 @@ This document defines how to apply semantic conventions when instrumenting Couch
 | Name                                | Instrument    | Value type | Unit       | Unit ([UCUM](../README.md#instrument-units)) | Description                         | Attribute Key | Attribute Values |
 |-------------------------------------| ------------- | ---------- | ---------- | -------------------------------------------- | ----------------------------------- | ------------- | ---------------- |
 | db.couchdb.average.request.time     | Gauge         | Double     | average    | `{average}`  | The average duration of a served request. | | |
-| db.couchdb.httpd.bulk.request.count | UpDownCounter | Int64      | count      | `{count} ` |The number of bulk requests. | | |
+| db.couchdb.httpd.bulk.request.count | UpDownCounter | Int64      | count      | `{count}` |The number of bulk requests. | | |
 | db.couchdb.httpd.request.count      | Counter       | Int64      | size       | `{count}` | The number of HTTP requests by method. | `http.method` | `COPY`, `DELETE`, `GET`, `HEAD`, `OPTIONS`, `POST`, `PUT` |
 | db.couchdb.httpd.response.count     | Counter       | Int64      | count      | `{count}` | The number of connections. | ` http.status_code` | An HTTP status code. |
 | db.couchdb.httpd.view.count         | Counter       | Int64      | count      | `{count}` | The number of views read. | `view` | `temporary_view_reads`, `view_reads` | 


### PR DESCRIPTION
Added Couchdb metrics from [Couchdb Metrics Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/couchdbbreceiver/metadata.yaml)

All these are the original metrics/values, with the only change of including `db` as a prefix.

## Added

- `average.request.time`
- `httpd.bulk.request.count`
- `httpd.request.count`
- `httpd.response.count`
- `httpd.view.count`
- `database.open`
- `file.descriptor.open`
- `database.operation.count`
