### PR TITLE
Specify seconds unit for measuring durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ release.
 
 ### Semantic Conventions
 
+- Specify that seconds should be used for measuring durations.
+  ([#3388](https://github.com/open-telemetry/opentelemetry-specification/pull/3388))
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -192,6 +192,7 @@ use `{packet}`, `{error}`, `{fault}`, etc.
   variant. For example, "Cel" for the unit with full name "degree Celsius".
 - Instruments SHOULD use non-prefixed units (i.e. `By` instead of `MiBy`)
   unless there is good technical reason to not do so.
+- When instruments are measuring durations, seconds (i.e. `s`) SHOULD be used.
 
 ### Instrument Types
 


### PR DESCRIPTION
Resolves #2977.

Also related to #3294, and discussed in in this [#3312](https://github.com/open-telemetry/opentelemetry-specification/pull/3312#discussion_r1157584440)

As mentioned [here](https://github.com/open-telemetry/opentelemetry-specification/issues/2977#issuecomment-1489150771) this was voted on by the TC.

