### PR TITLE
Clarify "automatic instrumentation" term

### DIFF
--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -105,7 +105,8 @@ Coding against the OpenTelemetry API such as the [Tracing API](trace/api.md), [M
 
 ### Automatic Instrumentation
 
-Refers to telemetry collection methods that do not require the end-user to write or access application code to use the OpenTelemetry APIs. Methods vary by programming language, and examples include bytecode injection or monkey patching.
+Refers to telemetry collection methods that do not require the end-user to modify application's source code.
+Methods vary by programming language, and examples include bytecode injection or monkey patching.
 
 Synonym: *Auto-instrumentation*.
 


### PR DESCRIPTION
Fixes #2336

## Changes

Clarify "automatic instrumentation" term by removing some fragments that can bring confusion. 

1. Remove "to use the OpenTelemetry APIs" which some may think that library instrumentation is a type of automatic instrumentation
2. Remove "access application code". Personally, I think that e.g. "assembly weaving" (instrumentation done as part of "compilation") is also a kind of automatic instrumentation. For some languages, like .NET, source code is not required, but I imagine some interpreted languages require accessing the code anyway 🤷 I just think that we can remove this part.
3. Change "application code" to "application's source code". To make it more obvious that it is "source code" and e.g. not "bytecode".
