### PR TITLE
[editorial] Fix Tencent Cloud link

### DIFF
--- a/semantic_conventions/resource/cloud.yaml
+++ b/semantic_conventions/resource/cloud.yaml
@@ -45,7 +45,7 @@ groups:
           [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/),
           [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/),
           [Google Cloud regions](https://cloud.google.com/about/locations),
-          or [Tencent Cloud regions](https://intl.cloud.tencent.com/document/product/213/6091).
+          or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
         examples: ['us-central1', 'us-east-1']
       - id: availability_zone
         type: string

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -175,4 +175,4 @@ Valid cloud providers are:
 - [Amazon Web Services](https://aws.amazon.com/) ([`aws`](cloud_provider/aws/README.md))
 - [Google Cloud Platform](https://cloud.google.com/) (`gcp`)
 - [Microsoft Azure](https://azure.microsoft.com/) (`azure`)
-- [Tencent Cloud](https://intl.cloud.tencent.com/) (`tencent_cloud`)
+- [Tencent Cloud](https://www.tencentcloud.com/) (`tencent_cloud`)

--- a/specification/resource/semantic_conventions/cloud.md
+++ b/specification/resource/semantic_conventions/cloud.md
@@ -15,7 +15,7 @@
 | `cloud.availability_zone` | string | Cloud regions often have multiple, isolated locations known as zones to increase availability. Availability zone represents the zone where the resource is running. [2] | `us-east-1c` | Recommended |
 | `cloud.platform` | string | The cloud platform in use. [3] | `alibaba_cloud_ecs` | Recommended |
 
-**[1]:** Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://intl.cloud.tencent.com/document/product/213/6091).
+**[1]:** Refer to your provider's docs to see the available regions, for example [Alibaba Cloud regions](https://www.alibabacloud.com/help/doc-detail/40654.htm), [AWS regions](https://aws.amazon.com/about-aws/global-infrastructure/regions_az/), [Azure regions](https://azure.microsoft.com/en-us/global-infrastructure/geographies/), [Google Cloud regions](https://cloud.google.com/about/locations), or [Tencent Cloud regions](https://www.tencentcloud.com/document/product/213/6091).
 
 **[2]:** Availability zones are called "zones" on Alibaba Cloud and Google Cloud.
 


### PR DESCRIPTION
- Replaces `https://intl.cloud.tencent.com` by `https://www.tencentcloud.com`, the new canonical URL for Tencent Cloud
- Note that other PRs (like #3230) are currently failing because of the invalid Tencent link:
  > FILE: ./specification/resource/semantic_conventions/README.md
  >  [✖] https://intl.cloud.tencent.com/