### PR TITLE
Remove underspecified and unused Span decorator from Trace SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ release.
 
 ### Traces
 
-* Clarify required parent information in ReadableSpan. Technically a relaxation,
+- Clarify required parent information in ReadableSpan. Technically a relaxation,
   but previously it was easy to overlook certain properties were required.
   [#3257](https://github.com/open-telemetry/opentelemetry-specification/pull/3257)
+- Remove underspecified and unused Span decorator from Trace SDK.
+  ([#3363](https://github.com/open-telemetry/opentelemetry-specification/pull/3363))
 
 ### Metrics
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -470,8 +470,7 @@ Each processor registered on `TracerProvider` is a start of pipeline that consis
 of span processor and optional exporter. SDK MUST allow to end each pipeline with
 individual exporter.
 
-SDK MUST allow users to implement and configure custom processors and decorate
-built-in processors for advanced scenarios such as tagging or filtering.
+SDK MUST allow users to implement and configure custom processors.
 
 The following diagram shows `SpanProcessor`'s relationship to other components
 in the SDK:


### PR DESCRIPTION
## Changes

This removes the "decorate" language from span processors. Technically a breaking change but since consensus seemed to be that something new needed to be designed I figured it best to get it out of the spec first.

Open question if the "for advanced scenarios such as tagging or filtering" part should be left in. I'd say it doesn't apply to custom processors but you technically could use them to do that in OnStart.