### PR TITLE
Add Trino to db.system semantic conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ release.
 - Stabilize key components of `service.*` and `telemetry.sdk.*` resource
   semantic conventions.
   ([#3202](https://github.com/open-telemetry/opentelemetry-specification/pull/3202))
+- Add Trino to Database specific conventions
+  ([#3347](https://github.com/open-telemetry/opentelemetry-specification/pull/3347))
 
 ### Compatibility
 

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -166,6 +166,9 @@ groups:
             - id: spanner
               value: 'spanner'
               brief: 'Cloud Spanner'
+            - id: trino
+              value: 'trino'
+              brief: 'Trino'
       - id: connection_string
         tag: connection-level
         type: string

--- a/specification/trace/semantic_conventions/database.md
+++ b/specification/trace/semantic_conventions/database.md
@@ -121,6 +121,7 @@ Some database systems may allow a connection to switch to a different `db.user`,
 | `opensearch` | OpenSearch |
 | `clickhouse` | ClickHouse |
 | `spanner` | Cloud Spanner |
+| `trino` | Trino |
 <!-- endsemconv -->
 
 ### Notes and well-known identifiers for `db.system`


### PR DESCRIPTION
## Changes

Add [Trino](https://trino.io/) to the list of well-known identifiers for `db.system`.
