### PR TITLE
Mark LogRecord EnvVars stable

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -121,7 +121,7 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 ## Batch LogRecord Processor
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 | Name                            | Description                                                      | Default  | Notes                                                  |
 | ------------------------------- | ---------------------------------------------------------------- | -------  | ------------------------------------------------------ |
@@ -159,7 +159,7 @@ See the SDK [Span Limits](../trace/sdk.md#span-limits) section for the definitio
 
 ## LogRecord Limits
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 See the SDK [LogRecord Limits](../logs/sdk.md#logrecord-limits) section for the definition of the limits.
 


### PR DESCRIPTION
Relates to #3376

## Changes

* Mark LogRecord Environment Variable spec regions as stable

## Details

#3376 marked most of the logs spec stable but we noticed implementing things in .NET that the EnvVars were still experimental. This felt like an oversight so here's a PR to fix things up.

/cc @alanwest @utpilla @jack-berg @tigrannajaryan
