### PR TITLE
Verify that schema files are correctly published

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,3 +266,39 @@ owner should bring it to the [OpenTelemetry Specification SIG
 meeting](https://github.com/open-telemetry/community#cross-language-specification).
 
 [nvm]: https://github.com/nvm-sh/nvm/blob/master/README.md#installing-and-updating
+
+## Releasing
+
+Release Procedure:
+
+1. Prepare a [draft release here](https://github.com/open-telemetry/opentelemetry-specification/releases).
+   Don't publish it yet.
+2. Create a PR with updated [CHANGELOG.md](CHANGELOG.md). The CHANGELOG.md must have a
+   heading with the new version number. The PR will fail the `schemas-check` Github action
+   (all other actions must pass).
+   This is expected and will be fixed in the next steps. Have this PR reviewed and approved
+   and ready to be merged. While it is being reviewed you can work on step 3-4 in parallel.
+3. Prepare the schema file for the upcoming release. The schema file should be placed
+   in [schemas](schemas) directory. If no changes to semantic conventions happened
+   since the last release which require a corresponding section in the schema file then
+   simply copy the previous schema file, rename it to the new version and add a section
+   with the new version number to the file. See for example the schema file for [1.9.0](
+   https://github.com/open-telemetry/opentelemetry-specification/blob/main/schemas/1.9.0)
+   that has no changes from 1.8.0.
+   The schema file may already exist if there were changes done to semantic conventions
+   and the schema file was created with corresponding changes.
+4. Create and merge the PR with the new schema file. Note the commit hash after merging.
+   If the schema file for the new release version previously existed then no new PR is
+   necessary, just note that latest commit hash of this repository.
+5. Once CHANGELOG.md PR is approved and ready to be merged we are ready to make the release.
+   Update [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io) repository.
+   The [opentelemetry-specification](
+   https://github.com/open-telemetry/opentelemetry.io/tree/main/content-modules)
+   submodule points to this repository. Create a PR and update the submodule to point to
+   the commit hash from step 4. Merge this PR. This should update the
+   [https://opentelemetry.io/](https://opentelemetry.io/) website and the new schema file
+   should be downloadable at `https://opentelemetry.io/schemas/<version>`.
+6. Re-trigger the `schema-checks` Github action on the PR that updates the CHANGELOG.md.
+   The action should pass now. Merge the PR.
+7. Publish the previously created [draft release here](
+   https://github.com/open-telemetry/opentelemetry-specification/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -279,7 +279,7 @@ Release Procedure:
    This is expected and will be fixed in the next steps. Have this PR reviewed and approved
    and ready to be merged. While it is being reviewed you can work on step 3-4 in parallel.
 3. Prepare the schema file for the upcoming release. The schema file should be placed
-   in [schemas](schemas) directory. If no changes to semantic conventions happened
+   in `schemas` directory. If no changes to semantic conventions happened
    since the last release which require a corresponding section in the schema file then
    simply copy the previous schema file, rename it to the new version and add a section
    with the new version number to the file. See for example the schema file for [1.9.0](

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -274,12 +274,13 @@ Release Procedure:
 1. Prepare a [draft release here](https://github.com/open-telemetry/opentelemetry-specification/releases).
    Don't publish it yet.
 2. Create a PR with updated [CHANGELOG.md](CHANGELOG.md). The CHANGELOG.md must have a
-   heading with the new version number. The PR will fail the `schemas-check` Github action
-   (all other actions must pass).
+   heading with the new version number. Ensure that no CHANGELOG entries are missing or
+   ended up in the wrong section (e.g., in the last released version rather than Unreleased).
+   The PR will fail the `schemas-check` Github action (all other actions must pass).
    This is expected and will be fixed in the next steps. Have this PR reviewed and approved
    and ready to be merged. While it is being reviewed you can work on step 3-4 in parallel.
 3. Prepare the schema file for the upcoming release. The schema file should be placed
-   in `schemas` directory. If no changes to semantic conventions happened
+   in the `schemas` directory. If no changes to semantic conventions happened
    since the last release which require a corresponding section in the schema file then
    simply copy the previous schema file, rename it to the new version and add a section
    with the new version number to the file. See for example the schema file for [1.9.0](
@@ -291,8 +292,8 @@ Release Procedure:
    If the schema file for the new release version previously existed then no new PR is
    necessary, just note that latest commit hash of this repository.
 5. Once CHANGELOG.md PR is approved and ready to be merged we are ready to make the release.
-   Update [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io) repository.
-   The [opentelemetry-specification](
+   Update the [opentelemetry.io](https://github.com/open-telemetry/opentelemetry.io)
+   repository: the [opentelemetry-specification](
    https://github.com/open-telemetry/opentelemetry.io/tree/main/content-modules)
    submodule points to this repository. Create a PR and update the submodule to point to
    the commit hash from step 4. Merge this PR. This should update the
@@ -300,5 +301,6 @@ Release Procedure:
    should be downloadable at `https://opentelemetry.io/schemas/<version>`.
 6. Re-trigger the `schema-checks` Github action on the PR that updates the CHANGELOG.md.
    The action should pass now. Merge the PR.
-7. Publish the previously created [draft release here](
-   https://github.com/open-telemetry/opentelemetry-specification/releases).
+7. Add the changelog entries from `CHANGELOG.md` to the description of the previously
+   created [draft release here](
+   https://github.com/open-telemetry/opentelemetry-specification/releases) and publish it.

--- a/internal/tools/schema_check.sh
+++ b/internal/tools/schema_check.sh
@@ -31,6 +31,13 @@ grep -o -e '## v[1-9].*\s' $root_dir/CHANGELOG.md | grep -o '[1-9].*' | while re
     echo "FAILED: $file does not exist. The schema file must exist because the version is declared in CHANGELOG.md."
     exit 3
   fi
+
+  curl --no-progress-meter https://opentelemetry.io/schemas/$ver > verify$ver
+
+  diff verify$ver $file && echo "Published schema at https://opentelemetry.io/schemas/$ver is correct" \
+    || (echo "Published schema at https://opentelemetry.io/schemas/$ver is incorrect!" && exit 3)
+
+  rm verify$ver
 done
 
 # Now check the content of all schema files in the ../shemas directory.
@@ -55,11 +62,5 @@ for file in $schemas_dir/*; do
   docker run -v $schemas_dir:/schemas \
   		otel/build-tool-schemas:$BUILD_TOOL_SCHEMAS_VERSION --file /schemas/$ver --version=$ver
 
-  curl --no-progress-meter https://opentelemetry.io/schemas/$ver > verify$ver
-
-  diff verify$ver $file && echo "Published schema at https://opentelemetry.io/schemas/$ver is correct" \
-    || (echo "Published schema at https://opentelemetry.io/schemas/$ver is incorrect!" && exit 3)
-
-  rm verify$ver
 
 done

--- a/internal/tools/schema_check.sh
+++ b/internal/tools/schema_check.sh
@@ -55,5 +55,11 @@ for file in $schemas_dir/*; do
   docker run -v $schemas_dir:/schemas \
   		otel/build-tool-schemas:$BUILD_TOOL_SCHEMAS_VERSION --file /schemas/$ver --version=$ver
 
-  echo "OK"
+  curl --no-progress-meter https://opentelemetry.io/schemas/$ver > verify$ver
+
+  diff verify$ver $file && echo "Published schema at https://opentelemetry.io/schemas/$ver is correct" \
+    || (echo "Published schema at https://opentelemetry.io/schemas/$ver is incorrect!" && exit 3)
+
+  rm verify$ver
+
 done

--- a/internal/tools/schema_check.sh
+++ b/internal/tools/schema_check.sh
@@ -62,5 +62,5 @@ for file in $schemas_dir/*; do
   docker run -v $schemas_dir:/schemas \
   		otel/build-tool-schemas:$BUILD_TOOL_SCHEMAS_VERSION --file /schemas/$ver --version=$ver
 
-
+  echo "OK"
 done


### PR DESCRIPTION
This downloads the schema files from https://opentelemetry.io/schemas/ and
verifies their content.

Next time we make a release this will force us to make sure 
https://github.com/open-telemetry/opentelemetry.io repo is updated
before we make the release.

This helps prevent issues like https://github.com/open-telemetry/opentelemetry.io/issues/1846