### PR TITLE
Add the short_name scope attribute

### DIFF
--- a/semantic_conventions/scope/scope.yaml
+++ b/semantic_conventions/scope/scope.yaml
@@ -8,5 +8,9 @@ groups:
         type: string
         requirement_level: recommended
         brief: >
-         The single-word name for the instrumentation scope.
-        examples: ['mylibrary']
+         The short name for the instrumentation scope, which should generally be less than 15
+         characters, and generally consist of a single word. It is not required to be globally
+         unique, but should be unique enough to make it very unlikely to collide with other short
+         names.  An example use is as the [namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces)
+         (prefix) for OpenMetrics metric names.
+        examples: ['mylibrary', 'otelhttp']

--- a/semantic_conventions/scope/scope.yaml
+++ b/semantic_conventions/scope/scope.yaml
@@ -1,6 +1,6 @@
 groups:
   - id: scope
-    prefix:
+    prefix: ""
     type: scope
     brief: >
        Scope attributes

--- a/semantic_conventions/scope/scope.yaml
+++ b/semantic_conventions/scope/scope.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: scope
-    prefix: scope
+    prefix:
+    type: scope
     brief: >
        Scope attributes
     attributes:
@@ -12,5 +13,6 @@ groups:
          characters, and generally consist of a single word. It is not required to be globally
          unique, but should be unique enough to make it very unlikely to collide with other short
          names.  An example use is as the [namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces)
-         (prefix) for OpenMetrics metric names.
-        examples: ['mylibrary', 'otelhttp']
+         (prefix) for OpenMetrics metric names. It is recommended for the short_name to be
+         related to the name of the scope.
+        examples: ['mylibrary', 'otelmacaron']

--- a/semantic_conventions/scope/scope.yaml
+++ b/semantic_conventions/scope/scope.yaml
@@ -1,0 +1,12 @@
+groups:
+  - id: scope
+    prefix: scope
+    brief: >
+       Scope attributes
+    attributes:
+      - id: short_name
+        type: string
+        requirement_level: recommended
+        brief: >
+         The single-word name for the instrumentation scope.
+        examples: ['mylibrary']

--- a/specification/scope/README.md
+++ b/specification/scope/README.md
@@ -7,5 +7,5 @@ This document defines standard attributes for the [instrumentation scope](../glo
 <!-- semconv scope -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `scope.short_name` | string | The single-word name for the instrumentation scope. | `mylibrary` | Recommended |
+| `scope.short_name` | string | The short name for the instrumentation scope, which should generally be less than 15 characters, and generally consist of a single word. It is not required to be globally unique, but should be unique enough to make it very unlikely to collide with other short names.  An example use is as the [namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces) (prefix) for OpenMetrics metric names. | `mylibrary`; `otelhttp` | Recommended |
 <!-- endsemconv -->

--- a/specification/scope/README.md
+++ b/specification/scope/README.md
@@ -7,5 +7,5 @@ This document defines standard attributes for the [instrumentation scope](../glo
 <!-- semconv scope -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `scope.short_name` | string | The short name for the instrumentation scope, which should generally be less than 15 characters, and generally consist of a single word. It is not required to be globally unique, but should be unique enough to make it very unlikely to collide with other short names.  An example use is as the [namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces) (prefix) for OpenMetrics metric names. | `mylibrary`; `otelhttp` | Recommended |
+| `short_name` | string | The short name for the instrumentation scope, which should generally be less than 15 characters, and generally consist of a single word. It is not required to be globally unique, but should be unique enough to make it very unlikely to collide with other short names.  An example use is as the [namespace](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metric-naming-and-namespaces) (prefix) for OpenMetrics metric names. It is recommended for the short_name to be related to the name of the scope. | `mylibrary`; `otelmacaron` | Recommended |
 <!-- endsemconv -->

--- a/specification/scope/README.md
+++ b/specification/scope/README.md
@@ -1,0 +1,11 @@
+# Scope Semantic Conventions
+
+**Status**: [Experimental](../document-status.md)
+
+This document defines standard attributes for the instrumentation scope.
+
+<!-- semconv scope -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `scope.short_name` | string | The single-word name for the instrumentation scope. | `mylibrary` | Recommended |
+<!-- endsemconv -->

--- a/specification/scope/README.md
+++ b/specification/scope/README.md
@@ -2,7 +2,7 @@
 
 **Status**: [Experimental](../document-status.md)
 
-This document defines standard attributes for the instrumentation scope.
+This document defines standard attributes for the [instrumentation scope](../glossary.md#instrumentation-scope).
 
 <!-- semconv scope -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/2682

## Changes

Add the `short_name` scope attribute.  Alternatively, it could have been added as `otel.short_name` to distinguish it from non-otel attributes, or `prometheus.namespace` to make it explicitly associated with prefixing prometheus metrics.

@jmacd @tigrannajaryan @jsuereth 