### PR TITLE
[editorial] Add note to Hugo front matter

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Specification
 no_list: true
 cascade:

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 aliases: [/docs/reference/specification/common/common]
 --->
 # Common specification concepts

--- a/specification/context/README.md
+++ b/specification/context/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 aliases: [/docs/reference/specification/context/context]
 --->
 # Context

--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Logs
 aliases: [/docs/reference/specification/logs/overview]
 --->

--- a/specification/metrics/README.md
+++ b/specification/metrics/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Metrics
 --->
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: API
 --->
 

--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Data Model
 --->
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: SDK
 --->
 

--- a/specification/metrics/sdk_exporters/README.md
+++ b/specification/metrics/sdk_exporters/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Exporters
 --->
 

--- a/specification/metrics/sdk_exporters/in-memory.md
+++ b/specification/metrics/sdk_exporters/in-memory.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: In-memory
 --->
 

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: OTLP
 --->
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Prometheus
 --->
 

--- a/specification/metrics/sdk_exporters/stdout.md
+++ b/specification/metrics/sdk_exporters/stdout.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Stdout
 --->
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Semantic Conventions
 --->
 

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Database
 --->
 

--- a/specification/metrics/semantic_conventions/faas-metrics.md
+++ b/specification/metrics/semantic_conventions/faas-metrics.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: FaaS
 --->
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: HTTP
 --->
 

--- a/specification/metrics/semantic_conventions/instrumentation/kafka.md
+++ b/specification/metrics/semantic_conventions/instrumentation/kafka.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Kafka
 --->
 

--- a/specification/metrics/semantic_conventions/openmetrics-guidelines.md
+++ b/specification/metrics/semantic_conventions/openmetrics-guidelines.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: OpenMetrics
 --->
 

--- a/specification/metrics/semantic_conventions/process-metrics.md
+++ b/specification/metrics/semantic_conventions/process-metrics.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Process
 --->
 

--- a/specification/metrics/semantic_conventions/rpc.md
+++ b/specification/metrics/semantic_conventions/rpc.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: RPC
 --->
 

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Runtime Environment
 --->
 

--- a/specification/metrics/semantic_conventions/system-metrics.md
+++ b/specification/metrics/semantic_conventions/system-metrics.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 linkTitle: System
 --->
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -1,4 +1,4 @@
-<!---
+<!--- Hugo front matter used to generate the website version of this page:
 weight: 1
 --->
 


### PR DESCRIPTION
- Some Markdown files begin with Hugo front matter in HTML comments, which is used to generate the website version of the page. This PR adds a note to inform contributors about the purpose of these HTML comments.
- Followup to https://github.com/open-telemetry/opentelemetry-specification/pull/2635#discussion_r910155744

/cc @arminru 