### PR TITLE
Prom compatibility: allow disabling the addition of _total suffixes on prometheus counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ release.
 - Prometheus: Do not add `_total` suffix if the metric already ends in `_total`.
   ([#3581](https://github.com/open-telemetry/opentelemetry-specification/pull/3581))
 - Prometheus type and unit suffixes are not trimmed by default. ([#3580](https://github.com/open-telemetry/opentelemetry-specification/pull/3580))
+- Prometheus exporters SHOULD provide configuration to disable the addition of `_total` suffixes. ([#3590](https://github.com/open-telemetry/opentelemetry-specification/pull/3590))
 
 ### OpenTelemetry Protocol
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -276,7 +276,7 @@ An [OpenTelemetry Gauge](../metrics/data-model.md#gauge) MUST be converted to a 
   - The new data point's start time must match the time of the accumulated data point. If not, see [detecting alignment issues](../metrics/data-model.md#sums-detecting-alignment-issues).
 - Otherwise, it MUST be dropped.
 
-If the metric name for monotonic Sum metric points does not end in a suffix of `_total` a suffix of `_total` MUST be added, otherwise the name MUST remain unchanged.
+If the metric name for monotonic Sum metric points does not end in a suffix of `_total` a suffix of `_total` MUST be added by default, otherwise the name MUST remain unchanged. Exporters SHOULD provide a configuration option to disable the addition of `_total` suffixes.
 Monotonic Sum metric points with `StartTimeUnixNano` should export the `{name}_created` metric as well.
 
 ### Histograms


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-go/issues/4305

### Motivation

When migrating from OpenCensus to OpenTelemetry, and using Prometheus exporters, it causes a breaking change in the metric name for counters that were not complying with Prometheus naming recommendations. This is because OpenCensus does not add `_total` suffixes for counters. For example, the metric `my.metric.foo` became `my_metric_foo` in OpenCensus. But in OpenTelemetry, it now becomes `my_metric_foo_total`.

## Changes

Prometheus exporters should allow disabling the addition of `_total` suffixes through configuration.

cc @open-telemetry/wg-prometheus @jmacd @jsuereth 
