### PR TITLE
Remove markdown link to jsonlines.org

### DIFF
--- a/experimental/serialization/json.md
+++ b/experimental/serialization/json.md
@@ -22,7 +22,7 @@ This document describes the serialization of OpenTelemetry data as JSON objects 
 
 #### JSON lines file
 
-This file is a [JSON lines file](https://jsonlines.org/), and therefore follows those requirements:
+This file is a JSON lines file (jsonlines.org), and therefore follows those requirements:
 
 * UTF-8 encoding
 * Each line is a valid JSON value


### PR DESCRIPTION
I noticed a linter/link check failing on a PR due to jsonlines.org domain not resolving.