### PR TITLE
[editorial] Ensure logs section has a README

### DIFF
--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -1,3 +1,8 @@
+<!---
+linkTitle: Logs
+aliases: [/docs/reference/specification/logs/overview]
+--->
+
 # OpenTelemetry Logging Overview
 
 **Status**: [Experimental](../document-status.md)

--- a/specification/logs/logging-library-sdk.md
+++ b/specification/logs/logging-library-sdk.md
@@ -8,7 +8,7 @@ This document contains the first cut from the
 This specification defines how the OpenTelemetry Logging Library SDK exposes its
 functionality to authors of extensions to language-specific 3rd party logging
 libraries and to end users that want to produce logs in the
-[OpenTelemetry manner](overview.md).
+[OpenTelemetry manner](README.md).
 
 The specification defines SDK elements that to some extent mirror the
 OpenTelemetry [Trace SDK](../trace/sdk.md). This ensures uniformity and
@@ -120,7 +120,7 @@ Methods:
 An Appender implementation can be used to allow emitting log records via
 OpenTelemetry Logging Library exporters. This approach is typically used for
 applications which are fine with changing the log transport and is
-[one of the supported](overview.md#direct-to-collector) log collection
+[one of the supported](README.md#direct-to-collector) log collection
 approaches.
 
 The Appender implementation will typically acquire a LogEmitter from the global


### PR DESCRIPTION
- Contributes to #2558
- Renames spec `logs/overview.md` to `logs/README.md` and adjusts links

/cc @tigrannajaryan @reyang @austinlparker 