### PR TITLE
Update Node SERVICE_NAME env var

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -268,7 +268,7 @@ Note: Support for environment variables is optional.
 |Feature                                           |Go | Java |JS |Python|Ruby|Erlang|PHP|Rust|C++|.NET|Swift|
 |--------------------------------------------------|---|------|---|------|----|------|---|----|---|----|-----|
 |OTEL_RESOURCE_ATTRIBUTES                          | + | +    | + | +    | +  | +    | + | +  | + | +  | -   |
-|OTEL_SERVICE_NAME                                 | + | +    |   |      | +  | +    | + |    |   | +  |     |
+|OTEL_SERVICE_NAME                                 | + | +    | + |      | +  | +    | + |    |   | +  |     |
 |OTEL_LOG_LEVEL                                    | - | -    | + | [-][py1059] | +  | - | -  |    | - | -  | -   |
 |OTEL_PROPAGATORS                                  | - | +    |   | +    | +  | +    | - | -  | - | -  | -   |
 |OTEL_BSP_*                                        | + | +    |   | +    | +  | +    | - | +  | - | -  | -   |


### PR DESCRIPTION
## Fixes
Updates the Compliance Matrix to state that `OTEL_SERVICE_NAME` is read by the Node SDK, which it currently does not.

See: https://github.com/open-telemetry/opentelemetry-js/pull/2227

## Changes
Markdown
