### PR TITLE
Add OpenCensus propagators as allowed in OTel repositories

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -346,6 +346,10 @@ as OpenTelemetry extension packages:
 * [OT Trace](https://github.com/opentracing?q=basic&type=&language=). Propagation format
   used by the OpenTracing Basic Tracers. It MUST NOT use `OpenTracing` in the resulting
   propagator name as it is not widely adopted format in the OpenTracing ecosystem.
+* [OpenCensus BinaryFormat](https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md#trace-context).
+  Propagation format used by OpenCensus, which describes how to format the span context
+  into the binary format, and does not prescribe a key. It is commonly used with
+  OpenCensus gRPC using the `grpc-trace-bin` propagation key.
 
 Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/1175

Addresses https://github.com/open-telemetry/opentelemetry-specification/pull/3015#discussion_r1047817750.  We don't currently list OpenCensus propagators anywhere in our specification, even though they have been implemented (e.g. [go's BinaryFormat propagator](https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/propagators/opencensus#opencensus-binary-propagation-format)).

This does not require implementing these propagators, but adds them to the list of propagators allowed in core repositories.  My primary motivation is to document them somewhere in the specification for reference.

cc @jsuereth @bogdandrutu @jack-berg @reyang 