### PR TITLE
Add semantic convention attributes for capturing the application layer protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ release.
 
 ### Semantic Conventions
 
+- Add `net.app.protocol.*` attributes
+  ([#2602](https://github.com/open-telemetry/opentelemetry-specification/pull/2602)).
+
 ### Compatibility
 
 ### OpenTelemetry Protocol
@@ -87,8 +90,6 @@ release.
 - Change JVM runtime metric `process.runtime.jvm.memory.max`
   to `process.runtime.jvm.memory.limit`
 - ([#2605](https://github.com/open-telemetry/opentelemetry-specification/pull/2605)).
-- Add `net.app.protocol.*` attributes
-  ([#2602](https://github.com/open-telemetry/opentelemetry-specification/pull/2602)).
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ release.
 - Change JVM runtime metric `process.runtime.jvm.memory.max`
   to `process.runtime.jvm.memory.limit`
 - ([#2605](https://github.com/open-telemetry/opentelemetry-specification/pull/2605)).
+- Add `net.app.protocol.*` attributes
+  ([#2602](https://github.com/open-telemetry/opentelemetry-specification/pull/2602)).
 
 ### Compatibility
 

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -33,6 +33,14 @@ groups:
               brief: 'Something else (non IP-based).'
         brief: >
           Transport protocol used. See note below.
+      - id: protocol.name
+        type: string
+        brief: 'Application layer protocol used. The value SHOULD be normalized to lowercase.'
+        examples: ['amqp', 'http', 'nntp']
+      - id: protocol.version
+        type: string
+        brief: 'Version of the application layer protocol used.'
+        examples: '0.9.1'
       - id: peer.ip
         type: string
         brief: >

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -33,14 +33,14 @@ groups:
               brief: 'Something else (non IP-based).'
         brief: >
           Transport protocol used. See note below.
-      - id: protocol.name
+      - id: app.protocol.name
         type: string
         brief: 'Application layer protocol used. The value SHOULD be normalized to lowercase.'
-        examples: ['amqp', 'http', 'nntp']
-      - id: protocol.version
+        examples: ['amqp', 'http', 'mqtt']
+      - id: app.protocol.version
         type: string
         brief: 'Version of the application layer protocol used.'
-        examples: '0.9.1'
+        examples: '3.1.1'
       - id: peer.ip
         type: string
         brief: >

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -39,8 +39,12 @@ groups:
         examples: ['amqp', 'http', 'mqtt']
       - id: app.protocol.version
         type: string
-        brief: 'Version of the application layer protocol used.'
+        brief: 'Version of the application layer protocol used. See note below.'
         examples: '3.1.1'
+        note: >
+          `net.app.protocol.version` refers to the version of the protocol used and might be
+          different from the protocol client's version. If the HTTP client used has a version
+          of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
       - id: peer.ip
         type: string
         brief: >

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -35,6 +35,8 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `net.transport` | string | Transport protocol used. See note below. | `ip_tcp` | No |
+| `net.protocol.name` | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `nntp` | No |
+| `net.protocol.version` | string | Version of the application layer protocol used. | `0.9.1` | No |
 | `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
 | `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | No |
 | `net.peer.name` | string | Remote hostname or similar, see note below. [1] | `example.com` | No |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -35,8 +35,8 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | Attribute  | Type | Description  | Examples  | Required |
 |---|---|---|---|---|
 | `net.transport` | string | Transport protocol used. See note below. | `ip_tcp` | No |
-| `net.protocol.name` | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `nntp` | No |
-| `net.protocol.version` | string | Version of the application layer protocol used. | `0.9.1` | No |
+| `net.app.protocol.name` | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | No |
+| `net.app.protocol.version` | string | Version of the application layer protocol used. | `3.1.1` | No |
 | `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
 | `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | No |
 | `net.peer.name` | string | Remote hostname or similar, see note below. [1] | `example.com` | No |

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -36,10 +36,10 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 |---|---|---|---|---|
 | `net.transport` | string | Transport protocol used. See note below. | `ip_tcp` | No |
 | `net.app.protocol.name` | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `http`; `mqtt` | No |
-| `net.app.protocol.version` | string | Version of the application layer protocol used. | `3.1.1` | No |
+| `net.app.protocol.version` | string | Version of the application layer protocol used. See note below. [1] | `3.1.1` | No |
 | `net.peer.ip` | string | Remote address of the peer (dotted decimal for IPv4 or [RFC5952](https://tools.ietf.org/html/rfc5952) for IPv6) | `127.0.0.1` | No |
 | `net.peer.port` | int | Remote port number. | `80`; `8080`; `443` | No |
-| `net.peer.name` | string | Remote hostname or similar, see note below. [1] | `example.com` | No |
+| `net.peer.name` | string | Remote hostname or similar, see note below. [2] | `example.com` | No |
 | `net.host.ip` | string | Like `net.peer.ip` but for the host IP. Useful in case of a multi-IP host. | `192.168.0.1` | No |
 | `net.host.port` | int | Like `net.peer.port` but for the host port. | `35555` | No |
 | `net.host.name` | string | Local hostname or similar, see note below. | `localhost` | No |
@@ -50,7 +50,9 @@ the `net.peer.*` properties of a client are equal to the `net.host.*` properties
 | `net.host.carrier.mnc` | string | The mobile carrier network code. | `001` | No |
 | `net.host.carrier.icc` | string | The ISO 3166-1 alpha-2 2-character country code associated with the mobile carrier network. | `DE` | No |
 
-**[1]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+**[1]:** `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+
+**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
 
 `net.transport` MUST be one of the following:
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/2548

### Changes

This PR proposed the two additional attributes `net.app.protocol.name` and `net.app.protocol.version`. These allow capturing the name and version of the application layer protocol used (in addition to the name of the transport protocol captured in net.transport). The naming is consistent with ECS, where [network.protocol](https://www.elastic.co/guide/en/ecs/current/ecs-network.html#field-network-protocol) is used.

Those general attributes can be used to capture information about application layer protocols for which no dedicated semantic conventions exist (e. g. AMQT, or MQTT).

@Oberon00 proposed using a new [`net.app` namespace for this](https://github.com/open-telemetry/opentelemetry-specification/issues/2548#issuecomment-1140923341).