### PR TITLE
Clarify that recording status refers to IsRecording and not Set Status

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -436,7 +436,7 @@ Links SHOULD preserve the order in which they're set.
 ### Span operations
 
 With the exception of the function to retrieve the `Span`'s `SpanContext` and
-the `IsRecording` status, none of the below may be called after the `Span` is
+`IsRecording`, none of the below may be called after the `Span` is
 finished.
 
 #### Get Context

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -436,7 +436,8 @@ Links SHOULD preserve the order in which they're set.
 ### Span operations
 
 With the exception of the function to retrieve the `Span`'s `SpanContext` and
-recording status, none of the below may be called after the `Span` is finished.
+the `IsRecording` status, none of the below may be called after the `Span` is
+finished.
 
 #### Get Context
 


### PR DESCRIPTION
Small clarification for the specs about what operations can be called after span finishes. There are other improvements that can be made here such as using right capitalized word for may, but that is a different concern/PR.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>
