### PR TITLE
FaaS conventions: make faas.document.time and faas.time attributes recommended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ release.
   ([#2456](https://github.com/open-telemetry/opentelemetry-specification/pull/2456))
 - Change `cloudevents.event_spec_version` and `cloudevents.event_type` level from `required` to `recommended`
   ([#2618](https://github.com/open-telemetry/opentelemetry-specification/pull/2618))
+- Change `faas.document.time` and `faas.time` level from `required` to `recommended`
+  ([#2627](https://github.com/open-telemetry/opentelemetry-specification/pull/2627))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/faas.yaml
+++ b/semantic_conventions/trace/faas.yaml
@@ -73,7 +73,6 @@ groups:
         brief: 'Describes the type of the operation that was performed on the data.'
       - id: time
         type: string
-        requirement_level: required
         brief: >
           A string containing the time when the data was accessed in the
           [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)
@@ -111,7 +110,6 @@ groups:
     attributes:
       - id: time
         type: string
-        requirement_level: required
         brief: >
           A string containing the function invocation time in the
           [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html)

--- a/specification/trace/semantic_conventions/faas.md
+++ b/specification/trace/semantic_conventions/faas.md
@@ -171,14 +171,14 @@ This section describes how to handle the span creation and additional attributes
 ### Datasource
 
 A datasource function is triggered as a response to some data source operation such as a database or filesystem read/write.
-For `faas` spans with trigger `datasource`, it is recommended to set the following attributes.
+FaaS instrumentations that produce `faas` spans with trigger `datasource`, SHOULD use the following set of attributes.
 
 <!-- semconv faas_span.datasource -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `faas.document.collection` | string | The name of the source on which the triggering operation was performed. For example, in Cloud Storage or S3 corresponds to the bucket name, and in Cosmos DB to the database name. | `myBucketName`; `myDbName` | Required |
 | `faas.document.operation` | string | Describes the type of the operation that was performed on the data. | `insert` | Required |
-| `faas.document.time` | string | A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | Required |
+| `faas.document.time` | string | A string containing the time when the data was accessed in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | Recommended |
 | `faas.document.name` | string | The document name/table subjected to the operation. For example, in Cloud Storage or S3 is the name of the file, and in Cosmos DB the table name. | `myFile.txt`; `myTableName` | Recommended |
 
 `faas.document.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
@@ -208,7 +208,7 @@ A function is scheduled to be executed regularly. The following additional attri
 <!-- semconv faas_span.timer -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `faas.time` | string | A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | Required |
+| `faas.time` | string | A string containing the function invocation time in the [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) format expressed in [UTC](https://www.w3.org/TR/NOTE-datetime). | `2020-01-23T13:47:06Z` | Recommended |
 | `faas.cron` | string | A string containing the schedule period as [Cron Expression](https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm). | `0/5 * * * ? *` | Recommended |
 <!-- endsemconv -->
 


### PR DESCRIPTION
Fixes #2599

## Changes
`faas.document.time` and `faas.time` levels are changed from `requirement` to `recommended` as  span start time can be used instead when high precision is not so important.