### PR TITLE
Inserts links to each Protocol Buffer definition by Telemetry signal

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -86,11 +86,12 @@ All server components MUST support the following transport compression options:
 
 After establishing the underlying gRPC transport the client starts sending
 telemetry data using unary requests using
-[Export*ServiceRequest](https://github.com/open-telemetry/opentelemetry-proto)
-messages (`ExportTraceServiceRequest` for traces, `ExportMetricsServiceRequest`
-for metrics, `ExportLogsServiceRequest` for logs). The client continuously sends
-a sequence of requests to the server and expects to receive a response to each
-request:
+[ExportServiceRequest](https://github.com/open-telemetry/opentelemetry-proto)
+messages ([ExportLogsServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto) for logs,
+[ExportMetricsServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/metrics/v1/metrics_service.proto) for metrics,
+[ExportTraceServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto) for traces).
+The client continuously sends a sequence of requests to the server and expects 
+to receive a response to each request:
 
 ![Request-Response](img/otlp-request-response.png)
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -86,7 +86,7 @@ All server components MUST support the following transport compression options:
 
 After establishing the underlying gRPC transport the client starts sending
 telemetry data using unary requests using
-[ExportServiceRequest](https://github.com/open-telemetry/opentelemetry-proto)
+[Export*ServiceRequest](https://github.com/open-telemetry/opentelemetry-proto)
 messages ([ExportLogsServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto) for logs,
 [ExportMetricsServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/metrics/v1/metrics_service.proto) for metrics,
 [ExportTraceServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto) for traces).

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -90,7 +90,7 @@ telemetry data using unary requests using
 messages ([ExportLogsServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/logs/v1/logs_service.proto) for logs,
 [ExportMetricsServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/metrics/v1/metrics_service.proto) for metrics,
 [ExportTraceServiceRequest](https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/collector/trace/v1/trace_service.proto) for traces).
-The client continuously sends a sequence of requests to the server and expects 
+The client continuously sends a sequence of requests to the server and expects
 to receive a response to each request:
 
 ![Request-Response](img/otlp-request-response.png)


### PR DESCRIPTION
## Changes

This pull request simply contributes with this documentation file by adding links to
protocol buffers definitions for each telemetry signal type.

While reading Open Telemetry protocol documentation I found it interesting to be able to read
how the protocol is defined using Protocol Buffers. In my humble opinion, it simplifies
the understanding and enriches the document by adding external code references. 