### PR TITLE
Simplify language for async API use outside of callback

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -581,9 +581,8 @@ performing collection, such that observations made or produced by
 executing callbacks only apply to the intended `MetricReader` during
 collection.
 
-The implementation SHOULD disregard the accidental use of APIs
-appurtenant to asynchronous instruments outside of registered
-callbacks in the context of a single `MetricReader` collection.
+The implementation SHOULD disregard the use of asynchronous instrument
+APIs outside of registered callbacks.
 
 The implementation SHOULD use a timeout to prevent indefinite callback
 execution.


### PR DESCRIPTION
- Using the term "appurtenant" is not necessary and makes the meaning of the sentence unclear.
- Scoping the use of these APIs to the "context of a single `MetricReader` collection" is a meaningless statement. They should be disregarded in all context outside of a callback.
- Remove the qualifier that the use has to be "accidental". This was likely originally included to explain why a user would do this, but it also complicates things as the implementer may think they need to determine if the use was accidental or not.
