### PR TITLE
Make clear that context is not mutable when setting a span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ release.
 
 - Clarify the return of `Export(batch)` in the Batch Span Processor and exporter
   concurrency ([#2452](https://github.com/open-telemetry/opentelemetry-specification/pull/2452))
+- Clarify that Context should not be mutable when setting a span ([#2637](https://github.com/open-telemetry/opentelemetry-specification/pull/2637)) 
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ release.
 
 - Clarify the return of `Export(batch)` in the Batch Span Processor and exporter
   concurrency ([#2452](https://github.com/open-telemetry/opentelemetry-specification/pull/2452))
-- Clarify that Context should not be mutable when setting a span ([#2637](https://github.com/open-telemetry/opentelemetry-specification/pull/2637)) 
+- Clarify that Context should not be mutable when setting a span ([#2637](https://github.com/open-telemetry/opentelemetry-specification/pull/2637))
 
 ### Metrics
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -173,7 +173,7 @@ If the language has support for implicitly propagated `Context` (see
 the following functionality:
 
 - Get the currently active span from the implicit context. This is equivalent to getting the implicit context, then extracting the `Span` from the context.
-- Set the currently active span to the implicit context. This is equivalent to getting the implicit context, then inserting the `Span` to the context.
+- Set the currently active span into a new context, and make that the implicit context. This is equivalent to getting the implicit context, copying it, and then inserting the `Span` into the copy.
 
 All the above functionalities operate solely on the context API, and they MAY be
 exposed as either static methods on the trace module, or as static methods on a class

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -173,7 +173,7 @@ If the language has support for implicitly propagated `Context` (see
 the following functionality:
 
 - Get the currently active span from the implicit context. This is equivalent to getting the implicit context, then extracting the `Span` from the context.
-- Set the currently active span into a new context, and make that the implicit context. This is equivalent to getting the implicit context, copying it, and then inserting the `Span` into the copy.
+- Set the currently active span into a new context, and make that the implicit context. This is equivalent to combining the current implicit context's values with the `Span` to create a new context, which is then made the current implicit context.
 
 All the above functionalities operate solely on the context API, and they MAY be
 exposed as either static methods on the trace module, or as static methods on a class

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -163,7 +163,7 @@ The API MUST provide the following functionality to interact with a `Context`
 instance:
 
 - Extract the `Span` from a `Context` instance
-- Insert the `Span` to a `Context` instance
+- Combine the `Span` with a `Context` instance, creating a new `Context` instance
 
 The functionality listed above is necessary because API users SHOULD NOT have
 access to the [Context Key](../context/README.md#create-a-key) used by the Tracing API implementation.


### PR DESCRIPTION
Fixes #2624 

## Changes

Tries to clarify the sentence to make it clear that setting a span should not mutate the current context.

Related issues #

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
