### PR TITLE
Rename trace context field names used in legacy logging formats to match ECS

### DIFF
--- a/specification/compatibility/logging_trace_context.md
+++ b/specification/compatibility/logging_trace_context.md
@@ -24,9 +24,9 @@ representing [trace context](../logs/data-model.md#trace-context-fields). This
 document defines how trace context should be recorded in non-OTLP Log Formats.
 To summarize, the following field names should be used in legacy formats:
 
-- "trace_id" for [TraceId](../logs/data-model.md#field-traceid), hex-encoded.
-- "span_id" for [SpanId](../logs/data-model.md#field-spanid), hex-encoded.
-- "trace_flags" for [trace flags](../logs/data-model.md#field-traceflags), formatted
+- "trace.id" for [TraceId](../logs/data-model.md#field-traceid), hex-encoded.
+- "span.id" for [SpanId](../logs/data-model.md#field-spanid), hex-encoded.
+- "trace.flags" for [trace flags](../logs/data-model.md#field-traceflags), formatted
   according to W3C traceflags format.
 
 All 3 fields are optional (see the [data model](../logs/data-model.md) for details of
@@ -39,7 +39,7 @@ Trace id, span id and traceflags SHOULD be recorded via SD-ID "opentelemetry".
 For example:
 
 ```
-[opentelemetry trace_id="102981ABCD2901" span_id="abcdef1010" trace_flags="01"]
+[opentelemetry trace.id="102981ABCD2901" span.id="abcdef1010" trace.flags="01"]
 ```
 
 ### Plain Text Formats
@@ -48,7 +48,7 @@ The fields SHOULD be recorded according to the customary approach used for a
 particular format (e.g. field:value format for LTSV). For example:
 
 ```
-host:192.168.0.1<TAB>trace_id:102981ABCD2901<TAB>span_id:abcdef1010<TAB>time:[01/Jan/2010:10:11:23 -0400]<TAB>req:GET /health HTTP/1.0<TAB>status:200
+host:192.168.0.1<TAB>trace.id:102981ABCD2901<TAB>span.id:abcdef1010<TAB>time:[01/Jan/2010:10:11:23 -0400]<TAB>req:GET /health HTTP/1.0<TAB>status:200
 ```
 
 ### JSON Formats
@@ -59,8 +59,8 @@ The fields SHOULD be recorded as top-level fields in the JSON structure. For exa
 {
   "timestamp":1581385157.14429,
   "body":"Incoming request",
-  "trace_id":"102981ABCD2901",
-  "span_id":"abcdef1010"
+  "trace.id":"102981ABCD2901",
+  "span.id":"abcdef1010"
 }
 ```
 


### PR DESCRIPTION
Fixes #3303

## Changes

Renames trace context field names used in legacy logging formats to match ECS:
* `trace_id` -> `trace.id`
* `span_id` -> `span.id`
* `trace_flags` -> `trace.flags`

