### PR TITLE
[Spec-compliance-matrix][.NET] Update entry for "Allow samplers to modify tracestate"

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -76,7 +76,7 @@ formats is required. Implementing more than one format is optional.
 | RecordException                                                                                  |          | -   | +    | +   | +      | +    | +      | +   | +    | -   | +    | -     |
 | RecordException with extra parameters                                                            |          | -   | +    | +   | +      | +    | +      | +   | +    | -   | +    | -     |
 | [Sampling](specification/trace/sdk.md#sampling)                                                  | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Allow samplers to modify tracestate                                                              |          | +   | +    |     | +      | +    | +      | +   | +    | +   | -    | +     |
+| Allow samplers to modify tracestate                                                              |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    | +     |
 | ShouldSample gets full parent Context                                                            |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | -    | +     |
 | Sampler: JaegerRemoteSampler                                                                     |          | +   | +    |     |        |      |        |     | +    |     |      |       |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          | +   | +    |     | +      | +    | +      | +   | +    | +   | -    | +     |


### PR DESCRIPTION
.NET SDK supports allowing samplers to modify tracestate starting the latest stable version `1.4.0`.

Here is the PR for reference: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3610


## Changes
- Update .NET entry for "Allow samplers to modify tracestate"
