### PR TITLE
[editorial] Metrics hardware sem. conv. front matter

### DIFF
--- a/specification/metrics/semantic_conventions/hardware-metrics.md
+++ b/specification/metrics/semantic_conventions/hardware-metrics.md
@@ -1,4 +1,7 @@
-<!-- omit in toc -->
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Hardware
+--->
+
 # Semantic Conventions for Hardware Metrics
 
 **Status**: [Experimental](../../document-status.md)


### PR DESCRIPTION
- Adds a `linkTitle` (short title) in the same manner that other pages have in that section. This will be the result in the side-nav: 
  > <img width="137" alt="image" src="https://user-images.githubusercontent.com/4140793/208150704-bb05eb3b-cde0-46e0-afeb-bf072edd64a9.png">

- Followup to:
  - https://github.com/open-telemetry/opentelemetry.io/issues/2079
    - https://github.com/open-telemetry/opentelemetry.io/pull/2109
  - #2518

/cc @bertysentry 