### PR TITLE
[editorial] Use path not URL for link to spec page

### DIFF
--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -13,10 +13,10 @@ instrumented codebases.
 Migrating from OpenCensus to OpenTelemetry may require breaking changes to the telemetry produced
 because of:
 
-* Different or new semantic conventions for names and attributes (e.g. [`grpc.io/server/server_latency`](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md#server) vs [`rpc.server.duration`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/rpc-metrics.md#rpc-server))
+* Different or new semantic conventions for names and attributes (e.g. [`grpc.io/server/server_latency`](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md#server) vs [`rpc.server.duration`](/specification/metrics/semantic_conventions/rpc-metrics.md#rpc-server))
 * Data model differences (e.g. OpenCensus supports [SumOfSquaredDeviations](https://github.com/census-instrumentation/opencensus-proto/blob/v0.3.0/src/opencensus/proto/metrics/v1/metrics.proto#L195), OTLP does not)
 * Instrumentation API feature differences (e.g. OpenCensus supports [context-based attributes](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/Record.md#recording-stats)), OTel does not)
-* Differences between equivalent OC and OTel exporters (e.g. the OpenTelemetry Prometheus exporter [adds type and unit suffixes](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#metric-metadata-1); OpenCensus [does not](https://github.com/census-ecosystem/opencensus-go-exporter-prometheus/blob/v0.4.1/prometheus.go#L227))
+* Differences between equivalent OC and OTel exporters (e.g. the OpenTelemetry Prometheus exporter [adds type and unit suffixes](/specification/metrics/data-model.md#metric-metadata-1); OpenCensus [does not](https://github.com/census-ecosystem/opencensus-go-exporter-prometheus/blob/v0.4.1/prometheus.go#L227))
 
 This migration path groups most breaking changes into the installation of bridges. This gives
 users control over introducing the initial breaking change, and makes subsequent migrations of

--- a/specification/metrics/semantic_conventions/database-metrics.md
+++ b/specification/metrics/semantic_conventions/database-metrics.md
@@ -58,4 +58,4 @@ Below is a table of the attributes that MUST be included on all connection pool 
 
 | Name        | Type   | Description                                                                  | Examples       | Requirement Level |
 |-------------|--------|------------------------------------------------------------------------------|----------------|-------------------|
-| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation does not provide a name, then the [db.connection_string](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md#connection-level-attributes) should be used. | `myDataSource` | Required          |
+| `pool.name` | string | The name of the connection pool; unique within the instrumented application. In case the connection pool implementation does not provide a name, then the [db.connection_string](/specification/trace/semantic_conventions/database.md#connection-level-attributes) should be used. | `myDataSource` | Required          |


### PR DESCRIPTION
- This is part of an effort to normalize links, for improved link checking of the OTel website.
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2429
