### PR TITLE
Add `process.start_time` resource attribute to semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ release.
   ([#2874](https://github.com/open-telemetry/opentelemetry-specification/pull/2874))
 - Add `process.paging.faults` metric to semantic conventions
   ([#2827](https://github.com/open-telemetry/opentelemetry-specification/pull/2827))
+- Add `process.start_time` resource attribute to semantic conventions
+  ([#2825](https://github.com/open-telemetry/opentelemetry-specification/pull/2825))
 
 ### Compatibility
 

--- a/semantic_conventions/resource/process.yaml
+++ b/semantic_conventions/resource/process.yaml
@@ -68,6 +68,12 @@ groups:
         brief: >
           The username of the user that owns the process.
         examples: 'root'
+      - id: start_time
+        type: int
+        brief: >
+          The start time of the process in UTC,
+          expressed as number of seconds since the Unix epoch.
+        examples: [1663931438]
     constraints:
       - any_of:
           - process.executable.name

--- a/specification/resource/semantic_conventions/process.md
+++ b/specification/resource/semantic_conventions/process.md
@@ -35,6 +35,7 @@
 | `process.command_line` | string | The full command used to launch the process as a single string representing the full command. On Windows, can be set to the result of `GetCommandLineW`. Do not set this if you have to assemble it just for monitoring; use `process.command_args` instead. | `C:\cmd\otecol --config="my directory\config.yaml"` | Conditionally Required: See alternative attributes below. |
 | `process.command_args` | string[] | All the command arguments (including the command/executable itself) as received by the process. On Linux-based systems (and some other Unixoid systems supporting procfs), can be set according to the list of null-delimited strings extracted from `proc/[pid]/cmdline`. For libc-based executables, this would be the full argv vector passed to `main`. | `[cmd/otecol, --config=config.yaml]` | Conditionally Required: See alternative attributes below. |
 | `process.owner` | string | The username of the user that owns the process. | `root` | Recommended |
+| `process.start_time` | int | The start time of the process in UTC, expressed as number of seconds since the Unix epoch. | `1663931438` | Recommended |
 
 **Additional attribute requirements:** At least one of the following sets of attributes is required:
 


### PR DESCRIPTION
Fixes #1273

## Changes

Adds a new resource attribute `process.start_time` to the semantic conventions.

Here's a related pull request that adds `process.uptime` and `system.uptime` metrics: https://github.com/open-telemetry/opentelemetry-specification/pull/2824.

I also wanted to add a `system.start_time` resource attribute, but I'm not sure where to put it - there's no `system` namespace in the resource attributes at the moment; the closest I could find is the [`os`](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.13.0/specification/resource/semantic_conventions/os.md) namespace. Should I add an `os.start_time` attribute?