### PR TITLE
Tracing SDK: Do not use comparison operator

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -260,8 +260,8 @@ It produces an output called `SamplingResult` which contains:
 * A sampling `Decision`. One of the following enum values:
   * `DROP` - `IsRecording` will be `false`, the span will not be recorded and all events and attributes
   will be dropped.
-  * `RECORD_ONLY` - `IsRecording` will be `true`, but `Sampled` flag MUST NOT be set.
-  * `RECORD_AND_SAMPLE` - `IsRecording` will be `true` and `Sampled` flag MUST be set.
+  * `RECORD_ONLY` - `IsRecording` will be `true`, but the `Sampled` flag MUST NOT be set.
+  * `RECORD_AND_SAMPLE` - `IsRecording` will be `true` and the `Sampled` flag MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 * A `Tracestate` that will be associated with the `Span` through the new

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -258,7 +258,7 @@ object.
 It produces an output called `SamplingResult` which contains:
 
 * A sampling `Decision`. One of the following enum values:
-  * `DROP` - `IsRecording` will be `false`, the span will not be recorded and all events and attributes
+  * `DROP` - `IsRecording` will be `false`, the `Span` will not be recorded and all events and attributes
   will be dropped.
   * `RECORD_ONLY` - `IsRecording` will be `true`, but the `Sampled` flag MUST NOT be set.
   * `RECORD_AND_SAMPLE` - `IsRecording` will be `true` and the `Sampled` flag MUST be set.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -258,10 +258,10 @@ object.
 It produces an output called `SamplingResult` which contains:
 
 * A sampling `Decision`. One of the following enum values:
-  * `DROP` - `IsRecording() == false`, span will not be recorded and all events and attributes
+  * `DROP` - `IsRecording() = false`, span will not be recorded and all events and attributes
   will be dropped.
-  * `RECORD_ONLY` - `IsRecording() == true`, but `Sampled` flag MUST NOT be set.
-  * `RECORD_AND_SAMPLE` - `IsRecording() == true` AND `Sampled` flag MUST be set.
+  * `RECORD_ONLY` - `IsRecording() = true`, but `Sampled` flag MUST NOT be set.
+  * `RECORD_AND_SAMPLE` - `IsRecording() = true` AND `Sampled` flag MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 * A `Tracestate` that will be associated with the `Span` through the new

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -258,7 +258,7 @@ object.
 It produces an output called `SamplingResult` which contains:
 
 * A sampling `Decision`. One of the following enum values:
-  * `DROP` - `IsRecording() = false`, span will not be recorded and all events and attributes
+  * `DROP` - `IsRecording` will be `false`, span will not be recorded and all events and attributes
   will be dropped.
   * `RECORD_ONLY` - `IsRecording() = true`, but `Sampled` flag MUST NOT be set.
   * `RECORD_AND_SAMPLE` - `IsRecording() = true` AND `Sampled` flag MUST be set.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -258,7 +258,7 @@ object.
 It produces an output called `SamplingResult` which contains:
 
 * A sampling `Decision`. One of the following enum values:
-  * `DROP` - `IsRecording` will be `false`, span will not be recorded and all events and attributes
+  * `DROP` - `IsRecording` will be `false`, the span will not be recorded and all events and attributes
   will be dropped.
   * `RECORD_ONLY` - `IsRecording` will be `true`, but `Sampled` flag MUST NOT be set.
   * `RECORD_AND_SAMPLE` - `IsRecording` will be `true` and `Sampled` flag MUST be set.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -260,8 +260,8 @@ It produces an output called `SamplingResult` which contains:
 * A sampling `Decision`. One of the following enum values:
   * `DROP` - `IsRecording` will be `false`, span will not be recorded and all events and attributes
   will be dropped.
-  * `RECORD_ONLY` - `IsRecording() = true`, but `Sampled` flag MUST NOT be set.
-  * `RECORD_AND_SAMPLE` - `IsRecording() = true` AND `Sampled` flag MUST be set.
+  * `RECORD_ONLY` - `IsRecording` will be `true`, but `Sampled` flag MUST NOT be set.
+  * `RECORD_AND_SAMPLE` - `IsRecording` will be `true` and `Sampled` flag MUST be set.
 * A set of span Attributes that will also be added to the `Span`. The returned
 object must be immutable (multiple calls may return different immutable objects).
 * A `Tracestate` that will be associated with the `Span` through the new


### PR DESCRIPTION
We use comparison operator. Especially on this paragraph it has confused me. Made me think that the sampling decision is based on what IsRecording returns but in reality we are trying to define what IsRecording returns.

Fixes #

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change) and link to the related issue(s) and/or [OTEP(s)](https://github.com/open-telemetry/oteps), update the [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md), and also be sure to update [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) if necessary.

Related issues #

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
