### PR TITLE
[editorial] Drop Google highlight "hash" from URL in metrics/data-model

### DIFF
--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -184,7 +184,7 @@ in scope for key design decisions:
 
 - Using OTLP as an intermediary format between two non-compatible formats
   - Importing [statsd](https://github.com/statsd/statsd) => Prometheus PRW
-  - Importing [collectd](https://collectd.org/wiki/index.php/Binary_protocol#:~:text=The%20binary%20protocol%20is%20the,some%20documentation%20to%20reimplement%20it)
+  - Importing [collectd](https://collectd.org/wiki/index.php/Binary_protocol)
     => Prometheus PRW
   - Importing Prometheus endpoint scrape => [statsd push | collectd | opencensus]
   - Importing OpenCensus "oca" => any non OC or OTel format


### PR DESCRIPTION
- This is part of an effort to normalize external links, for improved external link checking of the OTel website.
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/1052
