### PR TITLE
Messaging: remove source to better align with ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ release.
   ([#3390](https://github.com/open-telemetry/opentelemetry-specification/pull/3390))
 - BREAKING: Remove `messaging.consumer.id`, make `messaging.client_id` generic
   ([#3336](https://github.com/open-telemetry/opentelemetry-specification/pull/3336))
+- BREAKING: Remove `messaging.source.*` attributes and use `messaging.destination.*`
+  attributes on producer and consumer to describe messaging queue or topic.
+  ([#3450](https://github.com/open-telemetry/opentelemetry-specification/pull/3450))
 
 ### Compatibility
 

--- a/schemas/1.21.0
+++ b/schemas/1.21.0
@@ -9,6 +9,13 @@ versions:
             attribute_map:
               messaging.kafka.client_id: messaging.client_id
               messaging.rocketmq.client_id: messaging.client_id
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3450
+        - rename_attributes:
+            attribute_map:
+              messaging.source.name: messaging.destination.name
+              messaging.source.template: messaging.destination.template
+              messaging.source.temporary: messaging.destination.temporary
+              messaging.source.anonymous: messaging.destination.anonymous              
   1.20.0:
     spans:
       changes:

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -16,10 +16,16 @@ groups:
           The [conversation ID](#conversations) identifying the conversation to which the message belongs,
           represented as a string. Sometimes called "Correlation ID".
         examples: 'MyConversationId'
-      - id: message.payload.size
+      - id: message.payload_size_bytes
         type: int
-        brief: The size of the message payload in bytes.
+        brief: >
+          The (uncompressed) size of the message payload in bytes.
+          Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
         examples: 2738
+      - id: message.payload_compressed_size_bytes
+        type: int
+        brief: 'The compressed size of the message payload in bytes.'
+        examples: 2048
 
   - id: messaging.destination
     prefix: messaging.destination
@@ -64,7 +70,6 @@ groups:
       Original destination attributes SHOULD be set on publish, receive, or other span describing messaging messaging operation
       if it operates with single message or if the attribute value applies to all messages in the batch.
       In other cases, destination attributes MAY be set on links.
-
     attributes:
       - id: name
         type: string
@@ -154,7 +159,10 @@ groups:
       - ref: messaging.message.conversation_id
         requirement_level:
           recommended: Only if span represents operation on a single message.
-      - ref: messaging.message.payload.size
+      - ref: messaging.message.payload_size_bytes
+        requirement_level:
+          recommended: Only if span represents operation on a single message.
+      - ref: messaging.message.payload_compressed_size_bytes
         requirement_level:
           recommended: Only if span represents operation on a single message.
       - ref: net.peer.name
@@ -176,13 +184,6 @@ groups:
         examples: ['amqp', 'mqtt']
       - ref: net.protocol.version
 
-  - id: messaging.producer
-    prefix: messaging
-    type: span
-    extends: messaging
-    span_kind: producer
-    brief: 'Semantic convention for producers of messages sent to a messaging systems.'
-
   - id: messaging.consumer
     prefix: messaging
     type: span
@@ -191,6 +192,7 @@ groups:
     brief: 'Semantic convention for a consumer of messages received from a messaging system'
     attributes:
       - ref: messaging.destination_original.name
+      - ref: messaging.destination_original.template
       - ref: messaging.destination_original.temporary
       - ref: messaging.destination_original.anonymous
 

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -5,7 +5,7 @@ groups:
     brief: 'Semantic convention describing per-message attributes populated on messaging spans or links.'
     attributes:
       - ref: messaging.destination.name
-      - ref: messaging.source.name
+      - ref: messaging.destination_original.name
       - id: message.id
         type: string
         brief: 'A value used by the messaging system as an identifier for the message, represented as a string.'
@@ -16,21 +16,19 @@ groups:
           The [conversation ID](#conversations) identifying the conversation to which the message belongs,
           represented as a string. Sometimes called "Correlation ID".
         examples: 'MyConversationId'
-      - id: message.payload_size_bytes
+      - id: message.payload.size
         type: int
-        brief: >
-          The (uncompressed) size of the message payload in bytes.
-          Also use this attribute if it is unknown whether the compressed or uncompressed payload size is reported.
+        brief: The size of the message payload in bytes.
         examples: 2738
-      - id: message.payload_compressed_size_bytes
-        type: int
-        brief: 'The compressed size of the message payload in bytes.'
-        examples: 2048
 
   - id: messaging.destination
     prefix: messaging.destination
     type: attribute_group
     brief: 'Semantic convention for attributes that describe messaging destination on broker'
+    note: >
+      Destination attributes SHOULD be set on publish, receive, or other span describing messaging messaging operation
+      if it operates with single message or if the attribute value applies to all messages in the batch.
+      In other cases, destination attributes MAY be set on links.
     attributes:
       - id: name
         type: string
@@ -56,34 +54,41 @@ groups:
         type: boolean
         brief: 'A boolean that is true if the message destination is anonymous (could be unnamed or have auto-generated name).'
 
-  - id: messaging.source
-    prefix: messaging.source
+  - id: messaging.destination_original
+    prefix: messaging.destination_original
     type: attribute_group
-    brief: 'Semantic convention for attributes that describe messaging source on broker'
+    brief: > 
+      Semantic convention for attributes that describe destination messages were originally published to.
+      These attributes should be used on the consumer side when original destination is available and different than destination message are consumed from.'
+
+      Original destination attributes SHOULD be set on publish, receive, or other span describing messaging messaging operation
+      if it operates with single message or if the attribute value applies to all messages in the batch.
+      In other cases, destination attributes MAY be set on links.
+
     attributes:
       - id: name
         type: string
-        brief: 'The message source name'
+        brief: 'The original destination name'
         note: |
-          Source name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
-          the broker does not have such notion, the source name SHOULD uniquely identify the broker.
+          The name SHOULD uniquely identify a specific queue, topic, or other entity within the broker. If
+          the broker does not have such notion, the original destination name SHOULD uniquely identify the broker.
         examples: ['MyQueue', 'MyTopic']
       - id: template
         type: string
-        brief: 'Low cardinality representation of the messaging source name'
+        brief: 'Low cardinality representation of the original messaging destination name'
         examples: ['/customers/{customerId}']
         note: >
-          Source names could be constructed from templates.
-          An example would be a source name involving a user name or product id.
-          Although the source name in this case is of high cardinality,
+          Destination names could be constructed from templates.
+          An example would be a destination name involving a user name or product id.
+          Although the destination name in this case is of high cardinality,
           the underlying template is of low cardinality and can be effectively
           used for grouping and aggregation.
       - id: temporary
         type: boolean
-        brief: 'A boolean that is true if the message source is temporary and might not exist anymore after messages are processed.'
+        brief: 'A boolean that is true if the original message destination is temporary and might not exist anymore after messages are processed.'
       - id: anonymous
         type: boolean
-        brief: 'A boolean that is true if the message source is anonymous (could be unnamed or have auto-generated name).'
+        brief: 'A boolean that is true if the original message destination is anonymous (could be unnamed or have auto-generated name).'
 
   - id: messaging
     prefix: messaging
@@ -129,16 +134,27 @@ groups:
         brief: >
           A unique identifier for the client that consumes or produces a message.
         examples: ['client-5', 'myhost@8742@s8083jm']
+      - ref: messaging.destination.name
+        requirement_level:
+          conditionally_required: If span describes operation on a single message or if the value applies to all messages in the batch.
+      - ref: messaging.destination.template
+        requirement_level:
+          conditionally_required: >
+            If available. Instrumentations MUST NOT use `messaging.destination.name` as template
+            unless low-cardinality of destination name is guaranteed.
+      - ref: messaging.destination.temporary
+        requirement_level:
+          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
+      - ref: messaging.destination.anonymous
+        requirement_level:
+          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
       - ref: messaging.message.id
         requirement_level:
           recommended: Only for spans that represent an operation on a single message.
       - ref: messaging.message.conversation_id
         requirement_level:
           recommended: Only if span represents operation on a single message.
-      - ref: messaging.message.payload_size_bytes
-        requirement_level:
-          recommended: Only if span represents operation on a single message.
-      - ref: messaging.message.payload_compressed_size_bytes
+      - ref: messaging.message.payload.size
         requirement_level:
           recommended: Only if span represents operation on a single message.
       - ref: net.peer.name
@@ -166,30 +182,6 @@ groups:
     extends: messaging
     span_kind: producer
     brief: 'Semantic convention for producers of messages sent to a messaging systems.'
-    attributes:
-      - ref: messaging.destination.name
-        requirement_level:
-          conditionally_required: If one message is being published or if the value applies to all messages in the batch.
-      - ref: messaging.destination.template
-        requirement_level:
-          conditionally_required: >
-            If available. Instrumentations MUST NOT use `messaging.destination.name` as template
-            unless low-cardinality of destination name is guaranteed.
-      - ref: messaging.destination.temporary
-        requirement_level:
-          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
-      - ref: messaging.destination.anonymous
-        requirement_level:
-          conditionally_required: If value is `true`. When missing, the value is assumed to be `false`.
-
-  - id: messaging.producer.synchronous
-    prefix: messaging
-    type: span
-    extends: messaging
-    span_kind: client
-    brief: >
-      Semantic convention for clients of messaging systems that produce messages
-      and synchronously wait for responses.
 
   - id: messaging.consumer
     prefix: messaging
@@ -198,38 +190,9 @@ groups:
     span_kind: consumer
     brief: 'Semantic convention for a consumer of messages received from a messaging system'
     attributes:
-      - ref: messaging.source.name
-        requirement_level:
-          conditionally_required: If the value applies to all messages in the batch.
-      - ref: messaging.source.template
-        requirement_level:
-          conditionally_required: >
-            If available. Instrumentations MUST NOT use `messaging.source.name` as template
-            unless low-cardinality of source name is guaranteed.
-      - ref: messaging.source.temporary
-        requirement_level:
-          recommended: When supported by messaging system and only if the source is temporary. When missing, the value is assumed to be `false`.
-      - ref: messaging.source.anonymous
-        requirement_level:
-          recommended: When supported by messaging system and only if the source is anonymous. When missing, the value is assumed to be `false`.
-      - ref: messaging.destination.name
-        requirement_level:
-          recommended: If known on consumer
-      - ref: messaging.destination.temporary
-        requirement_level:
-          recommended: If known on consumer
-      - ref: messaging.destination.anonymous
-        requirement_level:
-          recommended: If known on consumer
-
-  - id: messaging.consumer.synchronous
-    prefix: messaging
-    type: span
-    extends: messaging.consumer
-    span_kind: server
-    brief: >
-      Semantic convention for servers that consume messages received from messaging systems
-      and always send back replies directed to the producers of these messages.
+      - ref: messaging.destination_original.name
+      - ref: messaging.destination_original.temporary
+      - ref: messaging.destination_original.anonymous
 
   - id: messaging.rabbitmq
     prefix: messaging.rabbitmq
@@ -273,11 +236,6 @@ groups:
         type: int
         brief: >
           Partition the message is sent to.
-        examples: 2
-      - id: source.partition
-        type: int
-        brief: >
-          Partition the message is received from.
         examples: 2
       - id: message.offset
         type: int

--- a/semantic_conventions/trace/messaging.yaml
+++ b/semantic_conventions/trace/messaging.yaml
@@ -57,7 +57,7 @@ groups:
   - id: messaging.destination_original
     prefix: messaging.destination_original
     type: attribute_group
-    brief: > 
+    brief: >
       Semantic convention for attributes that describe destination messages were originally published to.
       These attributes should be used on the consumer side when original destination is available and different than destination message are consumed from.'
 

--- a/specification/trace/semantic_conventions/messaging.md
+++ b/specification/trace/semantic_conventions/messaging.md
@@ -22,7 +22,6 @@
   * [Operation names](#operation-names)
 - [Messaging attributes](#messaging-attributes)
   * [Attribute namespaces](#attribute-namespaces)
-  * [Producer attributes](#producer-attributes)
   * [Consumer attributes](#consumer-attributes)
   * [Per-message attributes](#per-message-attributes)
   * [Attributes specific to certain messaging systems](#attributes-specific-to-certain-messaging-systems)


### PR DESCRIPTION
Fixes #3196

## Changes

- Removes `messaging.source` namespace. `Destination` and `source` namespaces are defined in ECS and unrelated to messaging. Removed to allow attribute reuse across signals (e.g. logs), to decrease confusion with ECS source, and resolve some usability issues with source/destination 
- Not removing `messaging.destination` because it's widely used in messaging 
- Introduces `destination_original`: in some cases when a message is routed,  consumer also knows the original destination and the destination it received a message from. With `messaging.source` removed, we need another namespace for the original destination.
