### PR TITLE
`.count` metric naming convention only applies to UpDownCounters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,8 @@ release.
   `http.scheme` to `url.scheme`,
   and removes `http.target` breaking it down to `http.target` to `url.path`, `url.query`, and `url.fragment`.
   ([#3355](https://github.com/open-telemetry/opentelemetry-specification/pull/3355))
-- Update `.count` metric naming convention so that it only applies to UpDownCounters
+- Update `.count` metric naming convention so that it only applies to UpDownCounters,
+  and add that `.total` should not be used by either Counters or UpDownCounters
   ([#3493](https://github.com/open-telemetry/opentelemetry-specification/pull/3493))
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ release.
   `http.scheme` to `url.scheme`,
   and removes `http.target` breaking it down to `http.target` to `url.path`, `url.query`, and `url.fragment`.
   ([#3355](https://github.com/open-telemetry/opentelemetry-specification/pull/3355))
+- Update `.count` metric naming convention so that it only applies to UpDownCounters
+  ([#3493](https://github.com/open-telemetry/opentelemetry-specification/pull/3493))
 
 ### Compatibility
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -129,6 +129,16 @@ This rule should only be applied to UpDownCounters, since (monotonic) Counters h
 `_total` appended to their names when they are mapped to Prometheus, which would lead to
 `_count_total`.
 
+#### Do not use `total`
+
+Counters have `_total` appended to their names when they are mapped to Prometheus,
+which would lead to `_total_total`. The reason that the Prometheus mapping cannot
+suppress adding the duplicate `_total` is because then the mapping wouldn't be
+bidirectional.
+
+UpDownCounters should not use `_total` either because then they will look like
+monotonic sums in Prometheus.
+
 ## General Metric Semantic Conventions
 
 **Status**: [Mixed](../../document-status.md)

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -127,7 +127,7 @@ to the processes then to represent the count of the processes we can have a metr
 `system.processes`.
 
 This rule should only be applied to UpDownCounters, since (monotonic) Counters have
-`_total` appended to their names when they are mapped to Prometheus, which would lead to
+`_total` appended to their names when they are [mapped to Prometheus](../../compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus), which would lead to
 `_count_total`.
 
 #### Do not use `total`

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -14,6 +14,7 @@ linkTitle: Semantic Conventions
   * [Units](#units)
   * [Pluralization](#pluralization)
     + [Use `count` Instead of Pluralization for UpDownCounters](#use-count-instead-of-pluralization-for-updowncounters)
+    + [Do not use `total`](#do-not-use-total)
 - [General Metric Semantic Conventions](#general-metric-semantic-conventions)
   * [Instrument Naming](#instrument-naming)
   * [Instrument Units](#instrument-units)

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -132,7 +132,7 @@ This rule should only be applied to UpDownCounters, since (monotonic) Counters h
 
 #### Do not use `total`
 
-Counters have `_total` appended to their names when they are mapped to Prometheus,
+Counters have `_total` appended to their names when they are [mapped to Prometheus](../../compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus),
 which would lead to `_total_total`. The reason that the Prometheus mapping cannot
 suppress adding the duplicate `_total` is because then the mapping wouldn't be
 bidirectional.

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -137,7 +137,7 @@ which would lead to `_total_total`. The reason that the Prometheus mapping canno
 suppress adding the duplicate `_total` is because then the mapping wouldn't be
 bidirectional.
 
-UpDownCounters should not use `_total` either because then they will look like
+UpDownCounters SHOULD NOT use `_total` either because then they will look like
 monotonic sums in Prometheus.
 
 ## General Metric Semantic Conventions

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -126,7 +126,7 @@ to the processes then to represent the count of the processes we can have a metr
 `system.processes.count`. The suffix `count` here indicates that it is the count of
 `system.processes`.
 
-This rule should only be applied to UpDownCounters, since (monotonic) Counters have
+This rule SHOULD only be applied to UpDownCounters, since (monotonic) Counters have
 `_total` appended to their names when they are [mapped to Prometheus](../../compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus), which would lead to
 `_count_total`.
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -13,7 +13,7 @@ linkTitle: Semantic Conventions
   * [Name Reuse Prohibition](#name-reuse-prohibition)
   * [Units](#units)
   * [Pluralization](#pluralization)
-    + [Use `count` Instead of Pluralization](#use-count-instead-of-pluralization)
+    + [Use `count` Instead of Pluralization for UpDownCounters](#use-count-instead-of-pluralization-for-updowncounters)
 - [General Metric Semantic Conventions](#general-metric-semantic-conventions)
   * [Instrument Naming](#instrument-naming)
   * [Instrument Units](#instrument-units)
@@ -114,7 +114,7 @@ should not be pluralized, even if many data points are recorded.
 * `system.paging.faults`, `system.disk.operations`, and `system.network.packets`
 should be pluralized, even if only a single data point is recorded.
 
-#### Use `count` Instead of Pluralization
+#### Use `count` Instead of Pluralization for UpDownCounters
 
 If the value being recorded represents the count of concepts signified
 by the namespace then the metric should be named `count` (within its namespace).
@@ -124,6 +124,10 @@ For example if we have a namespace `system.processes` which contains all metrics
 to the processes then to represent the count of the processes we can have a metric named
 `system.processes.count`. The suffix `count` here indicates that it is the count of
 `system.processes`.
+
+This rule should only be applied to UpDownCounters, since (monotonic) Counters have
+`_total` appended to their names when they are mapped to Prometheus, which would lead to
+`_count_total`.
 
 ## General Metric Semantic Conventions
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -132,7 +132,7 @@ This rule SHOULD only be applied to UpDownCounters, since (monotonic) Counters h
 
 #### Do not use `total`
 
-Counters have `_total` appended to their names when they are [mapped to Prometheus](../../compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus),
+Counters SHOULD NOT append `_total`  to their names. Counters have `_total` appended to their names when they are [mapped to Prometheus](../../compatibility/prometheus_and_openmetrics.md#otlp-metric-points-to-prometheus),
 which would lead to `_total_total`. The reason that the Prometheus mapping cannot
 suppress adding the duplicate `_total` is because then the mapping wouldn't be
 bidirectional.


### PR DESCRIPTION
Fixes #3457

## Changes

Updates `.count` metric naming convention so that it only applies to UpDownCounters, and adds that `.total` should not be used by either Counters or UpDownCounters 