### PR TITLE
Add OT/OC Binary propagators to the compliance matrix.

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -258,6 +258,8 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | TraceContext Propagator                                                          |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | B3 Propagator                                                                    |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Jaeger Propagator                                                                |          | +  | +    | +  | +      | +    | +      |     | +    | +   | -    | -     |
+| OT Propagator                                                                    |          | +  | +    | +  | +      |      |        |     |      |     |      |       |
+| OpenCensus Binary Propagator                                                     |          | +  |      |    |        |      |        |     |      |     |      |       |
 | [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          | +  | +    |    |        | +    |        | +   |      |     |      |       |
 | Fields                                                                           |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Setter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      |     | N/A  | +   | +    | +     |


### PR DESCRIPTION
Was reviewing the compliance matrix and realized these two are missing. Took a quick look at existing implementations and put a mark where needed - although I need confirmation for the OC case, as I'm not an expert there. Maybe @dashpole @open-telemetry/go-approvers can confirm?