### PR TITLE
Add MetricProducer to allow sdk.MeterProviders to incorporate metric data from third-party sources

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -797,7 +797,7 @@ to (T<sub>n+1</sub>, T<sub>n+2</sub>] - **ONLY** for this particular
 
 The SDK MUST NOT allow a `MetricReader` instance to be registered on more than
 one `MeterProvider` instance. The SDK MUST NOT allow a `MetricReader`
-configured with a `MetricProducer` to be registered with a `MeterProvider`.
+configured with a non-SDK `MetricProducer` to be registered with `MeterProvider`.
 
 ```text
 +-----------------+            +--------------+

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1100,7 +1100,7 @@ modeled to interact with other components in the SDK:
 
 `MetricProducer` defines the interface which bridges to third-party metric
 sources MUST implement so they can be plugged into an OpenTelemetry
-[MetricReader](#metricreader) as a source of aggregated metric data.
+[MeterProvider](#meterprovider) as a source of aggregated metric data.
 
 ```text
 +-----------------+            +--------------+

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -776,10 +776,11 @@ used with pull-based metrics collection.  A common sub-class of
 `MetricReader`, the periodic exporting `MetricReader` SHOULD be provided
 to be used typically with push-based metrics collection.
 
-The `MetricReader` MUST ensure that data points from OTel instruments are
-output in the configured aggregation temporality for each instrument kind. For
-synchronous instruments being output with Cumulative temporality, this
-means converting [Delta to Cumulative](supplementary-guidelines.md#synchronous-example-cumulative-aggregation-temporality)
+The `MetricReader` MUST ensure that data points from OTel
+[instruments](./api.md#instrument) are output in the configured aggregation
+temporality for each instrument kind. For synchronous instruments being output
+with Cumulative temporality, this means converting
+[Delta to Cumulative](supplementary-guidelines.md#synchronous-example-cumulative-aggregation-temporality)
 aggregation temporality.  For asynchronous instruments being output
 with Delta temporality, this means converting [Cumulative to
 Delta](supplementary-guidelines.md#asynchronous-example-delta-temporality) aggregation

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -86,6 +86,12 @@ Configuration (i.e., [MetricExporters](#metricexporter),
 provide a way to configure all options that are implemented by the SDK. This
 MAY be done at the time of MeterProvider creation if appropriate.
 
+If a meter is created which produces an
+[`InstrumentationScope`](../glossary.md#instrumentation-scope), which matches
+the InstrumentationScope of a [MetricProducer](#metricproducer), or if multiple
+[MetricProducers](#metricproducer) have the same InstrumenatationScope the SDK
+SHOULD emit a warning.
+
 The `MeterProvider` MAY provide methods to update the configuration. If
 configuration is updated (e.g., adding a `MetricReader`), the updated
 configuration MUST also apply to all already returned `Meters` (i.e. it MUST NOT

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -37,6 +37,7 @@ linkTitle: SDK
   * [Exemplar defaults](#exemplar-defaults)
 - [MetricReader](#metricreader)
   * [MetricReader operations](#metricreader-operations)
+    + [Register(MetricProducer)](#registermetricproducer)
     + [Collect](#collect)
     + [Shutdown](#shutdown-1)
   * [Periodic exporting MetricReader](#periodic-exporting-metricreader)
@@ -755,7 +756,9 @@ measurements using the equivalent of the following naive algorithm:
 common configurable aspects of the OpenTelemetry Metrics SDK and
 determines the following capabilities:
 
-* Collecting metrics from the SDK or a [MetricProducer](#metricproducer) on demand.
+* Registering a [MetricProducer](#metricproducer)
+* Collecting metrics from the registered [MetricProducer](#metricproducer) on
+  demand.
 * Handling the [ForceFlush](#forceflush) and [Shutdown](#shutdown) signals from
   the SDK.
 
@@ -763,7 +766,6 @@ To construct a `MetricReader` when setting up an SDK, the caller
 SHOULD provide at least the following:
 
 * The `exporter` to use, which is a `MetricExporter` instance.
-* A [MetricProducer](#metricproducer) (optional) to collect metrics from instead of collecting from the SDK.
 * The default output `aggregation` (optional), a function of instrument kind.  If not configured, the [default aggregation](#default-aggregation) SHOULD be used.
 * The default output `temporality` (optional), a function of instrument kind.  If not configured, the Cumulative temporality SHOULD be used.
 
@@ -797,7 +799,7 @@ to (T<sub>n+1</sub>, T<sub>n+2</sub>] - **ONLY** for this particular
 
 The SDK MUST NOT allow a `MetricReader` instance to be registered on more than
 one `MeterProvider` instance. The SDK MUST NOT allow a `MetricReader`
-configured with a non-SDK `MetricProducer` to be registered with `MeterProvider`.
+registered with a non-SDK `MetricProducer` to be registered with `MeterProvider`.
 
 ```text
 +-----------------+            +--------------+
@@ -820,6 +822,18 @@ idiomatic approach, for example, as `OnForceFlush` and `OnShutdown` callback
 functions.
 
 ### MetricReader operations
+
+#### Register(MetricProducer)
+
+Register causes the MetricReader to use the provided
+[MetricProducer](#metricproducer) for as a source of aggregated metric data in
+subsequent invokations of Collect. It MUST NOT allow more than one
+[MetricProducer](#metricproducer) or [MeterProvider](#meterprovider) instance
+to be registered with the [MetricReader](#metricreader).
+
+If the [MeterProvider](#meterprovider) is an instance of of
+[MetricProducer](#metricproducer), this MAY be used to register the
+MeterProvider.
 
 #### Collect
 
@@ -1060,10 +1074,11 @@ scraper, and `ForceFlush` would not make sense.
 Implementors MAY choose the best idiomatic design for their language. For
 example, they could generalize the [Push Metric Exporter
 interface](#push-metric-exporter) design and use that for consistency, they
-could model the pull exporter as [MetricReader](#metricreader), or they could
-design a completely different pull exporter interface. If the pull exporter is
-modeled as MetricReader, implementors MAY name the MetricExporter interface as
-PushMetricExporter to prevent naming confusion.
+could model the pull exporter as [MetricReader](#metricreader) or
+[MetricProducer](#metricproducer), or they could design a completely different
+pull exporter interface. If the pull exporter is modeled as MetricReader,
+implementors MAY name the MetricExporter interface as PushMetricExporter to
+prevent naming confusion.
 
 The following diagram gives some examples on how `Pull Metric Exporter` can be
 modeled to interact with other components in the SDK:

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1124,14 +1124,15 @@ A `MetricProducer` MUST support the following functions:
 
 #### Produce() batch
 
+`Produce` provides metrics from the MetricProducer to the caller. `Produce`
+MUST return a batch of [Metric points](./data-model.md#metric-points).
+`Produce` does not have any required parameters, however, [OpenTelemetry
+SDK](../overview.md#sdk) authors MAY choose to add parameters (e.g. timeout).
+
 `Produce` SHOULD provide a way to let the caller know whether it succeeded,
 failed or timed out. When the `Produce` operation fails, the `MetricProducer`
 MAY return successfully collected results and a failed reasons list to the
 caller.
-
-`Produce` does not have any required parameters, however, [OpenTelemetry
-SDK](../overview.md#sdk) authors MAY choose to add parameters (e.g. timeout).
-`Produce` MUST return a batch of [Metric points](./data-model.md#metric-points).
 
 ## Defaults and configuration
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -89,7 +89,7 @@ MAY be done at the time of MeterProvider creation if appropriate.
 If a meter is created which produces an
 [`InstrumentationScope`](../glossary.md#instrumentation-scope), which matches
 the InstrumentationScope of a [MetricProducer](#metricproducer), or if multiple
-[MetricProducers](#metricproducer) have the same InstrumenatationScope the SDK
+[MetricProducers](#metricproducer) have the same InstrumentationScope the SDK
 SHOULD emit a warning.
 
 The `MeterProvider` MAY provide methods to update the configuration. If

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -776,7 +776,7 @@ used with pull-based metrics collection.  A common sub-class of
 `MetricReader`, the periodic exporting `MetricReader` SHOULD be provided
 to be used typically with push-based metrics collection.
 
-The `MetricReader` MUST ensure that data points from OTel
+The `MetricReader` MUST ensure that data points from OpenTelemetry
 [instruments](./api.md#instrument) are output in the configured aggregation
 temporality for each instrument kind. For synchronous instruments being output
 with Cumulative temporality, this means converting

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -827,11 +827,11 @@ functions.
 
 Register causes the MetricReader to use the provided
 [MetricProducer](#metricproducer) for as a source of aggregated metric data in
-subsequent invokations of Collect. It MUST NOT allow more than one
+subsequent invocations of Collect. It MUST NOT allow more than one
 [MetricProducer](#metricproducer) or [MeterProvider](#meterprovider) instance
 to be registered with the [MetricReader](#metricreader).
 
-If the [MeterProvider](#meterprovider) is an instance of of
+If the [MeterProvider](#meterprovider) is an instance of a
 [MetricProducer](#metricproducer), this MAY be used to register the
 MeterProvider.
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/1175

Related to https://github.com/open-telemetry/opentelemetry-specification/pull/2730

Required for https://github.com/open-telemetry/opentelemetry-specification/pull/2732

## Changes

Add a MetricProducer interface to the metrics SDK. It is an optional argument when creating a MetricReader meant to support non-SDK sources of metric data.

Metric data from a MetricProducer is not subject to the MeterProviders or MetricReaders configuration for instruments.  This means Views on MeterProviders, and default Aggregations and Aggregation Temporalities configured on MetricReaders are not applied to data from MetricProducers.

This is needed to support an OpenCensus metric bridge, which is [proposed separately](https://github.com/open-telemetry/opentelemetry-specification/pull/2732).  It could also be used to support other bridges as well, such as a Prometheus bridge.

### Discussion from the spec sig on 8/30:

@dashpole presented high level design options:

1. Bridge incorporated into MeterProvider
1. Bridge separate from MeterProvider, and works with a MetricReader
1. Bridge separate from MeterProvider and MetricReader, works with MetricExporter

3 was eliminated because it won't work easily with pull-based exporters.  The overall sentiment was to stick with option 1, because then resource and exporter configuration for the MeterProvider would be shared.  See https://github.com/open-telemetry/opentelemetry-specification/pull/2722#issuecomment-1231888284 for more details.
