### PR TITLE
Add semantic conventions for Elasticsearch client instrumentation

### DIFF
--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -424,28 +424,12 @@ groups:
           The url of the request, including the target and exact document id.
         examples: [ '/test-index/_search', '/test-index/_doc/123' ]
       - id: method
-        type:
-          allow_custom_values: false
-          members:
-            - id: get
-              value: 'GET'
-              brief: GET request
-            - id: post
-              value: 'POST'
-              brief: POST request
-            - id: put
-              value: 'PUT'
-              brief: PUT request
-            - id: delete
-              value: 'DELETE'
-              brief: DELETE request
-            - id: head
-              value: 'HEAD'
-              brief: HEAD request
+        type: string
         requirement_level: required
         tag: call-level-tech-specific
         brief: >
           The HTTP method of the request.
+        examples: [ 'GET', 'PUT' ]
   - id: db.sql
     prefix: 'db.sql'
     type: span

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -385,6 +385,64 @@ groups:
           The collection being accessed within the database stated in `db.name`.
         examples: [ 'customers', 'products' ]
 
+  - id: db.elasticsearch
+    prefix: db.elasticsearch
+    type: span
+    extends: db
+    brief: >
+      Call-level attributes for Elasticsearch
+    attributes:
+      - id: doc_id
+        type: string
+        requirement_level:
+          conditionally_required: when the request targets a specific document by id
+        tag: call-level-tech-specific
+        brief: >
+          The document that the request targets.
+        examples: [ '123', '456' ]
+      - id: params
+        type: string
+        requirement_level:
+          conditionally_required: when params are provided as part of the request
+        tag: call-level-tech-specific
+        brief: >
+          The query params of the request, as a json string.
+        examples: [ '"{\"q\":\"test\"}", "{\"refresh\":true}"' ]
+      - id: target
+        type: string
+        requirement_level:
+          conditionally_required: when a specific index or data stream is targeted by the request
+        tag: call-level-tech-specific
+        brief: >
+          The name of the data stream or index that is targeted.
+        examples: [ 'users' ]
+      - id: url
+        type: string
+        requirement_level: required
+        tag: call-level-tech-specific
+        brief: >
+          The url of the request, including the target and exact document id.
+        examples: [ '/test-index/_search', '/test-index/_doc/123' ]
+      - id: method
+        type:
+          allow_custom_values: false
+          members:
+            - id: get
+              value: 'GET'
+              brief: GET request
+            - id: post
+              value: 'POST'
+              brief: POST request
+            - id: put
+              value: 'PUT'
+              brief: PUT request
+            - id: delete
+              value: 'DELETE'
+              brief: DELETE request
+        requirement_level: required
+        tag: call-level-tech-specific
+        brief: >
+          The HTTP method of the request.
   - id: db.sql
     prefix: 'db.sql'
     type: span

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -396,7 +396,7 @@ groups:
         type: string
         requirement_level:
           conditionally_required: when the request targets a specific document by id
-        tag: call-level-tech-specific
+        tag: call-level-tech-specific-elasticsearch
         brief: >
           The document that the request targets.
         examples: [ '123', '456' ]

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -439,6 +439,9 @@ groups:
             - id: delete
               value: 'DELETE'
               brief: DELETE request
+            - id: head
+              value: 'HEAD'
+              brief: HEAD request
         requirement_level: required
         tag: call-level-tech-specific
         brief: >

--- a/semantic_conventions/trace/database.yaml
+++ b/semantic_conventions/trace/database.yaml
@@ -400,10 +400,10 @@ groups:
         brief: >
           The document that the request targets.
         examples: [ '123', '456' ]
-      - id: params
+      - id: url.query
         type: string
         requirement_level:
-          conditionally_required: when params are provided as part of the request
+          conditionally_required: when query params are provided as part of the request
         tag: call-level-tech-specific
         brief: >
           The query params of the request, as a json string.
@@ -416,20 +416,16 @@ groups:
         brief: >
           The name of the data stream or index that is targeted.
         examples: [ 'users' ]
-      - id: url
+      - id: url.path
         type: string
         requirement_level: required
         tag: call-level-tech-specific
         brief: >
-          The url of the request, including the target and exact document id.
+          The path of the request, including the target and exact document id.
         examples: [ '/test-index/_search', '/test-index/_doc/123' ]
