### PR TITLE
[editorial] Use path, not external URL, for link into glossary

### DIFF
--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -19,7 +19,7 @@
 
 _This section applies to Log, Metric, Resource, and Span, and describes requirement levels for attributes defined in semantic conventions._
 
-Attribute requirement levels apply to the [instrumentation library](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/glossary.md#instrumentation-library).
+Attribute requirement levels apply to the [instrumentation library](../glossary.md#instrumentation-library).
 
 The following attribute requirement levels are specified:
 


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2429
- This is part of an effort to normalize links, for improved link checking on the OTel website

/cc @carlosalberto @trask 