### PR TITLE
[editorial] Adds alias for redirect rule due to name change - metrics/data-model

### DIFF
--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1,5 +1,6 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Data Model
+aliases: [/docs/reference/specification/metrics/datamodel]
 --->
 
 # Metrics Data Model
@@ -731,8 +732,8 @@ double-width floating point values have indices in the range
 func MapToIndexScale0(value float64) int32 {
     rawBits := math.Float64bits(value)
 
-    // rawExponent is an 11-bit biased representation of the base-2 
-    // exponent: 
+    // rawExponent is an 11-bit biased representation of the base-2
+    // exponent:
     // - value 0 indicates a subnormal representation or a zero value
     // - value 2047 indicates an Inf or NaN value
     // - value [1, 2046] are offset by ExponentBias (1023)
@@ -752,13 +753,13 @@ func MapToIndexScale0(value float64) int32 {
         rawExponent -= int64(bits.LeadingZeros64(rawFragment - 1) - 12)
 
         // In the example with 0x1p-1023, the preceding expression subtracts
-        // (13-12)=1, leaving the rawExponent equal to -1.  The next statement 
-        // below subtracts `ExponentBias` (1023), leaving `ieeeExponent` equal 
+        // (13-12)=1, leaving the rawExponent equal to -1.  The next statement
+        // below subtracts `ExponentBias` (1023), leaving `ieeeExponent` equal
         // to -1024, which is the correct upper-inclusive bucket index for
         // the value 0x1p-1023.
     }
     ieeeExponent := int32(rawExponent - ExponentBias)
-    // Note that rawFragment and rawExponent cannot both be zero, 
+    // Note that rawFragment and rawExponent cannot both be zero,
     // or else the value is exactly zero, in which case the the ZeroCount
     // bucket is used.
     if rawFragment == 0 {
@@ -777,7 +778,7 @@ smallest normal value, which may permit the use of a built-in function:
 func MapToIndexScale0(value float64) int {
     // Note: Frexp() rounds submnormal values to the smallest normal
     // value and returns an exponent corresponding to fractions in the
-    // range [0.5, 1), whereas an exponent for the range [1, 2), so 
+    // range [0.5, 1), whereas an exponent for the range [1, 2), so
     // subtract 1 from the exponent immediately.
     frac, exp := math.Frexp(value)
     exp--
@@ -876,7 +877,7 @@ func MapToIndex(value float64) int {
         return ((exp - 1) << scale) - 1
     }
     scaleFactor := math.Ldexp(math.Log2E, scale)
-    // Note: math.Floor(value) equals math.Ceil(value)-1 when value 
+    // Note: math.Floor(value) equals math.Ceil(value)-1 when value
     // is not a power of two, which is checked above.
     return math.Floor(math.Log(value) * scaleFactor)
 }


### PR DESCRIPTION
- Adds an alias, which creates a redirect rule for the spec published on the website.
- Specifically, this addresses https://github.com/open-telemetry/opentelemetry-specification/pull/2586#issuecomment-1154100618
- Best viewed by ignoring whitespace changes :)

/cc @tigrannajaryan @reyang 