### PR TITLE
Update build-tools to 1.16.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "MD040": false,
     },
     "yaml.schemas": {
-        "https://raw.githubusercontent.com/open-telemetry/build-tools/v0.15.1/semantic-conventions/semconv.schema.json": [
+        "https://raw.githubusercontent.com/open-telemetry/build-tools/v0.16.0/semantic-conventions/semconv.schema.json": [
             "semantic_conventions/**/*.yaml"
         ]
     },

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MISSPELL = $(TOOLS_DIR)/$(MISSPELL_BINARY)
 
 # see https://github.com/open-telemetry/build-tools/releases for semconvgen updates
 # Keep links in semantic_conventions/README.md and .vscode/settings.json in sync!
-SEMCONVGEN_VERSION=0.15.1
+SEMCONVGEN_VERSION=0.16.0
 
 # TODO: add `yamllint` step to `all` after making sure it works on Mac.
 .PHONY: all

--- a/internal/tools/schema_check.sh
+++ b/internal/tools/schema_check.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-BUILD_TOOL_SCHEMAS_VERSION=0.13.0
+BUILD_TOOL_SCHEMAS_VERSION=0.16.0
 
 # List of versions that do not require or have a schema.
 declare -a skip_versions=("1.0.0" "1.0.1" "1.1.0" "1.2.0" "1.3.0" "1.6.0")

--- a/semantic_conventions/README.md
+++ b/semantic_conventions/README.md
@@ -19,12 +19,12 @@ Semantic conventions for the spec MUST adhere to the
 [attribute requirement level](../specification/common/attribute-requirement-level.md),
 and [metric requirement level](../specification/metrics/metric-requirement-level.md) conventions.
 
-Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.15.1/semantic-conventions/syntax.md)
+Refer to the [syntax](https://github.com/open-telemetry/build-tools/tree/v0.16.0/semantic-conventions/syntax.md)
 for how to write the YAML files for semantic conventions and what the YAML properties mean.
 
 A schema file for VS code is configured in the `/.vscode/settings.json` of this
 repository, enabling auto-completion and additional checks. Refer to
-[the generator README](https://github.com/open-telemetry/build-tools/tree/v0.15.1/semantic-conventions/README.md) for what extension you need.
+[the generator README](https://github.com/open-telemetry/build-tools/tree/v0.16.0/semantic-conventions/README.md) for what extension you need.
 
 ## Generating markdown
 
@@ -35,7 +35,7 @@ formatted Markdown tables for all semantic conventions in the specification. Run
 make table-generation
 ```
 
-For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/v0.15.1/semantic-conventions)
+For more information, see the [semantic convention generator](https://github.com/open-telemetry/build-tools/tree/v0.16.0/semantic-conventions)
 in the OpenTelemetry build tools repository.
 Using this build tool, it is also possible to generate code for use in OpenTelemetry
 language projects.


### PR DESCRIPTION
build-tools 1.16.0 was just released and is necessary to unblock https://github.com/open-telemetry/opentelemetry-specification/pull/3190
