### PR TITLE
Mark Metrics SDK env vars as Stable

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -303,7 +303,7 @@ Known values for `OTEL_LOGS_EXPORTER` are:
 
 ## Metrics SDK Configuration
 
-**Status**: [Mixed](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 | Name            | Description | Default | Notes |
 |-----------------|---------|-------------|---------|


### PR DESCRIPTION
It looks like `OTEL_METRICS_EXEMPLAR_FILTER` is pretty stable. Java, Python, PHP are already implementing it.