### PR TITLE
Fix 1.12.0 and 1.13.0 schema file

### DIFF
--- a/schemas/1.12.0
+++ b/schemas/1.12.0
@@ -2,12 +2,6 @@ file_format: 1.0.0
 schema_url: https://opentelemetry.io/schemas/1.12.0
 versions:
   1.12.0:
-    spans:
-      changes:
-        - rename_attributes:
-            attribute_map:
-              net.peer.ip: net.sock.peer.addr
-              net.host.ip: net.sock.host.addr
   1.11.0:
   1.10.0:
   1.9.0:

--- a/schemas/1.13.0
+++ b/schemas/1.13.0
@@ -88,14 +88,14 @@ versions:
             metrics_from_attributes:
                 system.network.tcp.connections: tcp
                 system.network.udp.connections: udp
-
-  1.12.0:
     spans:
       changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2614
         - rename_attributes:
             attribute_map:
               net.peer.ip: net.sock.peer.addr
               net.host.ip: net.sock.host.addr
+  1.12.0:
   1.11.0:
   1.10.0:
   1.9.0:


### PR DESCRIPTION
Fixes #2717.

## Changes

The changes specified for v1.12.0 in both files here were actually only applied on main so far and will be released in v1.13.0 within the upcoming days. They were introduced in https://github.com/open-telemetry/opentelemetry-specification/pull/2614.