### PR TITLE
Clarify guidance regarding excessive logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,20 @@ release.
 
 ### Traces
 
+- Clarify guidance regarding excessive logging when attributes are dropped
+  or truncated.
+  ([#3151](https://github.com/open-telemetry/opentelemetry-specification/pull/3151))
+
 ### Metrics
 
 ### Logs
 
 - Define BatchLogRecordProcessor default configuration values.
   ([#3002](https://github.com/open-telemetry/opentelemetry-specification/pull/3002))
+
+- Clarify guidance regarding excessive logging when attributes are dropped
+  or truncated.
+  ([#3151](https://github.com/open-telemetry/opentelemetry-specification/pull/3151))
 
 ### Resource
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -153,8 +153,8 @@ public interface LogRecordLimits {
 
 There SHOULD be a message printed in the SDK's log to indicate to the user
 that an attribute was discarded due to such a limit.
-To prevent excessive logging, the message should not be printed once per
-`LogRecord` or per discarded attribute.
+To prevent excessive logging, the message MUST be printed at most once per
+`LogRecord` (i.e., not per discarded attribute).
 
 ## LogRecordProcessor
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -412,9 +412,10 @@ public final class SpanLimits {
 * `AttributePerEventCountLimit` (Default=128) - Maximum allowed attribute per span event count;
 * `AttributePerLinkCountLimit` (Default=128) - Maximum allowed attribute per span link count;
 
-There SHOULD be a log emitted to indicate to the user that an attribute, event,
-or link was discarded due to such a limit. To prevent excessive logging, the log
-should not be emitted once per span, or per discarded attribute, event, or links.
+There SHOULD be a message printed in the SDK's log to indicate to the user
+that an attribute was discarded due to such a limit.
+To prevent excessive logging, the message MUST be printed at most once per
+span (i.e., not per discarded attribute, event, or link).
 
 ## Id Generators
 


### PR DESCRIPTION
Fixes #3147

Clarifies guidance with regards to logging when items (attributes, span links/events) are dropped or truncated on spans or log records.

I'm not certain what was originally intended to be communicated, so my initial proposal is to state that a message must only be printed once per Span/LogRecord regardless of how many items were dropped or truncated on the Span/LogRecord. However, some may argue this too may lead to excessive logging.

So the real question is what do we want to communicate here?

Another option may be to state something like:

> To prevent excessive logging, an SDK SHOULD take measures to limit how often it notifies the user an attribute was discarded or truncated. The exact measures an SDK takes is not specified.