### PR TITLE
Remove outdated Resource verbiage from Overview page

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -335,10 +335,7 @@ describe the host in the cloud and specific container or an application running
 in the process.
 
 Note, that some of the process identification information can be associated with
-telemetry automatically by OpenTelemetry SDK or specific exporter. See
-OpenTelemetry
-[proto](https://github.com/open-telemetry/opentelemetry-proto/blob/a46c815aa5e85a52deb6cb35b8bc182fb3ca86a0/src/opentelemetry/proto/agent/common/v1/common.proto#L28-L96)
-for an example.
+telemetry automatically by OpenTelemetry SDK.
 
 ## Context Propagation
 

--- a/specification/overview.md
+++ b/specification/overview.md
@@ -335,7 +335,7 @@ describe the host in the cloud and specific container or an application running
 in the process.
 
 Note, that some of the process identification information can be associated with
-telemetry automatically by OpenTelemetry SDK.
+telemetry automatically by the OpenTelemetry SDK.
 
 ## Context Propagation
 


### PR DESCRIPTION
## Changes

This PR updates the Resources section of the Overview page to remove outdated verbiage. The spec previously referred to specific exporters with a link to the `opentelemetry-proto` repo's `common.proto`, but the linked code was removed in the following PRs:

- https://github.com/open-telemetry/opentelemetry-proto/pull/80 (`Node` and `ProcessIdentifier`)
- https://github.com/open-telemetry/opentelemetry-proto/pull/62 (`LibraryInfo` and `ServiceInfo`)
