### PR TITLE
Make context available in log record processor onEmit

### DIFF
--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -179,7 +179,7 @@ fields:
 
 - [Timestamp](./data-model.md#field-timestamp)
 - [Observed Timestamp](./data-model.md#field-observedtimestamp)
-- [Trace Context](./data-model.md#trace-context-fields)
+- `Context` including [TraceContext](./data-model.md#trace-context-fields)
 - [Severity Number](./data-model.md#field-severitynumber)
 - [Severity Text](./data-model.md#field-severitytext)
 - [Body](./data-model.md#field-body)

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -179,6 +179,10 @@ therefore it SHOULD NOT block or throw exceptions.
 
 * `logRecord` - a [ReadWriteLogRecord](#readwritelogrecord) for the
   emitted `LogRecord`.
+* `context` - the `Context` that the SDK determined (the explicitly
+  passed `Context`, the current `Context`, or an empty `Context` if
+  the [Logger](./api.md#get-a-logger) was obtained
+  with `include_trace_context=false`)
 
 **Returns:** `Void`
 


### PR DESCRIPTION
Related to #2911. 

`Context` is not available to `LogRecordProcessor#onEmit` implementations at the moment. The API says that when emitting log records you [must be able to set Trace Context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md#logrecord), not a full [Context](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/context). Accessing context in `LogRecordProcessor#onEmit` is important for a variety of use cases, including extracting and baggage entries as attributes on log records. 

Implementations have to rely on languages [supporting implicit context](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/api.md#implicit-context-injection), something like:
```
    SdkLoggerProvider.builder()
        .addLogRecordProcessor(
            logRecord -> {
              Baggage baggage = Baggage.fromContext(Context.current());
              baggage
                  .asMap()
                  .forEach(
                      (key, entry) ->
                          logRecord.setAttribute(AttributeKey.stringKey(key), entry.getValue()));
            });
```

If implicit context is unavailable (i.e the language doesn't support it or the caller set the context explicitly) then accessing context is not possible.

This PR proposes extending `onEmit` with an additional argument, `Context`.

An alternative I considered was making `Context` accessible on `ReadWriteLogRecord`. This is a worse design because it causes references to `Context` to have to be held on longer in `BatchLogRecordProcessor` implementations.