### PR TITLE
Fix semantic-conventions link to the yaml files.

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -79,7 +79,7 @@ Both the collector and the client libraries SHOULD autogenerate semantic
 convention keys and enum values into constants (or language idiomatic
 equivalent). Generated values shouldn't be distributed in stable packages
 until semantic conventions are stable.
-The [YAML](https://github.com/open-telemetry/semantic-conventions/tree/main/semantic_conventions) files MUST be used as the
+The [YAML](https://github.com/open-telemetry/semantic-conventions/tree/main/model) files MUST be used as the
 source of truth for generation. Each language implementation SHOULD
 provide language-specific support to the
 [code generator](https://github.com/open-telemetry/build-tools/tree/main/semantic-conventions#code-generator).


### PR DESCRIPTION
Currently the build is broken as location were massaged in the semantic-conventions repository.