### PR TITLE
[CI/editorial] Report link-check error when external URL used for local spec page

### DIFF
--- a/.markdown_link_check_config.json
+++ b/.markdown_link_check_config.json
@@ -6,8 +6,12 @@
   ],
   "replacementPatterns": [
     {
-        "pattern": "^/",
-        "replacement": "{{BASEURL}}/"
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/"
+    },
+    {
+      "pattern": "^https://github.com/open-telemetry/opentelemetry-specification/(blob|tree)/[^/]+/(specification|supplementary-guidelines)/",
+      "replacement": "LINK-CHECK-ERROR-USE-LOCAL-PATH-TO-DOC-PAGE-NOT-EXTERNAL-URL/"
     }
   ],
   "retryOn429": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1705,7 +1705,7 @@ Added telemetry schemas documents to the specification ([#2008](https://github.c
 - Implementations can ignore links with invalid SpanContext([#1492](https://github.com/open-telemetry/opentelemetry-specification/pull/1492))
 - Add `none` as a possible value for OTEL_TRACES_EXPORTER to disable export
   ([#1439](https://github.com/open-telemetry/opentelemetry-specification/pull/1439))
-- Add [`ForceFlush`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#forceflush) to SDK's `TracerProvider` ([#1452](https://github.com/open-telemetry/opentelemetry-specification/pull/1452))
+- Add [`ForceFlush`](/specification/trace/sdk.md#forceflush) to SDK's `TracerProvider` ([#1452](https://github.com/open-telemetry/opentelemetry-specification/pull/1452))
 
 ### Metrics
 


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/2429
  - This is part of an effort to normalize links, for improved link checking on the OTel website.
- This is meant to catch and prevent fixes like with a local check in this repo rather than the OTel-website build:
  - #3375
  - #3310

/cc @svrnm @cartermp @jsuereth 