### PR TITLE
Rename `process.runtime.jvm.buffer.*` metrics to `process.runtime.jvm.buffers.*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ release.
 - Add transition plan for upcoming breaking changes to the unstable HTTP semantic
   conventions.
   ([#3443](https://github.com/open-telemetry/opentelemetry-specification/pull/3443))
+- BREAKING: Rename `process.runtime.jvm.buffer.*` metrics to
+  `process.runtime.jvm.buffers.*`
+  ([#3482](https://github.com/open-telemetry/opentelemetry-specification/pull/3482))
 
 ### Compatibility
 

--- a/schemas/1.21.0
+++ b/schemas/1.21.0
@@ -9,6 +9,13 @@ versions:
             attribute_map:
               messaging.kafka.client_id: messaging.client_id
               messaging.rocketmq.client_id: messaging.client_id
+    metrics:
+      changes:
+        # https://github.com/open-telemetry/opentelemetry-specification/pull/3482
+        - rename_metrics:
+            process.runtime.jvm.buffer.usage: process.runtime.jvm.buffers.usage
+            process.runtime.jvm.buffer.limit: process.runtime.jvm.buffers.limit
+            process.runtime.jvm.buffer.count: process.runtime.jvm.buffers.count
   1.20.0:
     spans:
       changes:

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -149,7 +149,7 @@ groups:
     instrument: gauge
     unit: "1"
 
-  - id: attributes.process.runtime.jvm.buffer
+  - id: attributes.process.runtime.jvm.buffers
     type: attribute_group
     brief: "Describes JVM buffer metric attributes."
     attributes:
@@ -160,26 +160,26 @@ groups:
           Pool names are generally obtained via
           [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).
 
-  - id: metric.process.runtime.jvm.buffer.usage
+  - id: metric.process.runtime.jvm.buffers.usage
     type: metric
-    metric_name: process.runtime.jvm.buffer.usage
-    extends: attributes.process.runtime.jvm.buffer
+    metric_name: process.runtime.jvm.buffers.usage
+    extends: attributes.process.runtime.jvm.buffers
     brief: "Measure of memory used by buffers."
     instrument: updowncounter
     unit: "By"
 
-  - id: metric.process.runtime.jvm.buffer.limit
+  - id: metric.process.runtime.jvm.buffers.limit
     type: metric
-    metric_name: process.runtime.jvm.buffer.limit
-    extends: attributes.process.runtime.jvm.buffer
+    metric_name: process.runtime.jvm.buffers.limit
+    extends: attributes.process.runtime.jvm.buffers
     brief: "Measure of total memory capacity of buffers."
     instrument: updowncounter
     unit: "By"
 
-  - id: metric.process.runtime.jvm.buffer.count
+  - id: metric.process.runtime.jvm.buffers.count
     type: metric
-    metric_name: process.runtime.jvm.buffer.count
-    extends: attributes.process.runtime.jvm.buffer
+    metric_name: process.runtime.jvm.buffers.count
+    extends: attributes.process.runtime.jvm.buffers
     brief: "Number of buffers in the pool."
     instrument: updowncounter
     unit: "{buffer}"

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -33,9 +33,9 @@ semantic conventions when instrumenting runtime environments.
   * [Metric: `process.runtime.jvm.cpu.utilization`](#metric-processruntimejvmcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.utilization`](#metric-processruntimejvmsystemcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.load_1m`](#metric-processruntimejvmsystemcpuload_1m)
-  * [Metric: `process.runtime.jvm.buffer.usage`](#metric-processruntimejvmbufferusage)
-  * [Metric: `process.runtime.jvm.buffer.limit`](#metric-processruntimejvmbufferlimit)
-  * [Metric: `process.runtime.jvm.buffer.count`](#metric-processruntimejvmbuffercount)
+  * [Metric: `process.runtime.jvm.buffers.usage`](#metric-processruntimejvmbuffersusage)
+  * [Metric: `process.runtime.jvm.buffers.limit`](#metric-processruntimejvmbufferslimit)
+  * [Metric: `process.runtime.jvm.buffers.count`](#metric-processruntimejvmbufferscount)
 
 <!-- tocstop -->
 
@@ -341,18 +341,18 @@ This metric is obtained from [`OperatingSystemMXBean#getSystemLoadAverage()`](ht
 <!-- semconv metric.process.runtime.jvm.system.cpu.load_1m(full) -->
 <!-- endsemconv -->
 
-### Metric: `process.runtime.jvm.buffer.usage`
+### Metric: `process.runtime.jvm.buffers.usage`
 
 This metric is [recommended](../metric-requirement-level.md#recommended).
 This metric is obtained from [`BufferPoolMXBean#getMemoryUsed()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getMemoryUsed--).
 
-<!-- semconv metric.process.runtime.jvm.buffer.usage(metric_table) -->
+<!-- semconv metric.process.runtime.jvm.buffers.usage(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.buffer.usage` | UpDownCounter | `By` | Measure of memory used by buffers. |
+| `process.runtime.jvm.buffers.usage` | UpDownCounter | `By` | Measure of memory used by buffers. |
 <!-- endsemconv -->
 
-<!-- semconv metric.process.runtime.jvm.buffer.usage(full) -->
+<!-- semconv metric.process.runtime.jvm.buffers.usage(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `pool` | string | Name of the buffer pool. [1] | `mapped`; `direct` | Recommended |
@@ -360,18 +360,18 @@ This metric is obtained from [`BufferPoolMXBean#getMemoryUsed()`](https://docs.o
 **[1]:** Pool names are generally obtained via [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).
 <!-- endsemconv -->
 
-### Metric: `process.runtime.jvm.buffer.limit`
+### Metric: `process.runtime.jvm.buffers.limit`
 
 This metric is [recommended](../metric-requirement-level.md#recommended).
 This metric is obtained from [`BufferPoolMXBean#getTotalCapacity()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getTotalCapacity--).
 
-<!-- semconv metric.process.runtime.jvm.buffer.limit(metric_table) -->
+<!-- semconv metric.process.runtime.jvm.buffers.limit(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.buffer.limit` | UpDownCounter | `By` | Measure of total memory capacity of buffers. |
+| `process.runtime.jvm.buffers.limit` | UpDownCounter | `By` | Measure of total memory capacity of buffers. |
 <!-- endsemconv -->
 
-<!-- semconv metric.process.runtime.jvm.buffer.limit(full) -->
+<!-- semconv metric.process.runtime.jvm.buffers.limit(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `pool` | string | Name of the buffer pool. [1] | `mapped`; `direct` | Recommended |
@@ -379,18 +379,18 @@ This metric is obtained from [`BufferPoolMXBean#getTotalCapacity()`](https://doc
 **[1]:** Pool names are generally obtained via [BufferPoolMXBean#getName()](https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html#getName()).
 <!-- endsemconv -->
 
-### Metric: `process.runtime.jvm.buffer.count`
+### Metric: `process.runtime.jvm.buffers.count`
 
 This metric is [recommended](../metric-requirement-level.md#recommended).
 This metric is obtained from [`BufferPoolMXBean#getCount()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/BufferPoolMXBean.html#getCount--).
 
-<!-- semconv metric.process.runtime.jvm.buffer.count(metric_table) -->
+<!-- semconv metric.process.runtime.jvm.buffers.count(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |
 | -------- | --------------- | ----------- | -------------- |
-| `process.runtime.jvm.buffer.count` | UpDownCounter | `{buffer}` | Number of buffers in the pool. |
+| `process.runtime.jvm.buffers.count` | UpDownCounter | `{buffer}` | Number of buffers in the pool. |
 <!-- endsemconv -->
 
-<!-- semconv metric.process.runtime.jvm.buffer.count(full) -->
+<!-- semconv metric.process.runtime.jvm.buffers.count(full) -->
 | Attribute  | Type | Description  | Examples  | Requirement Level |
 |---|---|---|---|---|
 | `pool` | string | Name of the buffer pool. [1] | `mapped`; `direct` | Recommended |


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-specification/issues/3429#issuecomment-1536438723

## Changes

Renames `process.runtime.jvm.buffer.*` metrics to `process.runtime.jvm.buffers.*`

Based on guidance from https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/README.md#pluralization.

And similar to `system.processes.*`.