### PR TITLE
Release 1.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ release.
 
 ### Traces
 
+### Metrics
+
+### Logs
+
+### Resource
+
+### Compatibility
+
+### SDK Configuration
+
+### Common
+
+### Supplemenatary Guidelines
+
+## v1.23.0 (2023-07-07)
+
+### Context
+
+-  No changes.
+
+### Traces
+
 - Make SDK Tracer Creation more normative.
   ([#3529](https://github.com/open-telemetry/opentelemetry-specification/pull/3529))
 
@@ -32,23 +54,25 @@ release.
 
 ### Resource
 
+-  No changes.
+
 ### Compatibility
-
-### OpenTelemetry Protocol
-
-### SDK Configuration
-
-- Extract Examplar section and mark it as Experimental.
-  ([#3533](https://github.com/open-telemetry/opentelemetry-specification/pull/3533))
 
 - BREAKING: Remove the Jaeger Exporter
   ([#3567](https://github.com/open-telemetry/opentelemetry-specification/pull/3567))
 
-### Telemetry Schemas
+### SDK Configuration
+
+- Extract Exemplar section and mark it as Experimental.
+  ([#3533](https://github.com/open-telemetry/opentelemetry-specification/pull/3533))
 
 ### Common
 
+-  No changes.
+
 ### Supplemenatary Guidelines
+
+-  No changes.
 
 ## v1.22.0 (2023-06-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ release.
 
 ### Context
 
--  No changes.
+- No changes.
 
 ### Traces
 
@@ -54,7 +54,7 @@ release.
 
 ### Resource
 
--  No changes.
+- No changes.
 
 ### Compatibility
 
@@ -68,11 +68,11 @@ release.
 
 ### Common
 
--  No changes.
+- No changes.
 
 ### Supplemenatary Guidelines
 
--  No changes.
+- No changes.
 
 ## v1.22.0 (2023-06-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ release.
 
 ### Supplemenatary Guidelines
 
-## v1.23.0 (2023-07-07)
+## v1.23.0 (2023-07-10)
 
 ### Context
 
@@ -62,7 +62,7 @@ release.
 
 ### Compatibility
 
-- BREAKING: Remove the Jaeger Exporter
+- NOTICE: Remove the Jaeger Exporter
   ([#3567](https://github.com/open-telemetry/opentelemetry-specification/pull/3567))
 - Prometheus: Do not add `_total` suffix if the metric already ends in `_total`.
   ([#3581](https://github.com/open-telemetry/opentelemetry-specification/pull/3581))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ release.
 
 ### Supplemenatary Guidelines
 
-## v1.23.0 (2023-07-10)
+## v1.23.0 (2023-07-11)
 
 ### Context
 
@@ -48,6 +48,8 @@ release.
   ([#3524](https://github.com/open-telemetry/opentelemetry-specification/pull/3524))
 - Make SDK Meter Creation more normative.
   ([#3529](https://github.com/open-telemetry/opentelemetry-specification/pull/3529))
+- Clarify duplicate instrument registration scope to be a MeterProvider.
+  ([#3538](https://github.com/open-telemetry/opentelemetry-specification/pull/3538))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ release.
 
 ### Supplemenatary Guidelines
 
-## v1.23.0 (2023-07-11)
+## v1.23.0 (2023-07-12)
 
 ### Context
 
@@ -68,7 +68,8 @@ release.
   ([#3567](https://github.com/open-telemetry/opentelemetry-specification/pull/3567))
 - Prometheus: Do not add `_total` suffix if the metric already ends in `_total`.
   ([#3581](https://github.com/open-telemetry/opentelemetry-specification/pull/3581))
-- Prometheus type and unit suffixes are not trimmed by default. ([#3580](https://github.com/open-telemetry/opentelemetry-specification/pull/3580))
+- Prometheus type and unit suffixes are not trimmed by default.
+  ([#3580](https://github.com/open-telemetry/opentelemetry-specification/pull/3580))
 
 ### SDK Configuration
 


### PR DESCRIPTION
July Release.

PS - removed the "Protocol" and "Telemetry Schemas" sections of the CHANGELOG, as they now reside in their respective repos.