### PR TITLE
Add OpenSearch in the database group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ release.
   ([#2691](https://github.com/open-telemetry/opentelemetry-specification/pull/2691)).
 - Separate tcp/udp protocols for metric `system.network.connections`.
   ([#2675](https://github.com/open-telemetry/opentelemetry-specification/pull/2675))
+- Add OpenSearch in the database group.
+  ([#2718](https://github.com/open-telemetry/opentelemetry-specification/pull/2718))
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,8 @@ release.
   ([#2691](https://github.com/open-telemetry/opentelemetry-specification/pull/2691)).
 - Separate tcp/udp protocols for metric `system.network.connections`.
   ([#2675](https://github.com/open-telemetry/opentelemetry-specification/pull/2675))
-- Add OpenSearch in the database group.
-  ([#2718](https://github.com/open-telemetry/opentelemetry-specification/pull/2718))
+- Add OpenSearch to db.system semantic conventions
+  ([#2718](https://github.com/open-telemetry/opentelemetry-specification/pull/2718)).
 
 ### Compatibility
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -148,6 +148,9 @@ groups:
             - id: elasticsearch
               value: 'elasticsearch'
               brief: 'Elasticsearch'
+            - id: opensearch
+              value: 'opensearch'
+              brief: 'OpenSearch'
             - id: memcached
               value: 'memcached'
               brief: 'Memcached'

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -148,15 +148,15 @@ groups:
             - id: elasticsearch
               value: 'elasticsearch'
               brief: 'Elasticsearch'
-            - id: opensearch
-              value: 'opensearch'
-              brief: 'OpenSearch'
             - id: memcached
               value: 'memcached'
               brief: 'Memcached'
             - id: cockroachdb
               value: 'cockroachdb'
               brief: 'CockroachDB'
+            - id: opensearch
+              value: 'opensearch'
+              brief: 'OpenSearch'
       - id: connection_string
         tag: connection-level
         type: string

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -113,6 +113,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `neo4j` | Neo4j |
 | `geode` | Apache Geode |
 | `elasticsearch` | Elasticsearch |
+| `opensearch` | OpenSearch |
 | `memcached` | Memcached |
 | `cockroachdb` | CockroachDB |
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -113,9 +113,9 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `neo4j` | Neo4j |
 | `geode` | Apache Geode |
 | `elasticsearch` | Elasticsearch |
-| `opensearch` | OpenSearch |
 | `memcached` | Memcached |
 | `cockroachdb` | CockroachDB |
+| `opensearch` | OpenSearch |
 <!-- endsemconv -->
 
 ### Notes and well-known identifiers for `db.system`


### PR DESCRIPTION
This PR adds OpenSearch in the database section of semantic conventions.
This is necessary for example to provide support for java instrumentation of OpenSearch clients.

Signed-off-by: Cédric Pelvet <cedric.pelvet@gmail.com>

