### PR TITLE
Define conversion mapping from OTel Exponential Histograms to Prometheus Native Histograms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,6 @@ release.
 
 ### Metrics
 
-- Define conversion mapping from OTel Exponential Histograms to Prometheus Native
-  Histograms.
-  ([#3078](https://github.com/open-telemetry/opentelemetry-specification/issues/3078))
-
 ### Logs
 
 - Define BatchLogRecordProcessor default configuration values.
@@ -46,6 +42,10 @@ release.
   ([#3165](https://github.com/open-telemetry/opentelemetry-specification/pull/3165))
 
 ### Compatibility
+
+- Define conversion mapping from OTel Exponential Histograms to Prometheus Native
+  Histograms.
+  ([#3078](https://github.com/open-telemetry/opentelemetry-specification/issues/3078))
 
 - Fix Prometheus histogram metric suffixes. Bucket series end in `_bucket`
   ([#3018](https://github.com/open-telemetry/opentelemetry-specification/pull/3018)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ release.
 
 ### Metrics
 
+- Define conversion mapping from OTel Exponential Histograms to Prometheus Native
+  Histograms.
+  ([#3078](https://github.com/open-telemetry/opentelemetry-specification/issues/3078))
+
 ### Logs
 
 - Define BatchLogRecordProcessor default configuration values.

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -295,24 +295,25 @@ OpenTelemetry Histograms with Delta aggregation temporality SHOULD be aggregated
 
 ### Exponential Histograms
 
-An [OpenTelemetry Histogram](../metrics/data-model.md#exponentialhistogram) with
+An [OpenTelemetry Exponential Histogram](../metrics/data-model.md#exponentialhistogram) with
 a cumulative aggregation temporality MUST be converted to a Prometheus Native
 Histogram as follows:
 
 - `Scale` is converted to the Native Histogram `Schema`. Currently,
   [valid values](https://github.com/prometheus/prometheus/commit/d9d51c565c622cdc7d626d3e7569652bc28abe15#diff-bdaf80ebc5fa26365f45db53435b960ce623ea6f86747fb8870ad1abc355f64fR76-R83)
-  for `schema` are -4 <= n <= 8. Exponential Histogram data points are dropped,
+  for `schema` are -4 <= n <= 8. Exponential Histogram data points are dropped
   if their `Schema` is not within this range.
 - `Count` is converted to Native Histogram `Count` if the `NoRecordedValue`
-  flag is set to `false`.
+  flag is set to `false`, otherwise, Native Histogram `Count` is set to the
+  Stale NaN value.
 - `Sum` is converted to the Native Histogram `Sum` if `Sum` is set and the
-  `NoRecordedValue` flag is set to `false`.
+  `NoRecordedValue` flag is set to `false`, otherwise, Native Histogram `Sum` is
+  set to the Stale NaN value.
 - `TimeUnixNano` is converted to the Native Histogram `Timestamp` after
-  converting nano to milliseconds.
+  converting nanoseconds to milliseconds.
 - `ZeroCount` is converted directly to the Native Histogram `ZeroCount`.
 - `ZeroThreshold`, if set, is converted to the Native Histogram `ZeroThreshold`.
   Otherwise, it is set to the default value `1e-128`.
-
 - The dense bucket layout represented by `Positive` bucket counts and `Offset` is
   converted to the Native Histogram sparse layout represented by `PositiveSpans`
   and `PositiveDeltas`. The same holds for the `Negative` bucket counts
@@ -320,8 +321,8 @@ Histogram as follows:
 - `Min` and `Max` are not used.
 - `StartTimeUnixNano` is not used.
 
-[OpenTelemetry Histogram](../metrics/data-model.md#exponentialhistogram) metric
-with the delta aggregation temporality is dropped.
+[OpenTelemetry Exponential Histogram](../metrics/data-model.md#exponentialhistogram)
+metrics with the delta aggregation temporality are dropped.
 
 ### Summaries
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -317,7 +317,9 @@ Histogram as follows:
 - The dense bucket layout represented by `Positive` bucket counts and `Offset` is
   converted to the Native Histogram sparse layout represented by `PositiveSpans`
   and `PositiveDeltas`. The same holds for the `Negative` bucket counts
-  and `Offset`.
+  and `Offset`. Note that Prometheus Native Histograms buckets are indexed by
+  upper boundary while Exponential Histograms are indexed by lower boundary, the
+  result being that the Offset fields are different-by-one.
 - `Min` and `Max` are not used.
 - `StartTimeUnixNano` is not used.
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -320,6 +320,9 @@ Histogram as follows:
 - `Min` and `Max` are not used.
 - `StartTimeUnixNano` is not used.
 
+[OpenTelemetry Histogram](../metrics/data-model.md#exponentialhistogram) metric
+with the delta aggregation temporality is dropped.
+
 ### Summaries
 
 An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be converted to a Prometheus metric family with the following metrics:

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -27,8 +27,8 @@
   * [Gauges](#gauges-1)
   * [Sums](#sums)
   * [Histograms](#histograms-1)
+  * [Exponential Histograms](#exponential-histograms)
   * [Summaries](#summaries-1)
-  * [Dropped Data Points](#dropped-data-points)
   * [Metric Attributes](#metric-attributes)
   * [Exemplars](#exemplars-1)
   * [Resource Attributes](#resource-attributes-1)
@@ -293,6 +293,33 @@ An [OpenTelemetry Histogram](../metrics/data-model.md#histogram) with a cumulati
 
 OpenTelemetry Histograms with Delta aggregation temporality SHOULD be aggregated into a Cumulative aggregation temporality and follow the logic above, or MUST be dropped.
 
+### Exponential Histograms
+
+An [OpenTelemetry Histogram](../metrics/data-model.md#exponentialhistogram) with
+a cumulative aggregation temporality MUST be converted to a Prometheus Native
+Histogram as follows:
+
+- `Scale` is converted to the Native Histogram `Schema`. Currently,
+  [valid values](https://github.com/prometheus/prometheus/commit/d9d51c565c622cdc7d626d3e7569652bc28abe15#diff-bdaf80ebc5fa26365f45db53435b960ce623ea6f86747fb8870ad1abc355f64fR76-R83)
+  for `schema` are -4 <= n <= 8. Exponential Histogram data points are dropped,
+  if their `Schema` is not within this range.
+- `Count` is converted to Native Histogram `Count` if the `NoRecordedValue`
+  flag is set to `false`.
+- `Sum` is converted to the Native Histogram `Sum` if `Sum` is set and the
+  `NoRecordedValue` flag is set to `false`.
+- `TimeUnixNano` is converted to the Native Histogram `Timestamp` after
+  converting nano to milliseconds.
+- `ZeroCount` is converted directly to the Native Histogram `ZeroCount`.
+- `ZeroThreshold`, if set, is converted to the Native Histogram `ZeroThreshold`.
+  Otherwise, it is set to the default value `1e-128`.
+
+- The dense bucket layout represented by `Positive` bucket counts and `Offset` is
+  converted to the Native Histogram sparse layout represented by `PositiveSpans`
+  and `PositiveDeltas`. The same holds for the `Negative` bucket counts
+  and `Offset`.
+- `Min` and `Max` are not used.
+- `StartTimeUnixNano` is not used.
+
 ### Summaries
 
 An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be converted to a Prometheus metric family with the following metrics:
@@ -309,12 +336,6 @@ An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be conv
   starting from lowest to highest, and all being non-negative.  The value of
   each point is the computed value of the quantile point.
 - Summaries with `StartTimeUnixNano` set should export the `{name}_created` metric as well.
-
-### Dropped Data Points
-
-The following OTLP data points MUST be dropped:
-
-* [ExponentialHistogram](../metrics/data-model.md#exponentialhistogram)
 
 ### Metric Attributes
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -301,8 +301,10 @@ Histogram as follows:
 
 - `Scale` is converted to the Native Histogram `Schema`. Currently,
   [valid values](https://github.com/prometheus/prometheus/commit/d9d51c565c622cdc7d626d3e7569652bc28abe15#diff-bdaf80ebc5fa26365f45db53435b960ce623ea6f86747fb8870ad1abc355f64fR76-R83)
-  for `schema` are -4 <= n <= 8. Exponential Histogram data points are dropped
-  if their `Schema` is not within this range.
+  for `schema` are -4 <= n <= 8.
+  If `Scale` is > 8 then Exponential Histogram data points SHOULD be downscaled
+  to a scale accepted by Prometheus (in range [-4,8]). Any data point unable to
+  be rescaled to an acceptable range MUST be dropped.
 - `Count` is converted to Native Histogram `Count` if the `NoRecordedValue`
   flag is set to `false`, otherwise, Native Histogram `Count` is set to the
   Stale NaN value.


### PR DESCRIPTION
Fixes #
https://github.com/open-telemetry/opentelemetry-specification/issues/3078

## Changes
Define conversion mapping from OTel Exponential Histograms to Prometheus Native Histograms. See, the implementation https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/17370

Related issues #

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16207
https://github.com/open-telemetry/opentelemetry-proto/issues/440

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
https://github.com/open-telemetry/oteps/blob/main/text/0149-exponential-histogram.md
