### PR TITLE
Remove log readme document status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ release.
 
 - Update log readme "request context" to "trace context".
   ([#3332](https://github.com/open-telemetry/opentelemetry-specification/pull/3332))
+- Remove log readme document status.
+  ([#3334](https://github.com/open-telemetry/opentelemetry-specification/pull/3334))
 
 ### Resource
 

--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -24,6 +24,7 @@ aliases: [/docs/reference/specification/logs/overview]
   * [New First-Party Application Logs](#new-first-party-application-logs)
 - [OpenTelemetry Collector](#opentelemetry-collector)
 - [Auto-Instrumenting Existing Logging](#auto-instrumenting-existing-logging)
+- [Specifications](#specifications)
 - [Trace Context in Legacy Formats](#trace-context-in-legacy-formats)
   * [Syslog RFC5424](#syslog-rfc5424)
   * [Plain Text Formats](#plain-text-formats)

--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -3,9 +3,7 @@ linkTitle: Logs
 aliases: [/docs/reference/specification/logs/overview]
 --->
 
-# OpenTelemetry Logging Overview
-
-**Status**: [Experimental](../document-status.md)
+# OpenTelemetry Logging
 
 <details>
 <summary>Table of Contents</summary>
@@ -442,6 +440,14 @@ that do this.
 A further optional modification would be to auto-instrument loggers to send logs
 directly to the backend via OTLP instead or in addition to writing to a file or
 standard output.
+
+## Specifications
+
+* [Logs Bridge API](./bridge-api.md)
+* [Logs SDK](./sdk.md)
+* [Logs Data Model](./data-model.md)
+* [Event API](./event-api.md)
+* [Semantic Conventions](./semantic_conventions/README.md)
 
 ## Trace Context in Legacy Formats
 


### PR DESCRIPTION
Related to #2911.

The log readme contains useful context and history behind the design of the log signal, but is not normative. Well, it won't contain normative language after #3331 is merged.

Removing the document status to reflect this and match the [metrics readme](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/README.md).