### PR TITLE
Fix copy-paste error

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -709,7 +709,7 @@ API](../overview.md#api) authors might consider:
 # Python
 
 http_server_duration.Record(50, {"http.method": "POST", "http.scheme": "https"})
-http_server_duration.Record(100, http_method="GET", http_scheme="http"})
+http_server_duration.Record(100, http_method="GET", http_scheme="http")
 ```
 
 ```csharp


### PR DESCRIPTION
There is an extra `}` character in the python method call. Probably it is there from copy-paste of the other method.