### PR TITLE
[editorial] Ensure trace subsections have a README

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: API
+--->
+
 # Tracing API
 
 **Status**: [Stable, Feature-freeze](../document-status.md)

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: SDK
+--->
+
 # Tracing SDK
 
 **Status**: [Stable](../document-status.md)

--- a/specification/trace/sdk_exporters/README.md
+++ b/specification/trace/sdk_exporters/README.md
@@ -1,0 +1,5 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Exporters
+--->
+
+# Trace Exporters

--- a/specification/trace/sdk_exporters/jaeger.md
+++ b/specification/trace/sdk_exporters/jaeger.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Jaeger
+--->
+
 # OpenTelemetry to Jaeger Transformation
 
 **Status**: [Stable](../../document-status.md)

--- a/specification/trace/sdk_exporters/zipkin.md
+++ b/specification/trace/sdk_exporters/zipkin.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Zipkin
+--->
+
 # OpenTelemetry to Zipkin Transformation
 
 **Status**: [Stable](../../document-status.md)

--- a/specification/trace/tracestate-handling.md
+++ b/specification/trace/tracestate-handling.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: TraceState
+--->
+
 # TraceState Handling
 
 **Status**: [Experimental](../document-status.md)

--- a/specification/trace/tracestate-probability-sampling.md
+++ b/specification/trace/tracestate-probability-sampling.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Probability Sampling
+--->
+
 # TraceState: Probability Sampling
 
 **Status**: [Experimental](../document-status.md)


### PR DESCRIPTION
- Contributes to #2558 by adding `specification/trace/sdk_exporters/README.md`
- Adds `linkTitle` front-matter entries for selected pages

/cc @svrnm @cartermp  