### PR TITLE
Add 'type' to all groups

### DIFF
--- a/semantic_conventions/resource/browser.yaml
+++ b/semantic_conventions/resource/browser.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: browser
     prefix: browser
+    type: resource
     brief: >
         The web browser in which the application represented by the resource is running.
         The `browser.*` attributes MUST be used only for resources that represent applications

--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: cloud
     prefix: cloud
+    type: resource
     brief: >
       A cloud environment (e.g. GCP, Azure, AWS)
     attributes:

--- a/semantic_conventions/resource/cloud_provider/aws/ecs.yaml
+++ b/semantic_conventions/resource/cloud_provider/aws/ecs.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: aws.ecs
     prefix: aws.ecs
+    type: resource
     brief: >
       Resources used by AWS Elastic Container Service (ECS).
     attributes:

--- a/semantic_conventions/resource/cloud_provider/aws/eks.yaml
+++ b/semantic_conventions/resource/cloud_provider/aws/eks.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: aws.eks
     prefix: aws.eks
+    type: resource
     brief: >
       Resources used by AWS Elastic Kubernetes Service (EKS).
     attributes:

--- a/semantic_conventions/resource/cloud_provider/aws/logs.yaml
+++ b/semantic_conventions/resource/cloud_provider/aws/logs.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: aws.log
     prefix: aws.log
+    type: resource
     brief: >
       Resources specific to Amazon Web Services.
     attributes:

--- a/semantic_conventions/resource/container.yaml
+++ b/semantic_conventions/resource/container.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: container
     prefix: container
+    type: resource
     brief: >
       A container instance.
     attributes:

--- a/semantic_conventions/resource/deployment_environment.yaml
+++ b/semantic_conventions/resource/deployment_environment.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: deployment
     prefix: deployment
+    type: resource
     brief: >
       The software deployment.
     attributes:

--- a/semantic_conventions/resource/device.yaml
+++ b/semantic_conventions/resource/device.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: device
     prefix: device
+    type: resource
     brief: >
         The device on which the process represented by this resource is running.
     attributes:

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: faas_resource
     prefix: faas
+    type: resource
     brief: >
       A serverless instance.
     attributes:

--- a/semantic_conventions/resource/host.yaml
+++ b/semantic_conventions/resource/host.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: host
     prefix: host
+    type: resource
     brief: >
         A host is defined as a general computing instance.
     attributes:

--- a/semantic_conventions/resource/k8s.yaml
+++ b/semantic_conventions/resource/k8s.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: k8s.cluster
     prefix: k8s.cluster
+    type: resource
     brief: >
       A Kubernetes Cluster.
     attributes:
@@ -12,6 +13,7 @@ groups:
 
   - id: k8s.node
     prefix: k8s.node
+    type: resource
     brief: >
       A Kubernetes Node object.
     attributes:
@@ -28,6 +30,7 @@ groups:
 
   - id: k8s.namespace
     prefix: k8s.namespace
+    type: resource
     brief: >
       A Kubernetes Namespace.
     attributes:
@@ -39,6 +42,7 @@ groups:
 
   - id: k8s.pod
     prefix: k8s.pod
+    type: resource
     brief: >
       A Kubernetes Pod object.
     attributes:
@@ -55,6 +59,7 @@ groups:
 
   - id: k8s.container
     prefix: k8s.container
