### PR TITLE
Prometheus compatibility: don't add duplicate _total suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,8 @@ release.
 
 ### Compatibility
 
-- Prometheus: Do not add _total suffix if the metric already ends in _total.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-specification/pull/TODO))
+- Prometheus: Do not add `_total` suffix if the metric already ends in `_total`.
+  ([#3581](https://github.com/open-telemetry/opentelemetry-specification/pull/3581))
 
 ### OpenTelemetry Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ release.
 
 ### Compatibility
 
+- Prometheus: Do not add _total suffix if the metric already ends in _total.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-specification/pull/TODO))
+
 ### OpenTelemetry Protocol
 
 ### SDK Configuration

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -279,7 +279,7 @@ An [OpenTelemetry Gauge](../metrics/data-model.md#gauge) MUST be converted to a 
   - The new data point's start time must match the time of the accumulated data point. If not, see [detecting alignment issues](../metrics/data-model.md#sums-detecting-alignment-issues).
 - Otherwise, it MUST be dropped.
 
-Monotonic Sum metric points MUST have `_total` added as a suffix to the metric name.
+Monotonic Sum metric points MUST have `_total` added as a suffix to the metric name, if it does not already end in `_total`.
 Monotonic Sum metric points with `StartTimeUnixNano` should export the `{name}_created` metric as well.
 
 ### Histograms

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -279,7 +279,7 @@ An [OpenTelemetry Gauge](../metrics/data-model.md#gauge) MUST be converted to a 
   - The new data point's start time must match the time of the accumulated data point. If not, see [detecting alignment issues](../metrics/data-model.md#sums-detecting-alignment-issues).
 - Otherwise, it MUST be dropped.
 
-Monotonic Sum metric points MUST have `_total` added as a suffix to the metric name, if it does not already end in `_total`.
+If the metric name for monotonic Sum metric points does not end in a suffix of `_total` a suffix of `_total` MUST be added, otherwise the name MUST remain unchanged.
 Monotonic Sum metric points with `StartTimeUnixNano` should export the `{name}_created` metric as well.
 
 ### Histograms


### PR DESCRIPTION
Clarifies that _total does not need to be added as a suffix to counters if it already exists.  There was confusion in https://github.com/open-telemetry/opentelemetry-java/issues/5304#issuecomment-1523356583 if that was correct or not.

cc @open-telemetry/wg-prometheus @jack-berg
