### PR TITLE
Check Fetch InstrumentationScope from ReadableSpan Box for PHP

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -83,7 +83,7 @@ formats is required. Implementing more than one format is optional.
 | [SpanLimits](specification/trace/sdk.md#span-limits)                                             | X        | +   | +    |     | +      | +    | +      | +   |      | -   |      | +     |
 | [Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1) |          |     | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
 | [Attribute Limits](specification/common/README.md#attribute-limits)                              | X        |     | +    |     |        |      | +      | +   |      |     |      |       |
-| Fetch InstrumentationScope from ReadableSpan                                                     |          |     | +    |     |        |      |        |     |      |     |      |       |
+| Fetch InstrumentationScope from ReadableSpan                                                     |          |     | +    |     |        |      |        | +   |      |     |      |       |
 
 ## Baggage
 


### PR DESCRIPTION
## Changes

OTEL-PHP at some point switched to using InstrumentationScope instead of InstrumentationLibrary everywhere, which incidentally satisfied the ["Fetch InstrumentationScope from ReadableSpan"](https://github.com/open-telemetry/opentelemetry-specification/blob/9abbdd39d0b35f635f833f072013431da419894e/specification/common/mapping-to-non-otlp.md#instrumentationscope) part of the spec (otel-php is still alpha so it seemed ok to not deprecate the instrumentation library and just remove it's use entirely)

Related issues #
https://github.com/open-telemetry/opentelemetry-php/issues/705

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
Don't think it was an OTEP but https://github.com/open-telemetry/opentelemetry-specification/pull/2276 is where the push for the change originally came from I believe
