### PR TITLE
Update exporter.md

### DIFF
--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -158,6 +158,6 @@ The `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXP
 
 Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
 
-For OTLP/HTTP, the errors `408 (Request Timeout)` and `5xx (Server Errors)` are defined as transient, detailed information about erros can be found in the [HTTP failures section](otlp.md#failures). For the OTLP/gRPC, the full list of the gRPC retryable status codes can be found in the [gRPC response section](otlp.md#otlpgrpc-response).
+For OTLP/HTTP, the errors `408 (Request Timeout)` and `5xx (Server Errors)` are defined as transient, detailed information about errors can be found in the [HTTP failures section](otlp.md#failures). For the OTLP/gRPC, the full list of the gRPC retryable status codes can be found in the [gRPC response section](otlp.md#otlpgrpc-response).
 
 [otlphttp-req]: otlp.md#otlphttp-request


### PR DESCRIPTION
While reading documentation I found an erroneous spelling mistake (erros vs errors).

Fixes #
Small spelling issue in documentation

## Changes
Spelling mistake corrected from "erros" to "errors".
