### PR TITLE
Don't recommend converting to prometheus base units, but do convert to full words

### DIFF
--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -224,9 +224,8 @@ consecutive `_` characters MUST be replaced with a single `_` character.
 The Unit of an OTLP metric point MUST be added as
 [OpenMetrics UNIT metadata](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily).
 Additionally, the unit MUST be added as a suffix to the metric name, and SHOULD
-be converted to [base units](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#units-and-base-units)
-recommended by OpenMetrics when possible.  The unit suffix comes before any
-type-specific suffixes.
+be converted from abbreviations to full words (e.g. ms to milliseconds) where
+possible. The unit suffix comes before any type-specific suffixes.
 
 The description of an OTLP metrics point MUST be added as
 [OpenMetrics HELP metadata](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily).


### PR DESCRIPTION
As described in https://github.com/open-telemetry/opentelemetry-specification/issues/2497#issuecomment-1102740872 (and the following discussion), it isn't possible to convert from units to base units (e.g. convert milliseconds to seconds) for all metric types.  This PR withdraws that recommendation.

I opened a few issues for adding units to metric names:

* https://github.com/open-telemetry/opentelemetry-swift/issues/359
* https://github.com/open-telemetry/opentelemetry-rust/issues/927
* https://github.com/open-telemetry/opentelemetry-dotnet/issues/3975
* https://github.com/open-telemetry/opentelemetry-cpp/issues/1840
* https://github.com/open-telemetry/opentelemetry-js/issues/3466

During that process, I didn't want to recommend converting to base units for the reasons above, but I do still think implementations should convert to full words where possible.

cc @gouthamve @jmacd 