### PR TITLE
Refactor messaging attributes and per-message attributes in batching scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,9 @@ release.
   `messaging.kafka.message_key` to `messaging.kafka.message.key`,
   `messaging.rocketmq.message_type` to `messaging.rocketmq.message.type`,
   `messaging.rocketmq.message_tag` to `messaging.rocketmq.message.tag`,
-  `messaging.rocketmq.message_keys` to `messaging.rocketmq.message.keys`,
+  `messaging.rocketmq.message_keys` to `messaging.rocketmq.message.keys`;
+  Removed `messaging.url`;
+  Renamed `send` operation to `publish`;
   Split `destination` and `source` namespaces and clarify per-message attributes in batching scenarios.
   ([#2763](https://github.com/open-telemetry/opentelemetry-specification/pull/2763)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,15 +46,19 @@ release.
 - Rename `http.retry_count` to `http.resend_count` and clarify its meaning.
   ([#2743](https://github.com/open-telemetry/opentelemetry-specification/pull/2743))
 - BREAKING: rename `messaging.destination` to `messaging.destination.name`,
+  `messaging.temp_destination` to `messaging.destination.temporary`,
+  `messaging.destination_kind` to `messaging.destination.kind`,
   `messaging.message_id` to `messaging.message.id`,
+  `messaging.protocol` to `net.app.protocol.name`,
+  `messaging.protocol_version`, `net.app.protocol.version`,
   `messaging.conversation_id` to `messaging.message.conversation_id`,
   `messaging.message_payload_size_bytes` to `messaging.message.payload_size_bytes`,
   `messaging.message_payload_compressed_size_bytes` to `messaging.message.payload_compressed_size_bytes`,
   `messaging.kafka.message_key` to `messaging.kafka.message.key`,
   `messaging.rocketmq.message_type` to `messaging.rocketmq.message.type`,
   `messaging.rocketmq.message_tag` to `messaging.rocketmq.message.tag`,
-  `messaging.rocketmq.message_keys` to `messaging.rocketmq.message.keys`.
-  Clarify that per-message attributes should be populated on links for batching scenarios.
+  `messaging.rocketmq.message_keys` to `messaging.rocketmq.message.keys`,
+  Split `destination` and `source` namespaces and clarify per-message attributes in batching scenarios.
   ([#2763](https://github.com/open-telemetry/opentelemetry-specification/pull/2763)).
 
 ### Metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ release.
 
 - Rename `http.retry_count` to `http.resend_count` and clarify its meaning.
   ([#2743](https://github.com/open-telemetry/opentelemetry-specification/pull/2743))
+- BREAKING: rename `messaging.destination` to `messaging.destination.name`,
+  `messaging.message_id` to `messaging.message.id`,
+  `messaging.conversation_id` to `messaging.message.conversation_id`,
+  `messaging.message_payload_size_bytes` to `messaging.message.payload_size_bytes`,
+  `messaging.message_payload_compressed_size_bytes` to `messaging.message.payload_compressed_size_bytes`,
+  `messaging.kafka.message_key` to `messaging.kafka.message.key`,
+  `messaging.rocketmq.message_type` to `messaging.rocketmq.message.type`,
+  `messaging.rocketmq.message_tag` to `messaging.rocketmq.message.tag`,
+  `messaging.rocketmq.message_keys` to `messaging.rocketmq.message.keys`.
+  Clarify that per-message attributes should be populated on links for batching scenarios.
+  ([#2763](https://github.com/open-telemetry/opentelemetry-specification/pull/2763)).
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,10 @@ release.
   `messaging.conversation_id` to `messaging.message.conversation_id`,
   `messaging.message_payload_size_bytes` to `messaging.message.payload_size_bytes`,
   `messaging.message_payload_compressed_size_bytes` to `messaging.message.payload_compressed_size_bytes`,
+  `messaging.rabbitmq.routing_key`: `messaging.rabbitmq.message.routing_key`,
   `messaging.kafka.message_key` to `messaging.kafka.message.key`,
+  `messaging.kafka.partition` to `messaging.kafka.message.partition`,
+  `messaging.kafka.tombstone` to `messaging.kafka.message.tombstone`,
   `messaging.rocketmq.message_type` to `messaging.rocketmq.message.type`,
   `messaging.rocketmq.message_tag` to `messaging.rocketmq.message.tag`,
   `messaging.rocketmq.message_keys` to `messaging.rocketmq.message.keys`;

--- a/schemas/1.15.0
+++ b/schemas/1.15.0
@@ -18,7 +18,10 @@ versions:
               messaging.conversation_id: messaging.message.conversation_id
               messaging.message_payload_size_bytes: messaging.message.payload_size_bytes
               messaging.message_payload_compressed_size_bytes: messaging.message.payload_compressed_size_bytes
+              messaging.rabbitmq.routing_key: messaging.rabbitmq.message.routing_key
               messaging.kafka.message_key: messaging.kafka.message.key
+              messaging.kafka.partition: messaging.kafka.message.partition
+              messaging.kafka.tombstone: messaging.kafka.message.tombstone
               messaging.rocketmq.message_type: messaging.rocketmq.message.type
               messaging.rocketmq.message_tag: messaging.rocketmq.message.tag
               messaging.rocketmq.message_keys: messaging.rocketmq.message.keys

--- a/schemas/1.15.0
+++ b/schemas/1.15.0
@@ -4,14 +4,16 @@ versions:
   1.15.0:
     spans:
       changes:
-        # https://github.com/open-telemetry/opentelemetry-specification/pull/2743
         - rename_attributes:
             attribute_map:
+              # https://github.com/open-telemetry/opentelemetry-specification/pull/2743            
               http.retry_count: http.resend_count
-        # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
-        - rename_attributes:
-            attribute_map:
+              # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
+              messaging.protocol: net.app.protocol.name
+              messaging.protocol_version: net.app.protocol.version
               messaging.destination: messaging.destination.name
+              messaging.temp_destination: messaging.destination.temporary,
+              messaging.destination_kind: messaging.destination.kind,
               messaging.message_id: messaging.message.id
               messaging.conversation_id: messaging.message.conversation_id
               messaging.message_payload_size_bytes: messaging.message.payload_size_bytes
@@ -19,7 +21,7 @@ versions:
               messaging.kafka.message_key: messaging.kafka.message.key
               messaging.rocketmq.message_type: messaging.rocketmq.message.type
               messaging.rocketmq.message_tag: messaging.rocketmq.message.tag
-              messaging.rocketmq.message_keys: messaging.rocketmq.message.keys 
+              messaging.rocketmq.message_keys: messaging.rocketmq.message.keys
   1.14.0:
   1.13.0:
     spans:

--- a/schemas/1.15.0
+++ b/schemas/1.15.0
@@ -4,27 +4,10 @@ versions:
   1.15.0:
     spans:
       changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2743
         - rename_attributes:
             attribute_map:
-              # https://github.com/open-telemetry/opentelemetry-specification/pull/2743
               http.retry_count: http.resend_count
-              # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
-              messaging.protocol: net.app.protocol.name
-              messaging.protocol_version: net.app.protocol.version
-              messaging.destination: messaging.destination.name
-              messaging.temp_destination: messaging.destination.temporary
-              messaging.destination_kind: messaging.destination.kind
-              messaging.message_id: messaging.message.id
-              messaging.conversation_id: messaging.message.conversation_id
-              messaging.message_payload_size_bytes: messaging.message.payload_size_bytes
-              messaging.message_payload_compressed_size_bytes: messaging.message.payload_compressed_size_bytes
-              messaging.rabbitmq.routing_key: messaging.rabbitmq.message.routing_key
-              messaging.kafka.message_key: messaging.kafka.message.key
-              messaging.kafka.partition: messaging.kafka.message.partition
-              messaging.kafka.tombstone: messaging.kafka.message.tombstone
-              messaging.rocketmq.message_type: messaging.rocketmq.message.type
-              messaging.rocketmq.message_tag: messaging.rocketmq.message.tag
-              messaging.rocketmq.message_keys: messaging.rocketmq.message.keys
   1.14.0:
   1.13.0:
     spans:

--- a/schemas/1.15.0
+++ b/schemas/1.15.0
@@ -8,6 +8,18 @@ versions:
         - rename_attributes:
             attribute_map:
               http.retry_count: http.resend_count
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
+        - rename_attributes:
+            attribute_map:
+              messaging.destination: messaging.destination.name
+              messaging.message_id: messaging.message.id
+              messaging.conversation_id: messaging.message.conversation_id
+              messaging.message_payload_size_bytes: messaging.message.payload_size_bytes
+              messaging.message_payload_compressed_size_bytes: messaging.message.payload_compressed_size_bytes
+              messaging.kafka.message_key: messaging.kafka.message.key
+              messaging.rocketmq.message_type: messaging.rocketmq.message.type
+              messaging.rocketmq.message_tag: messaging.rocketmq.message.tag
+              messaging.rocketmq.message_keys: messaging.rocketmq.message.keys 
   1.14.0:
   1.13.0:
     spans:

--- a/schemas/1.15.0
+++ b/schemas/1.15.0
@@ -6,14 +6,14 @@ versions:
       changes:
         - rename_attributes:
             attribute_map:
-              # https://github.com/open-telemetry/opentelemetry-specification/pull/2743            
+              # https://github.com/open-telemetry/opentelemetry-specification/pull/2743
               http.retry_count: http.resend_count
               # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
               messaging.protocol: net.app.protocol.name
               messaging.protocol_version: net.app.protocol.version
               messaging.destination: messaging.destination.name
-              messaging.temp_destination: messaging.destination.temporary,
-              messaging.destination_kind: messaging.destination.kind,
+              messaging.temp_destination: messaging.destination.temporary
+              messaging.destination_kind: messaging.destination.kind
               messaging.message_id: messaging.message.id
               messaging.conversation_id: messaging.message.conversation_id
               messaging.message_payload_size_bytes: messaging.message.payload_size_bytes

--- a/schemas/1.16.0
+++ b/schemas/1.16.0
@@ -1,0 +1,56 @@
+file_format: 1.1.0
+schema_url: https://opentelemetry.io/schemas/1.16.0
+versions:
+  1.16.0:
+    spans:
+      # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
+      changes:
+        - rename_attributes:
+            attribute_map:
+              messaging.protocol: net.app.protocol.name
+              messaging.protocol_version: net.app.protocol.version
+              messaging.destination: messaging.destination.name
+              messaging.temp_destination: messaging.destination.temporary
+              messaging.destination_kind: messaging.destination.kind
+              messaging.message_id: messaging.message.id
+              messaging.conversation_id: messaging.message.conversation_id
+              messaging.message_payload_size_bytes: messaging.message.payload_size_bytes
+              messaging.message_payload_compressed_size_bytes: messaging.message.payload_compressed_size_bytes
+              messaging.rabbitmq.routing_key: messaging.rabbitmq.message.routing_key
+              messaging.kafka.message_key: messaging.kafka.message.key
+              messaging.kafka.partition: messaging.kafka.message.partition
+              messaging.kafka.tombstone: messaging.kafka.message.tombstone
+              messaging.rocketmq.message_type: messaging.rocketmq.message.type
+              messaging.rocketmq.message_tag: messaging.rocketmq.message.tag
+              messaging.rocketmq.message_keys: messaging.rocketmq.message.keys
+  1.15.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2743
+        - rename_attributes:
+            attribute_map:
+              http.retry_count: http.resend_count
+  1.14.0:
+  1.13.0:
+    spans:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2614
+        - rename_attributes:
+            attribute_map:
+              net.peer.ip: net.sock.peer.addr
+              net.host.ip: net.sock.host.addr
+  1.12.0:
+  1.11.0:
+  1.10.0:
+  1.9.0:
+  1.8.0:
+    spans:
+      changes:
+        - rename_attributes:
+            attribute_map:
+              db.cassandra.keyspace: db.name
+              db.hbase.namespace: db.name
+  1.7.0:
+  1.6.1:
+  1.5.0:
+  1.4.0:

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -103,7 +103,7 @@ groups:
         requirement_level:
           recommended: If different than `net.peer.name` and if `net.sock.peer.addr` is set.
       - ref: net.app.protocol.name
-        examples: ['AMQP', 'MQTT']
+        examples: ['amqp', 'mqtt']
       - ref: net.app.protocol.version
     constraints:
       - include: network
@@ -231,7 +231,7 @@ groups:
     brief: >
       Attributes for RabbitMQ
     attributes:
-      - id: routing_key
+      - id: message.routing_key
         type: string
         requirement_level:
           conditionally_required: If not empty.
@@ -267,12 +267,12 @@ groups:
         brief: >
           Client Id for the Consumer or Producer that is handling the message.
         examples: 'client-5'
-      - id: partition
+      - id: message.partition
         type: int
         brief: >
           Partition the message is sent to.
         examples: 2
-      - id: tombstone
+      - id: message.tombstone
         type: boolean
         requirement_level:
           conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -1,4 +1,40 @@
 groups:
+  - id: messaging.message
+    prefix: messaging
+    type: span
+    brief: 'Semantic convention describing per-message attributes populated on messaging spans or links.'
+    attributes:
+      - id: destination.name
+        type: string
+        brief: 'The message destination name'
+        note: |
+          Destination name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
+          broker does not have such notion, destination name SHOULD uniquely identify broker.
+
+          If destination name is the same for all messages being published, 
+          it MUST be set on corresponding publish, receive, process or other span.
+        examples: ['MyQueue', 'MyTopic']
+      - id: message.id
+        type: string
+        brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
+        examples: '452a7c7c7c7048c2f887f61572b18fc2'
+      - id: message.conversation_id
+        type: string
+        brief: >
+          The [conversation ID](#conversations) identifying the conversation to which the message belongs,
+          represented as a string. Sometimes called "Correlation ID".
+        examples: 'MyConversationId'
+      - id: message.payload_size_bytes
+        type: int
+        brief: >
+          The (uncompressed) size of the message payload in bytes.
+          Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
+        examples: 2738
+      - id: message.payload_compressed_size_bytes
+        type: int
+        brief: 'The compressed size of the message payload in bytes.'
+        examples: 2048
+
   - id: messaging
     prefix: messaging
     type: span
@@ -11,13 +47,6 @@ groups:
         requirement_level: required
         brief: 'A string identifying the messaging system.'
         examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS']
-      - id: destination
-        type: string
-        requirement_level: required
-        brief: >
-          The message destination name. This might be equal to the span name
-          but is required nevertheless.
-        examples: ['MyQueue', 'MyTopic']
       - id: destination_kind
         type:
           allow_custom_values: false
@@ -48,26 +77,31 @@ groups:
         type: string
         brief: 'Connection string.'
         examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
-      - id: message_id
-        type: string
-        brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
-        examples: '452a7c7c7c7048c2f887f61572b18fc2'
-      - id: conversation_id
-        type: string
-        brief: >
-          The [conversation ID](#conversations) identifying the conversation to which the message belongs,
-          represented as a string. Sometimes called "Correlation ID".
-        examples: 'MyConversationId'
-      - id: message_payload_size_bytes
+      - id: batch.size
         type: int
-        brief: >
-          The (uncompressed) size of the message payload in bytes.
-          Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
-        examples: 2738
-      - id: message_payload_compressed_size_bytes
-        type: int
-        brief: 'The compressed size of the message payload in bytes.'
-        examples: 2048
+        brief: The number of messages sent, received, or processed in the scope of the batching operation.
+        requirement_level:
+          conditionally_required: >
+            If available within the messaging system, and only if the span describes operations that operate with message batches.
+        note: >
+            Instrumentation SHOULD always set it on batch `receive` operations regardless
+            of the actual number of received messages (e.g. 0, 1, or more).
+        examples: [0, 1, 2]
+      - ref: messaging.destination.name
+        requirement_level:
+          conditionally_required: if available and if the value applies to all messages in the batch.
+      - ref: messaging.message.id
+        requirement_level:
+          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+      - ref: messaging.message.conversation_id
+        requirement_level:
+          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+      - ref: messaging.message.payload_size_bytes
+        requirement_level:
+          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+      - ref: messaging.message.payload_compressed_size_bytes
+        requirement_level:
+          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
       - ref: net.peer.name
         note: >
           This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
@@ -163,11 +197,11 @@ groups:
     brief: >
       Attributes for Apache Kafka
     attributes:
-      - id: message_key
+      - id: message.key
         type: string
         brief: >
           Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition.
-          They differ from `messaging.message_id` in that they're not unique.
+          They differ from `messaging.message.id` in that they're not unique.
           If the key is `null`, the attribute MUST NOT be set.
         note: >
           If the key type is not string, it's string representation has to be supplied for the attribute.
@@ -220,28 +254,28 @@ groups:
         brief: >
           The unique identifier for each client.
         examples: 'myhost@8742@s8083jm'
-      - id: delivery_timestamp
+      - id: message.delivery_timestamp
         type: int
         requirement_level:
           conditionally_required: If the message type is delay and delay time level is not specified.
         brief: >
           The timestamp in milliseconds that the delay message is expected to be delivered to consumer.
         examples: 1665987217045
-      - id: delay_time_level
+      - id: message.delay_time_level
         type: int
         requirement_level:
           conditionally_required: If the message type is delay and delivery timestamp is not specified.
         brief: >
           The delay time level for delay message, which determines the message delay time.
         examples: 3
-      - id: message_group
+      - id: message.group
         type: string
         requirement_level:
           conditionally_required: If the message type is FIFO.
         brief: >
           It is essential for FIFO message. Messages that belong to the same message group are always processed one by one within the same consumer group.
         examples: 'myMessageGroup'
-      - id: message_type
+      - id: message.type
         type:
           allow_custom_values: false
           members:
@@ -259,12 +293,12 @@ groups:
               brief: 'Transaction message'
         brief: >
           Type of message.
-      - id: message_tag
+      - id: message.tag
         type: string
         brief: >
           The secondary classifier of message besides topic.
         examples: tagA
-      - id: message_keys
+      - id: message.keys
         type: string[]
         brief: >
           Key(s) of message, another way to mark message besides message id.

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -71,20 +71,18 @@ groups:
         type: int
         brief: The number of messages sent, received, or processed in the scope of the batching operation.
         requirement_level:
-          conditionally_required: >
-            If available within the messaging system, and only if the span describes operations that operate with message batches.
+          conditionally_required: If the span describes operation on a batch of messages.
         note: >
-            Instrumentation MUST set it on batch `receive` operations regardless
-            of the actual number of received messages (e.g. 0, 1, or more).
-            Instrumentations SHOULD set `messaging.batch.size` on spans representing
-            other operations - when it's not set, it's assumed to be `1`.
+            Instrumentations SHOULD NOT set `messaging.batch.size` on spans that operate with a single message.
+            When client library supports batch and single-message API for the same operation, instrumentations SHOULD
+            use `messaging.batch.size` for batching APIs and SHOULD NOT use it for single-message APIs.
         examples: [0, 1, 2]
       - ref: messaging.message.id
         requirement_level:
           recommended: Only if span represents operation on a single message.
       - ref: messaging.message.conversation_id
         requirement_level:
-          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+          recommended: Only if span represents operation on a single message.
       - ref: messaging.message.payload_size_bytes
         requirement_level:
           recommended: Only if span represents operation on a single message.

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -11,9 +11,6 @@ groups:
         note: |
           Destination name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
           broker does not have such notion, destination name SHOULD uniquely identify broker.
-
-          If destination name is the same for all messages being published,
-          it MUST be set on corresponding span.
         examples: ['MyQueue', 'MyTopic']
       - id: source.name
         type: string
@@ -21,9 +18,6 @@ groups:
         note: |
           Source name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
           broker does not have such notion, source name SHOULD uniquely identify broker.
-
-          If source name is the same for all messages being received or processed,
-          it MUST be set on corresponding span.
         examples: ['MyQueue', 'MyTopic']
       - id: message.id
         type: string
@@ -58,10 +52,21 @@ groups:
         requirement_level: required
         brief: 'A string identifying the messaging system.'
         examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS']
-      - id: url
-        type: string
-        brief: 'Connection string.'
-        examples: ['tibjmsnaming://localhost:7222', 'https://queue.amazonaws.com/80398EXAMPLE/MyQueue']
+      - id: operation
+        type:
+          allow_custom_values: true
+          members:
+            - id: publish
+              value: "publish"
+            - id: receive
+              value: "receive"
+            - id: process
+              value: "process"
+        brief: >
+          A string identifying the kind of messaging operation as defined in the
+          [Operation names](#operation-names) section above.
+        requirement_level:
+          conditionally_required:
       - id: batch.size
         type: int
         brief: The number of messages sent, received, or processed in the scope of the batching operation.
@@ -167,19 +172,6 @@ groups:
     span_kind: consumer
     brief: 'Semantic convention for a consumer of messages received from a messaging system'
     attributes:
-      - id: operation
-        type:
-          allow_custom_values: false
-          members:
-            - id: receive
-              value: "receive"
-            - id: process
-              value: "process"
-        brief: >
-          A string identifying the kind of message consumption as defined in the
-          [Operation names](#operation-names) section above.
-          If the operation is "send", this attribute MUST NOT be set, since the
-          operation can be inferred from the span kind in that case.
       - id: consumer_id
         type: string
         brief: >

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -1,6 +1,7 @@
 groups:
   - id: messaging.message
     prefix: messaging
+    # todo (https://github.com/open-telemetry/build-tools/issues/123)
     type: span
     brief: 'Semantic convention describing per-message attributes populated on messaging spans or links.'
     attributes:
@@ -11,8 +12,18 @@ groups:
           Destination name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
           broker does not have such notion, destination name SHOULD uniquely identify broker.
 
-          If destination name is the same for all messages being published, 
-          it MUST be set on corresponding publish, receive, process or other span.
+          If destination name is the same for all messages being published,
+          it MUST be set on corresponding span.
+        examples: ['MyQueue', 'MyTopic']
+      - id: source.name
+        type: string
+        brief: 'The message source name'
+        note: |
+          Source name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
+          broker does not have such notion, source name SHOULD uniquely identify broker.
+
+          If source name is the same for all messages being received or processed,
+          it MUST be set on corresponding span.
         examples: ['MyQueue', 'MyTopic']
       - id: message.id
         type: string
@@ -47,32 +58,6 @@ groups:
         requirement_level: required
         brief: 'A string identifying the messaging system.'
         examples: ['kafka', 'rabbitmq', 'rocketmq', 'activemq', 'AmazonSQS']
-      - id: destination_kind
-        type:
-          allow_custom_values: false
-          members:
-            - id: queue
-              value: "queue"
-              brief: "A message sent to a queue"
-            - id: topic
-              value: "topic"
-              brief: "A message sent to a topic"
-        requirement_level:
-          conditionally_required: If the message destination is either a `queue` or `topic`.
-        brief: 'The kind of message destination'
-      - id: temp_destination
-        type: boolean
-        requirement_level:
-          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
-        brief: 'A boolean that is true if the message destination is temporary.'
-      - id: protocol
-        type: string
-        brief: 'The name of the transport protocol.'
-        examples: ['AMQP', 'MQTT']
-      - id: protocol_version
-        type: string
-        brief: 'The version of the transport protocol.'
-        examples: '0.9.1'
       - id: url
         type: string
         brief: 'Connection string.'
@@ -87,12 +72,7 @@ groups:
             Instrumentation SHOULD always set it on batch `receive` operations regardless
             of the actual number of received messages (e.g. 0, 1, or more).
         examples: [0, 1, 2]
-      - ref: messaging.destination.name
-        requirement_level:
-          conditionally_required: if available and if the value applies to all messages in the batch.
       - ref: messaging.message.id
-        requirement_level:
-          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
       - ref: messaging.message.conversation_id
         requirement_level:
           recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
@@ -117,7 +97,9 @@ groups:
         tag: connection-level
         requirement_level:
           recommended: If different than `net.peer.name` and if `net.sock.peer.addr` is set.
-
+      - ref: net.app.protocol.name
+        examples: ['AMQP', 'MQTT']
+      - ref: net.app.protocol.version
     constraints:
       - include: network
 
@@ -127,6 +109,47 @@ groups:
     extends: messaging
     span_kind: producer
     brief: 'Semantic convention for producers of messages sent to a messaging systems.'
+    attributes:
+      - ref: messaging.destination.name
+        requirement_level:
+          conditionally_required: If the value applies to all messages in the batch.
+      - id: destination.kind
+        type:
+          allow_custom_values: false
+          members:
+            - id: queue
+              value: "queue"
+              brief: "A message sent to a queue"
+            - id: topic
+              value: "topic"
+              brief: "A message sent to a topic"
+        requirement_level:
+          conditionally_required: If the message destination is either a `queue` or `topic`.
+        brief: 'The kind of message destination'
+      - id: destination.template
+        type: string
+        requirement_level:
+          conditionally_required: >
+            If available. Instrumentations MUST NOT use `messaging.destination.name` as template
+            unless low-cardinality of destination name is guaranteed.
+        brief: Low cardinality field representing messaging destination
+        note: >
+          Destination names could be constructed from templates.
+          An example would be a destination name involving a user name or product id.
+          Although the destination name in this case is of high cardinality,
+          the underlying template is of low cardinality and can be effectively
+          used for grouping and searching spans.
+        examples: ['/customers/{customerId}']
+      - id: destination.temporary
+        type: boolean
+        requirement_level:
+          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
+        brief: 'A boolean that is true if the message destination is temporary and might not exist anymore after messages are processed.'
+      - id: destination.anonymous
+        type: boolean
+        requirement_level:
+          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
+        brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
 
   - id: messaging.producer.synchronous
     prefix: messaging
@@ -165,6 +188,40 @@ groups:
           `messaging.kafka.consumer_group`. For brokers, such as RabbitMQ and Artemis, set it to the `client_id`
           of the client consuming the message.
         examples: 'mygroup - client-6'
+      - ref: messaging.source.name
+        requirement_level:
+          conditionally_required: If the value applies to all messages in the batch.
+      - id: source.kind
+        type:
+          allow_custom_values: true
+          members:
+            - id: queue
+              value: "queue"
+              brief: "A message received from a queue"
+            - id: topic
+              value: "topic"
+              brief: "A message received from a topic"
+        requirement_level:
+          conditionally_required: If the message source is either a `queue` or `topic`.
+        brief: 'The kind of message source'
+      - id: source.template
+        type: string
+        brief: 'Low cardinality field representing messaging source'
+        requirement_level:
+          conditionally_required: >
+            If available. Instrumentations MUST NOT use `messaging.source.name` as template
+            unless low-cardinality of source name is guaranteed.
+        examples: ['/customers/{customerId}']
+      - id: source.temporary
+        type: boolean
+        requirement_level:
+          recommended: when supported by messaging system and only if the source is temporary. If missing, assumed to be false.
+        brief: 'denotes that the source is a temporary source and might not exist anymore after messages are processed'
+      - id: source.anonymous
+        type: boolean
+        requirement_level:
+          recommended: when supported by messaging system and only if the source is anonymous. If missing, assumed to be false.
+        brief: 'denotes that the source is an anonymous source (could be unnamed or have auto-generated name)'
 
   - id: messaging.consumer.synchronous
     prefix: messaging

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -62,11 +62,11 @@ groups:
               value: "receive"
             - id: process
               value: "process"
+        requirement_level: required
         brief: >
           A string identifying the kind of messaging operation as defined in the
           [Operation names](#operation-names) section above.
-        requirement_level:
-          conditionally_required:
+        note: If custom value is used, it MUST known to be of low cardinality.
       - id: batch.size
         type: int
         brief: The number of messages sent, received, or processed in the scope of the batching operation.

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -74,19 +74,23 @@ groups:
           conditionally_required: >
             If available within the messaging system, and only if the span describes operations that operate with message batches.
         note: >
-            Instrumentation SHOULD always set it on batch `receive` operations regardless
+            Instrumentation MUST set it on batch `receive` operations regardless
             of the actual number of received messages (e.g. 0, 1, or more).
+            Instrumentations SHOULD set `messaging.batch.size` on spans representing
+            other operations - when it's not set, it's assumed to be `1`.
         examples: [0, 1, 2]
       - ref: messaging.message.id
+        requirement_level:
+          recommended: Only if span represents operation on a single message.
       - ref: messaging.message.conversation_id
         requirement_level:
           recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
       - ref: messaging.message.payload_size_bytes
         requirement_level:
-          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+          recommended: Only if span represents operation on a single message.
       - ref: messaging.message.payload_compressed_size_bytes
         requirement_level:
-          recommended: Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+          recommended: Only if span represents operation on a single message.
       - ref: net.peer.name
         note: >
           This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
@@ -117,7 +121,7 @@ groups:
     attributes:
       - ref: messaging.destination.name
         requirement_level:
-          conditionally_required: If the value applies to all messages in the batch.
+          conditionally_required: If one message is being published or if the value applies to all messages in the batch.
       - id: destination.kind
         type:
           allow_custom_values: false
@@ -143,7 +147,7 @@ groups:
           An example would be a destination name involving a user name or product id.
           Although the destination name in this case is of high cardinality,
           the underlying template is of low cardinality and can be effectively
-          used for grouping and searching spans.
+          used for grouping and aggregation.
         examples: ['/customers/{customerId}']
       - id: destination.temporary
         type: boolean
@@ -155,7 +159,6 @@ groups:
         requirement_level:
           conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
         brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
-
   - id: messaging.producer.synchronous
     prefix: messaging
     type: span
@@ -204,16 +207,22 @@ groups:
             If available. Instrumentations MUST NOT use `messaging.source.name` as template
             unless low-cardinality of source name is guaranteed.
         examples: ['/customers/{customerId}']
+        note: >
+          Source names could be constructed from templates.
+          An example would be a source name involving a user name or product id.
+          Although the source name in this case is of high cardinality,
+          the underlying template is of low cardinality and can be effectively
+          used for grouping and aggregation.
       - id: source.temporary
         type: boolean
         requirement_level:
           recommended: when supported by messaging system and only if the source is temporary. If missing, assumed to be false.
-        brief: 'denotes that the source is a temporary source and might not exist anymore after messages are processed'
+        brief: 'A boolean that is true if the message source is temporary and might not exist anymore after messages are processed.'
       - id: source.anonymous
         type: boolean
         requirement_level:
           recommended: when supported by messaging system and only if the source is anonymous. If missing, assumed to be false.
-        brief: 'denotes that the source is an anonymous source (could be unnamed or have auto-generated name)'
+        brief: 'A boolean that is true if the message source is anonymous (could be unnamed or have auto-generated name).'
 
   - id: messaging.consumer.synchronous
     prefix: messaging

--- a/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
+++ b/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
@@ -123,7 +123,7 @@ added as a link to the span. This means the span may have as many links as messa
 - [`faas.trigger`][faas]] MUST be set to `pubsub`.
 - [`messaging.operation`](../messaging.md) MUST be set to `process`.
 - [`messaging.system`](../messaging.md) MUST be set to `AmazonSQS`.
-- [`messaging.destination_kind`](../messaging.md#messaging-attributes) MUST be set to `queue`.
+- [`messaging.destination.kind` or `messaging.source.kind`](../messaging.md#messaging-attributes) MUST be set to `queue`.
 
 ### SQS Message
 
@@ -136,7 +136,7 @@ added as a link to the span.
 - [`faas.trigger`][faas] MUST be set to `pubsub`.
 - [`messaging.operation`](../messaging.md#messaging-attributes) MUST be set to `process`.
 - [`messaging.system`](../messaging.md#messaging-attributes) MUST be set to `AmazonSQS`.
-- [`messaging.destination_kind`](../messaging.md#messaging-attributes) MUST be set to `queue`.
+- [`messaging.destination.kind` or `messaging.source.kind`](../messaging.md#messaging-attributes) MUST be set to `queue`.
 
 Other [Messaging attributes](../messaging.md#messaging-attributes) SHOULD be set based on the available information in the SQS message
 event.
@@ -219,13 +219,15 @@ Function F:                      | Span ProcBatch |
 | SpanKind | `PRODUCER` | `PRODUCER` | `CONSUMER` | `CONSUMER` | `CONSUMER` |
 | Status | `Ok` | `Ok` | `Ok` | `Ok` | `Ok` |
 | `messaging.system` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` | `AmazonSQS` |
-| `messaging.destination` | `Q` | `Q` | `Q` | `Q` | `Q` |
-| `messaging.destination_kind` | `queue` | `queue` | `queue` | `queue` | `queue` |
+| `messaging.destination.name` | `Q` | `Q` | | | |
+| `messaging.source.name` | | | `Q` | `Q` | `Q` |
+| `messaging.destination.kind` | `queue` | `queue` | | | |
+| `messaging.source.kind` | | | `queue` | `queue` | `queue` |
 | `messaging.operation` |  |  | `process` | `process` | `process` |
 | `messaging.message.id` | | | | `"a1"` | `"a2"` |
 
 Note that if Span Prod1 and Span Prod2 were sent to different queues, Span ProcBatch would not have
-`messaging.destination` set as it would correspond to multiple destinations.
+`messaging.source.name` set as it would correspond to multiple sources.
 
 The above requires user code change to create `Span Proc1` and `Span Proc2`. In Java, the user would inherit from
 [TracingSqsMessageHandler][] instead of Lambda's standard `RequestHandler` to enable them. Otherwise these two spans

--- a/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
+++ b/specification/trace/semantic_conventions/instrumentation/aws-lambda.md
@@ -222,7 +222,7 @@ Function F:                      | Span ProcBatch |
 | `messaging.destination` | `Q` | `Q` | `Q` | `Q` | `Q` |
 | `messaging.destination_kind` | `queue` | `queue` | `queue` | `queue` | `queue` |
 | `messaging.operation` |  |  | `process` | `process` | `process` |
-| `messaging.message_id` | | | | `"a1"` | `"a2"` |
+| `messaging.message.id` | | | | `"a1"` | `"a2"` |
 
 Note that if Span Prod1 and Span Prod2 were sent to different queues, Span ProcBatch would not have
 `messaging.destination` set as it would correspond to multiple destinations.

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -21,6 +21,8 @@
   * [Span kind](#span-kind)
   * [Operation names](#operation-names)
 - [Messaging attributes](#messaging-attributes)
+  * [Producer attributes](#producer-attributes)
+  * [Consumer attributes](#consumer-attributes)
   * [Per-message attributes](#per-message-attributes)
   * [Attributes specific to certain messaging systems](#attributes-specific-to-certain-messaging-systems)
     + [RabbitMQ](#rabbitmq)

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -198,7 +198,7 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended |
 | `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [4] |
 | `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [5] |
-| [`net.app.protocol.name`](span-general.md) | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `AMQP`; `MQTT` | Recommended |
+| [`net.app.protocol.name`](span-general.md) | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `mqtt` | Recommended |
 | [`net.app.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [6] | `3.1.1` | Recommended |
 | [`net.peer.name`](span-general.md) | string | Logical remote hostname, see note below. [7] | `example.com` | Conditionally Required: If available. |
 | [`net.sock.family`](span-general.md) | string | Protocol [address family](https://man7.org/linux/man-pages/man7/address_families.7.html) which is used for communication. | `inet6`; `bluetooth` | Conditionally Required: [8] |
@@ -359,12 +359,12 @@ All attributes that are specific for a messaging system SHOULD be populated in `
 #### RabbitMQ
 
 In RabbitMQ, the destination is defined by an *exchange* and a *routing key*.
-`messaging.destination` MUST be set to the name of the exchange. This will be an empty string if the default exchange is used.
+`messaging.destination.name` MUST be set to the name of the exchange. This will be an empty string if the default exchange is used.
 
 <!-- semconv messaging.rabbitmq -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `messaging.rabbitmq.routing_key` | string | RabbitMQ message routing key. | `myKey` | Conditionally Required: If not empty. |
+| `messaging.rabbitmq.message.routing_key` | string | RabbitMQ message routing key. | `myKey` | Conditionally Required: If not empty. |
 <!-- endsemconv -->
 
 #### Apache Kafka
@@ -377,8 +377,8 @@ For Apache Kafka, the following additional attributes are defined:
 | `messaging.kafka.message.key` | string | Message keys in Kafka are used for grouping alike messages to ensure they're processed on the same partition. They differ from `messaging.message.id` in that they're not unique. If the key is `null`, the attribute MUST NOT be set. [1] | `myKey` | Recommended |
 | `messaging.kafka.consumer_group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | Recommended |
 | `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `client-5` | Recommended |
-| `messaging.kafka.partition` | int | Partition the message is sent to. | `2` | Recommended |
-| `messaging.kafka.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | Conditionally Required: [2] |
+| `messaging.kafka.message.partition` | int | Partition the message is sent to. | `2` | Recommended |
+| `messaging.kafka.message.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | Conditionally Required: [2] |
 
 **[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -192,25 +192,25 @@ The following operations related to messages are defined for these semantic conv
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `messaging.system` | string | A string identifying the messaging system. | `kafka`; `rabbitmq`; `rocketmq`; `activemq`; `AmazonSQS` | Required |
-| `messaging.operation` | string | A string identifying the kind of messaging operation as defined in the [Operation names](#operation-names) section above. | `publish` | Required |
-| `messaging.batch.size` | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` | Conditionally Required: [2] |
-| `messaging.message.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | Recommended: [3] |
-| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [4] |
-| `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [5] |
-| `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [6] |
+| `messaging.operation` | string | A string identifying the kind of messaging operation as defined in the [Operation names](#operation-names) section above. [1] | `publish` | Required |
+| `messaging.batch.size` | int | The number of messages sent, received, or processed in the scope of the batching operation. [2] | `0`; `1`; `2` | Conditionally Required: [3] |
+| `messaging.message.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | Recommended: [4] |
+| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [5] |
+| `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [6] |
+| `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [7] |
 | [`net.app.protocol.name`](span-general.md) | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `mqtt` | Recommended |
-| [`net.app.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [7] | `3.1.1` | Recommended |
-| [`net.peer.name`](span-general.md) | string | Logical remote hostname, see note below. [8] | `example.com` | Conditionally Required: If available. |
-| [`net.sock.family`](span-general.md) | string | Protocol [address family](https://man7.org/linux/man-pages/man7/address_families.7.html) which is used for communication. | `inet6`; `bluetooth` | Conditionally Required: [9] |
+| [`net.app.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [8] | `3.1.1` | Recommended |
+| [`net.peer.name`](span-general.md) | string | Logical remote hostname, see note below. [9] | `example.com` | Conditionally Required: If available. |
+| [`net.sock.family`](span-general.md) | string | Protocol [address family](https://man7.org/linux/man-pages/man7/address_families.7.html) which is used for communication. | `inet6`; `bluetooth` | Conditionally Required: [10] |
 | [`net.sock.peer.addr`](span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
-| [`net.sock.peer.name`](span-general.md) | string | Remote socket peer name. | `proxy.example.com` | Recommended: [10] |
-| [`net.sock.peer.port`](span-general.md) | int | Remote socket peer port. | `16456` | Recommended: [11] |
+| [`net.sock.peer.name`](span-general.md) | string | Remote socket peer name. | `proxy.example.com` | Recommended: [11] |
+| [`net.sock.peer.port`](span-general.md) | int | Remote socket peer port. | `16456` | Recommended: [12] |
 
-**[1]:** Instrumentations SHOULD NOT set `messaging.batch.size` on spans that operate with a single message. When client library supports batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.size` for batching APIs and SHOULD NOT use it for single-message APIs.
+**[1]:** If custom value is used, it MUST known to be of low cardinality.
 
-**[2]:** If the span describes operation on a batch of messages.
+**[2]:** Instrumentations SHOULD NOT set `messaging.batch.size` on spans that operate with a single message. When client library supports batch and single-message API for the same operation, instrumentations SHOULD use `messaging.batch.size` for batching APIs and SHOULD NOT use it for single-message APIs.
 
-**[3]:** Only if span represents operation on a single message.
+**[3]:** If the span describes operation on a batch of messages.
 
 **[4]:** Only if span represents operation on a single message.
 
@@ -218,15 +218,17 @@ The following operations related to messages are defined for these semantic conv
 
 **[6]:** Only if span represents operation on a single message.
 
-**[7]:** `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[7]:** Only if span represents operation on a single message.
 
-**[8]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[8]:** `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[9]:** If different than `inet` and if any of `net.sock.peer.addr` or `net.sock.host.addr` are set. Consumers of telemetry SHOULD accept both IPv4 and IPv6 formats for the address in `net.sock.peer.addr` if `net.sock.family` is not set. This is to support instrumentations that follow previous versions of this document.
+**[9]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
 
-**[10]:** If different than `net.peer.name` and if `net.sock.peer.addr` is set.
+**[10]:** If different than `inet` and if any of `net.sock.peer.addr` or `net.sock.host.addr` are set. Consumers of telemetry SHOULD accept both IPv4 and IPv6 formats for the address in `net.sock.peer.addr` if `net.sock.family` is not set. This is to support instrumentations that follow previous versions of this document.
 
-**[11]:** If defined for the address family and if different than `net.peer.port` and if `net.sock.peer.addr` is set.
+**[11]:** If different than `net.peer.name` and if `net.sock.peer.addr` is set.
+
+**[12]:** If defined for the address family and if different than `net.peer.port` and if `net.sock.peer.addr` is set.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -243,7 +245,7 @@ These attributes should be set to the broker to which the message is sent/from w
 
 Note that attributes in `messaging.message` namespace describe an individual message, `messaging.destination` namespace
 contains attributes that describe the logical entity messages are published to, and `messaging.source` describes
-logical entity messages are received from.
+logical entity messages are received from. Attributes in `messaging.batch` namespace describe batch properties.
 
 [network attributes]: span-general.md#general-network-connection-attributes
 [`net.transport`]: span-general.md#network-transport-attributes
@@ -341,11 +343,12 @@ set on links. Corresponding instrumentations MAY set source and destination attr
 
 ### Attributes specific to certain messaging systems
 
-All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that are specific to the message, the message destination, or the message source SHOULD be populated under corresponding namespace:
+All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that are specific to the message, the message destination, the message source, or the whole batch SHOULD be populated under corresponding namespace:
 
 * message-specific under `messaging.{system}.message`
 * destination-specific under `messaging.{system}.destination`
 * source-specific under `messaging.{system}.source`
+* batch-specific under `messaging.{system}.batch`
 
 #### RabbitMQ
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -195,36 +195,38 @@ The following operations related to messages are defined for these semantic conv
 | `messaging.operation` | string | A string identifying the kind of messaging operation as defined in the [Operation names](#operation-names) section above. | `publish` | Required |
 | `messaging.batch.size` | int | The number of messages sent, received, or processed in the scope of the batching operation. [1] | `0`; `1`; `2` | Conditionally Required: [2] |
 | `messaging.message.conversation_id` | string | The [conversation ID](#conversations) identifying the conversation to which the message belongs, represented as a string. Sometimes called "Correlation ID". | `MyConversationId` | Recommended: [3] |
-| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended |
-| `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [4] |
-| `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [5] |
+| `messaging.message.id` | string | A value used by the messaging system as an identifier for the message, represented as a string. | `452a7c7c7c7048c2f887f61572b18fc2` | Recommended: [4] |
+| `messaging.message.payload_compressed_size_bytes` | int | The compressed size of the message payload in bytes. | `2048` | Recommended: [5] |
+| `messaging.message.payload_size_bytes` | int | The (uncompressed) size of the message payload in bytes. Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported. | `2738` | Recommended: [6] |
 | [`net.app.protocol.name`](span-general.md) | string | Application layer protocol used. The value SHOULD be normalized to lowercase. | `amqp`; `mqtt` | Recommended |
-| [`net.app.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [6] | `3.1.1` | Recommended |
-| [`net.peer.name`](span-general.md) | string | Logical remote hostname, see note below. [7] | `example.com` | Conditionally Required: If available. |
-| [`net.sock.family`](span-general.md) | string | Protocol [address family](https://man7.org/linux/man-pages/man7/address_families.7.html) which is used for communication. | `inet6`; `bluetooth` | Conditionally Required: [8] |
+| [`net.app.protocol.version`](span-general.md) | string | Version of the application layer protocol used. See note below. [7] | `3.1.1` | Recommended |
+| [`net.peer.name`](span-general.md) | string | Logical remote hostname, see note below. [8] | `example.com` | Conditionally Required: If available. |
+| [`net.sock.family`](span-general.md) | string | Protocol [address family](https://man7.org/linux/man-pages/man7/address_families.7.html) which is used for communication. | `inet6`; `bluetooth` | Conditionally Required: [9] |
 | [`net.sock.peer.addr`](span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
-| [`net.sock.peer.name`](span-general.md) | string | Remote socket peer name. | `proxy.example.com` | Recommended: [9] |
-| [`net.sock.peer.port`](span-general.md) | int | Remote socket peer port. | `16456` | Recommended: [10] |
+| [`net.sock.peer.name`](span-general.md) | string | Remote socket peer name. | `proxy.example.com` | Recommended: [10] |
+| [`net.sock.peer.port`](span-general.md) | int | Remote socket peer port. | `16456` | Recommended: [11] |
 
-**[1]:** Instrumentation SHOULD always set it on batch `receive` operations regardless of the actual number of received messages (e.g. 0, 1, or more).
+**[1]:** Instrumentation MUST set it on batch `receive` operations regardless of the actual number of received messages (e.g. 0, 1, or more). Instrumentations SHOULD set `messaging.batch.size` on spans representing other operations - when it's not set, it's assumed to be `1`.
 
 **[2]:** If available within the messaging system, and only if the span describes operations that operate with message batches.
 
 **[3]:** Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
 
-**[4]:** Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+**[4]:** Only if span represents operation on a single message.
 
-**[5]:** Only if messaging.batch.size is not set or if the value applies to all messages in the batch.
+**[5]:** Only if span represents operation on a single message.
 
-**[6]:** `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
+**[6]:** Only if span represents operation on a single message.
 
-**[7]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
+**[7]:** `net.app.protocol.version` refers to the version of the protocol used and might be different from the protocol client's version. If the HTTP client used has a version of `0.27.2`, but sends HTTP version `1.1`, this attribute should be set to `1.1`.
 
-**[8]:** If different than `inet` and if any of `net.sock.peer.addr` or `net.sock.host.addr` are set. Consumers of telemetry SHOULD accept both IPv4 and IPv6 formats for the address in `net.sock.peer.addr` if `net.sock.family` is not set. This is to support instrumentations that follow previous versions of this document.
+**[8]:** This should be the IP/hostname of the broker (or other network-level peer) this specific message is sent to/received from.
 
-**[9]:** If different than `net.peer.name` and if `net.sock.peer.addr` is set.
+**[9]:** If different than `inet` and if any of `net.sock.peer.addr` or `net.sock.host.addr` are set. Consumers of telemetry SHOULD accept both IPv4 and IPv6 formats for the address in `net.sock.peer.addr` if `net.sock.family` is not set. This is to support instrumentations that follow previous versions of this document.
 
-**[10]:** If defined for the address family and if different than `net.peer.port` and if `net.sock.peer.addr` is set.
+**[10]:** If different than `net.peer.name` and if `net.sock.peer.addr` is set.
+
+**[11]:** If defined for the address family and if different than `net.peer.port` and if `net.sock.peer.addr` is set.
 
 `messaging.operation` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -249,7 +251,7 @@ logical entity messages are received from.
 
 ### Producer attributes
 
-For message producers, the following additional attributes may be set:
+Following additional attributes describe message producer operations.
 
 <!-- semconv messaging.producer -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
@@ -262,7 +264,7 @@ For message producers, the following additional attributes may be set:
 
 **[1]:** If the message destination is either a `queue` or `topic`.
 
-**[2]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and searching spans.
+**[2]:** Destination names could be constructed from templates. An example would be a destination name involving a user name or product id. Although the destination name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
 
 **[3]:** If available. Instrumentations MUST NOT use `messaging.destination.name` as template unless low-cardinality of destination name is guaranteed.
 
@@ -273,7 +275,7 @@ For message producers, the following additional attributes may be set:
 **[6]:** Destination name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
 broker does not have such notion, destination name SHOULD uniquely identify broker.
 
-**[7]:** If the value applies to all messages in the batch.
+**[7]:** If one message is being published or if the value applies to all messages in the batch.
 
 `messaging.destination.kind` MUST be one of the following:
 
@@ -285,30 +287,32 @@ broker does not have such notion, destination name SHOULD uniquely identify brok
 
 ### Consumer attributes
 
-For message consumers, the following additional attributes may be set:
+Following additional attributes describe message consumer operations.
 
 <!-- semconv messaging.consumer -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `messaging.consumer_id` | string | The identifier for the consumer receiving a message. For Kafka, set it to `{messaging.kafka.consumer_group} - {messaging.kafka.client_id}`, if both are present, or only `messaging.kafka.consumer_group`. For brokers, such as RabbitMQ and Artemis, set it to the `client_id` of the client consuming the message. | `mygroup - client-6` | Recommended |
 | `messaging.source.kind` | string | The kind of message source | `queue` | Conditionally Required: [1] |
-| `messaging.source.template` | string | Low cardinality field representing messaging source | `/customers/{customerId}` | Conditionally Required: [2] |
-| `messaging.source.temporary` | boolean | denotes that the source is a temporary source and might not exist anymore after messages are processed |  | Recommended: [3] |
-| `messaging.source.anonymous` | boolean | denotes that the source is an anonymous source (could be unnamed or have auto-generated name) |  | Recommended: [4] |
-| `messaging.source.name` | string | The message source name [5] | `MyQueue`; `MyTopic` | Conditionally Required: [6] |
+| `messaging.source.template` | string | Low cardinality field representing messaging source [2] | `/customers/{customerId}` | Conditionally Required: [3] |
+| `messaging.source.temporary` | boolean | A boolean that is true if the message source is temporary and might not exist anymore after messages are processed. |  | Recommended: [4] |
+| `messaging.source.anonymous` | boolean | A boolean that is true if the message source is anonymous (could be unnamed or have auto-generated name). |  | Recommended: [5] |
+| `messaging.source.name` | string | The message source name [6] | `MyQueue`; `MyTopic` | Conditionally Required: [7] |
 
 **[1]:** If the message source is either a `queue` or `topic`.
 
-**[2]:** If available. Instrumentations MUST NOT use `messaging.source.name` as template unless low-cardinality of source name is guaranteed.
+**[2]:** Source names could be constructed from templates. An example would be a source name involving a user name or product id. Although the source name in this case is of high cardinality, the underlying template is of low cardinality and can be effectively used for grouping and aggregation.
 
-**[3]:** when supported by messaging system and only if the source is temporary. If missing, assumed to be false.
+**[3]:** If available. Instrumentations MUST NOT use `messaging.source.name` as template unless low-cardinality of source name is guaranteed.
 
-**[4]:** when supported by messaging system and only if the source is anonymous. If missing, assumed to be false.
+**[4]:** when supported by messaging system and only if the source is temporary. If missing, assumed to be false.
 
-**[5]:** Source name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
+**[5]:** when supported by messaging system and only if the source is anonymous. If missing, assumed to be false.
+
+**[6]:** Source name SHOULD uniquely identify specific queue, topic, or other entity within broker. If
 broker does not have such notion, source name SHOULD uniquely identify broker.
 
-**[6]:** If the value applies to all messages in the batch.
+**[7]:** If the value applies to all messages in the batch.
 
 `messaging.source.kind` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 
@@ -329,7 +333,7 @@ Instead span kind should be set to either `CONSUMER` or `SERVER` according to th
 
 All messaging operations (`publish`, `receive`, `process`, or other not covered by this specification) can describe a batch of messages.
 
-The following attributes describe individual messages. For batch operations per-message attributes cannot be set on the corresponding unless they are the same for all batch and MAY instead be set on a link. See [Batch Receiving](#batch-receiving) and [Batch Processing](#batch-processing) for more information on correlation using links.
+The following attributes describe individual messages. For batch operations per-message attributes cannot be set on the corresponding span unless they are the same for all messages in the batch and MAY instead be set on a link. See [Batch Receiving](#batch-receiving) and [Batch Processing](#batch-processing) for more information on correlation using links.
 
 <!-- semconv messaging.message -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
@@ -350,10 +354,10 @@ broker does not have such notion, source name SHOULD uniquely identify broker.
 
 ### Attributes specific to certain messaging systems
 
-All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Message-, destination-, or source-specific attributes SHOULD be populated under corresponding namespace:
+All attributes that are specific for a messaging system SHOULD be populated in `messaging.{system}` namespace. Attributes that are specific to the message, the message destination, or the message source SHOULD be populated under corresponding namespace:
 
-* Message-specific under `messaging.{system}.message`
-* Destination-specific under `messaging.{system}.destination`
+* message-specific under `messaging.{system}.message`
+* destination-specific under `messaging.{system}.destination`
 * source-specific under `messaging.{system}.source`
 
 #### RabbitMQ

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -336,7 +336,7 @@ Attributes in `messaging.message` or `messaging.{system}.message` namespace desc
 
 For batch operations per-message attributes are usually different and cannot be set on the corresponding span and MAY be set on links. See [Batch Receiving](#batch-receiving) and [Batch Processing](#batch-processing) for more information on correlation using links.
 
-Some messaging systems such as Kafka, Azure EventGrid allow to publish a single batch of messages to different topics, in such cases attributes in `messaging.destination` and `messaging.source` MAY be 
+Some messaging systems such as Kafka, Azure EventGrid allow to publish a single batch of messages to different topics, in such cases attributes in `messaging.destination` and `messaging.source` MAY be
 set on links. Corresponding instrumentations MAY set source and destination attributes on the span if all messages in the batch share the same destination or source.
 
 ### Attributes specific to certain messaging systems

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -356,8 +356,6 @@ All attributes that are specific for a messaging system SHOULD be populated in `
 * Destination-specific under `messaging.{system}.destination`
 * source-specific under `messaging.{system}.source`
 
-System name in the namespace MUST match `messaging.system` attribute value.
-
 #### RabbitMQ
 
 In RabbitMQ, the destination is defined by an *exchange* and a *routing key*.

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -456,8 +456,10 @@ Process CB:                 | Span CB1 |
 | `net.peer.name` | `"ms"` | `"ms"` | `"ms"` |
 | `net.peer.port` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
-| `messaging.destination` | `"T"` | `"T"` | `"T"` |
-| `messaging.destination_kind` | `"topic"` | `"topic"` | `"topic"` |
+| `messaging.destination.name` | `"T"` | | |
+| `messaging.destination.kind` | `"topic"` |  |  |
+| `messaging.source.name` | | `"T"` | `"T"` |
+| `messaging.source.kind` | | `"topic"` | `"topic"` |
 | `messaging.operation` |  | `"process"` | `"process"` |
 | `messaging.message.id` | `"a1"` | `"a1"`| `"a1"` |
 
@@ -491,8 +493,10 @@ Process CB:                           | Span Rcv2 |
 | `peer.service` | `"myKafka"` |  |  | `"myKafka"` |  |
 | `service.name` |  | `"myConsumer1"` | `"myConsumer1"` |  | `"myConsumer2"` |
 | `messaging.system` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` | `"kafka"` |
-| `messaging.destination` | `"T1"` | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
-| `messaging.destination_kind` | `"topic"` | `"topic"` | `"topic"` | `"topic"` | `"topic"` |
+| `messaging.destination.name` | `"T1"` | | | | |
+| `messaging.destination.kind` | `"topic"` | | | | |
+| `messaging.source.name` |  | `"T1"` | `"T1"` | `"T2"` | `"T2"` |
+| `messaging.source.kind` |  | `"topic"` | `"topic"` | `"topic"` | `"topic"` |
 | `messaging.operation` |  |  | `"process"` |  | `"receive"` |
 | `messaging.kafka.message.key` | `"myKey"` | `"myKey"` | `"myKey"` | `"anotherKey"` | `"anotherKey"` |
 | `messaging.kafka.consumer_group` |  | `"my-group"` | `"my-group"` |  | `"another-group"` |
@@ -523,8 +527,10 @@ Process C:                      | Span Recv1 |
 | `net.peer.name` | `"ms"` | `"ms"` | `"ms"` | `"ms"` | `"ms"` |
 | `net.peer.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
-| `messaging.destination` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.destination_kind` | `"queue"` | `"queue"` | `"queue"` | `"queue"` | `"queue"` |
+| `messaging.destination.name` | `"Q"` | `"Q"` | | | |
+| `messaging.destination.kind` | `"queue"` | `"queue"` | | | |
+| `messaging.source.name` | | | `"Q"` | `"Q"` | `"Q"` |
+| `messaging.source.kind` | | | `"queue"` | `"queue"` | `"queue"` |
 | `messaging.operation` |  |  | `"receive"` | `"process"` | `"process"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | | `"a1"` | `"a2"` |
 | `messaging.batch.size` |  |  | 2 |  |  |
@@ -558,8 +564,10 @@ Process C:                              | Span Recv1 | Span Recv2 |
 | `net.peer.name` | `"ms"` | `"ms"` | `"ms"` | `"ms"` | `"ms"` |
 | `net.peer.port` | `1234` | `1234` | `1234` | `1234` | `1234` |
 | `messaging.system` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` | `"rabbitmq"` |
-| `messaging.destination` | `"Q"` | `"Q"` | `"Q"` | `"Q"` | `"Q"` |
-| `messaging.destination_kind` | `"queue"` | `"queue"` | `"queue"` | `"queue"` | `"queue"` |
+| `messaging.destination.name` | `"Q"` | `"Q"` | | | |
+| `messaging.destination.kind` | `"queue"` | `"queue"` | | | |
+| `messaging.source.name` | | | `"Q"` | `"Q"` | `"Q"` |
+| `messaging.source.kind` | | | `"queue"` | `"queue"` | `"queue"` |
 | `messaging.operation` |  |  | `"receive"` | `"receive"` | `"process"` |
 | `messaging.message.id` | `"a1"` | `"a2"` | `"a1"` | `"a2"` | |
 | `messaging.batch.size` | | | 1 | 1 | 2 |


### PR DESCRIPTION
Messaging instrumentation SIG is working on [spec changes](https://github.com/open-telemetry/oteps/pull/192) and this change is one of the first steps to bring the consensus we reached in SIG to the spec.

This change clarifies that per-message attributes should be set on links when the corresponding span represents a batching operation. It introduced breaking changes (attribute renames)
- `messaging.message_id` to `messaging.message.id`
- `messaging.conversation_id` to `messaging.message.conversation_id`
- `messaging.message_payload_size_bytes` to `messaging.message.payload_size_bytes`
- `messaging.message_payload_compressed_size_bytes` to `messaging.message.payload_compressed_size_bytes`.

Going forward, we'd like to reserve `messaging.message.` namespace for other possible per-message attributes.

It also adds the `messaging.batch_size` attribute which intends to:
- denote a bathing operation
- record number of messages sent/received/processed - since links can be dropped or there can be some other links not describing messages, link count is not a reliable indicator of batch size. Assuming a high-scale scenario, users might want to opt-out from per-message tracing, but then batch_size would still be useful
