### PR TITLE
Add OpenCensus migration plan

### DIFF
--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -137,18 +137,14 @@ Finally, the Application would update all usages of OpenCensus to OpenTelemetry.
 
 ### Requirements
 
-OpenTelemetry<->OpenCensus compatibility has the following requirements:
+The OpenTelemetry<->OpenCensus trace bridge has the following requirements:
 
-1. OpenCensus has no hard dependency on OpenTelemetry
-2. Minimal changes to OpenCensus for implementation
-3. Easy for users to use, ideally no change to their code
-
-Additionally, for tracing there are the following requirements:
-
-1. Maintain parent-child span relationship between applications and libraries
-2. Maintain span link relationships between applications and libraries
-
-This component MUST be an optional dependency.
+* OpenCensus has no hard dependency on OpenTelemetry
+* Minimal changes to OpenCensus for implementation
+* Easy for users to use, ideally no change to their code
+* Maintain parent-child span relationship between applications and libraries
+* Maintain span link relationships between applications and libraries
+* This component MUST be an optional dependency.
 
 ### Creating Spans in OpenCensus
 

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -39,6 +39,7 @@ Starting with an application using entirely OpenCensus instrumention for traces 
 
 1. Migrate the exporters (SDK)
     1. Install the OpenTelemetry SDK, with an equivalent exporter
+        1. If using an OpenCensus exporter, switch to using an OTLP exporter
     2. Install equivalent OpenTelemetry resource detectors
     3. Install OpenTelemetry propagators for OpenCensus' `TextFormat` and `BinaryPropagator` formats.
     4. **breaking**: Install the metrics and trace bridges


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/1175

Supersedes https://github.com/open-telemetry/oteps/pull/210.

## Changes

While OpenTelemetry has a specification for an
[OpenCensus trace bridge](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.12.0/specification/compatibility/opencensus.md),
it lacks a broader context on how such bridges should be used to perform a migration from
OpenCensus to OpenTelemetry. Additionally, OpenTelemetry should provide guidance to libraries
currently using OpenCensus on how to migrate instrumentation to OpenTelemetry.

## Open questions

* Should we recommend one of the library migration strategies (in-place or config-based)?
* Should we require bridges to implement semantic convention mapping (MUST instead of SHOULD)?
* Is it reasonable to expect users to migrate (by installing a bridge) before libraries migrate?