### PR TITLE
Suggest column # as an extra source code attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ release.
 
 ### Semantic Conventions
 
+- Add `code.lineno` source code attribute
+  ([#3029](https://github.com/open-telemetry/opentelemetry-specification/pull/3029))
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/semantic_conventions/exception.yaml
+++ b/semantic_conventions/exception.yaml
@@ -1,5 +1,6 @@
 groups:
   - id: exception
+    type: span
     prefix: exception
     brief: >
       This document defines the shared attributes used to

--- a/semantic_conventions/logs/events.yaml
+++ b/semantic_conventions/logs/events.yaml
@@ -1,5 +1,6 @@
 groups:
   - id: event
+    type: span
     prefix: event
     brief: >
         This document defines attributes for Events represented using Log Records.

--- a/semantic_conventions/logs/log-exception.yaml
+++ b/semantic_conventions/logs/log-exception.yaml
@@ -1,5 +1,6 @@
 groups:
   - id: log-exception
+    type: span
     prefix: exception
     brief: >
       This document defines attributes for exceptions represented using Log

--- a/semantic_conventions/trace/general.yaml
+++ b/semantic_conventions/trace/general.yaml
@@ -289,3 +289,8 @@ groups:
         brief: >
           The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
         examples: 42
+      - id: column
+        type: int
+        brief: >
+          The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`.
+        examples: 16

--- a/specification/trace/semantic_conventions/span-general.md
+++ b/specification/trace/semantic_conventions/span-general.md
@@ -315,4 +315,5 @@ about the span.
 | `code.namespace` | string | The "namespace" within which `code.function` is defined. Usually the qualified class or module name, such that `code.namespace` + some separator + `code.function` form a unique identifier for the code unit. | `com.example.MyHttpService` | Recommended |
 | `code.filepath` | string | The source code file name that identifies the code unit as uniquely as possible (preferably an absolute file path). | `/usr/local/MyApplication/content_root/app/index.php` | Recommended |
 | `code.lineno` | int | The line number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`. | `42` | Recommended |
+| `code.column` | int | The column number in `code.filepath` best representing the operation. It SHOULD point within the code unit named in `code.function`. | `16` | Recommended |
 <!-- endsemconv -->


### PR DESCRIPTION
# Changes

In some languages such as Javascript or Haskell, it's common to have multiple lambdas/anonymous functions defined on the same line. 

`function myEval(code){return eval(code)}function handleJSONP(a){return a}(function(){function a(b){var c=myEval(b)}})();`

Without a column number, it's impossible to accurately pinpoint which of the anonymous functions in the same file and the same line we are talking about. A column attribute is necessary to fully specify which unit of code we are interested in.
