### PR TITLE
Show relationship between http target and route in example usage

### DIFF
--- a/semantic_conventions/trace/http.yaml
+++ b/semantic_conventions/trace/http.yaml
@@ -96,7 +96,7 @@ groups:
         brief: 'The full request target as passed in a HTTP request line or equivalent.'
         requirement_level: required
         sampling_relevant: true
-        examples: ['/path/12314/?q=ddds']
+        examples: ['/users/12314/?q=ddds']
       - id: client_ip
         type: string
         brief: >

--- a/specification/trace/semantic_conventions/http.md
+++ b/specification/trace/semantic_conventions/http.md
@@ -244,7 +244,7 @@ If the route cannot be determined, the `name` attribute MUST be set as defined i
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `http.route` | string | The matched route (path template in the format used by the respective server framework). See note below [1] | `/users/:userID?`; `{controller}/{action}/{id?}` | Conditionally Required: If and only if it's available |
-| `http.target` | string | The full request target as passed in a HTTP request line or equivalent. | `/path/12314/?q=ddds` | Required |
+| `http.target` | string | The full request target as passed in a HTTP request line or equivalent. | `/users/12314/?q=ddds` | Required |
 | `http.client_ip` | string | The IP address of the original client behind all proxies, if known (e.g. from [X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For)). [2] | `83.164.160.102` | Recommended |
 | `http.scheme` | string | The URI scheme identifying the used protocol. | `http`; `https` | Required |
 | [`net.host.name`](span-general.md) | string | Name of the local HTTP server that received the request. [3] | `localhost` | Required |


### PR DESCRIPTION
## Changes

Clarify relationship between `http.target` and `http.route` by using the same pattern in the example usage. Having different patterns for the attribute values distorts the relationship between the two attributes.

A similar pattern is seen in the docs for [`aws-lambda.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/instrumentation/aws-lambda.md#api-gateway-request-proxy-lambda-tracing-passive), where `http.target` is `/pets/10` and `http.route` is `/pets/{petId}`. It's a minor adjustment but should help provide clarity for new users.