### PR TITLE
Fix Histogram parameter: use value term instead of `Measurement`

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -690,7 +690,7 @@ certain programming languages or systems, for example `null`, `undefined`).
 
 Parameters:
 
-* The amount of the `Measurement`, which MUST be a non-negative numeric value.
+* The numeric value to record, which MUST be a non-negative numeric value.
 * Optional [attributes](../common/README.md#attribute).
 
 [OpenTelemetry API](../overview.md#api) authors MAY decide to allow flexible


### PR DESCRIPTION
A `Measurement` is defined as the encapsulation of a value and attributes. The Histogram record API currently is defined to accept a `Measurement` and attributes. This means, if implemented as currently defined, a user would pass a value/attributes pair and then additional attributes. It is not likely what was the original intent of the specified parameters.