### PR TITLE
Add http metrics yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ release.
 - Rename google openshift platform attribute from `google_cloud_openshift` to `gcp_openshift`
   to match the existing `cloud.provider` prefix.
   [#3095](https://github.com/open-telemetry/opentelemetry-specification/pull/3095)
+- Mark `http.server.duration` and `http.client.duration` metrics as required, and mark
+  all other HTTP metrics as optional.
+  [#3158](https://github.com/open-telemetry/opentelemetry-specification/pull/3158)
+- Add `net.host.port` to `http.server.active_requests` metrics attributes.
+  [#3158](https://github.com/open-telemetry/opentelemetry-specification/pull/3158)
 
 ### Compatibility
 

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -1,0 +1,161 @@
+groups:
+  - id: metric.http.server.duration
+    prefix: http
+    type: metric
+    metric_name: http.server.duration
+    brief: "Measures the duration of inbound HTTP requests."
+    instrument: histogram
+    unit: "ms"
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.scheme
+        requirement_level: required
+      - ref: http.route
+        requirement_level:
+          conditionally_required: If and only if it's available
+      - ref: http.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
+      - ref: http.flavor
+      - ref: net.host.name
+        requirement_level: required
+      - ref: net.host.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+
+  - id: metric.http.server.active_requests
+    prefix: http
+    type: metric
+    metric_name: http.server.active_requests
+    brief: "Measures the number of concurrent HTTP requests that are currently in-flight."
+    instrument: updowncounter
+    unit: "{requests}"
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.scheme
+        requirement_level: required
+      - ref: http.flavor
+      - ref: net.host.name
+        requirement_level: required
+      - ref: net.host.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+
+  - id: metric.http.server.request.size
+    prefix: http
+    type: metric
+    metric_name: http.server.request.size
+    brief: "Measures the size of HTTP request messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    # TODO (trask) below attributes are identical to above in metric.http.server.duration
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.scheme
+        requirement_level: required
+      - ref: http.route
+        requirement_level:
+          conditionally_required: If and only if it's available
+      - ref: http.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
+      - ref: http.flavor
+      - ref: net.host.name
+        requirement_level: required
+      - ref: net.host.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+
+  - id: metric.http.server.response.size
+    prefix: http
+    type: metric
+    metric_name: http.server.response.size
+    brief: "Measures the size of HTTP response messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    # TODO (trask) below attributes are identical to above in metric.http.server.duration
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.scheme
+        requirement_level: required
+      - ref: http.route
+        requirement_level:
+          conditionally_required: If and only if it's available
+      - ref: http.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
+      - ref: http.flavor
+      - ref: net.host.name
+        requirement_level: required
+      - ref: net.host.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+
+  - id: metric.http.client.duration
+    prefix: http
+    type: metric
+    metric_name: http.client.duration
+    brief: "Measures the duration of outbound HTTP requests."
+    instrument: histogram
+    unit: "ms"
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
+      - ref: http.flavor
+      - ref: net.peer.name
+        requirement_level: required
+      - ref: net.peer.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+      - ref: net.sock.peer.addr
+
+  - id: metric.http.client.request.size
+    prefix: http
+    type: metric
+    metric_name: http.client.request.size
+    brief: "Measures the size of HTTP request messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    # TODO (trask) below attributes are identical to above in metric.http.client.duration
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
+      - ref: http.flavor
+      - ref: net.peer.name
+        requirement_level: required
+      - ref: net.peer.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+      - ref: net.sock.peer.addr
+
+  - id: metric.http.client.response.size
+    prefix: http
+    type: metric
+    metric_name: http.client.response.size
+    brief: "Measures the size of HTTP response messages (compressed)."
+    instrument: histogram
+    unit: "By"
+    # TODO (trask) below attributes are identical to above in metric.http.client.duration
+    attributes:
+      - ref: http.method
+        requirement_level: required
+      - ref: http.status_code
+        requirement_level:
+          conditionally_required: If and only if one was received/sent.
+      - ref: http.flavor
+      - ref: net.peer.name
+        requirement_level: required
+      - ref: net.peer.port
+        requirement_level:
+          conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+      - ref: net.sock.peer.addr

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -20,9 +20,30 @@ groups:
       - ref: http.flavor
       - ref: net.host.name
         requirement_level: required
+        brief: >
+          Name of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+            include host identifier.
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
       - ref: net.host.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Port identifier of the `Host` header
 
   - id: metric.http.server.active_requests
     prefix: http
@@ -39,9 +60,30 @@ groups:
       - ref: http.flavor
       - ref: net.host.name
         requirement_level: required
+        brief: >
+          Name of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+            include host identifier.
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
       - ref: net.host.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Port identifier of the `Host` header
 
   - id: metric.http.server.request.size
     prefix: http
@@ -65,9 +107,30 @@ groups:
       - ref: http.flavor
       - ref: net.host.name
         requirement_level: required
+        brief: >
+          Name of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+            include host identifier.
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
       - ref: net.host.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Port identifier of the `Host` header
 
   - id: metric.http.server.response.size
     prefix: http
@@ -91,9 +154,30 @@ groups:
       - ref: http.flavor
       - ref: net.host.name
         requirement_level: required
+        brief: >
+          Name of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+            include host identifier.
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
       - ref: net.host.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port of the local HTTP server that received the request.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form.
+          - Port identifier of the `Host` header
 
   - id: metric.http.client.duration
     prefix: http
@@ -111,9 +195,24 @@ groups:
       - ref: http.flavor
       - ref: net.peer.name
         requirement_level: required
+        brief: >
+          Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if capturing it would require an extra DNS lookup.
       - ref: net.peer.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+        note: >
+          When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match
+          URI port identifier, otherwise it MUST match `Host` header port identifier.
       - ref: net.sock.peer.addr
 
   - id: metric.http.client.request.size
@@ -133,9 +232,24 @@ groups:
       - ref: http.flavor
       - ref: net.peer.name
         requirement_level: required
+        brief: >
+          Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if capturing it would require an extra DNS lookup.
       - ref: net.peer.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+        note: >
+          When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match
+          URI port identifier, otherwise it MUST match `Host` header port identifier.
       - ref: net.sock.peer.addr
 
   - id: metric.http.client.response.size
@@ -155,7 +269,22 @@ groups:
       - ref: http.flavor
       - ref: net.peer.name
         requirement_level: required
+        brief: >
+          Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+        note: |
+          Determined by using the first of the following that applies
+
+          - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+            if it's sent in absolute-form
+          - Host identifier of the `Host` header
+
+          SHOULD NOT be set if capturing it would require an extra DNS lookup.
       - ref: net.peer.port
         requirement_level:
           conditionally_required: If not default (`80` for `http` scheme, `443` for `https`).
+        brief: >
+          Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+        note: >
+          When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match
+          URI port identifier, otherwise it MUST match `Host` header port identifier.
       - ref: net.sock.peer.addr

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -25,7 +25,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+          - The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
             include host identifier.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
@@ -40,7 +40,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
@@ -65,7 +65,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+          - The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
             include host identifier.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
@@ -80,7 +80,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
@@ -112,7 +112,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+          - The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
             include host identifier.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
@@ -127,7 +127,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
           - Port identifier of the `Host` header
@@ -159,7 +159,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+          - The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
             include host identifier.
           - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
@@ -174,7 +174,7 @@ groups:
         note: |
           Determined by using the first of the following that applies
 
-          - Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+          - Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
           - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
             if it's sent in absolute-form.
           - Port identifier of the `Host` header

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -1,6 +1,5 @@
 groups:
   - id: metric.http.server.duration
-    prefix: http
     type: metric
     metric_name: http.server.duration
     brief: "Measures the duration of inbound HTTP requests."
@@ -46,7 +45,6 @@ groups:
           - Port identifier of the `Host` header
 
   - id: metric.http.server.active_requests
-    prefix: http
     type: metric
     metric_name: http.server.active_requests
     brief: "Measures the number of concurrent HTTP requests that are currently in-flight."
@@ -86,7 +84,6 @@ groups:
           - Port identifier of the `Host` header
 
   - id: metric.http.server.request.size
-    prefix: http
     type: metric
     metric_name: http.server.request.size
     brief: "Measures the size of HTTP request messages (compressed)."
@@ -133,7 +130,6 @@ groups:
           - Port identifier of the `Host` header
 
   - id: metric.http.server.response.size
-    prefix: http
     type: metric
     metric_name: http.server.response.size
     brief: "Measures the size of HTTP response messages (compressed)."
@@ -180,7 +176,6 @@ groups:
           - Port identifier of the `Host` header
 
   - id: metric.http.client.duration
-    prefix: http
     type: metric
     metric_name: http.client.duration
     brief: "Measures the duration of outbound HTTP requests."
@@ -216,7 +211,6 @@ groups:
       - ref: net.sock.peer.addr
 
   - id: metric.http.client.request.size
-    prefix: http
     type: metric
     metric_name: http.client.request.size
     brief: "Measures the size of HTTP request messages (compressed)."
@@ -253,7 +247,6 @@ groups:
       - ref: net.sock.peer.addr
 
   - id: metric.http.client.response.size
-    prefix: http
     type: metric
     metric_name: http.client.response.size
     brief: "Measures the size of HTTP response messages (compressed)."

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -41,7 +41,7 @@ This metric is required.
 
 **[3]:** Determined by using the first of the following that applies
 
-- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+- The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
@@ -51,7 +51,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 **[4]:** Determined by using the first of the following that applies
 
-- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
@@ -82,7 +82,7 @@ This metric is optional.
 
 **[2]:** Determined by using the first of the following that applies
 
-- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+- The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
@@ -92,7 +92,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 **[3]:** Determined by using the first of the following that applies
 
-- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
@@ -127,7 +127,7 @@ This metric is optional.
 
 **[3]:** Determined by using the first of the following that applies
 
-- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+- The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
@@ -137,7 +137,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 **[4]:** Determined by using the first of the following that applies
 
-- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header
@@ -172,7 +172,7 @@ This metric is optional.
 
 **[3]:** Determined by using the first of the following that applies
 
-- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+- The [primary server name](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host. MUST only
   include host identifier.
 - Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
@@ -182,7 +182,7 @@ SHOULD NOT be set if only IP address is available and capturing name would requi
 
 **[4]:** Determined by using the first of the following that applies
 
-- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [primary server host](../../trace/semantic_conventions/http.md#http-server-definitions) of the matched virtual host.
 - Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
   if it's sent in absolute-form.
 - Port identifier of the `Host` header

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -32,14 +32,31 @@ This metric is required.
 | [`http.route`](../../trace/semantic_conventions/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
 | [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
-| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [3] |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [3] | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [4] | `8080` | Conditionally Required: [5] |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 **[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[3]:** Determined by using the first of the following that applies
+
+- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[4]:** Determined by using the first of the following that applies
+
+- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Port identifier of the `Host` header
+
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.server.active_requests`
@@ -58,12 +75,29 @@ This metric is optional.
 | [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
 | [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
-| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
-| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [2] |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [2] | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [3] | `8080` | Conditionally Required: [4] |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[2]:** Determined by using the first of the following that applies
+
+- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[3]:** Determined by using the first of the following that applies
+
+- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Port identifier of the `Host` header
+
+**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.server.request.size`
@@ -84,14 +118,31 @@ This metric is optional.
 | [`http.route`](../../trace/semantic_conventions/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
 | [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
-| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [3] |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [3] | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [4] | `8080` | Conditionally Required: [5] |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 **[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[3]:** Determined by using the first of the following that applies
+
+- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[4]:** Determined by using the first of the following that applies
+
+- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Port identifier of the `Host` header
+
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.server.response.size`
@@ -112,14 +163,31 @@ This metric is optional.
 | [`http.route`](../../trace/semantic_conventions/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
 | [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
 | [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
-| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [3] |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Name of the local HTTP server that received the request. [3] | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Port of the local HTTP server that received the request. [4] | `8080` | Conditionally Required: [5] |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 **[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+**[3]:** Determined by using the first of the following that applies
+
+- The [primary server name](#http-server-definitions) of the matched virtual host. MUST only
+  include host identifier.
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if only IP address is available and capturing name would require a reverse DNS lookup.
+
+**[4]:** Determined by using the first of the following that applies
+
+- Port identifier of the [primary server host](#http-server-definitions) of the matched virtual host.
+- Port identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form.
+- Port identifier of the `Host` header
+
+**[5]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ## HTTP Client
@@ -140,15 +208,23 @@ This metric is required.
 | [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
 | [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Logical remote hostname, see note below. [2] | `example.com` | Required |
-| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Logical remote port number | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | [`net.sock.peer.addr`](../../trace/semantic_conventions/span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+**[2]:** Determined by using the first of the following that applies
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if capturing it would require an extra DNS lookup.
+
+**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+
+**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.client.request.size`
@@ -167,15 +243,23 @@ This metric is optional.
 | [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
 | [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Logical remote hostname, see note below. [2] | `example.com` | Required |
-| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Logical remote port number | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | [`net.sock.peer.addr`](../../trace/semantic_conventions/span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+**[2]:** Determined by using the first of the following that applies
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if capturing it would require an extra DNS lookup.
+
+**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+
+**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->
 
 ### Metric: `http.client.response.size`
@@ -194,13 +278,21 @@ This metric is optional.
 | [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
 | [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
 | [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
-| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Logical remote hostname, see note below. [2] | `example.com` | Required |
-| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Logical remote port number | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [2] | `example.com` | Required |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to. [3] | `80`; `8080`; `443` | Conditionally Required: [4] |
 | [`net.sock.peer.addr`](../../trace/semantic_conventions/span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+**[2]:** Determined by using the first of the following that applies
 
-**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+- Host identifier of the [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource)
+  if it's sent in absolute-form
+- Host identifier of the `Host` header
+
+SHOULD NOT be set if capturing it would require an extra DNS lookup.
+
+**[3]:** When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match URI port identifier, otherwise it MUST match `Host` header port identifier.
+
+**[4]:** If not default (`80` for `http` scheme, `443` for `https`).
 <!-- endsemconv -->

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -12,61 +12,195 @@ operations. By adding HTTP attributes to metric events it allows for finely tune
 
 **Disclaimer:** These are initial HTTP metric instruments and attributes but more may be added in the future.
 
-## Metric Instruments
+## HTTP Server
 
-The following metric instruments MUST be used to describe HTTP operations. They MUST be of the specified
-type and units.
+### Metric: `http.server.duration`
 
-### HTTP Server
+This metric is required.
 
-Below is a table of HTTP server metric instruments.
+<!-- semconv metric.http.server.duration(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.server.duration` | Histogram | `ms` | Measures the duration of inbound HTTP requests. |
+<!-- endsemconv -->
 
-| Name                          | Instrument Type ([*](README.md#instrument-types)) | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                                                  |
-|-------------------------------|---------------------------------------------------|--------------|-------------------------------------------|------------------------------------------------------------------------------|
-| `http.server.duration`        | Histogram                                         | milliseconds | `ms`                                      | measures the duration inbound HTTP requests                                  |
-| `http.server.request.size`    | Histogram                                         | bytes        | `By`                                      | measures the size of HTTP request messages (compressed)                      |
-| `http.server.response.size`   | Histogram                                         | bytes        | `By`                                      | measures the size of HTTP response messages (compressed)                     |
-| `http.server.active_requests` | UpDownCounter                                     | requests     | `{requests}`                              | measures the number of concurrent HTTP requests that are currently in-flight |
+<!-- semconv metric.http.server.duration -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.route`](../../trace/semantic_conventions/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
+| [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
+| [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [3] |
 
-### HTTP Client
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-Below is a table of HTTP client metric instruments.
+**[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
 
-| Name                        | Instrument Type ([*](README.md#instrument-types)) | Unit         | Unit ([UCUM](README.md#instrument-units)) | Description                                              |
-|-----------------------------|---------------------------------------------------|--------------|-------------------------------------------|----------------------------------------------------------|
-| `http.client.duration`      | Histogram                                         | milliseconds | `ms`                                      | measures the duration outbound HTTP requests             |
-| `http.client.request.size`  | Histogram                                         | bytes        | `By`                                      | measures the size of HTTP request messages (compressed)  |
-| `http.client.response.size` | Histogram                                         | bytes        | `By`                                      | measures the size of HTTP response messages (compressed) |
+**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->
 
-## Attributes
+### Metric: `http.server.active_requests`
 
-Below is a table of the attributes that SHOULD be included on `duration` and `size` metric events
-and whether they should be on server, client, or both types of HTTP metric events:
+This metric is optional.
 
-| Name                 | Type                | Requirement Level                                                            | Notes and examples                                                                                                                      |
-|----------------------|---------------------|------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `http.method`        | `client` & `server` | Required                                                                     | The HTTP request method. E.g. `"GET"`                                                                                                   |
-| `http.scheme`        | `server`            | Required                                                                     | The URI scheme identifying the used protocol in lowercase: `"http"` or `"https"`                                                        |
-| `http.route`         | `server`            | Conditionally Required: If and only if it's available                        | The matched route (path template in the format used by the respective server framework). See note below [1]. E.g. `"/path/{id}/?q={}"`. |
-| `http.status_code`   | `client` & `server` | Conditionally Required: if and only if one was received/sent.                | [HTTP response status code][]. E.g. `200` (int)                                                                                      |
-| `http.flavor`        | `client` & `server` | Recommended                                                                  | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`.                                                              |
-| `net.peer.name`      | `client`            | Required                                                                     | Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.             |
-| `net.peer.port`      | `client`            | Conditionally Required: If not default (`80` for `http`, `443` for `https`). | Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.             |
-| `net.sock.peer.addr` | `client`            | Recommended                                                                  | See [general network connection attributes](../../trace/semantic_conventions/span-general.md#general-network-connection-attributes)     |
-| `net.host.name`      | `server`            | Required                                                                     | Host of the local HTTP server that received the request.                                                                                |
-| `net.host.port`      | `server`            | Conditionally Required: If not default (`80` for `http`, `443` for `https`). | Port of the local HTTP server that received the request.                                                                                |
+<!-- semconv metric.http.server.active_requests(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.server.active_requests` | UpDownCounter | `{requests}` | Measures the number of concurrent HTTP requests that are currently in-flight. |
+<!-- endsemconv -->
 
-**[1]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+<!-- semconv metric.http.server.active_requests -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [2] |
 
-The following attributes SHOULD be included in the `http.server.active_requests` observation:
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-| Name               | Requirement Level | Notes and examples                                                               |
-|--------------------|-------------------|----------------------------------------------------------------------------------|
-| `http.method`      | Required          | The HTTP request method. E.g. `"GET"`                                            |
-| `http.scheme`      | Required          | The URI scheme identifying the used protocol in lowercase: `"http"` or `"https"` |
-| `http.flavor`      | Recommended       | Kind of HTTP protocol used: `"1.0"`, `"1.1"`, `"2"`, `"SPDY"` or `"QUIC"`        |
-| `net.host.name`    | Required          | Host component of the ["origin"](https://www.rfc-editor.org/rfc/rfc9110.html#section-3.6) server HTTP request is sent to. |
+**[2]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->
 
-[HTTP host header]: https://www.rfc-editor.org/rfc/rfc9110.html#name-host-and-authority
-[HTTP response status code]: https://www.rfc-editor.org/rfc/rfc9110.html#name-status-codes
-[HTTP reason phrase]: https://www.rfc-editor.org/rfc/rfc9110.html#section-15.1
+### Metric: `http.server.request.size`
+
+This metric is optional.
+
+<!-- semconv metric.http.server.request.size(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.server.request.size` | Histogram | `By` | Measures the size of HTTP request messages (compressed). |
+<!-- endsemconv -->
+
+<!-- semconv metric.http.server.request.size -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.route`](../../trace/semantic_conventions/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
+| [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
+| [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [3] |
+
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+
+**[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->
+
+### Metric: `http.server.response.size`
+
+This metric is optional.
+
+<!-- semconv metric.http.server.response.size(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.server.response.size` | Histogram | `By` | Measures the size of HTTP response messages (compressed). |
+<!-- endsemconv -->
+
+<!-- semconv metric.http.server.response.size -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.route`](../../trace/semantic_conventions/http.md) | string | The matched route (path template in the format used by the respective server framework). See note below [2] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
+| [`http.scheme`](../../trace/semantic_conventions/http.md) | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
+| [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`net.host.name`](../../trace/semantic_conventions/span-general.md) | string | Logical local hostname or similar, see note below. | `localhost` | Required |
+| [`net.host.port`](../../trace/semantic_conventions/span-general.md) | int | Logical local port number, preferably the one that the peer used to connect | `8080` | Conditionally Required: [3] |
+
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+
+**[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->
+
+## HTTP Client
+
+### Metric: `http.client.duration`
+
+This metric is required.
+
+<!-- semconv metric.http.client.duration(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.client.duration` | Histogram | `ms` | Measures the duration of outbound HTTP requests. |
+<!-- endsemconv -->
+
+<!-- semconv metric.http.client.duration -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Logical remote hostname, see note below. [2] | `example.com` | Required |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Logical remote port number | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`net.sock.peer.addr`](../../trace/semantic_conventions/span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
+
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+
+**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+
+**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->
+
+### Metric: `http.client.request.size`
+
+This metric is optional.
+
+<!-- semconv metric.http.client.request.size(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.client.request.size` | Histogram | `By` | Measures the size of HTTP request messages (compressed). |
+<!-- endsemconv -->
+
+<!-- semconv metric.http.client.request.size -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Logical remote hostname, see note below. [2] | `example.com` | Required |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Logical remote port number | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`net.sock.peer.addr`](../../trace/semantic_conventions/span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
+
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+
+**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+
+**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->
+
+### Metric: `http.client.response.size`
+
+This metric is optional.
+
+<!-- semconv metric.http.client.response.size(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `http.client.response.size` | Histogram | `By` | Measures the size of HTTP response messages (compressed). |
+<!-- endsemconv -->
+
+<!-- semconv metric.http.client.response.size -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| [`http.flavor`](../../trace/semantic_conventions/http.md) | string | Kind of HTTP protocol used. [1] | `1.0` | Recommended |
+| [`http.method`](../../trace/semantic_conventions/http.md) | string | HTTP request method. | `GET`; `POST`; `HEAD` | Required |
+| [`http.status_code`](../../trace/semantic_conventions/http.md) | int | [HTTP response status code](https://tools.ietf.org/html/rfc7231#section-6). | `200` | Conditionally Required: If and only if one was received/sent. |
+| [`net.peer.name`](../../trace/semantic_conventions/span-general.md) | string | Logical remote hostname, see note below. [2] | `example.com` | Required |
+| [`net.peer.port`](../../trace/semantic_conventions/span-general.md) | int | Logical remote port number | `80`; `8080`; `443` | Conditionally Required: [3] |
+| [`net.sock.peer.addr`](../../trace/semantic_conventions/span-general.md) | string | Remote socket peer address: IPv4 or IPv6 for internet protocols, path for local communication, [etc](https://man7.org/linux/man-pages/man7/address_families.7.html). | `127.0.0.1`; `/tmp/mysql.sock` | Recommended |
+
+**[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
+
+**[2]:** `net.peer.name` SHOULD NOT be set if capturing it would require an extra DNS lookup.
+
+**[3]:** If not default (`80` for `http` scheme, `443` for `https`).
+<!-- endsemconv -->


### PR DESCRIPTION
Fixes #2972 by adding text to say whether each instrument is required or optional (ideally should be added to yaml?)
Fixes #2822
Fixes #2974 by including same definition of `net.host.name` from tracing
Fixes #2976 by making `http.server.request.size` and friends optional

## Changes

Adds http metrics yaml file based on @jamesmoessis build tool changes in https://github.com/open-telemetry/build-tools/pull/79

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change) and link to the related issue(s) and/or [OTEP(s)](https://github.com/open-telemetry/oteps), update the [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md), and also be sure to update [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) if necessary.

Related issues #2666, #2001

NOTE: Markdown rendering will be improved in a future PR, after https://github.com/open-telemetry/build-tools/issues/129