### PR TITLE
Make recommendation to reserve aggregator normative

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -340,7 +340,7 @@ informs the SDK on the ways and means to compute
 [Aggregated Metrics](./data-model.md#opentelemetry-protocol-data-model)
 from incoming Instrument [Measurements](./api.md#measurement).
 
-Note: the term _aggregation_ is used instead of _aggregator_. It is recommended
+Note: the term _aggregation_ is used instead of _aggregator_. It is RECOMMENDED
 that implementors reserve the "aggregator" term for the future when the SDK
 allows custom aggregation implementations.
 


### PR DESCRIPTION
Currently the recommendation does not use the key-word defined by [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119.txt)
