### PR TITLE
docs: fix typo

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -73,7 +73,7 @@ The **Semantic Conventions** define the keys and values which describe commonly 
 * [Metrics Conventions](metrics/semantic_conventions/README.md)
 
 Both the collector and the client libraries SHOULD autogenerate semantic
-convention keys and enum values into constants (or language idomatic
+convention keys and enum values into constants (or language idiomatic
 equivalent). Generated values shouldn't be distributed in stable packages
 until semantic conventions are stable.
 The [YAML](../semantic_conventions/README.md) files MUST be used as the


### PR DESCRIPTION
Fix a small typo. 

## Changes
Spelling mistake corrected from "idomatic" to "idiomatic".
