### PR TITLE
Fix typo in tracestate value ordering example

### DIFF
--- a/specification/trace/tracestate-handling.md
+++ b/specification/trace/tracestate-handling.md
@@ -66,7 +66,7 @@ in order to preserve existing values belonging to other OTel concerns. For examp
 if a given concern K wants to set `k1:13`:
 
 * `ot=p:8;r:62` will become `ot=p:8;r:62;k1:13`.
-* `ot=p:8;k1:7;r:62` will become `ot=p8;r:62;k1:13`. Preserving the order is not required.
+* `ot=p:8;k1:7;r:62` will become `ot=p:8;r:62;k1:13`. Preserving the order is not required.
 
 If setting a value ends up making the entire `ot` entry exceed the 256 characters limit,
 SDKs are advised to abort the operation and signal the user about the error, e.g.


### PR DESCRIPTION
## Changes

Fixes typo in tracestate example.