### PR TITLE
Remove mention of browser from process.runtime semantic convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ release.
 - Add `browser.mobile` and `browser.language` resource attributes
   ([#2761](https://github.com/open-telemetry/opentelemetry-specification/pull/2761))
 - Remove mention of browser from `process.runtime` semantic convention
-  ([#2815](https://github.com/open-telemetry/opentelemetry-specification/pull/2815/files))
+  ([#2815](https://github.com/open-telemetry/opentelemetry-specification/pull/2815))
 
 ### Semantic Conventions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ release.
 
 ### Resource
 
+- Remove mention of browser from `process.runtime` semantic convention
+  ([#2815](https://github.com/open-telemetry/opentelemetry-specification/pull/2815/files))
+
 ### Semantic Conventions
 
 ### Compatibility

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -138,14 +138,14 @@ Examples for some Java runtimes
 
 ### JavaScript runtimes
 
-JavaScript Node instrumentation should fill in the values by copying from built-in runtime constants.
+JavaScript Node.js instrumentation should fill in the values by copying from built-in runtime constants.
 
 - `process.runtime.name`:
   Fill in the constant value `nodejs`.
 - `process.runtime.version`:
   Fill in the value of `process.versions.node`.
 
-Example for a Node runtime:
+Example of a Node.js runtime:
 
 | Name | `process.runtime.name` | `process.runtime.version` |
 | --- | --- | --- |

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -138,21 +138,18 @@ Examples for some Java runtimes
 
 ### JavaScript runtimes
 
-JavaScript instrumentation should fill in the values by copying from built-in runtime constants.
+JavaScript Node instrumentation should fill in the values by copying from built-in runtime constants.
 
 - `process.runtime.name`:
-  - When the runtime is Node.js, fill in the constant value `nodejs`.
-  - When the runtime is Web Browser, fill in the constant value `browser`.
+  Fill in the constant value `nodejs`.
 - `process.runtime.version`:
-  - When the runtime is Node.js, fill in the value of `process.versions.node`.
-  - When the runtime is Web Browser, fill in the value of `navigator.userAgent`.
+  Fill in the value of `process.versions.node`.
 
-Examples for some JavaScript runtimes
+Example for a Node runtime:
 
 | Name | `process.runtime.name` | `process.runtime.version` |
 | --- | --- | --- |
 | Node.js | nodejs | 14.15.4 |
-| Web Browser | browser | Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.71 Safari/537.36 |
 
 ### .NET Runtimes
 


### PR DESCRIPTION
Fixes #2806


## Changes

In the Client Instrumentation SIG we agreed on using only `browser.` namespace in the browser resource for identification purpose. In this PR, we are removing the mention of Web Browsers in the `process.runtime.*` semantic convention as they will not be used in the resource from browser instrumentation. For more context, please see https://github.com/open-telemetry/opentelemetry-specification/issues/2806



Related issues #
[#2806](https://github.com/open-telemetry/opentelemetry-specification/issues/2806)

