### PR TITLE
Prevent duplicate Prometheus description comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ release.
 
 ### Metrics
 
+- Handle duplicate description comments during Prometheus conversion.
+  ([#2890](https://github.com/open-telemetry/opentelemetry-specification/pull/2890))
+
 ### Logs
 
 ### Resource

--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1469,9 +1469,12 @@ in keys).
 #### Metric Metadata
 
 Prometheus SDK exporters MUST NOT allow duplicate UNIT, HELP, or TYPE
-comments for the same metric name to be present on the Prometheus endpoint.
-Exporters MUST drop metrics to prevent conflicting TYPE comments, but
-SHOULD NOT drop metrics as a result of conflicting UNIT or HELP comments.
+comments for the same metric name to be returned in a single scrape of the
+Prometheus endpoint. Exporters MUST drop entire metrics to prevent conflicting
+TYPE comments, but SHOULD NOT drop metric points as a result of conflicting
+UNIT or HELP comments. Instead, all but one of the conflicting UNIT and HELP
+comments (but not metric points) SHOULD be dropped. If dropping a comment or
+metric points, the exporter SHOULD warn the user through error logging.
 
 The Name of an OTLP metric MUST be added as the
 [OpenMetrics MetricFamily Name](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily),

--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1468,6 +1468,11 @@ in keys).
 
 #### Metric Metadata
 
+Prometheus SDK exporters MUST NOT allow duplicate UNIT, HELP, or TYPE
+comments for the same metric name to be present on the Prometheus endpoint.
+Exporters MUST drop metrics to prevent conflicting TYPE comments, but
+SHOULD NOT drop metrics as a result of conflicting UNIT or HELP comments.
+
 The Name of an OTLP metric MUST be added as the
 [OpenMetrics MetricFamily Name](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily),
 with unit and type suffixes added as described below. The metric name is


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/2869

Follow-up to https://github.com/open-telemetry/opentelemetry-specification/pull/2703.  That PR prevents collisions between data points, but not collisions between the descriptions of the metrics.

## OpenMetrics requirements

From https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily:
> A MetricFamily MUST have a name, HELP, TYPE, and UNIT metadata.
> MetricFamily names are a string and MUST be unique within a MetricSet.

Basically, for a given metric name, we MUST have exactly one HELP, TYPE, and UNIT comment.

## Changes

This is a bit light on details, but I can add more if people think that would be helpful.

Basically, this is saying that exporters need to deduplicate Prometheus "descriptions" when sending.  For TYPE conflicts, some metric has to be dropped, as the data sent might not be valid (e.g. you can't send counter information with a histogram TYPE).  For UNIT and HELP comments, it is up to the exporter how to merge, but the exporter MUST NOT keep both comments.

### Example approach

* Keep a map of metric name -> Description when constructing a batch of metrics for a scrape.
* Each time a new metric (with Description) is added, look up the name in the map:
    * If it isn't found, add it to the map
    * If it is found, and the desc is the same, do nothing
    * If it is found, and has conflicting type information, drop the metric + log a warning
    * If it is found, and has conflicting help or unit, use the stored help + unit instead of the provided one + log a warning.