### PR TITLE
Drop spec matrix support of Java Thrift HTTP

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -330,7 +330,7 @@ Note: Support for environment variables is optional.
 | **[Jaeger](specification/trace/sdk_exporters/jaeger.md)**                      | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | [Jaeger Thrift over UDP][jaegerThriftUDP]                                      | *        | +  |      |    | +           | +    | -      | +   | +    | +   | +    | +     |
 | [Jaeger Protobuf via gRPC][jaegerProtobuf]                                     | *        | -  | +    |    | [-][py1437] | -    | -      | -   |      | -   | -    | -     |
-| [Jaeger Thrift over HTTP][jaegerThriftHTTP]                                    | *        | +  | +    |    | +           | +    | -      | +   | +    | +   | +    | -     |
+| [Jaeger Thrift over HTTP][jaegerThriftHTTP]                                    | *        | +  | -    |    | +           | +    | -      | +   | +    | +   | +    | -     |
 | Service name mapping                                                           |          | +  | +    |    | +           | +    | -      | +   |      | +   | +    | +     |
 | Resource to Process mapping                                                    |          | +  | +    |    | +           | +    | -      | +   | +    | -   | +    | -     |
 | InstrumentationLibrary mapping                                                 |          | +  | +    |    | +           | +    | -      | +   | +    | -   | +    | -     |


### PR DESCRIPTION
This is related to [an issue in the java sdk](https://github.com/open-telemetry/opentelemetry-java/issues/4577) concerning removal of Java's Thrift+HTTP support for Jaeger.

The current Java Thrift+HTTP Jaeger exporter is [built on top of](https://github.com/open-telemetry/opentelemetry-java/blob/main/exporters/jaeger-thrift/build.gradle.kts#L18) the [jaeger-client java library](https://github.com/jaegertracing/jaeger-client-java/tree/master/jaeger-thrift), which has recently been [deprecated](https://github.com/jaegertracing/jaeger-client-java#-this-library-is-deprecated). 

The existing exporter really only depends on the Jaeger client library to get the autogenerated Thrift classes. One could make the case that the java exporter could source the IDL itself directly from `jaegertracing` and autogenerate the classes at build time. That's definitely a possibility; however, I will make the case that reducing options will make for a clearer user experience. By dropping support, I think we also put forth a recommendation that is consistent with jaeger's messaging which now says 

> We urge all users to migrate to [OpenTelemetry](https://opentelemetry.io/). Please refer to the [notice in the documentation](https://www.jaegertracing.io/docs/latest/client-libraries/#deprecating-jaeger-clients) for details.

The docs site also claims [native support for OTLP](https://www.jaegertracing.io/docs/1.36/features/#native-support-for-opentracing-and-opentelemetry) from the otel SDKs. This gives users a clear path forward without depending on the Thrift HTTP exporter.

Once we get spec support of this, we can begin the process of deprecating the exporter in the java sdk.