### PR TITLE
Add scope attributes to tracer and meter creation

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -68,11 +68,12 @@ suggestions regarding how to implement this efficiently.
 
 ### Meter Creation
 
-New `Meter` instances are always created through a `MeterProvider` (see
-[API](./api.md#meterprovider)). The `name`, `version` (optional), and
-`schema_url` (optional) arguments supplied to the `MeterProvider` MUST be used
-to create an [`InstrumentationScope`](../glossary.md#instrumentation-scope)
-instance which is stored on the created `Meter`.
+New `Meter` instances are always created through a `MeterProvider`
+(see [API](./api.md#meterprovider)). The `name`, `version` (optional),
+`schema_url` (optional), and `attributes` (optional) arguments supplied to
+the `MeterProvider` MUST be used to create
+an [`InstrumentationScope`](../glossary.md#instrumentation-scope)instance which
+is stored on the created `Meter`.
 
 Configuration (i.e., [MetricExporters](#metricexporter),
 [MetricReaders](#metricreader) and [Views](#view)) MUST be managed solely by the

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -72,7 +72,7 @@ New `Meter` instances are always created through a `MeterProvider`
 (see [API](./api.md#meterprovider)). The `name`, `version` (optional),
 `schema_url` (optional), and `attributes` (optional) arguments supplied to
 the `MeterProvider` MUST be used to create
-an [`InstrumentationScope`](../glossary.md#instrumentation-scope)instance which
+an [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which
 is stored on the created `Meter`.
 
 Configuration (i.e., [MetricExporters](#metricexporter),

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -55,11 +55,12 @@
 
 ### Tracer Creation
 
-New `Tracer` instances are always created through a `TracerProvider` (see
-[API](api.md#tracerprovider)). The `name` and `version` arguments supplied to
-the `TracerProvider` must be used to create an
-[`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which is
-stored on the created `Tracer`.
+New `Tracer` instances are always created through a `TracerProvider`
+(see[API](api.md#tracerprovider)). The `name`, `version` (optional),
+`schema_url` (optional), and `attributes` (optional) arguments supplied to
+the `TracerProvider` must be used to create
+an [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which
+is stored on the created `Tracer`.
 
 Configuration (i.e., [SpanProcessors](#span-processor), [IdGenerator](#id-generators),
 [SpanLimits](#span-limits) and [`Sampler`](#sampling)) MUST be managed solely by


### PR DESCRIPTION
Looks like the SDKs were overlooked when adding scope attributes to the [trace](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#get-a-tracer) and [metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#get-a-meter) API specifications.

This syncs up the trace and metrics SDK with their respective APIs.