### PR TITLE
Add synchronous gauge instrument

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -416,6 +416,7 @@ an aggregation and `advice` to influence aggregation configuration parameters
 | [Asynchronous Counter](./api.md#asynchronous-counter)             | [Sum Aggregation](./sdk.md#sum-aggregation)                                                                                                                                    |
 | [UpDownCounter](./api.md#updowncounter)                           | [Sum Aggregation](./sdk.md#sum-aggregation)                                                                                                                                    |
 | [Asynchronous UpDownCounter](./api.md#asynchronous-updowncounter) | [Sum Aggregation](./sdk.md#sum-aggregation)                                                                                                                                    |
+| [Gauge](./api.md#gauge)                                           | [Last Value Aggregation](./sdk.md#last-value-aggregation)                                                                                                                      |
 | [Asynchronous Gauge](./api.md#asynchronous-gauge)                 | [Last Value Aggregation](./sdk.md#last-value-aggregation)                                                                                                                      |
 | [Histogram](./api.md#histogram)                                   | [Explicit Bucket Histogram Aggregation](./sdk.md#explicit-bucket-histogram-aggregation), with `ExplicitBucketBoundaries` from [advice](./api.md#instrument-advice) if provided |
 


### PR DESCRIPTION
Resolves #2318.

Extends the metrics API to include a new synchronous gauge instrument, whose value can be set as measurements occur. This is useful when the measurements are made accessible via subscription, such as JFR events.

There's an interesting question about what values to use for the `start_time_unix_nano` and `time_unix_nano` fields of [gauge data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#gauge).  The `time_unix_nano` is the time at which the value was sampled. For async gauges, this is also the collection time. For sync gauges time at which the value was sampled will not be equal to the collection time, which would yield metrics with different `time_unix_nano` values in the same export batch. This seems a bit strange, but ok and a better outcome than the setting `time_unix_nano` equal to the collection time, which needlessly erases useful information about when the value occurred.

There's also a question whether to include series without new measurements in exporters. When temporality is cumulative, all series since application start are exported with each collection. When temporality is delta, only series with measurements since last collection are exported. It seems natural to me to follow the delta behavior with synchronous gauges. Given that gauges don't have temporality, letting gauge export semantics be influenced by a temporality selection seems incorrect.

There's also the question of whether recording exemplars makes sense for synchronous gauges. I say no. In the synchronous gauge use cases I know about, the measurements are made accessible through a subscription, rather than an accessor that can be invoked in a callback. In these cases, there is no trace context to link with.