### PR TITLE
Define MetricProducer as a third-party provider of metric data to MetricReaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Define Experimental MetricProducer as a third-party provider of metric data to MetricReaders.
+  ([#2951](https://github.com/open-telemetry/opentelemetry-specification/pull/2951))
+
 ### Logs
 
 - Move `event.domain` from InstrumentationScope attributes to LogRecord

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -757,7 +757,7 @@ measurements using the equivalent of the following naive algorithm:
 common configurable aspects of the OpenTelemetry Metrics SDK and
 determines the following capabilities:
 
-* Registering a [MetricBridge](#metricbridge)
+* Registering [MetricBridge](#metricbridge)(s)
 * Collecting metrics from the SDK and any registered
   [MetricBridges](#metricbridge) on demand.
 * Handling the [ForceFlush](#forceflush) and [Shutdown](#shutdown) signals from

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -831,7 +831,7 @@ functions.
 RegisterProducer causes the MetricReader to use the provided
 [MetricProducer](#metricproducer) as a source of aggregated metric data in
 subsequent invocations of Collect. RegisterProducer is expected to be called
-during initialization, but MAY be invoked later.  Multiple registrations
+during initialization, but MAY be invoked later. Multiple registrations
 of the same MetricProducer MAY result in duplicate metric data being collected.
 
 If the [MeterProvider](#meterprovider) is an instance of

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -37,7 +37,7 @@ linkTitle: SDK
   * [Exemplar defaults](#exemplar-defaults)
 - [MetricReader](#metricreader)
   * [MetricReader operations](#metricreader-operations)
-    + [RegisterBridge(metricBridge)](#registerbridgemetricbridge)
+    + [RegisterProducer(metricProducer)](#registerproducermetricproducer)
     + [Collect](#collect)
     + [Shutdown](#shutdown-1)
   * [Periodic exporting MetricReader](#periodic-exporting-metricreader)
@@ -48,7 +48,7 @@ linkTitle: SDK
       - [ForceFlush()](#forceflush)
       - [Shutdown()](#shutdown)
   * [Pull Metric Exporter](#pull-metric-exporter)
-- [MetricBridge](#metricbridge)
+- [MetricProducer](#metricproducer)
   * [Interface Definition](#interface-definition-1)
     + [Produce() batch](#produce-batch)
 - [Defaults and configuration](#defaults-and-configuration)
@@ -757,9 +757,9 @@ measurements using the equivalent of the following naive algorithm:
 common configurable aspects of the OpenTelemetry Metrics SDK and
 determines the following capabilities:
 
-* Registering [MetricBridge](#metricbridge)(s)
+* Registering [MetricProducer](#metricproducer)(s)
 * Collecting metrics from the SDK and any registered
-  [MetricBridges](#metricbridge) on demand.
+  [MetricProducers](#metricproducer) on demand.
 * Handling the [ForceFlush](#forceflush) and [Shutdown](#shutdown) signals from
   the SDK.
 
@@ -786,7 +786,7 @@ Delta](supplementary-guidelines.md#asynchronous-example-delta-temporality) aggre
 temporality.
 
 The `MetricReader` is not required to ensure data points from a non-SDK
-[MetricBridge](#metricbridge) are output in the configured aggregation
+[MetricProducer](#metricproducer) are output in the configured aggregation
 temporality, as these data points are not collected using OpenTelemetry
 instruments.
 
@@ -824,23 +824,23 @@ functions.
 
 ### MetricReader operations
 
-#### RegisterBridge(metricBridge)
+#### RegisterProducer(metricProducer)
 
-RegisterBridge causes the MetricReader to use the provided
-[MetricBridge](#metricbridge) as a source of aggregated metric data in
-subsequent invocations of Collect. RegisterBridge is expected to be called
+RegisterProducer causes the MetricReader to use the provided
+[MetricProducer](#metricproducer) as a source of aggregated metric data in
+subsequent invocations of Collect. RegisterProducer is expected to be called
 during initialization, but MAY be invoked later.  Multiple registrations
-of the same metricBridge MAY result in duplicate metric data being collected.
+of the same MetricProducer MAY result in duplicate metric data being collected.
 
 If the [MeterProvider](#meterprovider) is an instance of
-[MetricBridge](#metricbridge), this MAY be used to register the
+[MetricProducer](#metricproducer), this MAY be used to register the
 MeterProvider, but MUST NOT allow multiple [MeterProviders](#meterprovider)
 to be registered with the same MetricReader.
 
 #### Collect
 
 Collects the metrics from the SDK and any registered
-[MetricBridges](#metricbridge). If there are
+[MetricProducers](#metricproducer). If there are
 [asynchronous SDK Instruments](./api.md#asynchronous-instrument-api) involved,
 their callback functions will be triggered.
 
@@ -1112,21 +1112,21 @@ modeled to interact with other components in the SDK:
                                  +-----------------------------+
   ```
 
-## MetricBridge
+## MetricProducer
 
 **Status**: [Experimental](../document-status.md)
 
-`MetricBridge` defines the interface which bridges to third-party metric
+`MetricProducer` defines the interface which bridges to third-party metric
 sources MUST implement so they can be plugged into an OpenTelemetry
 [MetricReader](#metricreader) as a source of aggregated metric data. The SDK's
-in-memory state MAY implement the `MetricBridge` interface for convenience.
+in-memory state MAY implement the `MetricProducer` interface for convenience.
 
-`MetricBridge` implementations SHOULD accept configuration for the
+`MetricProducer` implementations SHOULD accept configuration for the
 `AggregationTemporality` of produced metrics. SDK authors MAY provide utility
 libraries to facilitate conversion between delta and cumulative temporalities.
 
 If the batch of [Metric points](./data-model.md#metric-points) returned by
-`Produce()` includes a [Resource](../resource/sdk.md), the `MetricBridge` MUST
+`Produce()` includes a [Resource](../resource/sdk.md), the `MetricProducer` MUST
 accept configuration for the [Resource](../resource/sdk.md).
 
 ```text
@@ -1138,31 +1138,31 @@ accept configuration for the [Resource](../resource/sdk.md).
                                |              |
 +-----------------+            |              |
 |                 | Metrics... |              |
-| MetricBridge    +------------>              |
+| MetricProducer  +------------>              |
 |                 |            |              |
 +-----------------+            +--------------+
 ```
 
 ### Interface Definition
 
-A `MetricBridge` MUST support the following functions:
+A `MetricProducer` MUST support the following functions:
 
 #### Produce() batch
 
-`Produce` provides metrics from the MetricBridge to the caller. `Produce`
+`Produce` provides metrics from the MetricProducer to the caller. `Produce`
 MUST return a batch of [Metric points](./data-model.md#metric-points).
 `Produce` does not have any required parameters, however, [OpenTelemetry
 SDK](../overview.md#sdk) authors MAY choose to add parameters (e.g. timeout).
 
 `Produce` SHOULD provide a way to let the caller know whether it succeeded,
-failed or timed out. When the `Produce` operation fails, the `MetricBridge`
+failed or timed out. When the `Produce` operation fails, the `MetricProducer`
 MAY return successfully collected results and a failed reasons list to the
 caller.
 
 If a batch of [Metric points](./data-model.md#metric-points) can include
 [`InstrumentationScope`](../glossary.md#instrumentation-scope) information,
 `Produce` SHOULD include a single InstrumentationScope which identifies the
-bridge.
+`MetricProducer`.
 
 ## Defaults and configuration
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1158,6 +1158,11 @@ failed or timed out. When the `Produce` operation fails, the `MetricBridge`
 MAY return successfully collected results and a failed reasons list to the
 caller.
 
+If a batch of [Metric points](./data-model.md#metric-points) can include
+[`InstrumentationScope`](../glossary.md#instrumentation-scope) information,
+`Produce` SHOULD include a single InstrumentationScope which identifies the
+bridge.
+
 ## Defaults and configuration
 
 The SDK MUST provide configuration according to the [SDK environment

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -37,7 +37,7 @@ linkTitle: SDK
   * [Exemplar defaults](#exemplar-defaults)
 - [MetricReader](#metricreader)
   * [MetricReader operations](#metricreader-operations)
-    + [Register(MetricBridge)](#registermetricbridge)
+    + [RegisterBridge(metricBridge)](#registerbridgemetricbridge)
     + [Collect](#collect)
     + [Shutdown](#shutdown-1)
   * [Periodic exporting MetricReader](#periodic-exporting-metricreader)
@@ -824,11 +824,13 @@ functions.
 
 ### MetricReader operations
 
-#### Register(MetricBridge)
+#### RegisterBridge(metricBridge)
 
-Register causes the MetricReader to use the provided
+RegisterBridge causes the MetricReader to use the provided
 [MetricBridge](#metricbridge) for as a source of aggregated metric data in
-subsequent invokations of Collect.
+subsequent invocations of Collect. RegisterBridge is expected to be called
+during initialization, but MAY be invoked later.  Multiple registrations
+of the same metricBridge MAY result in duplicate metric data being collected.
 
 If the [MeterProvider](#meterprovider) is an instance of
 [MetricBridge](#metricbridge), this MAY be used to register the

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -826,6 +826,8 @@ functions.
 
 #### RegisterProducer(metricProducer)
 
+**Status**: [Experimental](../document-status.md)
+
 RegisterProducer causes the MetricReader to use the provided
 [MetricProducer](#metricproducer) as a source of aggregated metric data in
 subsequent invocations of Collect. RegisterProducer is expected to be called

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -37,7 +37,7 @@ linkTitle: SDK
   * [Exemplar defaults](#exemplar-defaults)
 - [MetricReader](#metricreader)
   * [MetricReader operations](#metricreader-operations)
-    + [Register(MetricProducer)](#registermetricproducer)
+    + [Register(MetricBridge)](#registermetricbridge)
     + [Collect](#collect)
     + [Shutdown](#shutdown-1)
   * [Periodic exporting MetricReader](#periodic-exporting-metricreader)
@@ -48,7 +48,7 @@ linkTitle: SDK
       - [ForceFlush()](#forceflush)
       - [Shutdown()](#shutdown)
   * [Pull Metric Exporter](#pull-metric-exporter)
-- [MetricProducer](#metricproducer)
+- [MetricBridge](#metricbridge)
   * [Interface Definition](#interface-definition-1)
     + [Produce() batch](#produce-batch)
 - [Defaults and configuration](#defaults-and-configuration)
@@ -757,8 +757,8 @@ measurements using the equivalent of the following naive algorithm:
 common configurable aspects of the OpenTelemetry Metrics SDK and
 determines the following capabilities:
 
-* Registering a [MetricProducer](#metricproducer)
-* Collecting metrics from the registered [MetricProducer](#metricproducer) on
+* Registering a [MetricBridge](#metricbridge)
+* Collecting metrics from the registered [MetricBridge](#metricbridge) on
   demand.
 * Handling the [ForceFlush](#forceflush) and [Shutdown](#shutdown) signals from
   the SDK.
@@ -786,7 +786,7 @@ Delta](supplementary-guidelines.md#asynchronous-example-delta-temporality) aggre
 temporality.
 
 The `MetricReader` is not required to ensure data points from a non-SDK
-[MetricProducer](#metricproducer) are output in the configured aggregation
+[MetricBridge](#metricbridge) are output in the configured aggregation
 temporality, as these data points are not collected using OpenTelemetry
 instruments.
 
@@ -824,22 +824,22 @@ functions.
 
 ### MetricReader operations
 
-#### Register(MetricProducer)
+#### Register(MetricBridge)
 
 Register causes the MetricReader to use the provided
-[MetricProducer](#metricproducer) for as a source of aggregated metric data in
+[MetricBridge](#metricbridge) for as a source of aggregated metric data in
 subsequent invokations of Collect. It MUST NOT allow more than one
-[MetricProducer](#metricproducer) or [MeterProvider](#meterprovider) instance
+[MetricBridge](#metricbridge) or [MeterProvider](#meterprovider) instance
 to be registered with the [MetricReader](#metricreader).
 
 If the [MeterProvider](#meterprovider) is an instance of of
-[MetricProducer](#metricproducer), this MAY be used to register the
+[MetricBridge](#metricbridge), this MAY be used to register the
 MeterProvider.
 
 #### Collect
 
 Collects the metrics from the SDK and any registered
-[MetricProducers](#metricproducer). If there are
+[MetricBridges](#metricbridge). If there are
 [asynchronous SDK Instruments](./api.md#asynchronous-instrument-api) involved,
 their callback functions will be triggered.
 
@@ -1111,14 +1111,14 @@ modeled to interact with other components in the SDK:
                                  +-----------------------------+
   ```
 
-## MetricProducer
+## MetricBridge
 
 **Status**: [Experimental](../document-status.md)
 
-`MetricProducer` defines the interface which bridges to third-party metric
+`MetricBridge` defines the interface which bridges to third-party metric
 sources MUST implement so they can be plugged into an OpenTelemetry
 [MetricReader](#metricreader) as a source of aggregated metric data. The SDK's
-in-memory state MAY implement the `MetricProducer` interface for convenience.
+in-memory state MAY implement the `MetricBridge` interface for convenience.
 
 ```text
 +-----------------+            +--------------+
@@ -1129,24 +1129,24 @@ in-memory state MAY implement the `MetricProducer` interface for convenience.
 
 +-----------------+            +--------------+
 |                 | Metrics... |              |
-| MetricProducer  +------------> MetricReader |
+| MetricBridge    +------------> MetricReader |
 |                 |            |              |
 +-----------------+            +--------------+
 ```
 
 ### Interface Definition
 
-A `MetricProducer` MUST support the following functions:
+A `MetricBridge` MUST support the following functions:
 
 #### Produce() batch
 
-`Produce` provides metrics from the MetricProducer to the caller. `Produce`
+`Produce` provides metrics from the MetricBridge to the caller. `Produce`
 MUST return a batch of [Metric points](./data-model.md#metric-points).
 `Produce` does not have any required parameters, however, [OpenTelemetry
 SDK](../overview.md#sdk) authors MAY choose to add parameters (e.g. timeout).
 
 `Produce` SHOULD provide a way to let the caller know whether it succeeded,
-failed or timed out. When the `Produce` operation fails, the `MetricProducer`
+failed or timed out. When the `Produce` operation fails, the `MetricBridge`
 MAY return successfully collected results and a failed reasons list to the
 caller.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1120,16 +1120,24 @@ sources MUST implement so they can be plugged into an OpenTelemetry
 [MetricReader](#metricreader) as a source of aggregated metric data. The SDK's
 in-memory state MAY implement the `MetricBridge` interface for convenience.
 
+`MetricBridge` implementations SHOULD accept configuration for the
+`AggregationTemporality` of produced metrics. SDK authors MAY provide utility
+libraries to facilitate conversion between delta and cumulative temporalities.
+
+If the batch of [Metric points](./data-model.md#metric-points) returned by
+`Produce()` includes a [Resource](../resource/sdk.md), the `MetricBridge` MUST
+accept configuration for the [Resource](../resource/sdk.md).
+
 ```text
 +-----------------+            +--------------+
 |                 | Metrics... |              |
 | In-memory state +------------> MetricReader |
 |                 |            |              |
-+-----------------+            +--------------+
-
-+-----------------+            +--------------+
++-----------------+            |              |
+                               |              |
++-----------------+            |              |
 |                 | Metrics... |              |
-| MetricBridge    +------------> MetricReader |
+| MetricBridge    +------------>              |
 |                 |            |              |
 +-----------------+            +--------------+
 ```

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -830,7 +830,7 @@ Register causes the MetricReader to use the provided
 [MetricBridge](#metricbridge) for as a source of aggregated metric data in
 subsequent invokations of Collect.
 
-If the [MeterProvider](#meterprovider) is an instance of of
+If the [MeterProvider](#meterprovider) is an instance of
 [MetricBridge](#metricbridge), this MAY be used to register the
 MeterProvider, but MUST NOT allow multiple [MeterProviders](#meterprovider)
 to be registered with the same MetricReader.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -827,7 +827,7 @@ functions.
 #### RegisterBridge(metricBridge)
 
 RegisterBridge causes the MetricReader to use the provided
-[MetricBridge](#metricbridge) for as a source of aggregated metric data in
+[MetricBridge](#metricbridge) as a source of aggregated metric data in
 subsequent invocations of Collect. RegisterBridge is expected to be called
 during initialization, but MAY be invoked later.  Multiple registrations
 of the same metricBridge MAY result in duplicate metric data being collected.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -758,8 +758,8 @@ common configurable aspects of the OpenTelemetry Metrics SDK and
 determines the following capabilities:
 
 * Registering a [MetricBridge](#metricbridge)
-* Collecting metrics from the registered [MetricBridge](#metricbridge) on
-  demand.
+* Collecting metrics from the SDK and any registered
+  [MetricBridges](#metricbridge) on demand.
 * Handling the [ForceFlush](#forceflush) and [Shutdown](#shutdown) signals from
   the SDK.
 
@@ -828,13 +828,12 @@ functions.
 
 Register causes the MetricReader to use the provided
 [MetricBridge](#metricbridge) for as a source of aggregated metric data in
-subsequent invokations of Collect. It MUST NOT allow more than one
-[MetricBridge](#metricbridge) or [MeterProvider](#meterprovider) instance
-to be registered with the [MetricReader](#metricreader).
+subsequent invokations of Collect.
 
 If the [MeterProvider](#meterprovider) is an instance of of
 [MetricBridge](#metricbridge), this MAY be used to register the
-MeterProvider.
+MeterProvider, but MUST NOT allow multiple [MeterProviders](#meterprovider)
+to be registered with the same MetricReader.
 
 #### Collect
 


### PR DESCRIPTION
Supersedes #2838 and #2722.

Issue: https://github.com/open-telemetry/opentelemetry-specification/issues/1175

This is needed to support an OpenCensus metric bridge, which is [will be proposed separately](https://github.com/open-telemetry/opentelemetry-specification/pull/2732). It could also be used to support other bridges as well, such as a Prometheus bridge.

## Changes

Define the MetricProducer interface, with one method: Produce().  MetricProducers SHOULD have a single InstrumentationScope, and can be configured with a Resource.

Add a RegisterProducer(metricProducer) function to MetricReader.

MetricProducers SHOULD allow configuration of temporality, but this isn't enforced via the metric reader.  This is because the reader's temporality is configured as a function of OpenTelemetry instrument.

### Changes from the previous iteration

* **Integrate with the MetricReader instead of MeterProvider** (Feedback from https://github.com/open-telemetry/opentelemetry-specification/pull/2838#issuecomment-1259910518)
* This no longer attempts to prevent duplicate Instrumentation Scopes, or limits a bridge to a single scope (it is still recommended to use a single scope).
* It now recommends that bridges allow configuration of the output temporality.

### Things that are left up to implementations

* How the MetricReader handles multiple metric batches is NOT specified.  SDKs are free to pass each metric batch to the exporter individually, or it may attempt to merge batches if, for example, the resource was the same between the batches.  This also implies that any merge logic (e.g. handling duplicate instrumentation scopes) is also not specified, and is left up to the implementation.

@jsuereth @bogdandrutu @jmacd @reyang @pirgeo @MadVikingGod @MrAlias @jack-berg
