### PR TITLE
Add `messaging.kafka.message.offset` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- Add `messaging.kafka.message.offset` attribute.
+  ([#2982](https://github.com/open-telemetry/opentelemetry-specification/pull/2982))
+
 ### Metrics
 
 - Define Experimental MetricProducer as a third-party provider of metric data to MetricReaders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ release.
 
 ### Traces
 
-- Add `messaging.kafka.message.offset` attribute.
-  ([#2982](https://github.com/open-telemetry/opentelemetry-specification/pull/2982))
-
 ### Metrics
 
 - Define Experimental MetricProducer as a third-party provider of metric data to MetricReaders.
@@ -36,6 +33,8 @@ release.
 - Rename `rpc.request.metadata.<key>` and `rpc.response.metadata.<key>` to
   `rpc.grpc.request.metadata.<key>` and `rpc.grpc.response.metadata.<key>`
   ([#2981](https://github.com/open-telemetry/opentelemetry-specification/pull/2981))
+- Add `messaging.kafka.message.offset` attribute.
+  ([#2982](https://github.com/open-telemetry/opentelemetry-specification/pull/2982))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -189,6 +189,11 @@ groups:
         brief: >
           Partition the message is sent to.
         examples: 2
+      - id: message.offset
+        type: int
+        brief: >
+          The offset of a record in the corresponding Kafka partition.
+        examples: 42
       - id: tombstone
         type: boolean
         requirement_level:

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -280,6 +280,7 @@ For Apache Kafka, the following additional attributes are defined:
 | `messaging.kafka.consumer_group` | string | Name of the Kafka Consumer Group that is handling the message. Only applies to consumers, not producers. | `my-group` | Recommended |
 | `messaging.kafka.client_id` | string | Client Id for the Consumer or Producer that is handling the message. | `client-5` | Recommended |
 | `messaging.kafka.partition` | int | Partition the message is sent to. | `2` | Recommended |
+| `messaging.kafka.message.offset` | int | The offset of a record in the corresponding Kafka partition. | `42` | Recommended |
 | `messaging.kafka.tombstone` | boolean | A boolean that is true if the message is a tombstone. |  | Conditionally Required: [2] |
 
 **[1]:** If the key type is not string, it's string representation has to be supplied for the attribute. If the key has no unambiguous, canonical string form, don't include its value.
@@ -395,7 +396,8 @@ Process CB:                           | Span Rcv2 |
 | `messaging.kafka.message_key` | `"myKey"` | `"myKey"` | `"myKey"` | `"anotherKey"` | `"anotherKey"` |
 | `messaging.kafka.consumer_group` |  | `"my-group"` | `"my-group"` |  | `"another-group"` |
 | `messaging.kafka.client_id` |  | `"5"` | `"5"` | `"5"` | `"8"` |
-| `messaging.kafka.partition` |  | `"1"` | `"1"` |  | `"3"` |
+| `messaging.kafka.partition` | `"1"` | `"1"` | `"1"` | `"3"` | `"3"` |
+| `messaging.kafka.message.offset` | `"12"` | `"12"` | `"12"` | `"32"` | `"32"` |
 
 ### Batch receiving
 


### PR DESCRIPTION
Fixes #2971

## Changes

Introduces a new `messaging.kafka.message.offset` attribute that is supposed to store the offset of a Kafka message. I used the naming pattern introduced in #2957, assuming it's probably going to land in the same release as this change.
