### PR TITLE
Make markdown-link-check work again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "markdown-link-check": "^3.9.3",
+    "markdown-link-check": "3.10.3",
     "markdown-toc": "^1.2.0",
     "markdownlint-cli": "0.31.0"
   }


### PR DESCRIPTION
Link check is broken due to https://github.com/tcort/markdown-link-check/issues/246, pinning previous version until it's fixed