### PR TITLE
Add semantic conventions for GCP resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ release.
 
 ### Resource
 
+- Add GCP-specific resource attributes for Compute Engine under `gcp.gce` ([#3384](https://github.com/open-telemetry/opentelemetry-specification/pull/3384))
+
 ### Semantic Conventions
 
 - Clarify the scope of the HTTP client span.

--- a/semantic_conventions/resource/cloud_provider/gcp/gce.yaml
+++ b/semantic_conventions/resource/cloud_provider/gcp/gce.yaml
@@ -1,0 +1,22 @@
+groups:
+  - id: gcp.gce
+    prefix: gcp.gce
+    type: resource
+    brief: >
+      Resources used by Google Compute Engine (GCE).
+    attributes:
+      - id: instance.name
+        type: string
+        brief: >
+          The instance name of a GCE instance. This is the value
+          provided by `host.name`, the visible name of the instance in
+          the Cloud Console UI, and the prefix for the default
+          hostname of the instance as defined by the [default internal
+          DNS
+          name](https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names).
+        examples: ['instance-1', 'my-vm-name']
+      - id: instance.hostname
+        type: string
+        brief: >
+          The hostname of a GCE instance. This is the full value of the default or [custom hostname](https://cloud.google.com/compute/docs/instances/custom-hostname-vm).
+        examples: ['my-host1234.example.com', 'sample-vm.us-west1-b.c.my-project.internal']

--- a/specification/resource/semantic_conventions/README.md
+++ b/specification/resource/semantic_conventions/README.md
@@ -219,7 +219,7 @@ Valid cloud providers are:
 
 - [Alibaba Cloud](https://www.alibabacloud.com/) (`alibaba_cloud`)
 - [Amazon Web Services](https://aws.amazon.com/) ([`aws`](cloud_provider/aws/README.md))
-- [Google Cloud Platform](https://cloud.google.com/) (`gcp`)
+- [Google Cloud Platform](https://cloud.google.com/) ([`gcp`](cloud_provider/gcp/README.md))
 - [Microsoft Azure](https://azure.microsoft.com/) (`azure`)
 - [Tencent Cloud](https://www.tencentcloud.com/) (`tencent_cloud`)
 - [Heroku dyno](./cloud_provider/heroku.md)

--- a/specification/resource/semantic_conventions/cloud_provider/gcp/README.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/README.md
@@ -1,0 +1,10 @@
+# GCP Semantic Conventions
+
+This directory defines standards for resource attributes that only apply to
+Google Cloud Platform (GCP). If an attribute could apply to resources from more than one cloud
+provider (like account ID, operating system, etc), it belongs in the parent
+`semantic_conventions` directory.
+
+## Services
+
+- [Google Compute Engine](./gce.md)

--- a/specification/resource/semantic_conventions/cloud_provider/gcp/gce.md
+++ b/specification/resource/semantic_conventions/cloud_provider/gcp/gce.md
@@ -1,0 +1,12 @@
+# Google Compute Engine
+
+**Type:** `gcp.gce`
+
+**Description:** Resource attributes for GCE instances.
+
+<!-- semconv gcp.gce -->
+| Attribute  | Type | Description  | Examples  | Requirement Level |
+|---|---|---|---|---|
+| `gcp.gce.instance.name` | string | The instance name of a GCE instance. This is the value provided by `host.name`, the visible name of the instance in the Cloud Console UI, and the prefix for the default hostname of the instance as defined by the [default internal DNS name](https://cloud.google.com/compute/docs/internal-dns#instance-fully-qualified-domain-names). | `instance-1`; `my-vm-name` | Recommended |
+| `gcp.gce.instance.hostname` | string | The hostname of a GCE instance. This is the full value of the default or [custom hostname](https://cloud.google.com/compute/docs/instances/custom-hostname-vm). | `my-host1234.example.com`; `sample-vm.us-west1-b.c.my-project.internal` | Recommended |
+<!-- endsemconv -->


### PR DESCRIPTION
Fixes #

## Changes

This adds GCP-specific semantic conventions for GCE instances. Specifically, we would like to provide 2 ways of identifying host names: by their GCE instance name and their fully-qualified hostname (see https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/511 for more downstream discussion)

(Following the pattern for AWS in https://github.com/open-telemetry/opentelemetry-specification/pull/1099)

Related issues # https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/issues/511

Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
