### PR TITLE
[Logs] Add semantic conventions for writing exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ release.
 - Add `process.context_switches`, and `process.open_file_descriptors`, to the
   metrics semantic conventions
   ([#2706](https://github.com/open-telemetry/opentelemetry-specification/pull/2706))
+- Add exceptions to the logs semantic conventions
+  ([#2819](https://github.com/open-telemetry/opentelemetry-specification/pull/2819))
 
 ### Compatibility
 

--- a/semantic_conventions/exception.yaml
+++ b/semantic_conventions/exception.yaml
@@ -1,7 +1,6 @@
 groups:
   - id: exception
     prefix: exception
-    type: event
     brief: >
       This document defines the shared attributes used to
       report a single exception associated with a span or log.

--- a/semantic_conventions/exception.yaml
+++ b/semantic_conventions/exception.yaml
@@ -1,0 +1,33 @@
+groups:
+  - id: exception
+    prefix: exception
+    type: event
+    brief: >
+      This document defines the shared attributes used to
+      report a single exception associated with a span or log.
+    attributes:
+      - id: type
+        type: string
+        brief: >
+          The type of the exception (its fully-qualified class name, if applicable).
+          The dynamic type of the exception should be preferred over the static type
+          in languages that support it.
+        examples: ["java.net.ConnectException", "OSError"]
+      - id: message
+        type: string
+        brief: The exception message.
+        examples: ["Division by zero", "Can't convert 'int' object to str implicitly"]
+      - id: stacktrace
+        type: string
+        brief: >
+          A stacktrace as a string in the natural representation for the language runtime.
+          The representation is to be determined and documented by each language SIG.
+        examples: 'Exception in thread "main" java.lang.RuntimeException: Test exception\n
+        at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n
+        at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n
+        at com.example.GenerateTrace.main(GenerateTrace.java:5)'
+
+    constraints:
+      - any_of:
+          - "exception.type"
+          - "exception.message"

--- a/semantic_conventions/logs/log-exception.yaml
+++ b/semantic_conventions/logs/log-exception.yaml
@@ -1,0 +1,15 @@
+groups:
+  - id: log-exception
+    prefix: exception
+    brief: >
+      This document defines attributes for exceptions represented using Log
+      Records.
+    attributes:
+      - ref: exception.type
+      - ref: exception.message
+      - ref: exception.stacktrace
+
+    constraints:
+      - any_of:
+          - "exception.type"
+          - "exception.message"

--- a/semantic_conventions/trace/exception.yaml
+++ b/semantic_conventions/trace/exception.yaml
@@ -13,10 +13,12 @@ groups:
           The dynamic type of the exception should be preferred over the static type
           in languages that support it.
         examples: ["java.net.ConnectException", "OSError"]
+        tag: logs-and-traces
       - id: message
         type: string
         brief: The exception message.
         examples: ["Division by zero", "Can't convert 'int' object to str implicitly"]
+        tag: logs-and-traces
       - id: stacktrace
         type: string
         brief: >
@@ -26,6 +28,7 @@ groups:
         at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n
         at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n
         at com.example.GenerateTrace.main(GenerateTrace.java:5)'
+        tag: logs-and-traces
       - id: escaped
         type: boolean
         brief: >

--- a/semantic_conventions/trace/exception.yaml
+++ b/semantic_conventions/trace/exception.yaml
@@ -13,12 +13,10 @@ groups:
           The dynamic type of the exception should be preferred over the static type
           in languages that support it.
         examples: ["java.net.ConnectException", "OSError"]
-        tag: logs-and-traces
       - id: message
         type: string
         brief: The exception message.
         examples: ["Division by zero", "Can't convert 'int' object to str implicitly"]
-        tag: logs-and-traces
       - id: stacktrace
         type: string
         brief: >
@@ -28,7 +26,6 @@ groups:
         at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n
         at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n
         at com.example.GenerateTrace.main(GenerateTrace.java:5)'
-        tag: logs-and-traces
       - id: escaped
         type: boolean
         brief: >

--- a/semantic_conventions/trace/trace-exception.yaml
+++ b/semantic_conventions/trace/trace-exception.yaml
@@ -1,31 +1,14 @@
 groups:
-  - id: exception
+  - id: trace-exception
     prefix: exception
     type: event
     brief: >
       This document defines the attributes used to
       report a single exception associated with a span.
     attributes:
-      - id: type
-        type: string
-        brief: >
-          The type of the exception (its fully-qualified class name, if applicable).
-          The dynamic type of the exception should be preferred over the static type
-          in languages that support it.
-        examples: ["java.net.ConnectException", "OSError"]
-      - id: message
-        type: string
-        brief: The exception message.
-        examples: ["Division by zero", "Can't convert 'int' object to str implicitly"]
-      - id: stacktrace
-        type: string
-        brief: >
-          A stacktrace as a string in the natural representation for the language runtime.
-          The representation is to be determined and documented by each language SIG.
-        examples: 'Exception in thread "main" java.lang.RuntimeException: Test exception\n
-        at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n
-        at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n
-        at com.example.GenerateTrace.main(GenerateTrace.java:5)'
+      - ref: exception.type
+      - ref: exception.message
+      - ref: exception.stacktrace
       - id: escaped
         type: boolean
         brief: >

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -470,7 +470,7 @@ Additional information about errors and/or exceptions that are associated with
 a log record MAY be included in the structured data in the `Attributes` section
 of the record.
 If included, they MUST follow the OpenTelemetry
-[semantic conventions for exception-related attributes](../trace/semantic_conventions/exceptions.md#attributes).
+[semantic conventions for exception-related attributes](./semantic_conventions/exceptions.md#attributes).
 
 ## Example Log Records
 

--- a/specification/logs/semantic_conventions/exceptions.md
+++ b/specification/logs/semantic_conventions/exceptions.md
@@ -2,7 +2,8 @@
 
 **Status**: [Experimental](../../document-status.md)
 
-This document defines semantic conventions for recording exceptions.
+This document defines semantic conventions for recording exceptions on "logs"
+and "events" emitted through the [Logger API](../api.md#logger).
 
 <!-- toc -->
 

--- a/specification/logs/semantic_conventions/exceptions.md
+++ b/specification/logs/semantic_conventions/exceptions.md
@@ -30,14 +30,12 @@ the language runtime.
 The table below indicates which attributes should be added to the
 [LogRecord](../api.md#logrecord) and their types.
 
-<!-- semconv exception(tag=logs-and-traces) -->
-The event name MUST be `exception`.
-
+<!-- semconv log-exception -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`exception.type`](../../trace/semantic_conventions/exceptions.md) | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
 | [`exception.message`](../../trace/semantic_conventions/exceptions.md) | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` | See below |
 | [`exception.stacktrace`](../../trace/semantic_conventions/exceptions.md) | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | Recommended |
+| [`exception.type`](../../trace/semantic_conventions/exceptions.md) | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:
 

--- a/specification/logs/semantic_conventions/exceptions.md
+++ b/specification/logs/semantic_conventions/exceptions.md
@@ -2,8 +2,7 @@
 
 **Status**: [Experimental](../../document-status.md)
 
-This document defines semantic conventions for recording application
-exceptions.
+This document defines semantic conventions for recording exceptions.
 
 <!-- toc -->
 

--- a/specification/logs/semantic_conventions/exceptions.md
+++ b/specification/logs/semantic_conventions/exceptions.md
@@ -1,0 +1,51 @@
+# Semantic Conventions for Exceptions
+
+**Status**: [Experimental](../../document-status.md)
+
+This document defines semantic conventions for recording application
+exceptions.
+
+<!-- toc -->
+
+- [Recording an Exception](#recording-an-exception)
+- [Attributes](#attributes)
+  * [Stacktrace Representation](#stacktrace-representation)
+
+<!-- tocstop -->
+
+## Recording an Exception
+
+Exceptions SHOULD be recorded as attributes on the
+[LogRecord](../api.md#logrecord) passed to the [Logger](../api.md#logger) emit
+operations. Exceptions MAY be recorded on "logs" or "events" depending on the
+context.
+
+To encapsulate proper handling of exceptions API authors MAY provide a
+constructor, `RecordException` method/extension, or similar helper mechanism on
+the `LogRecord` class/structure or wherever it makes the most sense depending on
+the language runtime.
+
+## Attributes
+
+The table below indicates which attributes should be added to the
+[LogRecord](../api.md#logrecord) and their types.
+
+<!-- semconv exception(tag=logs-and-traces) -->
+The event name MUST be `exception`.
+
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`exception.type`](../../trace/semantic_conventions/exceptions.md) | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
+| [`exception.message`](../../trace/semantic_conventions/exceptions.md) | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` | See below |
+| [`exception.stacktrace`](../../trace/semantic_conventions/exceptions.md) | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | Recommended |
+
+**Additional attribute requirements:** At least one of the following sets of attributes is required:
+
+* [`exception.type`](../../trace/semantic_conventions/exceptions.md)
+* [`exception.message`](../../trace/semantic_conventions/exceptions.md)
+<!-- endsemconv -->
+
+### Stacktrace Representation
+
+See [Trace Semantic Conventions for Exceptions - Stacktrace
+Representation](../../trace/semantic_conventions/exceptions.md#stacktrace-representation).

--- a/specification/logs/semantic_conventions/exceptions.md
+++ b/specification/logs/semantic_conventions/exceptions.md
@@ -34,17 +34,17 @@ The table below indicates which attributes should be added to the
 <!-- semconv log-exception -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| [`exception.message`](../../trace/semantic_conventions/exceptions.md) | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` | See below |
-| [`exception.stacktrace`](../../trace/semantic_conventions/exceptions.md) | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | Recommended |
-| [`exception.type`](../../trace/semantic_conventions/exceptions.md) | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
+| `exception.message` | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` | See below |
+| `exception.stacktrace` | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | Recommended |
+| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:
 
-* [`exception.type`](../../trace/semantic_conventions/exceptions.md)
-* [`exception.message`](../../trace/semantic_conventions/exceptions.md)
+* `exception.type`
+* `exception.message`
 <!-- endsemconv -->
 
 ### Stacktrace Representation
 
-See [Trace Semantic Conventions for Exceptions - Stacktrace
+Same as [Trace Semantic Conventions for Exceptions - Stacktrace
 Representation](../../trace/semantic_conventions/exceptions.md#stacktrace-representation).

--- a/specification/logs/semantic_conventions/exceptions.md
+++ b/specification/logs/semantic_conventions/exceptions.md
@@ -2,8 +2,9 @@
 
 **Status**: [Experimental](../../document-status.md)
 
-This document defines semantic conventions for recording exceptions on "logs"
-and "events" emitted through the [Logger API](../api.md#logger).
+This document defines semantic conventions for recording exceptions on
+[logs](../api.md#emit-logrecord) and [events](../api.md#emit-event) emitted
+through the [Logger API](../api.md#logger).
 
 <!-- toc -->
 

--- a/specification/trace/semantic_conventions/exceptions.md
+++ b/specification/trace/semantic_conventions/exceptions.md
@@ -39,15 +39,15 @@ try {
 The table below indicates which attributes should be added to the `Event` and
 their types.
 
-<!-- semconv exception -->
+<!-- semconv trace-exception -->
 The event name MUST be `exception`.
 
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
+| `exception.escaped` | boolean | SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. [1] |  | Recommended |
 | `exception.message` | string | The exception message. | `Division by zero`; `Can't convert 'int' object to str implicitly` | See below |
 | `exception.stacktrace` | string | A stacktrace as a string in the natural representation for the language runtime. The representation is to be determined and documented by each language SIG. | `Exception in thread "main" java.lang.RuntimeException: Test exception\n at com.example.GenerateTrace.methodB(GenerateTrace.java:13)\n at com.example.GenerateTrace.methodA(GenerateTrace.java:9)\n at com.example.GenerateTrace.main(GenerateTrace.java:5)` | Recommended |
-| `exception.escaped` | boolean | SHOULD be set to true if the exception event is recorded at a point where it is known that the exception is escaping the scope of the span. [1] |  | Recommended |
+| `exception.type` | string | The type of the exception (its fully-qualified class name, if applicable). The dynamic type of the exception should be preferred over the static type in languages that support it. | `java.net.ConnectException`; `OSError` | See below |
 
 **[1]:** An exception is considered to have escaped (or left) the scope of a span,
 if that span is ended while the exception is still logically "in flight".


### PR DESCRIPTION
## Changes

Defines how exceptions should be written when using the logs & events API.

/cc @jack-berg @scheler @MSNev 
