### PR TITLE
Allow adding links after span creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ release.
   or truncated.
   ([#3151](https://github.com/open-telemetry/opentelemetry-specification/pull/3151))
 - Allow adding links after span creation, add new `AddLink` method.
-  ([#2278](https://github.com/open-telemetry/opentelemetry-specification/pull/2278))
+  ([#3186](https://github.com/open-telemetry/opentelemetry-specification/pull/3186))
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ release.
 - Clarify guidance regarding excessive logging when attributes are dropped
   or truncated.
   ([#3151](https://github.com/open-telemetry/opentelemetry-specification/pull/3151))
+- Allow adding links after span creation, add new `AddLink` method.
+  ([#2278](https://github.com/open-telemetry/opentelemetry-specification/pull/2278))
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -66,7 +66,7 @@ formats is required. Implementing more than one format is optional.
 | Array of primitives (homogeneous)                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | `null` values documented as invalid/undefined                                                    |          | +   | +    | +   | +      | +    | N/A    | +   |      | +   |      | N/A   |
 | Unicode support for keys and string values                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Span linking](specification/trace/api.md#add-links)                                             |          |     |      |     |        |      |        |     |      |     |      |       |
+| [Span linking](specification/trace/api.md#add-links)                                             | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Links can be recorded on span creation                                                           |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
 | AddLink                                                                                          |          |     |      |     |        |      |        |     |      |     |      |       |
 | Links order is preserved                                                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -31,6 +31,7 @@ formats is required. Implementing more than one format is optional.
 | [Tracer](specification/trace/api.md#tracer-operations)                                           | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Create a new Span                                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Documentation defines adding attributes at span creation as preferred                            |          |     |      |     | +      | +    |        | +   |      |     | +    |       |
+| Documentation defines adding links at span creation as preferred                                 |          |     |      |     |        |      |        |     |      |     |      |       |
 | Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Mark Span active                                                                                 |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -66,8 +66,9 @@ formats is required. Implementing more than one format is optional.
 | Array of primitives (homogeneous)                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | `null` values documented as invalid/undefined                                                    |          | +   | +    | +   | +      | +    | N/A    | +   |      | +   |      | N/A   |
 | Unicode support for keys and string values                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Span linking](specification/trace/api.md#specifying-links)                                      | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| [Span linking](specification/trace/api.md#add-links)                                             |          |     |      |     |        |      |        |     |      |     |      |       |
 | Links can be recorded on span creation                                                           |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
+| AddLink                                                                                          |          |     |      |     |        |      |        |     |      |     |      |       |
 | Links order is preserved                                                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
 | [Span events](specification/trace/api.md#add-events)                                             |          |     |      |     |        |      |        |     |      |     |      |       |
 | AddEvent                                                                                         |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -122,7 +122,7 @@ at this time, as discussed in
 [data points](../metrics/data-model.md#metric-points),
 [Spans](../trace/api.md#set-attributes), Span
 [Events](../trace/api.md#add-events), Span
-[Links](../trace/api.md#specifying-links) and
+[Links](../trace/api.md#add-links) and
 [Log Records](../logs/data-model.md) may contain a collection of attributes. The
 keys in each such collection are unique, i.e. there MUST NOT exist more than one
 key-value pair with the same key. The enforcement of uniqueness may be performed

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -178,7 +178,7 @@ using the OpenCensus <-> OpenTelemetry bridge.
    This leads to some issues with OpenCensus APIs that allowed flexible
    specification of parent spans post-initialization.
 2. Links added to spans after the spans are created. This is [not supported in
-   OpenTelemetry](../trace/api.md#specifying-links), therefore OpenCensus spans
+   OpenTelemetry](../trace/api.md#add-links), therefore OpenCensus spans
    that have links added to them after creation will be mapped to OpenTelemetry
    spans without the links.
 3. OpenTelemetry specifies that samplers are

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -177,14 +177,10 @@ using the OpenCensus <-> OpenTelemetry bridge.
    that [parent spans must be specified during span creation](../trace/api.md#span-creation).
    This leads to some issues with OpenCensus APIs that allowed flexible
    specification of parent spans post-initialization.
-2. Links added to spans after the spans are created. This is [not supported in
-   OpenTelemetry](../trace/api.md#add-links), therefore OpenCensus spans
-   that have links added to them after creation will be mapped to OpenTelemetry
-   spans without the links.
-3. OpenTelemetry specifies that samplers are
+2. OpenTelemetry specifies that samplers are
    [attached to an entire Trace provider](../trace/sdk.md#sampling)
    while [OpenCensus allows custom samplers per span](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/Sampling.md#how-can-users-control-the-sampler-that-is-used-for-sampling).
-4. TraceFlags in both OpenCensus and OpenTelemetry only specify the single
+3. TraceFlags in both OpenCensus and OpenTelemetry only specify the single
    `sampled` flag ([OpenTelemetry](../trace/api.md#spancontext),
    [OpenCensus](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/TraceConfig.md#traceparams)).
    Some OpenCensus APIs support "debug" and "defer" tracing flags in addition to

--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -530,7 +530,7 @@ OpenTracing defines two types of references:
 
 OpenTelemetry does not define strict equivalent semantics for these
 references. These reference types must not be confused with the
-[Link](../trace/api.md##add-links) functionality. This information
+[Link](../trace/api.md#add-links) functionality. This information
 is however preserved as the `opentracing.ref_type` attribute.
 
 ## In process Propagation exceptions

--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -530,7 +530,7 @@ OpenTracing defines two types of references:
 
 OpenTelemetry does not define strict equivalent semantics for these
 references. These reference types must not be confused with the
-[Link](../trace/api.md#specifying-links) functionality. This information
+[Link](../trace/api.md##add-links) functionality. This information
 is however preserved as the `opentracing.ref_type` attribute.
 
 ## In process Propagation exceptions

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -493,7 +493,7 @@ attributes, cannot change their decisions.
 
 #### Add Links
 
-A `Span` MUST have the ability to add `Link`s associated with it. Linked
+A `Span` SHOULD have the ability to add `Link`s associated with it. Linked
 `Span`s can be from the same or a different trace (see
 [Links between spans](../overview.md#links-between-spans)).
 
@@ -503,7 +503,7 @@ A `Link` is structurally defined by the following properties:
 - Zero or more [`Attributes`](../common/common.md#attributes) further describing
   the link.
 
-The Span interface MUST provide:
+The Span interface SHOULD provide:
 
 - An API to record a single `Link` where the `Link` properties are passed as
   arguments. This MAY be called `AddLink`. This API takes the `SpanContext` of

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -517,7 +517,7 @@ The Span interface MAY provide:
 - An API to set multiple `Link`s at once, where the `Link`s are passed in a
   single method call.
 
-Links SHOULD preserve the order in which they're set.
+Spans SHOULD preserve the order in which Links are set.
 
 Note that [Samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any `Link`s added later cannot change their

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -292,7 +292,7 @@ the entire operation and, optionally, one or more sub-spans for its sub-operatio
 - A [`SpanKind`](#spankind)
 - A start timestamp
 - An end timestamp
-- [`Attributes`](../common/common.md#attributes)
+- [`Attributes`](../common/README.md#attribute)
 - A list of [`Link`s](#add-links) to other `Span`s
 - A list of timestamped [`Event`s](#add-events)
 - A [`Status`](#set-status).
@@ -500,7 +500,7 @@ A `Span` SHOULD have the ability to add `Link`s associated with it. Linked
 A `Link` is structurally defined by the following properties:
 
 - `SpanContext` of the `Span` to link to.
-- Zero or more [`Attributes`](../common/common.md#attributes) further describing
+- Zero or more [`Attributes`](../common/README.md#attribute) further describing
   the link.
 
 The Span interface SHOULD provide:

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -25,11 +25,11 @@
 - [Span](#span)
   * [Span Creation](#span-creation)
     + [Determining the Parent Span from a Context](#determining-the-parent-span-from-a-context)
-    + [Specifying links](#specifying-links)
   * [Span operations](#span-operations)
     + [Get Context](#get-context)
     + [IsRecording](#isrecording)
     + [Set Attributes](#set-attributes)
+    + [Add Links](#add-links)
     + [Add Events](#add-events)
     + [Set Status](#set-status)
     + [UpdateName](#updatename)
@@ -292,8 +292,8 @@ the entire operation and, optionally, one or more sub-spans for its sub-operatio
 - A [`SpanKind`](#spankind)
 - A start timestamp
 - An end timestamp
-- [`Attributes`](../common/README.md#attribute)
-- A list of [`Link`s](#specifying-links) to other `Span`s
+- [`Attributes`](../common/common.md#attributes)
+- A list of [`Link`s](#add-links) to other `Span`s
 - A list of timestamped [`Event`s](#add-events)
 - A [`Status`](#set-status).
 
@@ -378,8 +378,14 @@ The API MUST accept the following parameters:
   The API documentation MUST state that adding attributes at span creation is preferred
   to calling `SetAttribute` later, as samplers can only consider information
   already present during span creation.
+- [`Link`s](../overview.md#links-between-spans) - an ordered sequence of links.
+  Additionally, these links may be used to make a sampling decision as
+  noted in [sampling description](sdk.md#sampling). An empty collection will be
+  assumed if not specified.
 
-- `Link`s - an ordered sequence of Links, see API definition [here](#specifying-links).
+  The API documentation MUST state that adding links at span creation is
+  preferred to calling `AddLink` later, as samplers can only consider information
+  already present during span creation.
 - `Start timestamp`, default to current time. This argument SHOULD only be set
   when span creation time has already passed. If API is called at a moment of
   a Span logical start, API user MUST NOT explicitly set this argument.
@@ -413,30 +419,6 @@ If there is no `Span` in the `Context`, the newly created `Span` will be a root 
 A `SpanContext` cannot be set as active in a `Context` directly, but by
 [wrapping it into a Span](#wrapping-a-spancontext-in-a-span).
 For example, a `Propagator` performing context extraction may need this.
-
-#### Specifying links
-
-During `Span` creation, a user MUST have the ability to record links to other
-`Span`s. Linked `Span`s can be from the same or a different trace -- see [Links
-between spans](../overview.md#links-between-spans). `Link`s cannot be added after
-Span creation.
-
-A `Link` is structurally defined by the following properties:
-
-- `SpanContext` of the `Span` to link to.
-- Zero or more [`Attributes`](../common/README.md#attribute) further describing
-  the link.
-
-The Span creation API MUST provide:
-
-- An API to record a single `Link` where the `Link` properties are passed as
-  arguments. This MAY be called `AddLink`. This API takes the `SpanContext` of
-  the `Span` to link to and optional `Attributes`, either as individual
-  parameters or as an immutable object encapsulating them, whichever is most
-  appropriate for the language. Implementations MAY ignore links with an
-  [invalid](#isvalid) `SpanContext`.
-
-Links SHOULD preserve the order in which they're set.
 
 ### Span operations
 
@@ -508,6 +490,38 @@ attributes"](semantic_conventions/README.md) that have prescribed semantic meani
 Note that [Samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any changes done later, including new or changed
 attributes, cannot change their decisions.
+
+#### Add Links
+
+A `Span` MUST have the ability to add `Link`s associated with it. Linked
+`Span`s can be from the same or a different trace (see
+[Links between spans](../overview.md#links-between-spans)).
+
+A `Link` is structurally defined by the following properties:
+
+- `SpanContext` of the `Span` to link to.
+- Zero or more [`Attributes`](../common/common.md#attributes) further describing
+  the link.
+
+The Span interface MUST provide:
+
+- An API to record a single `Link` where the `Link` properties are passed as
+  arguments. This MAY be called `AddLink`. This API takes the `SpanContext` of
+  the `Span` to link to and optional `Attributes`, either as individual
+  parameters or as an immutable object encapsulating them, whichever is most
+  appropriate for the language. Implementations MAY ignore links with an
+  [invalid](#isvalid) `SpanContext`.
+
+The Span interface MAY provide:
+
+- An API to set multiple `Link`s at once, where the `Link`s are passed in a
+  single method call.
+
+Links SHOULD preserve the order in which they're set.
+
+Note that [Samplers](sdk.md#sampler) can only consider information already
+present during span creation. Any `Link`s added later cannot change their
+decisions.
 
 #### Add Events
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -514,10 +514,10 @@ The Span interface SHOULD provide:
 
 The Span interface MAY provide:
 
-- An API to set multiple `Link`s at once, where the `Link`s are passed in a
+- An API to add multiple `Link`s at once, where the `Link`s are passed in a
   single method call.
 
-Spans SHOULD preserve the order in which Links are set.
+Spans SHOULD preserve the order in which Links are added.
 
 Note that [Samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any `Link`s added later cannot change their


### PR DESCRIPTION
Fixes #454

The limitation caused by preventing adding links after span creation limits OpenTelemetry users in the ability to efficiently and intuitively create spans and traces in certain scenarios (see examples in the linked issues and PRs below).

Adding links after span creation allows to create more meaningful traces in those scenarios. Best-effort sampling based on links is still possible, but only based on links added at creation time (similar to attributes). This was discussed with members of the sampling SIG, and from their side there are no concerns regarding removing this restriction (also see [this PR comment](https://github.com/open-telemetry/opentelemetry-specification/issues/2918#issuecomment-1314333564)).

Some use cases from the related issue:
https://github.com/open-telemetry/opentelemetry-specification/issues/454#issuecomment-1287133337
https://github.com/open-telemetry/opentelemetry-specification/issues/454#issuecomment-1282120521
https://github.com/open-telemetry/opentelemetry-specification/issues/454#issuecomment-1325433228
https://github.com/open-telemetry/opentelemetry-specification/issues/454#issuecomment-1278992263
https://github.com/open-telemetry/opentelemetry-specification/pull/2278#issuecomment-1040504818

Users who are forced to come up with workarounds:
* https://github.com/open-telemetry/opentelemetry-js-api/issues/124
* https://github.com/elastic/apm-agent-java/issues/2489
* https://github.com/SumoLogic/the-coffee-bar/pull/63

## Changes

This moves the section about adding span links from "Span creation" to "Span operations", removing mentions of the limitation that links can only be added at creation time. The name AddLink is proposed, wording is kept consistent with the corresponding section for adding attributes.

Discussions about the need for indicating causality in link-relationships (e. g. via attributes) will be held in the messaging workgroup. If necessary, this will result in a follow-up PR.