### PR TITLE
JVM gc duration unit and bucket boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 - Add experimental histogram advice API.
   ([#3216](https://github.com/open-telemetry/opentelemetry-specification/pull/3216))
+- Specify second unit (`s`) and advice bucket boundaries of `[]`
+  for `process.runtime.jvm.gc.duration`.
+  ([#3458](https://github.com/open-telemetry/opentelemetry-specification/pull/3458))
 
 ### Logs
 

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -70,7 +70,7 @@ groups:
     metric_name: process.runtime.jvm.gc.duration
     brief: "Duration of JVM garbage collection actions."
     instrument: histogram
-    unit: "ms"
+    unit: "s"
     attributes:
       - id: gc
         type: string

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -209,10 +209,14 @@ This metric is [recommended](../metric-requirement-level.md#recommended).
 
 This metric is [recommended](../metric-requirement-level.md#recommended).
 
+This metric SHOULD be specified with
+[`ExplicitBucketBoundaries`](../../metrics/api.md#instrument-advice)
+of `[]` (single bucket histogram capturing count, sum, min, max).
+
 <!-- semconv metric.process.runtime.jvm.gc.duration(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.gc.duration` | Histogram | `ms` | Duration of JVM garbage collection actions. |
+| `process.runtime.jvm.gc.duration` | Histogram | `s` | Duration of JVM garbage collection actions. |
 <!-- endsemconv -->
 
 <!-- semconv metric.process.runtime.jvm.gc.duration(full) -->


### PR DESCRIPTION
Resolves #3414.

Indicate that seconds should be unit for `process.runtime.jvm.gc.duration`.

Also indicate that advice should specify bucket boundaries are `[]`. This effectively downgrades gc duration to a summary by default, capturing min, max, sum, and count. Users can opt in to the distribution using views or metric reader configuration.