### PR TITLE
Add cloud spanner and mssql compact to db specifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ release.
 - Remove spaces from example exporter User-Agent header to conform to RFC7231 & RFC7230.
   [#3052](https://github.com/open-telemetry/opentelemetry-specification/pull/3052)
 
+- Add Cloud Spanner and Microsoft SQL Server Compact to db.system semantic conventions.
+  [#3105](https://github.com/open-telemetry/opentelemetry-specification/pull/3105)
+
 ### Context
 
 ### Traces

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -160,6 +160,9 @@ groups:
             - id: clickhouse
               value: 'clickhouse'
               brief: 'ClickHouse'
+            - id: spanner
+              value: 'spanner'
+              brief: 'Cloud Spanner'
       - id: connection_string
         tag: connection-level
         type: string

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -19,6 +19,9 @@ groups:
             - id: mssql
               value: 'mssql'
               brief: 'Microsoft SQL Server'
+            - id: mssqlcompact
+              value: 'mssqlcompact'
+              brief: 'Microsoft SQL Server Compact'
             - id: mysql
               value: 'mysql'
               brief: 'MySQL'
@@ -163,9 +166,6 @@ groups:
             - id: spanner
               value: 'spanner'
               brief: 'Cloud Spanner'
-            - id: mssqlcompact
-              value: 'mssqlcompact'
-              brief: 'Microsoft SQL Server Compact'
       - id: connection_string
         tag: connection-level
         type: string

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -163,6 +163,9 @@ groups:
             - id: spanner
               value: 'spanner'
               brief: 'Cloud Spanner'
+            - id: mssqlcompact
+              value: 'mssqlcompact'
+              brief: 'Microsoft SQL Server Compact'
       - id: connection_string
         tag: connection-level
         type: string

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -6,10 +6,16 @@
 
 <!-- toc -->
 
-- [Semantic conventions for database client calls](#semantic-conventions-for-database-client-calls)
-  - [Connection-level attributes](#connection-level-attributes)
-  - [Call-level attributes](#call-level-attributes)
-  - [Examples](#examples)
+- [Connection-level attributes](#connection-level-attributes)
+  * [Notes and well-known identifiers for `db.system`](#notes-and-well-known-identifiers-for-dbsystem)
+  * [Connection-level attributes for specific technologies](#connection-level-attributes-for-specific-technologies)
+- [Call-level attributes](#call-level-attributes)
+  * [Call-level attributes for specific technologies](#call-level-attributes-for-specific-technologies)
+    + [Cassandra](#cassandra)
+- [Examples](#examples)
+  * [MySQL](#mysql)
+  * [Redis](#redis)
+  * [MongoDB](#mongodb)
 
 <!-- tocstop -->
 
@@ -112,6 +118,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `opensearch` | OpenSearch |
 | `clickhouse` | ClickHouse |
 | `spanner` | Cloud Spanner |
+| `mssqlcompact` | Microsoft SQL Server Compact |
 <!-- endsemconv -->
 
 ### Notes and well-known identifiers for `db.system`

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -6,16 +6,10 @@
 
 <!-- toc -->
 
-- [Connection-level attributes](#connection-level-attributes)
-  * [Notes and well-known identifiers for `db.system`](#notes-and-well-known-identifiers-for-dbsystem)
-  * [Connection-level attributes for specific technologies](#connection-level-attributes-for-specific-technologies)
-- [Call-level attributes](#call-level-attributes)
-  * [Call-level attributes for specific technologies](#call-level-attributes-for-specific-technologies)
-    + [Cassandra](#cassandra)
-- [Examples](#examples)
-  * [MySQL](#mysql)
-  * [Redis](#redis)
-  * [MongoDB](#mongodb)
+- [Semantic conventions for database client calls](#semantic-conventions-for-database-client-calls)
+  - [Connection-level attributes](#connection-level-attributes)
+  - [Call-level attributes](#call-level-attributes)
+  - [Examples](#examples)
 
 <!-- tocstop -->
 
@@ -117,6 +111,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `cockroachdb` | CockroachDB |
 | `opensearch` | OpenSearch |
 | `clickhouse` | ClickHouse |
+| `spanner` | Cloud Spanner |
 <!-- endsemconv -->
 
 ### Notes and well-known identifiers for `db.system`

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -70,6 +70,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 |---|---|
 | `other_sql` | Some other SQL database. Fallback only. See notes. |
 | `mssql` | Microsoft SQL Server |
+| `mssqlcompact` | Microsoft SQL Server Compact |
 | `mysql` | MySQL |
 | `oracle` | Oracle Database |
 | `db2` | IBM Db2 |
@@ -118,7 +119,6 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `opensearch` | OpenSearch |
 | `clickhouse` | ClickHouse |
 | `spanner` | Cloud Spanner |
-| `mssqlcompact` | Microsoft SQL Server Compact |
 <!-- endsemconv -->
 
 ### Notes and well-known identifiers for `db.system`


### PR DESCRIPTION
Fixes #3106

## Changes
Added Microsoft Sql Server Compact and Cloud Spanner to db spec. 

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change) and link to the related issue(s) and/or [OTEP(s)](https://github.com/open-telemetry/oteps), update the [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md), and also be sure to update [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) if necessary.

Related issues #

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
