### PR TITLE
Clarify logs vs events vocabulary and usage

### DIFF
--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -238,8 +238,8 @@ To avoid confusion we highly recommend to use the generic word "logs" when refer
 logs and events that are not OpenTelemetry Events.
 
 OpenTelemetry also defines an [API](
-https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md#emit-event
-) that helps to emit LogRecords that are shaped as OpenTelemetry Events.
+https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md#emit-event)
+that helps to emit LogRecords that are shaped as OpenTelemetry Events.
 
 ### FAQ
 
@@ -256,7 +256,7 @@ when referring to generic log and event data.
 
 OpenTelemetry Events are produced using OpenTelemetry Events API.
 
-**Why do OpenTelemetry Events exist as concept?**
+**Why do OpenTelemetry Events exist as a concept?**
 
 OpenTelemetry Events are a class of events designed within OpenTelemetry community
 or in compliance with OpenTelemetry recommendations. OpenTelemetry Events have a


### PR DESCRIPTION
The spec is currently not very clear about what is a log and what is an event.
Here is a for example a discussion that shows that there are different ways
to interpret what is written in the spec today: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/14474

This PR attempts to clarify the spec by defining the vocabulary more strictly
and by adding a relevant FAQ.