### PR TITLE
Add `ocbinary` to known values for `OTEL_PROPAGATORS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+- Add ocbinary to known values for OTEL_PROPAGATORS. ([#3561](https://github.com/open-telemetry/opentelemetry-specification/pull/3561))
+
 ### Metrics
 
 - Refine SDK MeterProvider configuration section.

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -91,6 +91,8 @@ Known values for `OTEL_PROPAGATORS` are:
 - `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
 - `"ottrace"`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)
+- `"ocbinary"`: [OC Binary](https://opencensus.io/api/python/trace/api/binary_format_propagation.html) (_third party_)
+
 - `"none"`: No automatically configured propagator.
 
 Known values for `OTEL_TRACES_SAMPLER` are:


### PR DESCRIPTION
OC Binary is part of the compliance matrix, this commit adds `ocbinary` to known values for `OTEL_PROPAGATORS` so that auto-instrumentation to recognise.