### PR TITLE
Require service.instance.id and define how to generate it.

### DIFF
--- a/semantic_conventions/resource/service.yaml
+++ b/semantic_conventions/resource/service.yaml
@@ -31,6 +31,7 @@ groups:
         examples: ["Shop"]
       - id: instance.id
         type: string
+        requirement_level: required
         brief: >
           The string ID of the service instance.
         note: >
@@ -45,6 +46,19 @@ groups:
           it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID
           (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122
           for more recommendations).
+
+          SDKs are required to follow the following algorithm when generating
+          `service.instance.id`:
+
+          - If the user has provided a `service.instance.id`, via environment
+            variable, configuration or custom resource detection, this will
+            always be used and honored over generated ids.
+          - When the SDK is running in an environment where a non-ambiguous IP
+            address exists, the ID should be set to this IP address.
+          - When the environment the SDK targets provides a stable identifier
+            matching the goals of `service.instance.id`, then this may be used.
+          - When no other source is available the SDK MUST generate an ID. This
+            ID SHOULD follow version 1, 4 or 5 of RFC 4122.
         examples: ["627cc493-f310-47de-96bd-71410b7dec09"]
       - id: version
         type: string

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -55,6 +55,7 @@ These are the attributes which MUST be provided by the SDK
 as specified in the [Resource SDK specification](../sdk.md#sdk-provided-resource-attributes):
 
 - [`service.name`](#service)
+- [`service.instance.id`](#service)
 
 ## Service
 
@@ -67,7 +68,7 @@ as specified in the [Resource SDK specification](../sdk.md#sdk-provided-resource
 |---|---|---|---|---|
 | `service.name` | string | Logical name of the service. [1] | `shoppingcart` | Required |
 | `service.namespace` | string | A namespace for `service.name`. [2] | `Shop` | Recommended |
-| `service.instance.id` | string | The string ID of the service instance. [3] | `627cc493-f310-47de-96bd-71410b7dec09` | Recommended |
+| `service.instance.id` | string | The string ID of the service instance. [3] | `627cc493-f310-47de-96bd-71410b7dec09` | Required |
 | `service.version` | string | The version string of the service API or implementation. | `2.0.0` | Recommended |
 
 **[1]:** MUST be the same for all instances of horizontally scaled services. If the value was not specified, SDKs MUST fallback to `unknown_service:` concatenated with [`process.executable.name`](process.md#process), e.g. `unknown_service:bash`. If `process.executable.name` is not available, the value MUST be set to `unknown_service`.
@@ -75,6 +76,16 @@ as specified in the [Resource SDK specification](../sdk.md#sdk-provided-resource
 **[2]:** A string value having a meaning that helps to distinguish a group of services, for example the team name that owns a group of services. `service.name` is expected to be unique within the same namespace. If `service.namespace` is not specified in the Resource then `service.name` is expected to be unique for all services that have no explicit namespace defined (so the empty/unspecified namespace is simply one more valid namespace). Zero-length namespace string is assumed equal to unspecified namespace.
 
 **[3]:** MUST be unique for each instance of the same `service.namespace,service.name` pair (in other words `service.namespace,service.name,service.instance.id` triplet MUST be globally unique). The ID helps to distinguish instances of the same service that exist at the same time (e.g. instances of a horizontally scaled service). It is preferable for the ID to be persistent and stay the same for the lifetime of the service instance, however it is acceptable that the ID is ephemeral and changes during important lifetime events for the service (e.g. service restarts). If the service has no inherent unique ID that can be used as the value of this attribute it is recommended to generate a random Version 1 or Version 4 RFC 4122 UUID (services aiming for reproducible UUIDs may also use Version 5, see RFC 4122 for more recommendations).
+SDKs are required to follow the following algorithm when generating `service.instance.id`:
+- If the user has provided a `service.instance.id`, via environment
+  variable, configuration or custom resource detection, this will
+  always be used and honored over generated ids.
+- When the SDK is running in an environment where a non-ambiguous IP
+  address exists, the ID should be set to this IP address.
+- When the environment the SDK targets provides a stable identifier
+  matching the goals of `service.instance.id`, then this may be used.
+- When no other source is available the SDK MUST generate an ID. This
+  ID SHOULD follow version 1, 4 or 5 of RFC 4122.
 <!-- endsemconv -->
 
 Note: `service.namespace` and `service.name` are not intended to be concatenated for the purpose of forming a single globally unique name for the service. For example the following 2 sets of attributes actually describe 2 different services (despite the fact that the concatenation would result in the same string):


### PR DESCRIPTION
Fixes ##136

## Changes

- Mark `service.instance.id` as required by SDKs
- Define algorithm for SDKs to provide `service.instance.id`
- Leave enough room for better `service.instance.id` algorithms on known platforms.

For full rationale, please read the [full proposal detailed here](https://docs.google.com/document/d/1BenPf9vsZHCf4JpHWGQBydKZAA4XdH38wuMD7JQnz9A/edit?usp=sharing)
