### PR TITLE
Clarify that issue triaging requires labeling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,13 +170,17 @@ The following diagram shows the initial triaging of new issues.
   the 3 responses:
   - Yes, this is a good issue and we want to work on it.
   - Maybe, this issue needs to be clarified and/or others have to be pulled in
-    before we can make a decision.
+    before we can make a decision. More information may be requested from the
+    issue author or others.
   - No, this issue should not be accepted. This can happen when the issue is a
     duplicate, was discussed and rejected in the past, is out of the project
     scope, etc. The assignee labels the issue "won't do", closes it and provides
     the reason for closing. The issue author has the choice to appeal the
     decision, in which case the issue is reopened and the assignee asks other
     spec approvers to help triage and facilitate the discussion.
+  - As a result of triaging one of the 3 labels must be applied to the issue:
+    `triaged-accepted`, `triaged-needmoreinfo`, `triaged-rejected`. Absence
+    of the label indicates that the issue still needs the first response.
 - If the first response is Yes, the assignee decides if they are the right
   person to work on the issue long-term. If not, they will look for another
   contributor who can work on the issue and re-assign to them, label the issue


### PR DESCRIPTION
We discussed this in the spec SIG meeting. We decided that we want
to make the first response to the new issues clearer. To enable that
I added 3 labels to the spec repo to use for the first response.