### PR TITLE
Do not check for valid links in semantic conventions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # All documents to be used in spell check.
-ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' | sort)
+ALL_DOCS := $(shell find . -type f -name '*.md' -not -path './.github/*' -not -path './node_modules/*' -not -path '*semantic_conventions*' | sort)
 PWD := $(shell pwd)
 
 TOOLS_DIR := ./internal/tools


### PR DESCRIPTION
Recently IBM changed docs referenced by our semconv, and hence our CI is broken - but there shouldn't be need to check links for it, as they are outdated (and will be removed eventually?).