### PR TITLE
add SuppressTracing flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ release.
 
 ### Context
 
+- Add `SuppressTracing` flag. [](https://github.com/open-telemetry/opentelemetry-specification/pull/)
+
 ### Traces
 
 - Clarify that the BatchSpanProcessor should export batches when the queue reaches the batch size

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -28,6 +28,8 @@ formats is required. Implementing more than one format is optional.
 | [Trace / Context interaction](specification/trace/api.md#context-interaction)                    |          |     |      |     |        |      |        |     |      |     |      |       |
 | Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Set active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
+| Set SuppressTracing                                                                                  |          |   |      |     |        |      |        |     |      |     |      |       |
+| Unset SuppressTracing                                                                                  |          |   |      |     |        |      |        |     |      |     |      |       |
 | [Tracer](specification/trace/api.md#tracer-operations)                                           |          |     |      |     |        |      |        |     |      |     |      |       |
 | Create a new Span                                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Documentation defines adding attributes at span creation as preferred                            |          |     |      |     | +      | +    |        | +   |      |     | +    |       |

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -177,7 +177,7 @@ instance:
 The functionality listed above is necessary because API users SHOULD NOT have
 access to the [Context Key](../context/README.md#create-a-key) used by the Tracing API implementation.
 
-The `SuppressTracing` flag is for cases, within a single service, it may be
+The `SuppressTracing` flag is for cases when, within a single service, it may be
 useful to temporarily suppress tracing. For example, this may be used to prevent
 `Span` exports from being traced and exported, or by an instrumentation which
 wraps a lower-level package which may also be instrumented in order to prevent

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -177,10 +177,11 @@ instance:
 The functionality listed above is necessary because API users SHOULD NOT have
 access to the [Context Key](../context/README.md#create-a-key) used by the Tracing API implementation.
 
-The `SuppressTracing` flag is for cases it may be useful to temporarily suppress
-tracing. For example, this may be used to prevent `Span` exports from being traced
-and exported, or by an instrumentation which wraps a lower-level package which
-may also be instrumented in order to prevent duplicate spans. 
+The `SuppressTracing` flag is for cases, within a single service, it may be
+useful to temporarily suppress tracing. For example, this may be used to prevent
+`Span` exports from being traced and exported, or by an instrumentation which
+wraps a lower-level package which may also be instrumented in order to prevent
+duplicate spans.
 
 If the language has support for implicitly propagated `Context` (see
 [here](../context/README.md#optional-global-operations)), the API SHOULD also provide

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -409,8 +409,7 @@ created in another process. Each propagators' deserialization must set
 parent is remote.
 
 If the [`SuppressTracing`](#suppress-tracing) `Context` flag is set then the API
-MUST return the parent Span marked as non-recording, if one exists, otherwise
-return an empty non-recording Span.
+MUST return a non-recording Span with SpanContext equal to that of the parent Span (if one exists). If the parent Span exists and is already non-recording, it may be returned directly, as an optimization.
 
 Any span that is created MUST also be ended.
 This is the responsibility of the user.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -169,9 +169,18 @@ instance:
 
 - Extract the `Span` from a `Context` instance
 - Combine the `Span` with a `Context` instance, creating a new `Context` instance
+- Set a `SuppressTracing` flag on a `Context` instance
+- Get the value of the `SuppressTracing` flag on a `Context`, returning `false`
+  if undefined
+- Unset the `SuppressTracing` flag on a `Context` instance
 
 The functionality listed above is necessary because API users SHOULD NOT have
 access to the [Context Key](../context/README.md#create-a-key) used by the Tracing API implementation.
+
+The `SuppressTracing` flag is for cases it may be useful to temporarily suppress
+tracing. For example, this may be used to prevent `Span` exports from being traced
+and exported, or by an instrumentation which wraps a lower-level package which
+may also be instrumented in order to prevent duplicate spans. 
 
 If the language has support for implicitly propagated `Context` (see
 [here](../context/README.md#optional-global-operations)), the API SHOULD also provide
@@ -397,6 +406,10 @@ A `Span` is said to have a *remote parent* if it is the child of a `Span`
 created in another process. Each propagators' deserialization must set
 `IsRemote` to true on a parent `SpanContext` so `Span` creation knows if the
 parent is remote.
+
+If the [`SuppressTracing`](#suppress-tracing) `Context` flag is set then the API
+MUST return the parent Span marked as non-recording, if one exists, otherwise
+return an empty non-recording Span.
 
 Any span that is created MUST also be ended.
 This is the responsibility of the user.


### PR DESCRIPTION
Fixes #530 

## Changes

This PR proposes a new Context key to be used at Span creation time to disable creation of any child Spans. This feature is useful in cases like disabling tracing within an exporter when it calls the HTTP or grpc client.

The feature exists already in multiple implementations. 

Prior art:

- This PR is based on the PR from @dyladan but with the difference in how
  StartSpan operates when suppressed. https://github.com/open-telemetry/opentelemetry-specification/pull/1653

- Ruby: `untraced` https://github.com/open-telemetry/opentelemetry-ruby/pull/1412
- Javascript: `suppressTracing` / `unsuppressTracing` https://github.com/open-telemetry/opentelemetry-js/blob/main/packages/opentelemetry-core/src/trace/suppress-tracing.ts

### Why return the parent

My thinking here is that `Unsuppress` picks up where it left off. The user does
not end up with an invalid parent or, if valid spans were used in this PR
instead, with a parent that is not recorded.

I'm torn on the usefulness of this because usually the user would be instead
returning to the previous Context (Contexts being immutable) and have no need to
either `Unsuppress` or be tracking the parent.

### Why not suppress all signals

The plan I have is to add suppression for all signals, which can be wrapped in a
`SuppressSignals` or similar function. The reason is I think it would be very
common to want to suppress tracing and possibly metrics but would not want
suppression logging. In the example of not tracing an exporter you'd likely
still want any logs from the HTTP/grpc client in case something goes wrong.

### What about Propagation

That is an open question not covered by this PR yet. I think I've come around to
suppression not having an effect on propagation and leave it up to libraries to
support overriding the global propagator with a no-op propagator so the user is
able to disable propagation.