### PR TITLE
Remove language around uniqueness of event names within a domain

### DIFF
--- a/semantic_conventions/logs/events.yaml
+++ b/semantic_conventions/logs/events.yaml
@@ -12,7 +12,7 @@ groups:
         examples: ['click', 'exception']
       - id: domain
         brief: >
-          The domain identifies the context in which an event happened. An event name is unique only within a domain.
+          The domain identifies the context in which an event happened.
         type:
           allow_custom_values: true
           members:
@@ -27,6 +27,5 @@ groups:
               brief: 'Events from Kubernetes'
         requirement_level: required
         note: |
-          An `event.name` is supposed to be unique only in the context of an
-          `event.domain`, so this allows for two events in different domains to
-          have same `event.name`, yet be unrelated events.
+          Events across different domains may have same `event.name`, yet be
+          unrelated events.

--- a/specification/logs/semantic_conventions/events.md
+++ b/specification/logs/semantic_conventions/events.md
@@ -11,11 +11,10 @@ event names.
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `event.name` | string | The name identifies the event. | `click`; `exception` | Required |
-| `event.domain` | string | The domain identifies the context in which an event happened. An event name is unique only within a domain. [1] | `browser` | Required |
+| `event.domain` | string | The domain identifies the context in which an event happened. [1] | `browser` | Required |
 
-**[1]:** An `event.name` is supposed to be unique only in the context of an
-`event.domain`, so this allows for two events in different domains to
-have same `event.name`, yet be unrelated events.
+**[1]:** Events across different domains may have same `event.name`, yet be
+unrelated events.
 
 `event.domain` has the following list of well-known values. If one of them applies, then the respective value MUST be used, otherwise a custom value MAY be used.
 


### PR DESCRIPTION

## Changes


This came up in
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14474 where it was highlighted that just `name` is not sufficient to provide for uniqueness of a Kubernetes Event.

The attribute `event.domain` is only meant to be a logical separation across different event systems, so it allows for similar looking names in different domains but with a completely different purpose. However, within each domain we don't have to have any uniqueness constraints on the `name` and leave it to whatever is idiomatic to the particular event system the domain represents.




For non-trivial changes, follow the [change proposal
process](../CONTRIBUTING.md#proposing-a-change) and link to the related issue(s)
and/or [OTEP(s)](https://github.com/open-telemetry/oteps), update the
[`CHANGELOG.md`](../CHANGELOG.md), and also be sure to update
[`spec-compliance-matrix.md`](../spec-compliance-matrix.md) if necessary.

Related issues #

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
