### PR TITLE
Clarify identical instrument definition for SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ release.
   ([#3524](https://github.com/open-telemetry/opentelemetry-specification/pull/3524))
 - Make SDK Meter Creation more normative.
   ([#3529](https://github.com/open-telemetry/opentelemetry-specification/pull/3529))
+- Clarify identical instrument definition for SDK.
+  ([#3585](https://github.com/open-telemetry/opentelemetry-specification/pull/3585))
 
 ### Logs
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -191,6 +191,9 @@ are identified by all of these fields.
 Language-level features such as the distinction between integer and
 floating point numbers SHOULD be considered as identifying.
 
+The term *identical* applied to an Instrument describes instances where all
+identifying fields are equal.
+
 ### General characteristics
 
 #### Instrument name syntax

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -778,10 +778,10 @@ fields](./api.md#instrument) are equal.  The term _distinct_ applied
 to Instruments describes instances where at least one field value is
 different.
 
-Based on [the recommendations from the data
+To accomidate [the recommendations from the data
 model](data-model.md#opentelemetry-protocol-data-model-producer-recommendations),
-the SDK MUST aggregate data from identical Instruments together in its export
-pipeline.
+the SDK MUST aggregate data from [identical Instruments](api.md#instrument)
+together in its export pipeline.
 
 When a duplicate instrument registration occurs, and it is not corrected with a
 View, a warning SHOULD be emitted. The emitted warning SHOULD include


### PR DESCRIPTION
Currently, the SDK states that identical instruments need to have their data aggregated together. It is implied that the definition of "identical" is defined by the metric data-model. However, the linked data-model defines identical in a way that does not include the Instrument number type. Therefore, if two instruments are "identical" in all their fields, but one if defined for double-precision floating point values and the other integer values they will need to be aggregated together. This is challenging if not impossible for strongly typed implementations.

Instead, have the SDK explicitly use the definition added to the metric API defining the number type (and all other language-level features) as identifying and therefore included in the definition of identical.

This does mean that the issue of unifying instruments that differ only by the number type of the data values is left for downstream (e.g. exporter, collector) elements to handle.