### PR TITLE
Remove schema transformations from the concept of telemetry stability for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ release.
   ([#3202](https://github.com/open-telemetry/opentelemetry-specification/pull/3202))
 - Add Trino to Database specific conventions
   ([#3347](https://github.com/open-telemetry/opentelemetry-specification/pull/3347))
+- Remove schema transformations from the concept of telemetry stability for now
+  ([#3372](https://github.com/open-telemetry/opentelemetry-specification/pull/3372))
 
 ### Compatibility
 

--- a/specification/telemetry-stability.md
+++ b/specification/telemetry-stability.md
@@ -46,5 +46,5 @@ their language, e.g. via version numbers, artifact names, documentation, etc.
 
 Stable instrumentations authored by OpenTelemetry SHOULD include a schema URL indicating
 which version of OpenTelemetry semantic conventions it conforms to.
-Stable instrumentations SHOULD NOT produce telemetry that is not described by OpenTelemetry
+Stable instrumentations authored by OpenTelemetry SHOULD NOT produce telemetry that is not described by OpenTelemetry
 semantic conventions.

--- a/specification/telemetry-stability.md
+++ b/specification/telemetry-stability.md
@@ -9,8 +9,6 @@
 
 - [Unstable Instrumentations](#unstable-instrumentations)
 - [Stable Instrumentations](#stable-instrumentations)
-  * [Fixed Schema Telemetry Producers](#fixed-schema-telemetry-producers)
-  * [Schema-File Driven Telemetry Producers](#schema-file-driven-telemetry-producers)
 
 <!-- tocstop -->
 
@@ -21,13 +19,6 @@ OpenTelemetry instrumentations.
 
 All OpenTelemetry-authored instrumentations are labeled to be either `Unstable` or `Stable`
 from the perspective of the telemetry they produce.
-
-Adding of new metrics, spans, span events or log records and adding of
-new attributes to spans, span events, log records or resources are considered
-additive, non-breaking changes and are always allowed for `Unstable` and `Stable`
-instrumentations.
-
-Other changes in the produced telemetry are regulated by the following rules.
 
 ## Unstable Instrumentations
 
@@ -53,45 +44,7 @@ Stable telemetry-producing instrumentations (stable instrumentations for short) 
 be clearly labeled so by any means the instrumentations authors consider idiomatic for
 their language, e.g. via version numbers, artifact names, documentation, etc.
 
-Stable instrumentations fall into 2 categories: fixed-schema producers and schema-file
-driven producers.
-
-Stable instrumentations authored by OpenTelemetry SHOULD NOT produce telemetry that is
-not described by OpenTelemetry semantic conventions. If, however, this rule is broken the
-instrumentations MUST NOT change such telemetry, regardless of whether they
-are fixed-schema producers or schema-file driven producers. Once the produced telemetry
-is added to the semantic conventions, changes will be allowed as described below.
-
-### Fixed Schema Telemetry Producers
-
-Instrumentations that are labeled `Stable` and do not include the Schema URL in the
-produced telemetry are called Fixed Schema Telemetry Producers.
-
-Such instrumentations are prohibited from changing any produced telemetry. If the
-specification changes over time and the semantic conventions are updated, the
-instrumentation is still prohibited from adopting the changes. If the instrumentation
-wishes to adopt the semantic convention changes it must first become a
-[Schema-File Driven Telemetry Producer](#schema-file-driven-telemetry-producers) by
-adding an appropriate Schema URL in the produced telemetry.
-
-### Schema-File Driven Telemetry Producers
-
-Stable instrumentations that include the Schema URL in the produced telemetry are
-called Schema-File Driven Telemetry Producers.
-
-Such instrumentations are prohibited from changing the produced telemetry until
-April 1, 2023 and until that date are subject to exactly the same restrictions as
-[Fixed Schema Telemetry Producers](#fixed-schema-telemetry-producers).
-
-After April 1, 2023, stable instrumentations are allowed to change the produced telemetry
-if all the following conditions are fulfilled:
-
-- The change is part of OpenTelemetry semantic conventions and is in a released
-  version of the specification.
-- The change has a corresponding [published](schemas/README.md#opentelemetry-schema)
-  OpenTelemetry Schema File that describes the change.
-- The produced telemetry correctly specifies the respective Schema URL.
-
-If the change was introduced in the semantic conventions specification before
-April 1, 2023, the instrumentations must wait until April 1, 2023 before they can adopt
-the change and begin producing the changed telemetry.
+Stable instrumentations authored by OpenTelemetry SHOULD include a schema URL indicating
+which version of OpenTelemetry semantic conventions it conforms to.
+Stable instrumentations SHOULD NOT produce telemetry that is not described by OpenTelemetry
+semantic conventions.

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -168,9 +168,8 @@ relies on the concept of
 Semantic Conventions defines breaking changes as those that would break the
 common usage of tooling written against the telemetry it produces. That is, the
 portions of telemetry where specialized tooling (alerts, dashboards, e.g.)
-interact are expected to remain stable for that tooling *after schema
-transformations are applied*. These also assume no user interventions in the
-default configuration, e.g. Samplers, Views, etc.
+interact are expected to remain stable for that tooling. These also assume no
+user interventions in the default configuration, e.g. Samplers, Views, etc.
 
 Semantic Conventions defines the set of fields in the OTLP data model:
 

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -227,21 +227,6 @@ convention and are allowed (or expected) to change. A few examples:
 The list of telemetry fields which are covered by stability guarantees MAY be
 extended.
 
-Changes to semantic conventions in this specification are allowed, provided that
-the changes can be described by schema files. The following changes can be
-currently described and are allowed:
-
-- Renaming of span, metric, log and resource attributes.
-- Renaming of metrics.
-- Renaming of span events.
-
-All such changes MUST be described in the OpenTelemetry
-[Schema File Format](schemas/file_format_v1.1.0.md) and published in this repository.
-For details see [how OpenTelemetry Schemas are published](schemas/README.md#opentelemetry-schema).
-
-See the [Telemetry Stability](telemetry-stability.md) document for details on how
-instrumentations can use schemas to change the instrumentation they produce.
-
 **Exception:** Some resource attributes are embedded in various locations of the
 Specification, e.g. the `service.*` attributes which are required by SDKs to be
 produced and have corresponding [environment variables defined in general SDK configuration](sdk-environment-variables.md#general-sdk-configuration). These resource


### PR DESCRIPTION
Fixes #3296
Fixes #2606

## Changes

Prepares `versioning-and-stability.md` and `telemetry-stability.md` documents to be marked `Stable` themselves, by removing schema transformations from the concept of telemetry stability for now.

Note: I wasn't quite sure where to move the pieces that I removed, definitely open to feedback.