### PR TITLE
Clarify that lowerCamelCase field names MUST be used for OTLP/JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ release.
 
 ### OpenTelemetry Protocol
 
+- Clarify that lowerCamelCase field names MUST be used for OTLP/JSON
+  ([#2829](https://github.com/open-telemetry/opentelemetry-specification/pull/2829))
 - Add user agent to OTLP exporter specification
   ([#2684](https://github.com/open-telemetry/opentelemetry-specification/pull/2684))
 - Prohibit usage of enum value name strings in OTLP/JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ release.
 
 ### OpenTelemetry Protocol
 
+- Clarify that lowerCamelCase field names MUST be used for OTLP/JSON
+  ([#2829](https://github.com/open-telemetry/opentelemetry-specification/pull/2829))
+
 ### SDK Configuration
 
 ### Telemetry Schemas
@@ -81,8 +84,6 @@ release.
 
 ### OpenTelemetry Protocol
 
-- Clarify that lowerCamelCase field names MUST be used for OTLP/JSON
-  ([#2829](https://github.com/open-telemetry/opentelemetry-specification/pull/2829))
 - Add user agent to OTLP exporter specification
   ([#2684](https://github.com/open-telemetry/opentelemetry-specification/pull/2684))
 - Prohibit usage of enum value name strings in OTLP/JSON

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -424,6 +424,13 @@ for mapping between Protobuf and JSON, with the following deviations from that m
   This aligns with the behavior of the Binary Protobuf unmarshaler and ensures that adding
   new fields to OTLP messages does not break existing receivers.
 
+- The keys of JSON objects are field names converted to lowerCamelCase. Original
+  field names are not valid to use a keys of JSON objects.
+  For example this is a valid JSON representation of a Resource:
+  `{ "attributes": {...}, "droppedAttributesCount": 123 }`, and this is NOT a valid
+  representation:
+  `{ "attributes": {...}, "dropped_attributes_count": 123 }`.
+
 Note that according to [Protobuf specs](
 https://developers.google.com/protocol-buffers/docs/proto3#json) 64-bit integer
 numbers in JSON-encoded payloads are encoded as decimal strings, and either


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-specification/issues/2795

This is a breaking change for OTLP/JSON and is allowed because OTLP/JSON is not yet Stable.