### PR TITLE
Correct the spec status for Exponential Bucket Histogram

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -441,6 +441,8 @@ or equal to the measurement.
 
 ##### Exponential Bucket Histogram Aggregation
 
+**Status**: [Experimental](../document-status.md)
+
 The Exponential Histogram Aggregation informs the SDK to collect data
 for the [Exponential Histogram Metric
 Point](./data-model.md#exponentialhistogram), which uses an exponential


### PR DESCRIPTION
Editorial change.

## Changes

During the [7/26/2022 Spec SIG](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit#heading=h.d02nbnjvch7y) we noticed that the Exponential Bucket Histogram Aggregation section in the metrics SDK spec is inheriting the Stable status from MeterProvider, which is wrong.

This PR corrected it to "Experimental".