### PR TITLE
add parent.process_pid to spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ release.
 
 ### Resource
 
+- Add parent process pid (process.parent_pid) to semantic convention constants
+  ([#2619](https://github.com/open-telemetry/opentelemetry-specification/pull/)).
+
 ### Semantic Conventions
 
 - Add `net.app.protocol.*` attributes

--- a/semantic_conventions/resource/process.yaml
+++ b/semantic_conventions/resource/process.yaml
@@ -9,6 +9,11 @@ groups:
         brief: >
           Process identifier (PID).
         examples: [1234]
+      - id: parent_pid
+        type: int
+        brief: >
+          Parent Process identifier (PID).
+        examples: [1234]
       - id: executable.name
         type: string
         requirement_level:

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -28,6 +28,7 @@
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `process.pid` | int | Process identifier (PID). | `1234` | Recommended |
+| `process.parent_pid` | int | Parent Process identifier (PID). | `1234` | Recommended |
 | `process.executable.name` | string | The name of the process executable. On Linux based systems, can be set to the `Name` in `proc/[pid]/status`. On Windows, can be set to the base name of `GetProcessImageFileNameW`. | `otelcol` | Conditionally Required: See alternative attributes below. |
 | `process.executable.path` | string | The full path to the process executable. On Linux based systems, can be set to the target of `proc/[pid]/exe`. On Windows, can be set to the result of `GetProcessImageFileNameW`. | `/usr/bin/cmd/otelcol` | Conditionally Required: See alternative attributes below. |
 | `process.command` | string | The command used to launch the process (i.e. the command name). On Linux based systems, can be set to the zeroth string in `proc/[pid]/cmdline`. On Windows, can be set to the first parameter extracted from `GetCommandLineW`. | `cmd/otelcol` | Conditionally Required: See alternative attributes below. |


### PR DESCRIPTION
Fixes #

## Changes
Add process.parent_pid to specification

Please provide a brief description of the changes here.

This issue is related to allowing receiver/hostmetricsreciever reporting parent process ID (PID).

collector contrib issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12290
collector contrib PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/12637

Related issues #

https://github.com/open-telemetry/opentelemetry-specification/issues/2689
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/12290