### PR TITLE
HTTP client span clarification and establishing HTTP connection spec

### DIFF
--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -86,6 +86,26 @@ groups:
           When [request target](https://www.rfc-editor.org/rfc/rfc9110.html#target.resource) is absolute URI, `net.peer.name` MUST match
           URI port identifier, otherwise it MUST match `Host` header port identifier.
 
+  - id: trace.http.client_connect
+    type: span
+    span_kind: client
+    brief: 'Semantic Convention for establishing an HTTP connection'
+    attributes:
+      - ref: net.peer.name
+        sampling_relevant: true
+        requirement_level: required
+        brief: >
+          Host identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+      - ref: net.peer.port
+        sampling_relevant: true
+        brief: >
+          Port identifier of the ["URI origin"](https://www.rfc-editor.org/rfc/rfc9110.html#name-uri-origin) HTTP request is sent to.
+      - ref: net.sock.peer.addr
+      - ref: net.sock.peer.port
+      - ref: net.sock.peer.name
+      - ref: net.sock.family
+        examples: ['inet', 'inet6']
+
   - id: trace.http.server
     prefix: http
     type: span

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -502,11 +502,11 @@ request (SERVER, trace=t1, span=s1)
 Example of establishing an HTTP connection with no trace started upfront:
 
 ```
-CONNECT www.example.com:80 (CLIENT, trace=t1, span=s2)
+CONNECT www.example.com:80 (CLIENT, trace=t1, span=s1)
 
-GET /hello - 200 (CLIENT, trace=t1, span=s3)
+GET /hello - 200 (CLIENT, trace=t2, span=s1)
  |
- --- server (SERVER, trace=t1, span=s4)
+ --- server (SERVER, trace=t2, span=s2)
 ```
 
 ### HTTP client establishing connection error examples
@@ -522,9 +522,9 @@ request (SERVER, trace=t1, span=s1)
 Example of an error occurring during establishing an HTTP connection with no trace started upfront:
 
 ```
-CONNECT www.example.com:80 (CLIENT, trace=t1, span=s2)
+CONNECT www.example.com:80 (CLIENT, trace=t1, span=s1)
 
-GET /hello - 200 (CLIENT, trace=t1, span=s3)
+GET /hello - 200 (CLIENT, trace=t2, span=s1)
  |
- --- server (SERVER, trace=t1, span=s4)
+ --- server (SERVER, trace=t2, span=s2)
 ```


### PR DESCRIPTION
Fixes #3155

Ping @trask @lmolkova 

I've added both the additional clarifications about the "low-level" vs "high-level" HTTP span, and the connection span spec. The connection span spec is derived from the current behavior of some of the Java HTTP client instrumentations.

I've made several clauses stronger (SHOULD changed to MUST) to show how I think the two ways of instrumenting HTTP clients should work in principle - consider this a topic for discussion.