### PR TITLE
Refine SDK MeterProvider configuration section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Refine SDK MeterProvider configuration section.
+  ([#3522](https://github.com/open-telemetry/opentelemetry-specification/pull/3522))
+
 ### Logs
 
 ### Resource

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -116,7 +116,7 @@ that the emitted data format is capable of representing such association.
 
 Configuration (i.e. [MetricExporters](#metricexporter),
 [MetricReaders](#metricreader) and [Views](#view)) MUST be owned by the
-`MeterProvider`. The configuration MAY be applied at the time of MeterProvider
+`MeterProvider`. The configuration MAY be applied at the time of `MeterProvider`
 creation if appropriate.
 
 The `MeterProvider` MAY provide methods to update the configuration. If

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -94,19 +94,6 @@ suggestions regarding how to implement this efficiently.
 
 The SDK SHOULD allow the creation of multiple independent `MeterProvider`s.
 
-MeterProvider configuration (i.e. [MetricExporters](#metricexporter),
-[MetricReaders](#metricreader) and [Views](#view)) is owned by the
-`MeterProvider`. The configuration MAY be applied at the time of MeterProvider
-creation if appropriate.
-
-The `MeterProvider` MAY provide methods to update the configuration. If
-configuration is updated (e.g., adding a `MetricReader`), the updated
-configuration MUST also apply to all already returned `Meters` (i.e. it MUST NOT
-matter whether a `Meter` was obtained from the `MeterProvider` before or after
-the configuration change). Note: Implementation-wise, this could mean that
-`Meter` instances have a reference to their `MeterProvider` and access
-configuration only via this reference.
-
 ### Meter Creation
 
 New `Meter` instances are always created through a `MeterProvider`
@@ -124,6 +111,21 @@ message reporting that the specified value is invalid SHOULD be logged.
 When a Schema URL is passed as an argument when creating a `Meter` the emitted
 telemetry for that `Meter` MUST be associated with the Schema URL, provided
 that the emitted data format is capable of representing such association.
+
+### Configuration
+
+Configuration (i.e. [MetricExporters](#metricexporter),
+[MetricReaders](#metricreader) and [Views](#view)) MUST be owned by the
+`MeterProvider`. The configuration MAY be applied at the time of MeterProvider
+creation if appropriate.
+
+The `MeterProvider` MAY provide methods to update the configuration. If
+configuration is updated (e.g., adding a `MetricReader`), the updated
+configuration MUST also apply to all already returned `Meters` (i.e. it MUST NOT
+matter whether a `Meter` was obtained from the `MeterProvider` before or after
+the configuration change). Note: Implementation-wise, this could mean that
+`Meter` instances have a reference to their `MeterProvider` and access
+configuration only via this reference.
 
 ### Shutdown
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -95,9 +95,10 @@ suggestions regarding how to implement this efficiently.
 The SDK SHOULD allow the creation of multiple independent `MeterProvider`s.
 
 MeterProvider configuration (i.e. the passed [MetricExporters](#metricexporter),
-[MetricReaders](#metricreader) and [Views](#view)) are owned by the `MeterProvider`
-and the SDK MUST provide a way to configure all options that are implemented by
-the SDK. This MAY be done at the time of MeterProvider creation if appropriate.
+[MetricReaders](#metricreader) and [Views](#view)) are owned by the
+`MeterProvider`. The SDK MUST provide a way to configure all options that are
+implemented by the SDK. This MAY be done at the time of MeterProvider creation
+if appropriate.
 
 The `MeterProvider` MAY provide methods to update the configuration. If
 configuration is updated (e.g., adding a `MetricReader`), the updated

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -94,11 +94,10 @@ suggestions regarding how to implement this efficiently.
 
 The SDK SHOULD allow the creation of multiple independent `MeterProvider`s.
 
-MeterProvider configuration (i.e. the passed [MetricExporters](#metricexporter),
-[MetricReaders](#metricreader) and [Views](#view)) are owned by the
-`MeterProvider`. The SDK MUST provide a way to configure all options that are
-implemented by the SDK. This MAY be done at the time of MeterProvider creation
-if appropriate.
+MeterProvider configuration (i.e. [MetricExporters](#metricexporter),
+[MetricReaders](#metricreader) and [Views](#view)) is owned by the
+`MeterProvider`. The configuration MAY be applied at the time of MeterProvider
+creation if appropriate.
 
 The `MeterProvider` MAY provide methods to update the configuration. If
 configuration is updated (e.g., adding a `MetricReader`), the updated

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -94,6 +94,19 @@ suggestions regarding how to implement this efficiently.
 
 The SDK SHOULD allow the creation of multiple independent `MeterProvider`s.
 
+MeterProvider configuration (i.e. the passed [MetricExporters](#metricexporter),
+[MetricReaders](#metricreader) and [Views](#view)) are owned by the `MeterProvider`
+and the SDK MUST provide a way to configure all options that are implemented by
+the SDK. This MAY be done at the time of MeterProvider creation if appropriate.
+
+The `MeterProvider` MAY provide methods to update the configuration. If
+configuration is updated (e.g., adding a `MetricReader`), the updated
+configuration MUST also apply to all already returned `Meters` (i.e. it MUST NOT
+matter whether a `Meter` was obtained from the `MeterProvider` before or after
+the configuration change). Note: Implementation-wise, this could mean that
+`Meter` instances have a reference to their `MeterProvider` and access
+configuration only via this reference.
+
 ### Meter Creation
 
 New `Meter` instances are always created through a `MeterProvider`
@@ -111,20 +124,6 @@ message reporting that the specified value is invalid SHOULD be logged.
 When a Schema URL is passed as an argument when creating a `Meter` the emitted
 telemetry for that `Meter` MUST be associated with the Schema URL, provided
 that the emitted data format is capable of representing such association.
-
-Configuration (i.e., [MetricExporters](#metricexporter),
-[MetricReaders](#metricreader) and [Views](#view)) MUST be managed solely by the
-`MeterProvider` and the SDK MUST provide a way to configure all options that are
-implemented by the SDK. This MAY be done at the time of MeterProvider creation
-if appropriate.
-
-The `MeterProvider` MAY provide methods to update the configuration. If
-configuration is updated (e.g., adding a `MetricReader`), the updated
-configuration MUST also apply to all already returned `Meters` (i.e. it MUST NOT
-matter whether a `Meter` was obtained from the `MeterProvider` before or after
-the configuration change). Note: Implementation-wise, this could mean that
-`Meter` instances have a reference to their `MeterProvider` and access
-configuration only via this reference.
 
 ### Shutdown
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -14,6 +14,7 @@ linkTitle: SDK
 - [MeterProvider](#meterprovider)
   * [MeterProvider Creation](#meterprovider-creation)
   * [Meter Creation](#meter-creation)
+  * [Configuration](#configuration)
   * [Shutdown](#shutdown)
   * [ForceFlush](#forceflush)
   * [View](#view)


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-go/issues/3642#issuecomment-1568336829

## Changes

- Create a `MeterProvider - Configuration` section.
- Change "managed solely" to "owned". E.g. I do not think it is wrong that one would pass the same reader to a different metrics provider. But the provider has the permission to e.g. shutdown the reader during metrics provider shutdown.
- Remove _"The SDK MUST provide a way to configure all options that are implemented by the SDK."_ as I do not see any value in this sentence. For me (maybe wrongly) it means like "the configuration MUST by applied".
