### PR TITLE
Specify that Trace ID Ratio Based sampler ratio is based on trace

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -312,7 +312,7 @@ the `ParentBased` sampler specified below.
   represented as a decimal number. The precision of the number SHOULD follow
   implementation language standards and SHOULD be high enough to identify when
   Samplers have different ratios. For example, if a TraceIdRatioBased Sampler
-  had a sampling ratio of 1 to every 10,000 spans it COULD return
+  had a sampling ratio of 1 to every 10,000 traces it COULD return
   `"TraceIdRatioBased{0.000100}"` as its description.
 
 TODO: Add details about how the `TraceIdRatioBased` is implemented as a function


### PR DESCRIPTION


## Changes

This updates the description of the Trace ID Ratio Based sampler to indicate that the ratio is a fraction of traces rather than spans.
