### PR TITLE
Clarification about when to use UCUM c/s variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ release.
 
 ### Semantic Conventions
 
+- Add clarification that UCUM c/s variant applies to all units other than `1` and
+  those using [annotations](https://ucum.org/ucum.html#para-curly).
+  ([#3393](https://github.com/open-telemetry/opentelemetry-specification/pull/3393))
+
 ### Compatibility
 
 ### OpenTelemetry Protocol

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -188,8 +188,10 @@ total) are dimensionless and SHOULD use the default unit `1` (the unity).
 [annotations](https://ucum.org/ucum.html#para-curly) with curly braces to
 give additional meaning *without* the leading default unit (`1`). For example,
 use `{packet}`, `{error}`, `{fault}`, etc.
-- Instrument units SHOULD be specified using the UCUM case sensitive ("c/s")
-  variant. For example, "Cel" for the unit with full name "degree Celsius".
+- Instrument units other than `1` and those that use
+  [annotations](https://ucum.org/ucum.html#para-curly) SHOULD be specified using
+  the UCUM case sensitive ("c/s") variant.
+  For example, "Cel" for the unit with full name "degree Celsius".
 - Instruments SHOULD use non-prefixed units (i.e. `By` instead of `MiBy`)
   unless there is good technical reason to not do so.
 


### PR DESCRIPTION
Resolves @jack-berg's https://github.com/open-telemetry/opentelemetry-specification/pull/3294#issuecomment-1497982334

## Changes

Adds clarification that UCUM c/s variant applies to all units other than `1` and those using [annotations](https://ucum.org/ucum.html#para-curly).
