### PR TITLE
Clarification: metric namespaces are not allowed to be metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ release.
   ([#3390](https://github.com/open-telemetry/opentelemetry-specification/pull/3390))
 - BREAKING: Remove `messaging.consumer.id`, make `messaging.client_id` generic
   ([#3336](https://github.com/open-telemetry/opentelemetry-specification/pull/3336))
+- Clarification: metric namespaces are not allowed to be metric names
+  ([#3476](https://github.com/open-telemetry/opentelemetry-specification/pull/3476))
 
 ### Compatibility
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -61,6 +61,14 @@ OpenTelemetry artifacts define the metric structures and hierarchies for some
 categories of metrics, and these can assist decisions when creating future
 metrics.
 
+Metric names SHOULD NOT coincide with namespaces. For example if
+`system.processes.created` is a metric name then it is no longer valid to have
+a metric named `system.processes` because `system.processes` is already a
+namespace. Because of this rule be careful when choosing names: every existing
+name prohibits existence of an equally named namespace in the future, and vice
+versa: any existing namespace prohibits existence of an equally named
+metric in the future.
+
 Common attributes SHOULD be consistently named. This aids in discoverability and
 disambiguates similar attributes to metric names.
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-specification/issues/3457#issuecomment-1535001327

Note that this is the same as [attribute namespaces which are not allowed to coincide with attribute names](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/attribute-naming.md#attribute-naming):

> Names SHOULD NOT coincide with namespaces. For example if `service.instance.id` is an attribute name then it is no longer valid to have an attribute named `service.instance` because `service.instance` is already a namespace. Because of this rule be careful when choosing names: every existing name prohibits existence of an equally named namespace in the future, and vice versa: any existing namespace prohibits existence of an equally named attribute key in the future.

See alternative proposal (that metric namespaces ARE allowed to be metric names) at #3477

## Changes

Clarifies that metric namespaces are not allowed to be metric names.