### PR TITLE
Make periodic exporting MetricReader env vars stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ release.
 - Clarify the return of `Export(batch)` in the Batch Span Processor and exporter
   concurrency ([#2452](https://github.com/open-telemetry/opentelemetry-specification/pull/2452))
 - Clarify that Context should not be mutable when setting a span ([#2637](https://github.com/open-telemetry/opentelemetry-specification/pull/2637))
-- Mark `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_METRIC_EXPORT_TIMEOUT`
-  environment variables as stable
-  ([#2658](https://github.com/open-telemetry/opentelemetry-specification/pull/2658))
 
 ### Metrics
 
@@ -56,6 +53,10 @@ release.
 ### OpenTelemetry Protocol
 
 ### SDK Configuration
+
+- Mark `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_METRIC_EXPORT_TIMEOUT`
+  environment variables as Stable
+  ([#2658](https://github.com/open-telemetry/opentelemetry-specification/pull/2658))
 
 ### Telemetry Schemas
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ release.
 - Clarify the return of `Export(batch)` in the Batch Span Processor and exporter
   concurrency ([#2452](https://github.com/open-telemetry/opentelemetry-specification/pull/2452))
 - Clarify that Context should not be mutable when setting a span ([#2637](https://github.com/open-telemetry/opentelemetry-specification/pull/2637))
+- Mark `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_METRIC_EXPORT_TIMEOUT`
+  environment variables as stable
+  ([#2658](https://github.com/open-telemetry/opentelemetry-specification/pull/2658))
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -288,6 +288,8 @@ Note: Support for environment variables is optional.
 |OTEL_TRACES_SAMPLER_ARG                           | + | +    |   | +    | +  | +    |   | -  | - | -  |     |
 |OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                 | + | -    |   |      | +  | -    |   |    |   | -  |     |
 |OTEL_ATTRIBUTE_COUNT_LIMIT                        | + | -    |   |      | +  | -    |   |    |   | -  |     |
+|OTEL_METRIC_EXPORT_INTERVAL                       | - | +    |   |      |    |      | + |    |   | -  |     |
+|OTEL_METRIC_EXPORT_TIMEOUT                        | - | -    |   |      |    |      | + |    |   | -  |     |
 |OTEL_METRICS_EXEMPLAR_FILTER                      | - | +    |   |      |    |      |   |    |   | -  |     |
 |OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | - | +    |   |      |    |      |   |    |   | -  |     |
 

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -237,7 +237,7 @@ Known values for `OTEL_LOGS_EXPORTER` are:
 
 ## Metrics SDK Configuration
 
-**Status**: [Stable](document-status.md)
+**Status**: [Mixed](../../document-status.md)
 
 | Name            | Description | Default | Notes |
 |-----------------|---------|-------------|---------|
@@ -250,6 +250,11 @@ Known values for `OTEL_METRICS_EXEMPLAR_FILTER` are:
 - `"with_sampled_trace"`: Only allow measurements with a sampled parent span in context.
 
 ### Periodic exporting MetricReader
+
+**Status**: [Stable](document-status.md)
+
+Environment variables specific for the push metrics exporters (OTLP, stdout, in-memory)
+that use [periodic exporting MetricReader](metrics/sdk.md#periodic-exporting-metricreader).
 
 | Name                          | Description                                                                   | Default | Notes |
 | ----------------------------- | ----------------------------------------------------------------------------- | ------- | ----- |

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -237,7 +237,7 @@ Known values for `OTEL_LOGS_EXPORTER` are:
 
 ## Metrics SDK Configuration
 
-**Status**: [Experimental](document-status.md)
+**Status**: [Stable](document-status.md)
 
 | Name            | Description | Default | Notes |
 |-----------------|---------|-------------|---------|

--- a/specification/sdk-environment-variables.md
+++ b/specification/sdk-environment-variables.md
@@ -237,7 +237,7 @@ Known values for `OTEL_LOGS_EXPORTER` are:
 
 ## Metrics SDK Configuration
 
-**Status**: [Mixed](../../document-status.md)
+**Status**: [Mixed](document-status.md)
 
 | Name            | Description | Default | Notes |
 |-----------------|---------|-------------|---------|


### PR DESCRIPTION
## What

Mark `OTEL_METRIC_EXPORT_INTERVAL`, `OTEL_METRIC_EXPORT_TIMEOUT` environment variables as stable.

## Why

I think this change is representing the current state as all of these env vars are already implemented in OTel PHP, OTel Python, and partially by OTel Java.

See:
- [`OTEL_METRIC_EXPORT_INTERVAL` usage](https://github.com/search?p=1&q=org%3Aopen-telemetry+OTEL_METRIC_EXPORT_INTERVAL&type=Code)
- [`OTEL_METRIC_EXPORT_TIMEOUT` usage](https://github.com/search?p=1&q=org%3Aopen-telemetry+OTEL_METRIC_EXPORT_TIMEOUT&type=Code)

Created because of: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3424