-      - id: method
-        type: string
+      - ref: http.method
         requirement_level: required
-        tag: call-level-tech-specific
-        brief: >
-          The HTTP method of the request.
-        examples: [ 'GET', 'PUT' ]
+
   - id: db.sql
     prefix: 'db.sql'
     type: span
@@ -562,3 +558,4 @@ groups:
       - include: 'db.mongodb'
       - include: 'db.sql'
       - include: 'db.cosmosdb'
+      - include: 'db.elasticsearch'

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -29,8 +29,8 @@ The following library-specific semantic conventions are defined:
 
 * [AWS Lambda](instrumentation/aws-lambda.md): For AWS Lambda spans.
 * [AWS SDK](instrumentation/aws-sdk.md): For AWS SDK spans.
-* [GraphQL](instrumentation/graphql.md): For GraphQL spans.
 * [Elasticsearch](instrumentation/elasticsearch.md): For Elasticsearch spans.
+* [GraphQL](instrumentation/graphql.md): For GraphQL spans.
 
 Apart from semantic conventions for traces and [metrics](../../metrics/semantic_conventions/README.md),
 OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own

--- a/specification/trace/semantic_conventions/README.md
+++ b/specification/trace/semantic_conventions/README.md
@@ -30,6 +30,7 @@ The following library-specific semantic conventions are defined:
 * [AWS Lambda](instrumentation/aws-lambda.md): For AWS Lambda spans.
 * [AWS SDK](instrumentation/aws-sdk.md): For AWS SDK spans.
 * [GraphQL](instrumentation/graphql.md): For GraphQL spans.
+* [Elasticsearch](instrumentation/elasticsearch.md): For Elasticsearch spans.
 
 Apart from semantic conventions for traces and [metrics](../../metrics/semantic_conventions/README.md),
 OpenTelemetry also defines the concept of overarching [Resources](../../resource/sdk.md) with their own

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -87,4 +87,5 @@ would result in `'abc*'`, `'*xyz'` being added to the list of sanitized keys men
 | `POST`   | HTTP POST request   |
 | `PUT`    | HTTP PUT request    |
 | `DELETE` | HTTP DELETE request |
+| `HEAD`   | HTTP HEAD request   |
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -5,7 +5,7 @@
 This document defines semantic conventions to apply when instrumenting requests to Elasticsearch. They map Elasticsearch
 requests to attributes on a Span.
 
-### Span Name
+## Span Name
 
 The **span name** SHOULD be of the format `<db.elasticsearch.method> <db.elasticsearch.url *with placeholders*>`.
 

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -6,7 +6,7 @@ This document defines semantic conventions to apply when instrumenting requests 
 requests to attributes on a Span. It also describes the configuration options that may be proivded as part of the
 instrumentation.
 
-## Span Name
+### Span Name
 
 The **span name** SHOULD be of the format `<db.elasticsearch.method> <db.elasticsearch.url *with placeholders*>`.
 
