### PR TITLE
[editorial] Add config README and aliases for relocated pages

### DIFF
--- a/specification/configuration/README.md
+++ b/specification/configuration/README.md
@@ -1,0 +1,1 @@
+# Configuration

--- a/specification/configuration/file-configuration.md
+++ b/specification/configuration/file-configuration.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: File
+--->
+
 # File Configuration
 
 **Status**: [Experimental](../document-status.md)

--- a/specification/configuration/sdk-configuration.md
+++ b/specification/configuration/sdk-configuration.md
@@ -1,3 +1,8 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: SDK
+aliases: [/docs/reference/specification/sdk-configuration]
+--->
+
 # Default SDK Configuration
 
 <details>

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -1,3 +1,9 @@
+<!--- Hugo front matter used to generate the website version of this page:
+title: Environment Variable Specification
+linkTitle: Env var
+aliases: [/docs/reference/specification/sdk-environment-variables]
+--->
+
 # OpenTelemetry Environment Variable Specification
 
 **Status**: [Mixed](../document-status.md)


### PR DESCRIPTION
- Adds aliases for pages that were moved so as to avoid 404s on the OTel website
- Adds a landing page (`README`) to the new configuration section of the spec
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2698
- Adds `linkTitle` fields

/cc @svrnm @cartermp @tigrannajaryan 