### PR TITLE
Change to messaging.kafka.max.lag from UpDownCounter to Gauge (and rename it)

### DIFF
--- a/specification/metrics/semantic_conventions/instrumentation/kafka.md
+++ b/specification/metrics/semantic_conventions/instrumentation/kafka.md
@@ -31,7 +31,7 @@ This document defines how to apply semantic conventions when instrumenting Kafka
 | messaging.kafka.partitions.offline           | UpDownCounter | Int64      | partitions | `{partitions}` | The number of offline partitions. | | |
 | messaging.kafka.partitions.under-replicated  | UpDownCounter | Int64      | partition  | `{partitions}` | The number of under replicated partitions. | | |
 | messaging.kafka.isr.operations               | Counter       | Int64      | operations | `{operations}` | The number of in-sync replica shrink and expand operations. | `operation` | `shrink`, `expand` |
-| messaging.kafka.max.lag                      | UpDownCounter | Int64      | messages   | `{messages}`   | Max lag in messages between follower and leader replicas. | | |
+| messaging.kafka.lag_max                      | Gauge         | Int64      | lag max    | `{lag max}`    | Max lag in messages between follower and leader replicas. | | |
 | messaging.kafka.controllers.active           | UpDownCounter | Int64      | controllers | `{controllers}` | The number of active controllers in the broker. | | |
 | messaging.kafka.leader.elections             | Counter       | Int64      | elections | `{elections}` | Leader election rate (increasing values indicates broker failures). | | |
 | messaging.kafka.leader.unclean-elections     | Counter       | Int64      | elections | `{elections}` | Unclean leader election rate (increasing values indicates broker failures). | | |


### PR DESCRIPTION
## Changes

Changes to `messaging.kafka.max.lag` from UpDownCounter to Gauge, since doesn't make sense to aggregate maxes.

Also, renames `messaging.kafka.max.lag` to `messaging.kafka.lag_max`, to be consistent with `messaging.kafka.consumer.lag_sum`.

Schema translation for the rename is not included since also changing its type, so seems better(?) to treat it as a breaking change with no schema translation support.