### PR TITLE
Http route should contain application root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ release.
 - Rename google openshift platform attribute from `google_cloud_openshift` to `gcp_openshift`
   to match the existing `cloud.provider` prefix.
   [#3095](https://github.com/open-telemetry/opentelemetry-specification/pull/3095)
+- `http.route` SHOULD contain the "application root" if there is one.
+  ([#3164](https://github.com/open-telemetry/opentelemetry-specification/pull/3164))
 
 ### Compatibility
 

--- a/semantic_conventions/metrics/http.yaml
+++ b/semantic_conventions/metrics/http.yaml
@@ -13,6 +13,13 @@ groups:
       - ref: http.route
         requirement_level:
           conditionally_required: If and only if it's available
+        brief: >
+          The matched route (path template in the format used by the respective server framework). See note below
+        examples: ['/users/:userID?', '{controller}/{action}/{id?}']
+        note: >
+          MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+          SHOULD include the [application root](../../trace/semantic_conventions/http.md#http-server-definitions) if there is one.
       - ref: http.status_code
         requirement_level:
           conditionally_required: If and only if one was received/sent.
@@ -98,6 +105,13 @@ groups:
       - ref: http.route
         requirement_level:
           conditionally_required: If and only if it's available
+        brief: >
+          The matched route (path template in the format used by the respective server framework). See note below
+        examples: ['/users/:userID?', '{controller}/{action}/{id?}']
+        note: >
+          MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+          SHOULD include the [application root](../../trace/semantic_conventions/http.md#http-server-definitions) if there is one.
       - ref: http.status_code
         requirement_level:
           conditionally_required: If and only if one was received/sent.
@@ -144,6 +158,13 @@ groups:
       - ref: http.route
         requirement_level:
           conditionally_required: If and only if it's available
+        brief: >
+          The matched route (path template in the format used by the respective server framework). See note below
+        examples: ['/users/:userID?', '{controller}/{action}/{id?}']
+        note: >
+          MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+          SHOULD include the [application root](../../trace/semantic_conventions/http.md#http-server-definitions) if there is one.
       - ref: http.status_code
         requirement_level:
           conditionally_required: If and only if one was received/sent.

--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -152,7 +152,9 @@ groups:
             The matched route (path template in the format used by the respective server framework). See note below
         examples: ['/users/:userID?', '{controller}/{action}/{id?}']
         note: >
-          'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+          MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+
+          SHOULD include the [application root](#http-server-definitions) if there is one.
       - id: client_ip
         type: string
         brief: >

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -38,7 +38,7 @@ This metric is required.
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 **[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-SHOULD include the [application root](#http-server-definitions) if there is one.
+SHOULD include the [application root](../../trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
 **[3]:** Determined by using the first of the following that applies
 
@@ -125,7 +125,7 @@ This metric is optional.
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 **[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-SHOULD include the [application root](#http-server-definitions) if there is one.
+SHOULD include the [application root](../../trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
 **[3]:** Determined by using the first of the following that applies
 
@@ -171,7 +171,7 @@ This metric is optional.
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
 **[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
-SHOULD include the [application root](#http-server-definitions) if there is one.
+SHOULD include the [application root](../../trace/semantic_conventions/http.md#http-server-definitions) if there is one.
 
 **[3]:** Determined by using the first of the following that applies
 

--- a/specification/metrics/semantic_conventions/http-metrics.md
+++ b/specification/metrics/semantic_conventions/http-metrics.md
@@ -37,7 +37,8 @@ This metric is required.
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](#http-server-definitions) if there is one.
 
 **[3]:** Determined by using the first of the following that applies
 
@@ -123,7 +124,8 @@ This metric is optional.
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](#http-server-definitions) if there is one.
 
 **[3]:** Determined by using the first of the following that applies
 
@@ -168,7 +170,8 @@ This metric is optional.
 
 **[1]:** If `net.transport` is not specified, it can be assumed to be `IP.TCP` except if `http.flavor` is `QUIC`, in which case `IP.UDP` is assumed.
 
-**[2]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[2]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](#http-server-definitions) if there is one.
 
 **[3]:** Determined by using the first of the following that applies
 

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -200,8 +200,8 @@ Within a single virtual host, some servers support the concepts of an **HTTP app
 in a deployment of a Python application to Apache, the application would be the [PEP 3333][] conformant callable that is configured using the
 [`WSGIScriptAlias` directive][modwsgisetup] of `mod_wsgi`).
 
-An application can be "mounted" under some **application root**
-(also know as *[context root][]* *[context prefix][]*, or *[document base][]*)
+An application can be "mounted" under an **application root**
+(also known as a *[context root][]*, *[context prefix][]*, or *[document base][]*)
 which is a fixed path prefix of the URL that determines to which application a request is routed
 (e.g., the server could be configured to route all requests that go to an URL path starting with `/webshop/`
 at a particular virtual host

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -247,7 +247,8 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | [`net.sock.host.addr`](span-general.md) | string | Local socket address. Useful in case of a multi-IP host. | `192.168.0.1` | Optional |
 | [`net.sock.host.port`](span-general.md) | int | Local socket port number. | `35555` | Recommended: [6] |
 
-**[1]:** 'http.route' MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+**[1]:** MUST NOT be populated when this is not supported by the HTTP server framework as the route attribute should have low-cardinality and the URI path can NOT substitute it.
+SHOULD include the [application root](#http-server-definitions) if there is one.
 
 **[2]:** This is not necessarily the same as `net.sock.peer.addr`, which would
 identify the network-level peer, which may be a proxy.

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -232,7 +232,6 @@ This span type represents an inbound HTTP request.
 For an HTTP server span, `SpanKind` MUST be `Server`.
 
 Given an inbound request for a route (e.g. `"/users/:userID?"`) the `name` attribute of the span SHOULD be set to this route.
-If the route does not include the application root, it SHOULD be prepended to the span name.
 
 If the route cannot be determined, the `name` attribute MUST be set as defined in the general semantic conventions for HTTP.
 


### PR DESCRIPTION
Fixes #3156

## Changes

Makes it clear that `http.route` SHOULD contain the "application root" if there is one.
