### PR TITLE
[editorial] Add Hugo front-matter for protocol to match OTLP pages

### DIFF
--- a/specification/protocol/README.md
+++ b/specification/protocol/README.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Protocol
+--->
+
 # OpenTelemetry Protocol
 
 The OpenTelemetry protocol (OTLP) specification has moved to

--- a/specification/protocol/design-goals.md
+++ b/specification/protocol/design-goals.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Design Goals
+--->
+
 # Design Goals for OpenTelemetry Wire Protocol
 
 This page has moved to

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Exporter
+--->
+
 # OpenTelemetry Protocol Exporter
 
 **Status**: [Stable](../document-status.md)

--- a/specification/protocol/file-exporter.md
+++ b/specification/protocol/file-exporter.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: File Exporter
+--->
+
 # OpenTelemetry Protocol File Exporter
 
 **Status**: [Experimental](../../specification/document-status.md)

--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Specification
+--->
+
 # OpenTelemetry Protocol Specification
 
 This page has moved to

--- a/specification/protocol/requirements.md
+++ b/specification/protocol/requirements.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Requirements
+--->
+
 # OpenTelemetry Protocol Requirements
 
 This page has moved to


### PR DESCRIPTION
- Adds Hugo `linkTitle` to Protocol pages, to match OTLP pages
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2642
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2793

/cc @svrnm @cartermp 