### PR TITLE
fix: correct attribute of Histogram in Python

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -760,8 +760,8 @@ API](../overview.md#api) authors might consider:
 ```python
 # Python
 
-http_server_duration.Record(50, {"http.request.method": "POST", "url.scheme": "https"})
-http_server_duration.Record(100, http_method="GET", http_scheme="http")
+http_server_duration.record(50, {"http.request.method": "POST", "url.scheme": "https"})
+http_server_duration.record(100, http_method="GET", http_scheme="http")
 ```
 
 ```csharp


### PR DESCRIPTION
## Changes

Histogram class does not contain the function `Record`. It should be changed as `record`

