### PR TITLE
Introduce "Scope full name" for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,7 +94,7 @@ release.
 - Introduce Instrumentation Scope Attributes
   ([#2579](https://github.com/open-telemetry/opentelemetry-specification/pull/2579))
 - Introduce Instrumentation Scope Full name requirements
-  ([#2780])(https://github.com/open-telemetry/opentelemetry-specification/pull/2780).
+  ([#2780](https://github.com/open-telemetry/opentelemetry-specification/pull/2780)).
 
 ## v1.12.0 (2022-06-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ release.
 
 - Introduce Instrumentation Scope Attributes
   ([#2579](https://github.com/open-telemetry/opentelemetry-specification/pull/2579))
+- Introduce Instrumentation Scope Full name requirements
+  ([#2780])(https://github.com/open-telemetry/opentelemetry-specification/pull/2780).
 
 ## v1.12.0 (2022-06-10)
 

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -204,7 +204,7 @@ The example generates the following OTLP Scope data structure:
 
 ```golang
 InstrumentationScope{
-	Name: "Fancy path/%2Fa%2Fb%2Fc shard=1234 (int)",
+	Name: "Fancy path/%2Fa%2Fb%2Fc shard/1234 (int)",
 	Version: "1.0",
 	SchemaUrl: "http://schema.org/telemetry/sqldriver/v1.1",
 	Attributes: []*KeyValue{

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -15,6 +15,9 @@ aliases: [/docs/reference/specification/common/common]
     + [Configurable Parameters](#configurable-parameters)
     + [Exempt Entities](#exempt-entities)
 - [Attribute Collections](#attribute-collections)
+- [Full Scope naming requirements](#full-scope-naming-requirements)
+  * [Full scope naming: Producer requirements](#full-scope-naming-producer-requirements)
+  * [Full scope naming: Consumer recommendations](#full-scope-naming-consumer-recommendations)
 
 <!-- tocstop -->
 
@@ -186,7 +189,7 @@ include whitespace and `/` characters, for example.
 
 For example, an API call such as
 
-```
+```golang
     meter := meterProvider.Meter("Fancy", 
         metric.WithVersion("v1.0"), 
 	    metric.WithScopeAttributes(
@@ -199,15 +202,15 @@ For example, an API call such as
 
 The example generates the following OTLP Scope data structure:
 
-```
+```golang
 InstrumentationScope{
-	Name: "Fancy path/%2Fa%2Fb%2Fc shard=1234 (int)
-	Version: "1.0"
-	SchemaUrl: "http://schema.org/telemetry/sqldriver/v1.1"
+	Name: "Fancy path/%2Fa%2Fb%2Fc shard=1234 (int)",
+	Version: "1.0",
+	SchemaUrl: "http://schema.org/telemetry/sqldriver/v1.1",
 	Attributes: []*KeyValue{
 	  &KeyValue{Key: "path", Value: &AnyValue_StringValue{...}},
 	  &KeyValue{Key: "shard", Value: &AnyValue_IntValue{...}},
-	}
+	},
 }
 ```
 


### PR DESCRIPTION
Fixes #2762

## Changes

This requires producers to include Scope Attributes in the Scope "full name", which uses the same encoding as HTTP `User-Agent` to include multiple key-values with optional comments. This addresses the backwards-compatibility problem with Scope Attributes by ensuring that the full name uniquely (and redundantly) specifies the scope attributes.