### PR TITLE
Propose new StructuredBody field for logs

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -464,6 +464,15 @@ OpenTelemetry [semantic conventions for Log Attributes](./semantic_conventions/R
 [semantic conventions for Span Attributes](../trace/semantic_conventions/README.md).
 This field is optional.
 
+### Field: `StructuredBody`
+
+Type: `map<string, any>`.
+
+Description: A structured representation of the log record (see the description
+of `any` type above). Can vary for each occurrence of the event coming from the
+same source. This field is optional. SHOULD follow OpenTelemetry [semantic conventions
+for Log Bodies (TODO)](./semantic_conventions/README.md). This field is optional.
+
 #### Errors and Exceptions
 
 Additional information about errors and/or exceptions that are associated with
@@ -946,7 +955,7 @@ Field            | Type               | Description                             
 timestamp        | string             | The time the event described by the log entry occurred. | Timestamp
 resource         | MonitoredResource  | The monitored resource that produced this log entry.    | Resource
 log_name         | string             | The URL-encoded LOG_ID suffix of the log_name field identifies which log stream this entry belongs to. | Attributes["gcp.log_name"]
-json_payload     | google.protobuf.Struct | The log entry payload, represented as a structure that is expressed as a JSON object. | Body
+json_payload     | google.protobuf.Struct | The log entry payload, represented as a structure that is expressed as a JSON object. | StructuredBody
 proto_payload    | google.protobuf.Any | The log entry payload, represented as a protocol buffer. | Body
 text_payload     | string             | The log entry payload, represented as a Unicode string (UTF-8). | Body
 severity         | LogSeverity        | The severity of the log entry.                          | Severity


### PR DESCRIPTION
## Motivation

The log data model has already been declared stable, yet an important decision made by the Logs SIG has not been codified in the specification. Specifically, it was the intention of the Logs SIG that `Attributes` should be the appropriate field for representing structured log data. Several proposals to codify this notion in the spec have stalled out.

This proposal attempts to identify an alternative that would provide an explicit home for structured data, without breaking the data model.

Obviously this change may have implications for the SDK, Collector, etc, but I am suggesting that we fully explore this route in case it leads to a broadly acceptable solution.

## Changes

The proposal is to add an optional new field, tentatively called `StructuredBody`. This field would be dedicated to structured log data.

`Attributes` would still be intended for information _about_ the log (e.g. user specified values, or [semantic conventions](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/semantic_conventions/README.md))

`Body` would remain unchanged as well. Notably the indication that "First-party Applications SHOULD use a string message." would still be valid.

`StructuredBody` would also be an alternative to the "data" field proposed in https://github.com/open-telemetry/opentelemetry-specification/pull/2926.

### Related issues
- https://github.com/open-telemetry/opentelemetry-specification/pull/2096
- https://github.com/open-telemetry/opentelemetry-specification/issues/1613
- https://github.com/open-telemetry/opentelemetry-specification/pull/2888
- https://github.com/open-telemetry/opentelemetry-specification/pull/2861#discussion_r993531085
- https://github.com/open-telemetry/opentelemetry-specification/pull/2620
- https://github.com/open-telemetry/opentelemetry-specification/pull/2926
- https://github.com/open-telemetry/opentelemetry-specification/pull/1727
- https://github.com/open-telemetry/opentelemetry-specification/pull/1777
- https://github.com/open-telemetry/opentelemetry-specification/pull/2841
- https://github.com/open-telemetry/opentelemetry-specification/pull/596
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16495

### Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
- https://github.com/open-telemetry/oteps/pull/97
- https://github.com/open-telemetry/oteps/pull/188