### PR TITLE
[editorial] Ensure metrics subsections have a README

### DIFF
--- a/specification/metrics/README.md
+++ b/specification/metrics/README.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Metrics
+--->
+
 # OpenTelemetry Metrics
 
 <details>

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: API
+--->
+
 # Metrics API
 
 **Status**: [Stable](../document-status.md)

--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Data Model
+--->
+
 # Metrics Data Model
 
 **Status**: [Mixed](../document-status.md)

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: SDK
+--->
+
 # Metrics SDK
 
 **Status**: [Mixed](../document-status.md)

--- a/specification/metrics/sdk_exporters/README.md
+++ b/specification/metrics/sdk_exporters/README.md
@@ -1,0 +1,5 @@
+<!---
+linkTitle: Exporters
+--->
+
+# Metrics Exporters

--- a/specification/metrics/sdk_exporters/in-memory.md
+++ b/specification/metrics/sdk_exporters/in-memory.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: In-memory
+--->
+
 # OpenTelemetry Metrics Exporter - In-memory
 
 **Status**: [Stable](../../document-status.md)

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: OTLP
+--->
+
 # OpenTelemetry Metrics Exporter - OTLP
 
 **Status**: [Stable](../../document-status.md)

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Prometheus
+--->
+
 # OpenTelemetry Metrics Exporter - Prometheus
 
 **Status**: [Experimental](../../document-status.md)

--- a/specification/metrics/sdk_exporters/stdout.md
+++ b/specification/metrics/sdk_exporters/stdout.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Stdout
+--->
+
 # OpenTelemetry Metrics Exporter - Standard output
 
 **Status**: [Stable](../../document-status.md)

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -1,8 +1,10 @@
+<!---
+linkTitle: Semantic Conventions
+--->
+
 # Metrics Semantic Conventions
 
 **Status**: [Experimental](../../document-status.md)
-
-<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
 
 <!-- toc -->
 

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -1,4 +1,8 @@
-# General
+<!---
+linkTitle: Database
+--->
+
+# Semantic Conventions for Database Metrics
 
 **Status**: [Experimental](../../document-status.md)
 

--- a/specification/metrics/semantic_conventions/faas-metrics.md
+++ b/specification/metrics/semantic_conventions/faas-metrics.md
@@ -1,4 +1,8 @@
-# General
+<!---
+linkTitle: FaaS
+--->
+
+# Semantic Conventions for FaaS Metrics
 
 **Status**: [Experimental](../../document-status.md)
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -1,4 +1,8 @@
-# General
+<!---
+linkTitle: HTTP
+--->
+
+# Semantic Conventions for HTTP Metrics
 
 **Status**: [Experimental](../../document-status.md)
 

--- a/specification/metrics/semantic_conventions/instrumentation/README.md
+++ b/specification/metrics/semantic_conventions/instrumentation/README.md
@@ -1,0 +1,1 @@
+# Instrumentation

--- a/specification/metrics/semantic_conventions/instrumentation/kafka.md
+++ b/specification/metrics/semantic_conventions/instrumentation/kafka.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Kafka
+--->
+
 # Instrumenting Kafka
 
 **Status**: [Experimental](../../../document-status.md)

--- a/specification/metrics/semantic_conventions/openmetrics-guidelines.md
+++ b/specification/metrics/semantic_conventions/openmetrics-guidelines.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: OpenMetrics
+--->
+
 # Guidance for Interoperating with OpenMetrics
 
 **Status**: [Experimental](../../document-status.md)

--- a/specification/metrics/semantic_conventions/process-metrics.md
+++ b/specification/metrics/semantic_conventions/process-metrics.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Process
+--->
+
 # Semantic Conventions for OS Process Metrics
 
 **Status**: [Experimental](../../document-status.md)

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: RPC
+--->
+
 # General RPC conventions
 
 **Status**: [Experimental](../../document-status.md)

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: Runtime Environment
+--->
+
 # Semantic Conventions for Runtime Environment Metrics
 
 **Status**: [Experimental](../../document-status.md)

--- a/specification/metrics/semantic_conventions/system-metrics.md
+++ b/specification/metrics/semantic_conventions/system-metrics.md
@@ -1,3 +1,7 @@
+<!---
+linkTitle: System
+--->
+
 # Semantic Conventions for System Metrics
 
 **Status**: [Experimental](../../document-status.md)


### PR DESCRIPTION
- Contributes to #2558
- Some page titles have been fixed. I'll add inline comments to highlight those changes.
- Adds `linkTitle` front-matter entries (used by Hugo when generated spec pages on the OTel website). A `linkTitle` is a shortened (since the parent-section context is known) version of the full page title

/cc @tigrannajaryan @reyang @austinlparker 