### PR TITLE
Add OpenCensus metric bridge specification

### DIFF
--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -235,3 +235,6 @@ metric exporters.
 * OpenTelemetry does not support OpenCensus' GaugeHistogram type; these metrics
   MUST be dropped when using the bridge.
 * OpenTelemetry does not currently support context-based attributes (tags).
+* The OpenCensus bridge produces counters and distributions with a cumulative
+  AggregationTemporality. Many OpenTelemetry exporters do not support cumulative
+  AggregationTemporality, and will return errors if used with this bridge.

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -233,3 +233,5 @@ metric exporters.
 * The OpenCensus bridge produces counters and distributions with a cumulative
   AggregationTemporality. Many OpenTelemetry exporters do not support cumulative
   AggregationTemporality, and will return errors if used with this bridge.
+* OpenTelemetry does not support OpenCensus' SumOfSquaredDeviation field; this
+  is dropped when using the bridge.

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -192,11 +192,6 @@ implements the OpenTelemetry MetricProducer interface. When Produce() is
 invoked, the shim collects metrics from the OpenCensus global state, converts
 the metrics to an OpenTelemetry metrics batch, and returns.
 
-To construct a shim, the caller MUST be able to provide the following:
-
-* A resource (optional) to attach to metrics batches. If not provided, the
-default resource is used.
-
 ### Requirements
 
 * This component MUST be an optional dependency.
@@ -226,7 +221,7 @@ the shim.
 ### Usage
 
 The shim can be passed as an option to an OpenTelemetry
-[MetricReader](../metrics/sdk.md#metricreader) when configuring the
+[MeterProvider](../metrics/sdk.md#meterprovider) when configuring the
 OpenTelemetry SDK. This enables the bridge to work with both push and pull
 metric exporters.
 

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -187,11 +187,51 @@ OpenCensus specifies the following [HTTP Attributes](https://github.com/census-i
 
 ## Metrics / Stats
 
-Metric compatibility with OpenCensus remains unspecified as the OpenTelemetry
-metrics specification solidifies for GA.   Once GA on metrics is declared,
-this section will be filled out.
+OpenTelemetry will provide an OpenCensus-Metrics-Shim component which
+implements the OpenTelemetry MetricProducer interface. When Produce() is
+invoked, the shim collects metrics from the OpenCensus global state, converts
+the metrics to an OpenTelemetry metrics batch, and returns.
 
-> Philosophically, this should follow the same principles as Trace.
-> Specifically: Metric names/attributes should be converted to OTel semantic
-> conventions, All API surface area should map to the closest relevant OTel
-> API and no SDK usage of OpenCensus will be compatible.
+To construct a shim, the caller MUST be able to provide the following:
+
+* A resource (optional) to attach to metrics batches. If not provided, the
+default resource is used.
+
+### Requirements
+
+* This component MUST be an optional dependency.
+* MUST NOT require OpenCensus to depend on OpenTelemetry
+* MUST require few or no changes to OpenCensus
+* MUST be compatible with push and pull exporters
+* MUST support Gauges, Counters, Cumulative Histograms, and Summaries
+* are NOT REQUIRED to support Gauge Histograms
+* MUST support exemplars
+
+### Resource
+
+The shim MUST discard the resource attached to OpenCensus metrics, and insert
+the resource provided during initialization, or fall back to the the default
+OpenTelemetry resource.
+
+### Metric Attributes
+
+Metric attributes SHOULD be mapped following
+[semantic convention mappings](#semantic-convention-mappings).
+
+### Instrumentation Scope
+
+The shim MUST add an instrumentation scope name and version which identifies
+the shim.
+
+### Usage
+
+The shim can be passed as an option to an OpenTelemetry
+[MetricReader](../metrics/sdk.md#metricreader) when configuring the
+OpenTelemetry SDK. This enables the bridge to work with both push and pull
+metric exporters.
+
+#### Known Incompatibilities
+
+* OpenTelemetry does not support OpenCensus' GaugeHistogram type; these metrics
+  MUST be dropped when using the bridge.
+* OpenTelemetry does not currently support context-based attributes (tags).


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/1175

Related to https://github.com/open-telemetry/opentelemetry-specification/pull/2730

Depends on https://github.com/open-telemetry/opentelemetry-specification/pull/2722.  Do not merge until after that PR.

## Changes

Specify that OpenCensus metric bridges implement the MetricProducer interface, and describe non-trivial transformations involved.

This follows the path taken by the [java opencensus-shim](https://github.com/open-telemetry/opentelemetry-java/blob/main/opencensus-shim/src/main/java/io/opentelemetry/opencensusshim/metrics/OpenCensusMetricProducer.java#L27).
