### PR TITLE
Config option enabling exponential histogram as default histogram aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ release.
 
 ### Metrics
 
+- Add experimental `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION` variable for
+  configuring default histogram aggregation of OTLP metric exporter
+  ([#2619](https://github.com/open-telemetry/opentelemetry-specification/pull/2619)).
+
 ### Logs
 
 ### Resource

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -19,11 +19,11 @@
     + [Last Value Aggregation](#last-value-aggregation)
       - [Histogram Aggregation common behavior](#histogram-aggregation-common-behavior)
     + [Explicit Bucket Histogram Aggregation](#explicit-bucket-histogram-aggregation)
-    + [Exponential Histogram Aggregation](#exponential-histogram-aggregation)
-      - [Exponential Histogram Aggregation: Handle all normal values](#exponential-histogram-aggregation-handle-all-normal-values)
-      - [Exponential Histogram Aggregation: Support a minimum and maximum scale](#exponential-histogram-aggregation-support-a-minimum-and-maximum-scale)
-      - [Exponential Histogram Aggregation: Use the maximum scale for single measurements](#exponential-histogram-aggregation-use-the-maximum-scale-for-single-measurements)
-      - [Exponential Histogram Aggregation: Maintain the ideal scale](#exponential-histogram-aggregation-maintain-the-ideal-scale)
+    + [Exponential Bucket Histogram Aggregation](#exponential-bucket-histogram-aggregation)
+      - [Exponential Bucket Histogram Aggregation: Handle all normal values](#exponential-bucket-histogram-aggregation-handle-all-normal-values)
+      - [Exponential Bucket Histogram Aggregation: Support a minimum and maximum scale](#exponential-bucket-histogram-aggregation-support-a-minimum-and-maximum-scale)
+      - [Exponential Bucket Histogram Aggregation: Use the maximum scale for single measurements](#exponential-bucket-histogram-aggregation-use-the-maximum-scale-for-single-measurements)
+      - [Exponential Bucket Histogram Aggregation: Maintain the ideal scale](#exponential-bucket-histogram-aggregation-maintain-the-ideal-scale)
   * [Observations inside asynchronous callbacks](#observations-inside-asynchronous-callbacks)
   * [Resolving duplicate instrument registration conflicts](#resolving-duplicate-instrument-registration-conflicts)
 - [Attribute limits](#attribute-limits)
@@ -346,7 +346,7 @@ The SDK MUST provide the following `Aggregation` to support the
 
 The SDK MAY provide the following `Aggregation`:
 
-- [Exponential Histogram Aggregation](./sdk.md#exponential-histogram-aggregation)
+- [Exponential Bucket Histogram Aggregation](./sdk.md#exponential-bucket-histogram-aggregation)
 
 #### Drop Aggregation
 
@@ -435,7 +435,7 @@ bound (except at positive infinity).  A measurement is defined to fall
 into the greatest-numbered bucket with boundary that is greater than
 or equal to the measurement.
 
-#### Exponential Histogram Aggregation
+#### Exponential Bucket Histogram Aggregation
 
 The Exponential Histogram Aggregation informs the SDK to collect data
 for the [Exponential Histogram Metric
@@ -487,7 +487,7 @@ either:
 1. The maximum supported scale, generally used for single-value histogram Aggregations where scale is not otherwise constrained
 2. The largest value of scale such that no more than the maximum number of buckets are needed to represent the full range of input data in either of the positive or negative ranges.
 
-##### Exponential Histogram Aggregation: Handle all normal values
+##### Exponential Bucket Histogram Aggregation: Handle all normal values
 
 Implementations are REQUIRED to accept the entire normal range of IEEE
 floating point values (i.e., all values except for +Inf, -Inf and NaN
@@ -500,18 +500,18 @@ values do not map into a valid bucket.
 Implementations MAY round subnormal values away from zero to the
 nearest normal value.
 
-##### Exponential Histogram Aggregation: Support a minimum and maximum scale
+##### Exponential Bucket Histogram Aggregation: Support a minimum and maximum scale
 
 The implementation MUST maintain reasonable minimum and maximum scale
 parameters that the automatic scale parameter will not exceed.
 
-##### Exponential Histogram Aggregation: Use the maximum scale for single measurements
+##### Exponential Bucket Histogram Aggregation: Use the maximum scale for single measurements
 
 When the histogram contains not more than one value in either of the
 positive or negative ranges, the implementation SHOULD use the maximum
 scale.
 
-##### Exponential Histogram Aggregation: Maintain the ideal scale
+##### Exponential Bucket Histogram Aggregation: Maintain the ideal scale
 
 Implementations SHOULD adjust the histogram scale as necessary to
 maintain the best resolution possible, within the constraint of

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -1,5 +1,9 @@
 # OpenTelemetry Metrics Exporter - OTLP
 
+**Status**: [Mixed](../../document-status.md)
+
+## Overview
+
 **Status**: [Stable](../../document-status.md)
 
 OTLP Metrics Exporter is a [Push Metric
@@ -19,18 +23,31 @@ variable](../../sdk-environment-variables.md#exporter-selection)),
 then by default:
 
 * The exporter MUST be paired with a [periodic exporting
-MetricReader](../sdk.md#periodic-exporting-metricreader).
+  MetricReader](../sdk.md#periodic-exporting-metricreader).
 * The exporter MUST configure the default aggregation temporality on the
   basis of instrument kind using the
   `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` variable as described
-  below, otherwise the exporter MUST use Cumulative as the default
-  aggregation temporality for all instrument kinds.
+  below.
+* The exporter MUST configure the default aggregation on the basis of instrument kind using
+  the `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION` variable as described below.
 
-The `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable
-defines the default aggregation temporality policy
-to use on the basis of instrument kind.  The recognized (case-insensitive) values are:
+## Additional Configuration
 
-| Value      | Definition                                                                                                    |
-|------------|---------------------------------------------------------------------------------------------------------------|
-| CUMULATIVE | Choose Cumulative aggregation temporality for all instrument kinds.                                           |
-| DELTA      | Choose Delta aggregation temporality for Counter, Asynchronous Counter and Histogram instrument kinds, choose Cumulative aggregation temporality for UpDownCounter and Asynchronous UpDownCounter instrument kinds. |
+**Status**: [Mixed](../../document-status.md)
+
+| Name                                                | Status       | Description                                                         | Default                     |
+|-----------------------------------------------------|--------------|---------------------------------------------------------------------|-----------------------------|
+| `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` | Stable       | The aggregation temporality to use on the basis of instrument kind. | `cumulative`                |
+| `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION`  | Experimental | The default aggregation to use for histogram instruments.           | `explicit_bucket_histogram` |
+
+The recognized (case-insensitive) values for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` are:
+
+* `cumulative`: Choose cumulative aggregation temporality for all instrument kinds.
+* `delta`: Choose Delta aggregation temporality for Counter, Asynchronous Counter and Histogram instrument kinds, choose
+  Cumulative aggregation for UpDownCount and Asynchronous UpDownCounter instrument kinds.
+
+The recognized (case-insensitive) values for `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION` are:
+
+* `explicit_bucket_histogram`:
+  Use [Explicit Bucket Histogram Aggregation](../sdk.md#explicit-bucket-histogram-aggregation).
+* `exponential_hisotgram`: Use [Exponential Histogram Aggregation](../sdk.md#exponential-histogram-aggregation).

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -50,4 +50,4 @@ The recognized (case-insensitive) values for `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGR
 
 * `explicit_bucket_histogram`:
   Use [Explicit Bucket Histogram Aggregation](../sdk.md#explicit-bucket-histogram-aggregation).
-* `exponential_hisotgram`: Use [Exponential Histogram Aggregation](../sdk.md#exponential-histogram-aggregation).
+* `exponential_histogram`: Use [Exponential Histogram Aggregation](../sdk.md#exponential-histogram-aggregation).

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -2,7 +2,7 @@
 
 **Status**: [Mixed](../../document-status.md)
 
-## Overview
+## General
 
 **Status**: [Stable](../../document-status.md)
 
@@ -29,7 +29,7 @@ then by default:
   `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` variable as described
   below.
 * The exporter MUST configure the default aggregation on the basis of instrument kind using
-  the `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION` variable as described below.
+  the `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION` variable as described below if it is implemented.
 
 ## Additional Configuration
 
@@ -44,7 +44,7 @@ The recognized (case-insensitive) values for `OTEL_EXPORTER_OTLP_METRICS_TEMPORA
 
 * `cumulative`: Choose cumulative aggregation temporality for all instrument kinds.
 * `delta`: Choose Delta aggregation temporality for Counter, Asynchronous Counter and Histogram instrument kinds, choose
-  Cumulative aggregation for UpDownCount and Asynchronous UpDownCounter instrument kinds.
+  Cumulative aggregation for UpDownCounter and Asynchronous UpDownCounter instrument kinds.
 
 The recognized (case-insensitive) values for `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGRAM_AGGREGATION` are:
 

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -50,4 +50,5 @@ The recognized (case-insensitive) values for `OTEL_EXPORTER_OTLP_DEFAULT_HISTOGR
 
 * `explicit_bucket_histogram`:
   Use [Explicit Bucket Histogram Aggregation](../sdk.md#explicit-bucket-histogram-aggregation).
-* `exponential_histogram`: Use [Exponential Histogram Aggregation](../sdk.md#exponential-histogram-aggregation).
+* `exponential_bucket_histogram`:
+  Use [Exponential Bucket Histogram Aggregation](../sdk.md#exponential-bucket-histogram-aggregation).


### PR DESCRIPTION
Resolves #2471.

opentelemetry-java has an exponential histogram implementation, but its currently quite obscure / difficult to use because the exponential histograms aren't yet stable in the spec. As discussed in #2471 and #2429, we removed the "best available histogram" aggregation anticipating later adding an option like this to make it easy for users to opt in to exponential histograms. I'd like to add the configuration option now so that opentelemetry-java users can more easily use exponential histograms, and provide any feedback needed to stabilization of the specification. 