### PR TITLE
Add detail for GCP Cloud Run Job execution

### DIFF
--- a/semantic_conventions/resource/cloud_provider/gcp/cloud_run.yaml
+++ b/semantic_conventions/resource/cloud_provider/gcp/cloud_run.yaml
@@ -8,9 +8,11 @@ groups:
       - id: job.execution
         type: string
         brief: >
-          The
+          The name of the Cloud Run
           [execution](https://cloud.google.com/run/docs/managing/job-executions)
-          of the job.
+          being run for the Job, as set by the
+          [`CLOUD_RUN_EXECUTION`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars)
+          environment variable.
         examples: ['job-name-xxxx', 'sample-job-mdw84']
       - id: job.task_index
         type: int

--- a/semantic_conventions/resource/cloud_provider/gcp/cloud_run.yaml
+++ b/semantic_conventions/resource/cloud_provider/gcp/cloud_run.yaml
@@ -1,0 +1,21 @@
+groups:
+  - id: gcp.cloud_run
+    prefix: gcp.cloud_run
+    type: resource
+    brief: >
+      Resource used by Google Cloud Run.
+    attributes:
+      - id: job.execution
+        type: string
+        brief: >
+          The
+          [execution](https://cloud.google.com/run/docs/managing/job-executions)
+          of the job.
+        examples: ['job-name-xxxx', 'sample-job-mdw84']
+      - id: job.task_index
+        type: int
+        brief: >
+          The index for a task within an execution as provided by the
+          [`CLOUD_RUN_TASK_INDEX`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars)
+          environment variable.
+        examples: [0, 1]

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -36,15 +36,8 @@ groups:
 
           * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
             (an integer represented as a decimal string).
-          * **Google Cloud Run:**
-            * **Services:** The
-              [revision](https://cloud.google.com/run/docs/managing/revisions) (i.e.,
-              the function name plus the revision suffix).
-            * **Jobs:** The
-              [execution](https://cloud.google.com/run/docs/managing/job-executions) and
-              [task
-              index](https://cloud.google.com/run/docs/container-contract#jobs-env-vars),
-              eg `execution/0`.
+          * **Google Cloud Run (Services):** The [revision](https://cloud.google.com/run/docs/managing/revisions)
+            (i.e., the function name plus the revision suffix).
           * **Google Cloud Functions:** The value of the
             [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
           * **Azure Functions:** Not applicable. Do not set this attribute.

--- a/semantic_conventions/resource/faas.yaml
+++ b/semantic_conventions/resource/faas.yaml
@@ -36,8 +36,15 @@ groups:
 
           * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
             (an integer represented as a decimal string).
-          * **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
-            (i.e., the function name plus the revision suffix).
+          * **Google Cloud Run:**
+            * **Services:** The
+              [revision](https://cloud.google.com/run/docs/managing/revisions) (i.e.,
+              the function name plus the revision suffix).
+            * **Jobs:** The
+              [execution](https://cloud.google.com/run/docs/managing/job-executions) and
+              [task
+              index](https://cloud.google.com/run/docs/container-contract#jobs-env-vars),
+              eg `execution/0`.
           * **Google Cloud Functions:** The value of the
             [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
           * **Azure Functions:** Not applicable. Do not set this attribute.

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -219,7 +219,7 @@ Valid cloud providers are:
 
 - [Alibaba Cloud](https://www.alibabacloud.com/) (`alibaba_cloud`)
 - [Amazon Web Services](https://aws.amazon.com/) ([`aws`](cloud_provider/aws/README.md))
-- [Google Cloud Platform](https://cloud.google.com/) (`gcp`)
+- [Google Cloud Platform](https://cloud.google.com/) ([`gcp`](cloud_provider/gcp/README.md))
 - [Microsoft Azure](https://azure.microsoft.com/) (`azure`)
 - [Tencent Cloud](https://www.tencentcloud.com/) (`tencent_cloud`)
 - [Heroku dyno](./cloud_provider/heroku.md)

--- a/specification/resource/semantic_conventions/cloud_provider/gcp/README.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/README.md
@@ -1,0 +1,10 @@
+# GCP Semantic Conventions
+
+This directory defines standards for resource attributes that only apply to
+Google Cloud Platform (GCP). If an attribute could apply to resources from more than one cloud
+provider (like account ID, operating system, etc), it belongs in the parent
+`semantic_conventions` directory.
+
+## Services
+
+- [Cloud Run](./cloud_run.md)

--- a/specification/resource/semantic_conventions/cloud_provider/gcp/cloud_run.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/cloud_run.md
@@ -1,5 +1,7 @@
 # Google Cloud Run
 
+These conventions are recommended for resources running on Cloud Run.
+
 **Type:** `gcp.cloud_run`
 
 **Description:** Resource attributes for GCE instances.
@@ -7,6 +9,6 @@
 <!-- semconv gcp.cloud_run -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
-| `gcp.cloud_run.job.execution` | string | The [execution](https://cloud.google.com/run/docs/managing/job-executions) of the job. | `job-name-xxxx`; `sample-job-mdw84` | Recommended |
+| `gcp.cloud_run.job.execution` | string | The name of the Cloud Run [execution](https://cloud.google.com/run/docs/managing/job-executions) being run for the Job, as set by the [`CLOUD_RUN_EXECUTION`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars) environment variable. | `job-name-xxxx`; `sample-job-mdw84` | Recommended |
 | `gcp.cloud_run.job.task_index` | int | The index for a task within an execution as provided by the [`CLOUD_RUN_TASK_INDEX`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars) environment variable. | `0`; `1` | Recommended |
 <!-- endsemconv -->

--- a/specification/resource/semantic_conventions/cloud_provider/gcp/cloud_run.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/cloud_run.md
@@ -1,0 +1,12 @@
+# Google Cloud Run
+
+**Type:** `gcp.cloud_run`
+
+**Description:** Resource attributes for GCE instances.
+
+<!-- semconv gcp.cloud_run -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `gcp.cloud_run.job.execution` | string | The [execution](https://cloud.google.com/run/docs/managing/job-executions) of the job. | `job-name-xxxx`; `sample-job-mdw84` | Recommended |
+| `gcp.cloud_run.job.task_index` | int | The index for a task within an execution as provided by the [`CLOUD_RUN_TASK_INDEX`](https://cloud.google.com/run/docs/container-contract#jobs-env-vars) environment variable. | `0`; `1` | Recommended |
+<!-- endsemconv -->

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -43,8 +43,15 @@ definition of function name MUST be used for this attribute
 
 * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).
-* **Google Cloud Run:** The [revision](https://cloud.google.com/run/docs/managing/revisions)
-  (i.e., the function name plus the revision suffix).
+* **Google Cloud Run:**
+  * **Services:** The
+    [revision](https://cloud.google.com/run/docs/managing/revisions) (i.e.,
+    the function name plus the revision suffix).
+  * **Jobs:** The
+    [execution](https://cloud.google.com/run/docs/managing/job-executions) and
+    [task
+    index](https://cloud.google.com/run/docs/container-contract#jobs-env-vars),
+    eg `execution/0`.
 * **Google Cloud Functions:** The value of the
   [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
 * **Azure Functions:** Not applicable. Do not set this attribute.

--- a/specification/resource/semantic_conventions/faas.md
+++ b/specification/resource/semantic_conventions/faas.md
@@ -43,15 +43,8 @@ definition of function name MUST be used for this attribute
 
 * **AWS Lambda:** The [function version](https://docs.aws.amazon.com/lambda/latest/dg/configuration-versions.html)
   (an integer represented as a decimal string).
-* **Google Cloud Run:**
-  * **Services:** The
-    [revision](https://cloud.google.com/run/docs/managing/revisions) (i.e.,
-    the function name plus the revision suffix).
-  * **Jobs:** The
-    [execution](https://cloud.google.com/run/docs/managing/job-executions) and
-    [task
-    index](https://cloud.google.com/run/docs/container-contract#jobs-env-vars),
-    eg `execution/0`.
+* **Google Cloud Run (Services):** The [revision](https://cloud.google.com/run/docs/managing/revisions)
+  (i.e., the function name plus the revision suffix).
 * **Google Cloud Functions:** The value of the
   [`K_REVISION` environment variable](https://cloud.google.com/functions/docs/env-var#runtime_environment_variables_set_automatically).
 * **Azure Functions:** Not applicable. Do not set this attribute.


### PR DESCRIPTION
## Changes

Add a note for Cloud Run Jobs on how to identify `faas.version`.

Related issues 
Downstream PR proposing this semconv change: https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/465

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
