### PR TITLE
Clarify otel_scope_info labels for prometheus compatibility

### DIFF
--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -246,7 +246,7 @@ section below.
 
 Prometheus exporters MUST add the scope name as the `otel_scope_name` label and
 the scope version as the `otel_scope_version` label on all metric points by
-default.
+default, based on the scope the original data point was nested in.
 
 Prometheus exporters SHOULD provide a configuration option to disable the
 `otel_scope_info` metric and `otel_scope_` labels.


### PR DESCRIPTION
Fixes #

## Changes

This is a minor change to clarify the intent of `otel_scope_name` and `otel_scope_version` labels in prometheus compatibility. On my first read, I thought `all metric points` referred to "all data points in the `otel_scope_info` metric". This clarifies that it is all data points for all metrics within that scope.

Related issues #

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
