### PR TITLE
Clarify that unknown fields must be ignored when receiving OTLP/JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ release.
 
 - Add user agent to OTLP exporter specification
   ([#2684](https://github.com/open-telemetry/opentelemetry-specification/pull/2684))
+- Clarify that unknown fields must be ignored when receiving OTLP/JSON
+  ([#2816](https://github.com/open-telemetry/opentelemetry-specification/pull/2816))
 
 ### SDK Configuration
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -423,8 +423,6 @@ for mapping between Protobuf and JSON, with the following deviations from that m
   message as if the unknown field was not resent in the payload.
   This aligns with the behavior of the Binary Protobuf unmarshaler and ensures that adding
   new fields to OTLP messages does not break existing receivers.
-  Protobuf unmarshalling implementations often support this via an option called
-  "Ignore unknown fields".
 
 Note that according to [Protobuf specs](
 https://developers.google.com/protocol-buffers/docs/proto3#json) 64-bit integer

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -420,7 +420,7 @@ for mapping between Protobuf and JSON, with the following deviations from that m
   { "kind": 2, ... }
 
 - OTLP/JSON receivers MUST ignore message fields with unknown names and MUST unmarshal the
-  message as if the unknown field was not resent in the payload.
+  message as if the unknown field was not present in the payload.
   This aligns with the behavior of the Binary Protobuf unmarshaler and ensures that adding
   new fields to OTLP messages does not break existing receivers.
 

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -419,6 +419,13 @@ for mapping between Protobuf and JSON, with the following deviations from that m
   represented like this:
   { "kind": 2, ... }
 
+- OTLP/JSON receivers MUST ignore message fields with unknown names and MUST unmarshal the
+  message as if the unknown field was not resent in the payload.
+  This aligns with the behavior of the Binary Protobuf unmarshaler and ensures that adding
+  new fields to OTLP messages does not break existing receivers.
+  Protobuf unmarshalling implementations often support this via an option called
+  "Ignore unknown fields".
+
 Note that according to [Protobuf specs](
 https://developers.google.com/protocol-buffers/docs/proto3#json) 64-bit integer
 numbers in JSON-encoded payloads are encoded as decimal strings, and either


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-proto/issues/425

The proposed behavior is necessary for interoperability of senders and receivers when OTLP protocol evolves in an allowed way: by adding new fields to existing messages.
