### PR TITLE
Only monotonic sum are counters (with _total)

### DIFF
--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1341,7 +1341,7 @@ An [OpenTelemetry Gauge](#gauge) MUST be converted to a Prometheus Gauge.
   - The new data point's start time must match the time of the accumulated data point. If not, see [detecting alignment issues].(#sums-detecting-alignment-issues).
 - Otherwise, it MUST be dropped.
 
-Sum metric points MUST have `_total` added as a suffix to the metric name.
+Monotonic sum metric points MUST have `_total` added as a suffix to the metric name.
 
 #### Histograms
 


### PR DESCRIPTION
Gauges shouldn't have a `_total` attached to them according to OpenMetrics.