### PR TITLE
Clarify that changing the Span async from OnStart is undefined behavior

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -492,7 +492,7 @@ exceptions.
   For example, this is useful for creating a SpanProcessor that periodically
   evaluates/prints information about all active span from a background thread.
   When a reference is kept, the span MUST be treated as a readonly object,
-  trying to modify the Span is undefined behavior.
+  trying to modify the Span after `OnStart` method returns is undefined behavior.
 * `parentContext` - the parent `Context` of the span that the SDK determined
   (the explicitly passed `Context`, the current `Context` or an empty `Context`
   if that was explicitly requested).

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -491,6 +491,8 @@ exceptions.
   SHOULD be reflected in it.
   For example, this is useful for creating a SpanProcessor that periodically
   evaluates/prints information about all active span from a background thread.
+  When a reference is kept, the span MUST be treated as a readonly object,
+  trying to modify the Span is undefined behavior.
 * `parentContext` - the parent `Context` of the span that the SDK determined
   (the explicitly passed `Context`, the current `Context` or an empty `Context`
   if that was explicitly requested).


### PR DESCRIPTION
The reason to make this undefined behavior is because it is not guarantee that the span is still active after the call to OnStart finishes,
so instead of doing a very complicated synchronization logic which none of the SDK does, mark this as undefined behavior.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
