### PR TITLE
Clarify grammar for no criteria views being an error

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -173,10 +173,9 @@ are the inputs:
     _instrument name == "Foobar"_ and _instrument type is Histogram_, it will be
     treated as _(instrument name == "Foobar") AND (instrument type is
     Histogram)_.
-  * If _none_ the optional criteria is provided, the SDK SHOULD treat it as an
-    error. It is recommended that the SDK implementations fail fast. Please
-    refer to [Error handling in OpenTelemetry](../error-handling.md) for the
-    general guidance.
+  * If no criteria is provided, the SDK SHOULD treat it as an error. It is
+    recommended that the SDK implementations fail fast. Please refer to [Error
+    handling in OpenTelemetry](../error-handling.md) for the general guidance.
 * The `name` of the View (optional). If not provided, the Instrument `name`
   MUST be used by default. This will be used as the name of the [metrics
   stream](./datamodel.md#events--data-stream--timeseries).


### PR DESCRIPTION
This is an attempt to clarify an unparsable or confusing sentence fragment.

The sentence fragment "If none the optional criteria is provided" is either not grammatically correct (it uses the pronoun none to qualify a noun), or it is referring to an unspecified `none` optional criteria. Given the unspecified nature of a `none` criteria, I've assumed the original intent is to instead state that when no optional criteria is provided it should be treated as an error.

Additionally, the "optional" qualifier seems to be an error. The instrument name is non-optional and if it is provided it would seem that the view would be valid, and no error should be returned. Therefore, I think the original intent here was to say that if no criteria (not just optional) is provided that should be an error.

Based on these ideas, this changes the sentence fragment to instead refer to the negation of any provided criteria (not just optional) as an error.
