### PR TITLE
Adapt default histogram boundaries to seconds as the new base unit

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -473,10 +473,10 @@ explicit boundary values for histogram bucketing.
 
 This Aggregation honors the following configuration parameters:
 
-| Key | Value | Default Value | Description |
-| --- | --- | --- | --- |
-| Boundaries | double\[\] | [ 0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000 ] | Array of increasing values representing explicit bucket boundary values.<br><br>The Default Value represents the following buckets (heavily influenced by the default buckets of Prometheus clients, e.g. [Java](https://github.com/prometheus/client_java/blob/6730f3e32199d6bf0e963b306ff69ef08ac5b178/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88) and [Go](https://github.com/prometheus/client_golang/blob/83d56b1144a0c2eb10d399e7abbae3333bebc463/prometheus/histogram.go#L68)):<br>(-&infin;, 0], (0, 5.0], (5.0, 10.0], (10.0, 25.0], (25.0, 50.0], (50.0, 75.0], (75.0, 100.0], (100.0, 250.0], (250.0, 500.0], (500.0, 750.0], (750.0, 1000.0], (1000.0, 2500.0], (2500.0, 5000.0], (5000.0, 7500.0], (7500.0, 10000.0], (10000.0, +&infin;). SDKs SHOULD use the default value when boundaries are not explicitly provided, unless they have good reasons to use something different (e.g. for backward compatibility reasons in a stable SDK release). |
-| RecordMinMax | true, false | true | Whether to record min and max. |
+| Key          | Value       | Default Value                                                           | Description |
+| ------------ | ----------- | ----------------------------------------------------------------------- | --- |
+| Boundaries   | double\[\]  | [ 0, .005, .01, .025, .05, .075, .1, .25, .5, .75, 1, 2.5, 5, 7.5, 10 ] | Array of increasing values representing explicit bucket boundary values.<br><br>The Default Value represents the following buckets (heavily influenced by the default buckets of Prometheus clients, e.g. [Java](https://github.com/prometheus/client_java/blob/6730f3e32199d6bf0e963b306ff69ef08ac5b178/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88) and [Go](https://github.com/prometheus/client_golang/blob/83d56b1144a0c2eb10d399e7abbae3333bebc463/prometheus/histogram.go#L68)). SDKs SHOULD use the default value when boundaries are not explicitly provided, unless they have good reasons to use something different (e.g. for backward compatibility reasons in a stable SDK release). |
+| RecordMinMax | true, false | true                                                                    | Whether to record min and max. |
 
 Explicit buckets are stated in terms of their upper boundary.  Buckets
 are exclusive of their lower boundary and inclusive of their upper


### PR DESCRIPTION
## Changes

There was a [decision by the TC (technical committee)](https://github.com/open-telemetry/opentelemetry-specification/issues/2977#issuecomment-1489150771) to use seconds as the base unit in OpenTelemetry rather than milliseconds.

As a result, we should also scale down the default histogram bucket boundaries by a factor of 1000.

Note that scaled down boundaries are already in use, see for example [semantic conventions for `http.server.duration`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/semantic_conventions/http-metrics.md#metric-httpserverduration).

## Related issues

* [https://github.com/open-telemetry/opentelemetry-specification/issues/2977#issuecomment-1489150771](https://github.com/open-telemetry/opentelemetry-specification/issues/2977#issuecomment-1489150771)