### PR TITLE
Remove duplicated text from Log4J appender section

### DIFF
--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -164,7 +164,7 @@ that would prevent evolution into a user facing API.
 ### How to Create a Log4J Log Appender
 
 A [log appender](../glossary.md#log-appender--bridge) implementation can be used
-to can be used to bridge logs into the [Log SDK](./sdk.md)
+to bridge logs into the [Log SDK](./sdk.md)
 OpenTelemetry [LogRecordExporters](sdk.md#logrecordexporter). This approach is
 typically used for applications which are fine with changing the log transport
 and is [one of the supported](README.md#direct-to-collector) log collection


### PR DESCRIPTION
Found this small mistake while reading through the document.