### PR TITLE
Add opencensus compatibility spec compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -339,10 +339,17 @@ Note: Support for environment variables is optional.
 | Error Status mapping                                                           |          | +  | +    |    | +           | +    | -      | +   | +    | +   | +    | -     |
 | Event attributes mapping to Annotations                                        |          | +  | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
 | Integer microseconds in timestamps                                             |          | N/A| +    |    | +           | +    | -      | +   | +    | +   | +    | +     |
-| **OpenCensus**                                                                 |          |    |      |    |             |      |        |     |      |     |      |       |
-| TBD                                                                            |          |    |      |    |             |      |        |     |      |     |      |       |
 | **Prometheus**                                                                 |          |    |      |    |             |      |        |     |      |     |      |       |
 | TBD                                                                            |          |    |      |    |             |      |        |     |      |     |      |       |
+
+## OpenCensus Compatibility
+
+Languages not covered by the OpenCensus project, or that did not reach Alpha, are not listed here.
+
+| Feature                                                                                                 |Go |Java|JS |Python|C++|.NET|Erlang|
+|---------------------------------------------------------------------------------------------------------|---|----|---|------|----|---|----|
+| [Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)   |  + |  +  | +  |   +   |  -  | -  |  -  |
+| [Metric Bridge](specification/compatibility/opencensus.md#metrics--stats) |  + |  +  | -  |   -   |  -  | -  |  -  |
 
 ## OpenTracing Compatibility
 


### PR DESCRIPTION
Document the current state of OpenCensus bridges in the spec compliance matrix.

Go

* metric: https://github.com/open-telemetry/opentelemetry-go/blob/main/bridge/opencensus/metric.go#L40
* trace: https://github.com/open-telemetry/opentelemetry-go/blob/main/bridge/opencensus/bridge.go#L29

Java:

* metric: https://github.com/open-telemetry/opentelemetry-java/tree/main/opencensus-shim#metrics
* trace: https://github.com/open-telemetry/opentelemetry-java/tree/main/opencensus-shim#traces

Python

* trace: https://github.com/open-telemetry/opentelemetry-python/tree/main/shim/opentelemetry-opencensus-shim/src/opentelemetry/shim/opencensus

JS: 

* trace: https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/shim-opencensus
