### PR TITLE
Add `process.runtime.jvm.available_processors` metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ release.
 - Add transition plan for upcoming breaking changes to the unstable HTTP semantic
   conventions.
   ([#3443](https://github.com/open-telemetry/opentelemetry-specification/pull/3443))
+- Add `process.runtime.jvm.available_processors` metric.
+  ([#3484](https://github.com/open-telemetry/opentelemetry-specification/pull/3484))
 
 ### Compatibility
 

--- a/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
+++ b/semantic_conventions/metrics/process-runtime-jvm-metrics.yaml
@@ -149,6 +149,13 @@ groups:
     instrument: gauge
     unit: "1"
 
+  - id: metric.process.runtime.jvm.available_processors
+    type: metric
+    metric_name: process.runtime.jvm.available_processors
+    brief: "The number of processors available to the JVM."
+    instrument: updowncounter
+    unit: "{processor}"
+
   - id: attributes.process.runtime.jvm.buffer
     type: attribute_group
     brief: "Describes JVM buffer metric attributes."

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -33,6 +33,7 @@ semantic conventions when instrumenting runtime environments.
   * [Metric: `process.runtime.jvm.cpu.utilization`](#metric-processruntimejvmcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.utilization`](#metric-processruntimejvmsystemcpuutilization)
   * [Metric: `process.runtime.jvm.system.cpu.load_1m`](#metric-processruntimejvmsystemcpuload_1m)
+  * [Metric: `process.runtime.jvm.available_processors`](#metric-processruntimejvmavailable_processors)
   * [Metric: `process.runtime.jvm.buffer.usage`](#metric-processruntimejvmbufferusage)
   * [Metric: `process.runtime.jvm.buffer.limit`](#metric-processruntimejvmbufferlimit)
   * [Metric: `process.runtime.jvm.buffer.count`](#metric-processruntimejvmbuffercount)

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -345,7 +345,7 @@ This metric is obtained from [`OperatingSystemMXBean#getSystemLoadAverage()`](ht
 ### Metric: `process.runtime.jvm.available_processors`
 
 This metric is [recommended](../metric-requirement-level.md#recommended).
-This metric is obtained from [`OperatingSystemMXBean#getAvailableProcessors()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/OperatingSystemMXBean.html#getAvailableProcessors--).
+This metric is obtained from [`Runtime#availableProcessors()`](https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors--).
 
 <!-- semconv metric.process.runtime.jvm.available_processors(metric_table) -->
 | Name     | Instrument Type | Unit (UCUM) | Description    |

--- a/specification/metrics/semantic_conventions/runtime-environment-metrics.md
+++ b/specification/metrics/semantic_conventions/runtime-environment-metrics.md
@@ -341,6 +341,17 @@ This metric is obtained from [`OperatingSystemMXBean#getSystemLoadAverage()`](ht
 <!-- semconv metric.process.runtime.jvm.system.cpu.load_1m(full) -->
 <!-- endsemconv -->
 
+### Metric: `process.runtime.jvm.available_processors`
+
+This metric is [recommended](../metric-requirement-level.md#recommended).
+This metric is obtained from [`OperatingSystemMXBean#getAvailableProcessors()`](https://docs.oracle.com/javase/8/docs/api/java/lang/management/OperatingSystemMXBean.html#getAvailableProcessors--).
+
+<!-- semconv metric.process.runtime.jvm.available_processors(metric_table) -->
+| Name     | Instrument Type | Unit (UCUM) | Description    |
+| -------- | --------------- | ----------- | -------------- |
+| `process.runtime.jvm.available_processors` | UpDownCounter | `{processor}` | The number of processors available to the JVM. |
+<!-- endsemconv -->
+
 ### Metric: `process.runtime.jvm.buffer.usage`
 
 This metric is [recommended](../metric-requirement-level.md#recommended).


### PR DESCRIPTION
Fixes #3473

## Changes

Adds `process.runtime.jvm.available_processors` metric
