### PR TITLE
Unify Inject spell

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -133,7 +133,7 @@ avoid runtime allocations.
 ### Fields
 
 The predefined propagation fields. If your carrier is reused, you should delete the fields here
-before calling [inject](#inject).
+before calling [Inject](#inject).
 
 Fields are defined as string keys identifying format-specific components in a carrier.
 


### PR DESCRIPTION
Unify Inject spell
In section https://opentelemetry.io/docs/reference/specification/context/api-propagators/#textmap-inject is `Inject`
In section https://opentelemetry.io/docs/reference/specification/context/api-propagators/#fields is `inject`