### PR TITLE
Update error-handling.md

### DIFF
--- a/specification/error-handling.md
+++ b/specification/error-handling.md
@@ -91,7 +91,7 @@ func (IgnoreExporterErrorsHandler) Handle(err error) {
 
 func main() {
     // Other setup ...
-    opentelemetrysdk.SetHandler(IgnoreExporterErrorsHandler{})
+    otel.SetErrorHandler(IgnoreExporterErrorsHandler{})
 }
 
 ```


### PR DESCRIPTION
Fixes #
Documentation on the error handler appears to be outdated.

## Changes

The actual path to the SetErrorHandler looks to be wrong in this specification file - in the actual Golang repository it's found [here](https://github.com/open-telemetry/opentelemetry-go/blob/main/handler.go#L89). This looks like it's just slightly out of date.