@@ -16,70 +16,20 @@ index, it SHOULD be replaced by `{target}`.
 For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`. 
 When there is no target or document id, the span name will contain the exact url, as in `POST /_search`.
 
-
-## `db.statement` span attribute value and configuration options
-
-### `db_statement` configuration option
-
-The `db.statement` attribute MUST correspond to the request `body`, with sanitization. The implementation MUST have an
-option to control how the `db.statement` is set in the span attribute, called `db_statement`.
-
-The instrumentation MUST provide the following options for the `db_statement` configuration:
-- `omit`: Do not include anything in the `db.statement` span attribute
-- `sanitize`: Replace values at specific keys with `?`
-- `raw`: Include the request `body` as-is
-
-`sanitize` is the default. When the `sanitize` option is set, the values at the following keys are replaced by `?`:
-- `password`
-- `passwd`
-- `pwd`
-- `secret`
-- `*key`
-- `*token*`
-- `*session*`
-- `*credit*`
-- `*card*`
-- `*auth*`
-- `set-cookie`
-
-For example, given the request 
-```ruby
-client.index(
-  index: 'users',
-  id: '1',
-  body: { name: 'Emily', password: 'top_secret' }
-)
-```
-
-the `db.statement` span attribute would be set to the following, for each `db_statement` option:
-- `omit`: `{ db.statement: '' }`
-- `sanitize`: `{ db.statement: "{\"name\":\"Emily\",\"password\":\"?\"}" }`
-- `raw`: `{ db.statement: "{\"name\":\"Emily\",\"password\":\"top_secret\"}" }`
-
-### `sanitize_field_names` configuration option
-
-The instrumentation MAY have an option `sanitize_field_names` that accepts a list of wildcard patterns to match 
-keys against. The list provided by the user is concatenated to the default list. For example:
-
-```ruby
-config = { sanitize_field_names: ['abc*', '*xyz'] }
-```
-
-would result in `'abc*'`, `'*xyz'` being added to the list of sanitized keys mentioned above.
-
-## Span attributes
+### Span attributes
 
 <!-- semconv elasticsearch -->
-| Attribute                  | Type | Description                                                                                          | Examples                                     | Requirement Level      |
-|----------------------------|---|------------------------------------------------------------------------------------------------------|----------------------------------------------|------------------------|
-| `db.elasticsearch.doc_id`  | string | The document that the request targets, specified in the path.                                        | `'123'`                                      | Conditionally Required |
-| `db.elasticsearch.params`  | string | The query params of the request, as a json string.                                                   | `'"{\"q\":\"test\"}", "{\"refresh\":true}"'` | Conditionally Required |
-| `db.elasticsearch.target`  | string | The name of the data stream or index that is targeted.                                               | `'users'`                                    | Conditionally Required |
-| `db.elasticsearch.url`     | string | The url of the request, including the target and exact document id. | `'/test-index/_doc/123'`                     | Required |
-| `db.elasticsearch.method`* | string | The HTTP method of the request. | `'GET'`                                       | Required |
+| Attribute                 | Type | Description                                                         | Examples                                                | Requirement Level      |
+|---------------------------|---|---------------------------------------------------------------------|---------------------------------------------------------|------------------------|
+| `db.elasticsearch.doc_id` | string | The document that the request targets, specified in the path.       | `'123'`                                                 | Conditionally Required |
+| `db.elasticsearch.params` | string | The query params of the request, as a json string.                  | `'"{\"q\":\"test\"}", "{\"refresh\":true}"'`            | Conditionally Required |
+| `db.elasticsearch.target` | string | The name of the data stream or index that is targeted.              | `'users'`                                               | Conditionally Required |
+| `db.elasticsearch.url`    | string | The exact url of the request, including the target and document id. | `'/test-index/_doc/123'`                                | Required               |
+| `db.elasticsearch.method` | string | The HTTP method of the request. [1]                                 | `'GET'`                                                 | Required               |
+| `db.statement`            | string | The request body, as a json string. [2]                             | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required |
 
 
-*`db.elasticsearch.method` MUST be one of the following:
+**[1]:** The value MUST be one of the following:
 
 | Value    | Description         |
 |----------|---------------------|
@@ -88,4 +38,6 @@ would result in `'abc*'`, `'*xyz'` being added to the list of sanitized keys men
 | `PUT`    | HTTP PUT request    |
 | `DELETE` | HTTP DELETE request |
 | `HEAD`   | HTTP HEAD request   |
+
+**[2]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -25,19 +25,8 @@ When there is no target or document id, the span name will contain the exact url
 | `db.elasticsearch.params` | string | The query params of the request, as a json string.                  | `'"{\"q\":\"test\"}", "{\"refresh\":true}"'`            | Conditionally Required |
 | `db.elasticsearch.target` | string | The name of the data stream or index that is targeted.              | `'users'`                                               | Conditionally Required |
 | `db.elasticsearch.url`    | string | The exact url of the request, including the target and document id. | `'/test-index/_doc/123'`                                | Required               |
-| `db.elasticsearch.method` | string | The HTTP method of the request. [1]                                 | `'GET'`                                                 | Required               |
-| `db.statement`            | string | The request body, as a json string. [2]                             | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required |
+| `db.elasticsearch.method` | string | The HTTP method of the request.                                     | `'GET'`                                                 | Required               |
+| `db.statement`            | string | The request body, as a json string. [1]                             | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required |
 
-
-**[1]:** The value MUST be one of the following:
-
-| Value    | Description         |
-|----------|---------------------|
-| `GET`    | HTTP GET request    |
-| `POST`   | HTTP POST request   |
-| `PUT`    | HTTP PUT request    |
-| `DELETE` | HTTP DELETE request |
-| `HEAD`   | HTTP HEAD request   |
-
-**[2]:** The value may be sanitized to exclude sensitive information.
+**[1]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -12,7 +12,7 @@ The **span name** SHOULD be of the format `<db.elasticsearch.method> <db.elastic
 The elasticsearch url is modified with placeholders in order to reduce the cardinality of the span name. When the url
 contains a document id, it SHOULD be replaced by the identifier `{id}`. When the url contains a target data stream or
 index, it SHOULD be replaced by `{target}`.
