### PR TITLE
[Prometheus compatibility] Do not require trimming suffixes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ release.
 
 ### Compatibility
 
+- Prometheus type and unit suffixes are not trimmed by default. ([#3580](https://github.com/open-telemetry/opentelemetry-specification/pull/3580))
+
 ### OpenTelemetry Protocol
 
 ### SDK Configuration

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -48,13 +48,10 @@ OpenTelemetry metric data. Since OpenMetrics has a superset of Prometheus' types
 ### Metric Metadata
 
 The [OpenMetrics MetricFamily Name](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily)
-MUST be added as the Name of the OTLP metric after the removal of unit and type
-suffixes described below.
+MUST be added as the Name of the OTLP metric.  By default, the name MUST be unaltered, but translation SHOULD provide configuration which, when enabled, removes type (e.g. `_total`) and unit (e.g. `_seconds`) suffixes.
 
 The [OpenMetrics UNIT metadata](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily),
-if present, MUST be converted to the unit of the OTLP metric.  After trimming
-type-specific suffixes, such as `_total` for counters, the unit MUST be trimmed
-from the suffix as well, if the metric suffix matches the unit. The unit SHOULD
+if present, MUST be converted to the unit of the OTLP metric.  The unit SHOULD
 be translated from Prometheus conventions to OpenTelemetry conventions by:
 
 * Converting from full words to abbreviations (e.g. "milliseconds" to "ms").
@@ -71,7 +68,7 @@ metadata follow rules for [unknown-typed](#unknown-typed) metrics below.
 
 ### Counters
 
-A [Prometheus Counter](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#counter) MUST be converted to an OTLP Sum with `is_monotonic` equal to `true`.  If the counter has a `_total` suffix, it MUST be removed.
+A [Prometheus Counter](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#counter) MUST be converted to an OTLP Sum with `is_monotonic` equal to `true`.
 
 ### Gauges
 
@@ -79,7 +76,7 @@ A [Prometheus Gauge](https://github.com/OpenObservability/OpenMetrics/blob/main/
 
 ### Info
 
-An [OpenMetrics Info](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info) metric MUST be converted to an OTLP Non-Monotonic Sum unless it is the target_info metric, which is used to populate [resource attributes](#resource-attributes). An OpenMetrics Info can be thought of as a special-case of the OpenMetrics Gauge which has a value of 1, and whose labels generally stays constant over the life of the process. It is converted to a Non-Monotonic Sum, rather than a Gauge, because the value of 1 is intended to be viewed as a count, which should be summed together when aggregating away labels.  If it has an `_info` suffix, the suffix MUST be removed from the metric name.
+An [OpenMetrics Info](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#info) metric MUST be converted to an OTLP Non-Monotonic Sum unless it is the target_info metric, which is used to populate [resource attributes](#resource-attributes). An OpenMetrics Info can be thought of as a special-case of the OpenMetrics Gauge which has a value of 1, and whose labels generally stays constant over the life of the process. It is converted to a Non-Monotonic Sum, rather than a Gauge, because the value of 1 is intended to be viewed as a count, which should be summed together when aggregating away labels.
 
 ### StateSet
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/wg-prometheus/issues/72

## Changes

We currently require Prometheus -> OpenTelemetry translation to remove type and unit suffixes in metric names.  For example, the Prometheus metric `http_request_duration_seconds_total` would become `http_request_duration` in the resulting OTel metric.  When this change was made, it received a large amount of user pushback, as it broke many existing metric names.

This PR makes trimming suffixes from names disabled by default, and encourages implementations to provide a config knob to enable the suffix trimming.

The original motivation for trimming suffixes by default was so that metrics could be round-tripped between an OTel SDK and the collector through the prometheus endpoint.  For example, the OTel metric [`process.network.io`](https://opentelemetry.io/docs/specs/otel/metrics/semantic_conventions/process-metrics/#process) becomes `process_network_io_bytes_total` with type and unit suffixes.  When converting that back to OpenTelemetry, trimming suffixes would result in `process_network_io`, which is close to the original OpenTelemetry metric name, but isn't the same as the original.

We would like to make the removal of suffixes disabled by default because:

* It eliminates a breaking change for users
* It would preserve the name for existing prometheus metrics (e.g. not from OTel instrumentation) which many users are familiar with.
* Removing suffixes doesn't/didn't achieve the objective of round-tripping the metric name because `.` are substituted for `_`.

cc @open-telemetry/wg-prometheus @jmacd @gouthamve 
