### PR TITLE
Add log documents to specification README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ release.
 
 ### Common
 
+- Add log entries to specification README.md contents.
+  ([#3435](https://github.com/open-telemetry/opentelemetry-specification/pull/3435))
+
 ## v1.20.0 (2023-04-07)
 
 ### Context

--- a/specification/README.md
+++ b/specification/README.md
@@ -25,9 +25,13 @@ cascade:
   - [Baggage](baggage/api.md)
   - [Tracing](trace/api.md)
   - [Metrics](metrics/api.md)
+  - Logs
+    - [Bridge API](logs/bridge-api.md)
+    - [Event API](logs/event-api.md)
 - SDK Specification
   - [Tracing](trace/sdk.md)
   - [Metrics](metrics/sdk.md)
+  - [Logs](logs/sdk.md)
   - [Resource](resource/sdk.md)
   - [Configuration](sdk-configuration.md)
 - Data Specification
@@ -39,6 +43,7 @@ cascade:
     - [OpenCensus](compatibility/opencensus.md)
     - [OpenTracing](compatibility/opentracing.md)
     - [Prometheus and OpenMetrics](compatibility/prometheus_and_openmetrics.md)
+    - [Trace Context in non-OTLP Log Formats](compatibility/logging_trace_context.md)
 
 ## Notation Conventions and Compliance
 


### PR DESCRIPTION
The [specification readme](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/README.md) is missing entries for the log signal. This fixes that.