-For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`. 
+For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`.
 When there is no target or document id, the span name will contain the exact url, as in `POST /_search`.
 
 ### Span attributes

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -18,14 +18,14 @@ When there is no target or document id, the span name will contain the exact url
 ### Span attributes
 
 <!-- semconv elasticsearch -->
-| Attribute                 | Type | Description                                                         | Examples                                                | Requirement Level      |
-|---------------------------|---|---------------------------------------------------------------------|---------------------------------------------------------|------------------------|
-| `db.elasticsearch.doc_id` | string | The document that the request targets, specified in the path.       | `'123'`                                                 | Conditionally Required |
-| `db.elasticsearch.params` | string | The query params of the request, as a json string.                  | `'"{\"q\":\"test\"}", "{\"refresh\":true}"'`            | Conditionally Required |
-| `db.elasticsearch.target` | string | The name of the data stream or index that is targeted.              | `'users'`                                               | Conditionally Required |
-| `db.elasticsearch.url`    | string | The exact url of the request, including the target and document id. | `'/test-index/_doc/123'`                                | Required               |
-| `db.elasticsearch.method` | string | The HTTP method of the request.                                     | `'GET'`                                                 | Required               |
-| `db.statement`            | string | The request body, as a json string. [1]                             | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required |
+| Attribute                  | Type | Description                                                          | Examples                                                | Requirement Level      |
+|----------------------------|---|----------------------------------------------------------------------|---------------------------------------------------------|------------------------|
+| `db.elasticsearch.doc_id`  | string | The document that the request targets, specified in the path.        | `'123'`                                                 | Conditionally Required |
+| `db.elasticsearch.target`  | string | The name of the data stream or index that is targeted.               | `'users'`                                               | Conditionally Required |
+| `db.elasticsearch.url.path` | string | The exact path of the request, including the target and document id. | `'/test-index/_doc/123'`                                | Required               |
+| `db.elasticsearch.url.query` | string | The query params of the request, as a json string. | `'"{\"q\":\"test\"}", "{\"refresh\":true}"'`            | Conditionally Required |
+| `db.statement`             | string | The request body, as a json string. [1]                              | `"{\"name\":\"TestUser\",\"password\":\"top_secret\"}"` | Conditionally Required |
+| `http.method` | string | HTTP request method. | `GET`; `POST`; `HEAD`                                   | Required               |
 
 **[1]:** The value may be sanitized to exclude sensitive information.
 <!-- endsemconv -->

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -3,8 +3,7 @@
 **Status**: [Experimental](../../../document-status.md)
 
 This document defines semantic conventions to apply when instrumenting requests to Elasticsearch. They map Elasticsearch
-requests to attributes on a Span. It also describes the configuration options that may be proivded as part of the
-instrumentation.
+requests to attributes on a Span.
 
 ### Span Name
 

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -7,7 +7,7 @@ requests to attributes on a Span.
 
 ## Span Name
 
-The **span name** SHOULD be of the format `<db.elasticsearch.method> <db.elasticsearch.url *with placeholders*>`.
+The **span name** SHOULD be of the format `<http.method> <db.elasticsearch.url *with placeholders*>`.
 
 The elasticsearch url is modified with placeholders in order to reduce the cardinality of the span name. When the url
 contains a document id, it SHOULD be replaced by the identifier `{id}`. When the url contains a target data stream or

