### PR TITLE
Update the 1.17 Schema to reference the proper changes PR

### DIFF
--- a/schemas/1.17.0
+++ b/schemas/1.17.0
@@ -4,7 +4,7 @@ versions:
   1.17.0:
     spans:
       changes:
-        # https://github.com/open-telemetry/opentelemetry-specification/pull/2763
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/2957
         - rename_attributes:
             attribute_map:
               messaging.consumer_id: messaging.consumer.id


### PR DESCRIPTION
Upon preparing the Schema for opentelemetry.io, realized the incorrect PR is referenced from the 1.17.0 Schema changes.

See #2957 