### PR TITLE
[editorial] Hugo front-matter fixes for aliases and linkTitle

### DIFF
--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -1,6 +1,7 @@
 <!--- Hugo front matter used to generate the website version of this page:
 aliases: [/docs/reference/specification/common/common]
 --->
+
 # Common specification concepts
 
 **Status**: [Stable, Feature-freeze](../document-status.md)

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: OpenCensus
+--->
+
 # OpenCensus Compatibility
 
 **Status**: [Stable](../document-status.md), Unless otherwise specified.

--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -1,3 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: OpenTracing
+--->
+
 # OpenTracing Compatibility
 
 **Status**: [Stable](../document-status.md).

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -1,3 +1,10 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Prometheus and OpenMetrics
+aliases:
+  - /docs/reference/specification/compatibility/openmetrics
+  - /docs/specs/otel/compatibility/openmetrics
+--->
+
 # Prometheus and OpenMetrics Compatibility
 
 **Status**: [Experimental](../document-status.md)

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -1,7 +1,9 @@
 <!--- Hugo front matter used to generate the website version of this page:
 title: Environment Variable Specification
 linkTitle: Env var
-aliases: [/docs/reference/specification/sdk-environment-variables]
+aliases:
+  - /docs/reference/specification/sdk-environment-variables
+  - /docs/specs/otel/sdk-environment-variables
 --->
 
 # OpenTelemetry Environment Variable Specification

--- a/specification/context/README.md
+++ b/specification/context/README.md
@@ -1,6 +1,7 @@
 <!--- Hugo front matter used to generate the website version of this page:
 aliases: [/docs/reference/specification/context/context]
 --->
+
 # Context
 
 **Status**: [Stable, Feature-freeze](../document-status.md).

--- a/specification/logs/noop.md
+++ b/specification/logs/noop.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: noop
+linkTitle: No-Op
 --->
 
 # Logs Bridge API No-Op Implementation

--- a/specification/metrics/noop.md
+++ b/specification/metrics/noop.md
@@ -1,5 +1,5 @@
 <!--- Hugo front matter used to generate the website version of this page:
-linkTitle: noop
+linkTitle: No-Op
 --->
 
 # Metrics No-Op API Implementation


### PR DESCRIPTION
- Followup changes for https://github.com/open-telemetry/opentelemetry.io/issues/2793
- There are only changes to Hugo front matter
- Adds `likeTitle`s for "Compatibility" pages
- Adds aliases for pages that have moved or were renamed
  - Related: https://github.com/open-telemetry/opentelemetry.io/issues/3013 -- the `compatibility/openmetrics` spec page is in the list because it was renamed

/cc @svrnm @cartermp 