--- a/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
+++ b/specification/trace/semantic_conventions/instrumentation/elasticsearch.md
@@ -1,0 +1,90 @@
+# Semantic conventions for Elasticsearch
+
+**Status**: [Experimental](../../../document-status.md)
+
+This document defines semantic conventions to apply when instrumenting requests to Elasticsearch. They map Elasticsearch
+requests to attributes on a Span. It also describes the configuration options that may be proivded as part of the
+instrumentation.
+
+## Span Name
+
+The **span name** SHOULD be of the format `<db.elasticsearch.method> <db.elasticsearch.url *with placeholders*>`.
+
+The elasticsearch url is modified with placeholders in order to reduce the cardinality of the span name. When the url
+contains a document id, it SHOULD be replaced by the identifier `{id}`. When the url contains a target data stream or
+index, it SHOULD be replaced by `{target}`.
+For example, a request to `/test-index/_doc/123` should have the span name `GET /{target}/_doc/{id}`. 
+When there is no target or document id, the span name will contain the exact url, as in `POST /_search`.
+
+
+## `db.statement` span attribute value and configuration options
+
+### `db_statement` configuration option
+
+The `db.statement` attribute MUST correspond to the request `body`, with sanitization. The implementation MUST have an
+option to control how the `db.statement` is set in the span attribute, called `db_statement`.
+
+The instrumentation MUST provide the following options for the `db_statement` configuration:
+- `omit`: Do not include anything in the `db.statement` span attribute
+- `sanitize`: Replace values at specific keys with `?`
+- `raw`: Include the request `body` as-is
+
+`sanitize` is the default. When the `sanitize` option is set, the values at the following keys are replaced by `?`:
+- `password`
+- `passwd`
+- `pwd`
+- `secret`
+- `*key`
+- `*token*`
+- `*session*`
+- `*credit*`
+- `*card*`
+- `*auth*`
+- `set-cookie`
+
+For example, given the request 
+```ruby
+client.index(
+  index: 'users',
+  id: '1',
+  body: { name: 'Emily', password: 'top_secret' }
+)
+```
+
+the `db.statement` span attribute would be set to the following, for each `db_statement` option:
+- `omit`: `{ db.statement: '' }`
+- `sanitize`: `{ db.statement: "{\"name\":\"Emily\",\"password\":\"?\"}" }`
+- `raw`: `{ db.statement: "{\"name\":\"Emily\",\"password\":\"top_secret\"}" }`
+
+### `sanitize_field_names` configuration option
+
+The instrumentation MAY have an option `sanitize_field_names` that accepts a list of wildcard patterns to match 
+keys against. The list provided by the user is concatenated to the default list. For example:
+
+```ruby
+config = { sanitize_field_names: ['abc*', '*xyz'] }
+```
+
+would result in `'abc*'`, `'*xyz'` being added to the list of sanitized keys mentioned above.
+
+## Span attributes
+
+<!-- semconv elasticsearch -->
+| Attribute                  | Type | Description                                                                                          | Examples                                     | Requirement Level      |
+|----------------------------|---|------------------------------------------------------------------------------------------------------|----------------------------------------------|------------------------|
+| `db.elasticsearch.doc_id`  | string | The document that the request targets, specified in the path.                                        | `'123'`                                      | Conditionally Required |
+| `db.elasticsearch.params`  | string | The query params of the request, as a json string.                                                   | `'"{\"q\":\"test\"}", "{\"refresh\":true}"'` | Conditionally Required |
+| `db.elasticsearch.target`  | string | The name of the data stream or index that is targeted.                                               | `'users'`                                    | Conditionally Required |
+| `db.elasticsearch.url`     | string | The url of the request, including the target and exact document id. | `'/test-index/_doc/123'`                     | Required |
+| `db.elasticsearch.method`* | string | The HTTP method of the request. | `'GET'`                                       | Required |
+
+
+*`db.elasticsearch.method` MUST be one of the following:
+
+| Value    | Description         |
+|----------|---------------------|
+| `GET`    | HTTP GET request    |
+| `POST`   | HTTP POST request   |
+| `PUT`    | HTTP PUT request    |
+| `DELETE` | HTTP DELETE request |
+<!-- endsemconv -->


### PR DESCRIPTION
Fixes #3239

## Changes

Add semantic conventions for Elasticsearch client instrumentation span names and attributes.

Related [OTEP(s)](https://github.com/open-telemetry/oteps)

- #3239