+    type: resource
     brief: >
       A container in a [PodTemplate](https://kubernetes.io/docs/concepts/workloads/pods/#pod-templates).
     attributes:
@@ -75,6 +80,7 @@ groups:
 
   - id: k8s.replicaset
     prefix: k8s.replicaset
+    type: resource
     brief: >
       A Kubernetes ReplicaSet object.
     attributes:
@@ -91,6 +97,7 @@ groups:
 
   - id: k8s.deployment
     prefix: k8s.deployment
+    type: resource
     brief: >
       A Kubernetes Deployment object.
     attributes:
@@ -107,6 +114,7 @@ groups:
 
   - id: k8s.statefulset
     prefix: k8s.statefulset
+    type: resource
     brief: >
       A Kubernetes StatefulSet object.
     attributes:
@@ -123,6 +131,7 @@ groups:
 
   - id: k8s.daemonset
     prefix: k8s.daemonset
+    type: resource
     brief: >
       A Kubernetes DaemonSet object.
     attributes:
@@ -139,6 +148,7 @@ groups:
 
   - id: k8s.job
     prefix: k8s.job
+    type: resource
     brief: >
       A Kubernetes Job object.
     attributes:
@@ -155,6 +165,7 @@ groups:
 
   - id: k8s.cronjob
     prefix: k8s.cronjob
+    type: resource
     brief: >
       A Kubernetes CronJob object.
     attributes:

--- a/semantic_conventions/resource/os.yaml
+++ b/semantic_conventions/resource/os.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: os
     prefix: os
+    type: resource
     brief: >
         The operating system (OS) on which the process represented by this resource is running.
     note: >

--- a/semantic_conventions/resource/process.yaml
+++ b/semantic_conventions/resource/process.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: process
     prefix: process
+    type: resource
     brief: >
         An operating system process.
     attributes:
@@ -72,6 +73,7 @@ groups:
 
   - id: process.runtime
     prefix: process.runtime
+    type: resource
     brief: >
       The single (language) runtime instance which is monitored.
     attributes:

--- a/semantic_conventions/resource/service.yaml
+++ b/semantic_conventions/resource/service.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: service
     prefix: service
+    type: resource
     brief: >
       A service instance.
     attributes:

--- a/semantic_conventions/resource/telemetry.yaml
+++ b/semantic_conventions/resource/telemetry.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: telemetry
     prefix: telemetry
+    type: resource
     brief: >
       The telemetry SDK used to capture data recorded by the instrumentation libraries.
     attributes:

--- a/semantic_conventions/resource/webengine.yaml
+++ b/semantic_conventions/resource/webengine.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: webengine_resource
     prefix: webengine
+    type: resource
     brief: >
        Resource describing the packaged software running the application code. Web engines are typically executed using process.runtime.
     attributes:

--- a/semantic_conventions/trace/aws/lambda.yaml
+++ b/semantic_conventions/trace/aws/lambda.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: aws.lambda
     prefix: aws.lambda
+    type: span
     brief: >
       Span attributes used by AWS Lambda (in addition to general `faas` attributes).
     attributes:

--- a/semantic_conventions/trace/cloudevents.yaml
+++ b/semantic_conventions/trace/cloudevents.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: cloudevents
     prefix: cloudevents
+    type: span
     brief: >
         This document defines attributes for CloudEvents.
         CloudEvents is a specification on how to define event data in a standard way.

--- a/semantic_conventions/trace/compatibility.yaml
+++ b/semantic_conventions/trace/compatibility.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: opentracing
     prefix: opentracing
+    type: span
     brief: 'This document defines semantic conventions for the OpenTracing Shim'
     note: >
         These conventions are used by the OpenTracing Shim layer.

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: db
     prefix: db
+    type: span
     brief: >
       This document defines the attributes used to perform database client calls.
     span_kind: client
@@ -243,6 +244,7 @@ groups:
 
   - id: db.mssql
     prefix: db.mssql
+    type: span
     extends: db
     brief: >
       Connection-level attributes for Microsoft SQL Server
@@ -260,6 +262,7 @@ groups:
 
   - id: db.cassandra
     prefix: db.cassandra
+    type: span
     extends: db
     brief: >
       Call-level attributes for Cassandra
@@ -337,6 +340,7 @@ groups:
 
   - id: db.redis
     prefix: db.redis
+    type: span
     extends: db
     brief: >
       Call-level attributes for Redis
@@ -353,6 +357,7 @@ groups:
 
   - id: db.mongodb
     prefix: db.mongodb
+    type: span
     extends: db
     brief: >
       Call-level attributes for MongoDB
@@ -367,6 +372,7 @@ groups:
 
   - id: db.sql
     prefix: 'db.sql'
+    type: span
     extends: 'db'
     brief: >
       Call-level attributes for SQL databases
@@ -385,6 +391,7 @@ groups:
         examples: ['public.users', 'customers']
 
   - id: db.tech
+    type: span
     brief: "Semantic convention group for specific technologies"
     constraints:
       - include: 'db.cassandra'

--- a/semantic_conventions/trace/faas.yaml
+++ b/semantic_conventions/trace/faas.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: faas_span
     prefix: faas
+    type: span
     brief: >
         This semantic convention describes an instance of a function that
         runs without provisioning or managing of servers (also known as
@@ -43,6 +44,7 @@ groups:
 
   - id: faas_span.datasource
     prefix: faas.document
+    type: span
     extends: faas_span
     brief: >
       Semantic Convention for FaaS triggered as a response to some data
@@ -87,6 +89,7 @@ groups:
         examples: ["myFile.txt", "myTableName"]
 
   - id: faas_span.http
+    type: span
     extends: faas_span
     brief: >
       Semantic Convention for FaaS triggered as a response to some data
@@ -95,6 +98,7 @@ groups:
       - include: http.server
 
   - id: faas_span.pubsub
+    type: span
     extends: faas_span
     brief: >
       Semantic Convention for FaaS set to be executed when messages are
@@ -105,6 +109,7 @@ groups:
   - id: faas_span.timer
     extends: faas_span
     prefix: faas
+    type: span
     brief: >
       Semantic Convention for FaaS scheduled to be executed regularly.
     attributes:
@@ -126,6 +131,7 @@ groups:
     extends: faas_span
     span_kind: server
     prefix: faas
+    type: span
     brief: >
       Contains additional attributes for incoming FaaS spans.
     attributes:
@@ -141,6 +147,7 @@ groups:
     extends: faas_span
     span_kind: client
     prefix: faas
+    type: span
     brief: >
       Contains additional attributes for outgoing FaaS spans.
     attributes:

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: network
     prefix: net
+    type: span
     brief: >
         These attributes may be used for any network related operation.
     attributes:
@@ -210,6 +211,7 @@ groups:
         examples: "DE"
   - id: peer
     prefix: peer
+    type: span
     brief: "Operations that access some remote service."
     attributes:
       - id: service
@@ -221,6 +223,7 @@ groups:
         examples: "AuthTokenCache"
   - id: identity
     prefix: enduser
+    type: span
     brief: >
         These attributes may be used for any operation with an authenticated and/or authorized enduser.
     attributes:
@@ -245,6 +248,7 @@ groups:
         examples: 'read:message, write:files'
   - id: thread
     prefix: thread
+    type: span
     brief: >
       These attributes may be used for any operation to store information about a thread that started a span.
     attributes:
@@ -260,6 +264,7 @@ groups:
         examples: main
   - id: code
     prefix: code
+    type: span
     brief: >
       These attributes allow to report this unit of code and therefore to provide more context about the span.
     attributes:

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: http
     prefix: http
+    type: span
     brief: 'This document defines semantic conventions for HTTP client and server Spans.'
     note: >
         These conventions can be used for http and https schemes
@@ -124,6 +125,7 @@ groups:
 
   - id: http.client
     prefix: http
+    type: span
     extends: http
     span_kind: client
     brief: 'Semantic Convention for HTTP Client'
@@ -155,6 +157,7 @@ groups:
           - [http.scheme, net.sock.peer.addr, net.sock.peer.port, http.target]
   - id: http.server
     prefix: http
+    type: span
     extends: http
     span_kind: server
     brief: 'Semantic Convention for HTTP Server'

--- a/semantic_conventions/trace/instrumentation/aws-sdk.yml
+++ b/semantic_conventions/trace/instrumentation/aws-sdk.yml
@@ -1,6 +1,7 @@
 groups:
   - id: aws
     prefix: aws
+    type: span
     brief: >
       The `aws` conventions apply to operations using the AWS SDK. They map request or response parameters
       in AWS SDK API calls to attributes on a Span. The conventions have been collected over time based
@@ -27,6 +28,7 @@ groups:
           - PutItem
 
   - id: dynamodb.all
+    type: span
     brief: "Attributes always filled for all DynamoDB request types."
     attributes:
       - ref: db.system
@@ -38,6 +40,7 @@ groups:
   - id: dynamodb.shared
     extends: aws
     prefix: aws.dynamodb
+    type: span
     brief: "Attributes that exist for multiple DynamoDB request types."
     attributes:
       - ref: db.operation
@@ -158,6 +161,7 @@ groups:
     brief: DynamoDB.BatchGetItem
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
       - ref: aws.dynamodb.consumed_capacity
@@ -166,6 +170,7 @@ groups:
     brief: DynamoDB.BatchWriteItem
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
       - ref: aws.dynamodb.consumed_capacity
@@ -175,6 +180,7 @@ groups:
     brief: DynamoDB.CreateTable
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - id: global_secondary_indexes
         type: string[]
@@ -230,6 +236,7 @@ groups:
     brief: DynamoDB.DeleteItem
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
         brief: "A single-element array with the value of the TableName request parameter."
@@ -242,6 +249,7 @@ groups:
     brief: DynamoDB.DeleteTable
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
         brief: "A single-element array with the value of the TableName request parameter."
@@ -252,6 +260,7 @@ groups:
     brief: DynamoDB.DescribeTable
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
         brief: "A single-element array with the value of the TableName request parameter."
@@ -262,6 +271,7 @@ groups:
     brief: DynamoDB.GetItem
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
         brief: "A single-element array with the value of the TableName request parameter."
@@ -275,6 +285,7 @@ groups:
     brief: DynamoDB.ListTables
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - id: exclusive_start_table
         type: string
@@ -293,6 +304,7 @@ groups:
     brief: DynamoDB.PutItem
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
       - ref: aws.dynamodb.consumed_capacity
@@ -302,6 +314,7 @@ groups:
     brief: DynamoDB.Query
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - id: scan_forward
         type: boolean
@@ -322,6 +335,7 @@ groups:
     brief: DynamoDB.Scan
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - id: segment
         type: int
@@ -359,6 +373,7 @@ groups:
     brief: DynamoDB.UpdateItem
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - ref: aws.dynamodb.table_names
         brief: "A single-element array with the value of the TableName request parameter."
@@ -371,6 +386,7 @@ groups:
     brief: DynamoDB.UpdateTable
     extends: aws
     prefix: aws.dynamodb
+    type: span
     attributes:
       - id: attribute_definitions
         type: string[]

--- a/semantic_conventions/trace/instrumentation/graphql.yml
+++ b/semantic_conventions/trace/instrumentation/graphql.yml
@@ -1,6 +1,7 @@
 groups:
   - id: graphql
     prefix: graphql
+    type: span
     brief: >
       This document defines semantic conventions to apply when instrumenting the GraphQL implementation. They map
       GraphQL operations to attributes on a Span.

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: messaging
     prefix: messaging
+    type: span
     brief: >
         This document defines the attributes used in
         messaging systems.
@@ -88,12 +89,14 @@ groups:
 
   - id: messaging.producer
     prefix: messaging
+    type: span
     extends: messaging
     span_kind: producer
     brief: 'Semantic convention for producers of messages sent to a messaging systems.'
 
   - id: messaging.producer.synchronous
     prefix: messaging
+    type: span
     extends: messaging
     span_kind: client
     brief: >
@@ -102,6 +105,7 @@ groups:
 
   - id: messaging.consumer
     prefix: messaging
+    type: span
     extends: messaging
     span_kind: consumer
     brief: 'Semantic convention for a consumer of messages received from a messaging system'
@@ -130,6 +134,7 @@ groups:
 
   - id: messaging.consumer.synchronous
     prefix: messaging
+    type: span
     extends: messaging.consumer
     span_kind: server
     brief: >
@@ -138,6 +143,7 @@ groups:
 
   - id: messaging.rabbitmq
     prefix: messaging.rabbitmq
+    type: span
     extends: messaging
     brief: >
       Attributes for RabbitMQ
@@ -152,6 +158,7 @@ groups:
 
   - id: messaging.kafka
     prefix: messaging.kafka
+    type: span
     extends: messaging
     brief: >
       Attributes for Apache Kafka
@@ -190,6 +197,7 @@ groups:
 
   - id: messaging.rocketmq
     prefix: messaging.rocketmq
+    type: span
     extends: messaging
     brief: >
       Attributes for Apache RocketMQ

--- a/semantic_conventions/trace/rpc.yaml
+++ b/semantic_conventions/trace/rpc.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: rpc
     prefix: rpc
+    type: span
     brief: 'This document defines semantic conventions for remote procedure calls.'
     events: [rpc.message]
     attributes:
@@ -77,6 +78,7 @@ groups:
 
   - id: rpc.server
     prefix: rpc
+    type: span
     extends: rpc
     span_kind: server
     brief: 'Semantic Convention for RPC server spans'
@@ -88,6 +90,7 @@ groups:
 
   - id: rpc.grpc
     prefix: rpc.grpc
+    type: span
     extends: rpc
     brief: 'Tech-specific attributes for gRPC.'
     attributes:
@@ -150,6 +153,7 @@ groups:
 
   - id: rpc.jsonrpc
     prefix: rpc.jsonrpc
+    type: span
     extends: rpc
     brief: 'Tech-specific attributes for [JSON RPC](https://www.jsonrpc.org/).'
     attributes:


### PR DESCRIPTION
Adds a `type` to every group to resolve the build tools' unsilenceable warning mentioned in https://github.com/open-telemetry/build-tools/pull/109

## Changes

I added a `type` field to every group that was missing one. Since I didn't know what value to put, I guessed `resource` for the ones in the `resource` subdirectory, and left all the rest to `span` since that's what they were defaulting to.

This silences the warnings and results in zero differences in generated code in my testing.


Before this change (without https://github.com/open-telemetry/build-tools/pull/109#issuecomment-1194682078)

```
Using default SPAN type for semantic convention 'browser' @ line 5
Using default SPAN type for semantic convention 'cloud' @ line 5
Using default SPAN type for semantic convention 'aws.ecs' @ line 5
Using default SPAN type for semantic convention 'aws.eks' @ line 5
Using default SPAN type for semantic convention 'aws.log' @ line 5
Using default SPAN type for semantic convention 'container' @ line 5
Using default SPAN type for semantic convention 'deployment' @ line 5
Using default SPAN type for semantic convention 'device' @ line 5
Using default SPAN type for semantic convention 'faas_resource' @ line 5
Using default SPAN type for semantic convention 'host' @ line 5
Using default SPAN type for semantic convention 'k8s.cluster' @ line 5
Using default SPAN type for semantic convention 'k8s.node' @ line 5
Using default SPAN type for semantic convention 'k8s.namespace' @ line 5
Using default SPAN type for semantic convention 'k8s.pod' @ line 5
Using default SPAN type for semantic convention 'k8s.container' @ line 5
Using default SPAN type for semantic convention 'k8s.replicaset' @ line 5
Using default SPAN type for semantic convention 'k8s.deployment' @ line 5
Using default SPAN type for semantic convention 'k8s.statefulset' @ line 5
Using default SPAN type for semantic convention 'k8s.daemonset' @ line 5
Using default SPAN type for semantic convention 'k8s.job' @ line 5
Using default SPAN type for semantic convention 'k8s.cronjob' @ line 5
Using default SPAN type for semantic convention 'os' @ line 5
Using default SPAN type for semantic convention 'process' @ line 5
Using default SPAN type for semantic convention 'process.runtime' @ line 5
Using default SPAN type for semantic convention 'service' @ line 5
Using default SPAN type for semantic convention 'telemetry' @ line 5
Using default SPAN type for semantic convention 'webengine_resource' @ line 5
```

Also **before** this change (with https://github.com/open-telemetry/build-tools/pull/109#issuecomment-1194682078)

```
Please set the type for group 'browser' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'cloud' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'aws.ecs' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'aws.eks' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'aws.log' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'container' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'deployment' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'device' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'faas_resource' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'host' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.cluster' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.node' on line 13 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.namespace' on line 29 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.pod' on line 40 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.container' on line 56 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.replicaset' on line 76 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.deployment' on line 92 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.statefulset' on line 108 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.daemonset' on line 124 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.job' on line 140 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'k8s.cronjob' on line 156 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'os' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'process' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'process.runtime' on line 73 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'service' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'telemetry' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
Please set the type for group 'webengine_resource' on line 2 - defaulting to type 'span'. See https://github.com/open-telemetry/build-tools/blob/main/semantic-conventions/syntax.md#groups
```

After this change:

- (There is no no warning output afterwards)