### PR TITLE
MetricProducers are passed via config to MetricReaders instead of RegisterProducer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
   ([#3546](https://github.com/open-telemetry/opentelemetry-specification/pull/3546))
 - Revise the exemplar default reservoirs.
   ([#3627](https://github.com/open-telemetry/opentelemetry-specification/pull/3627))
+- MetricProducers are provided as config to MetricReaders instead of through a RegisterProducer operation.
+  ([#3613](https://github.com/open-telemetry/opentelemetry-specification/pull/3613))
 
 ### Logs
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -59,7 +59,6 @@ linkTitle: SDK
     + [AlignedHistogramBucketExemplarReservoir](#alignedhistogrambucketexemplarreservoir)
 - [MetricReader](#metricreader)
   * [MetricReader operations](#metricreader-operations)
-    + [RegisterProducer(metricProducer)](#registerproducermetricproducer)
     + [Collect](#collect)
     + [Shutdown](#shutdown-1)
   * [Periodic exporting MetricReader](#periodic-exporting-metricreader)
@@ -1047,6 +1046,7 @@ SHOULD provide at least the following:
 * The default output `aggregation` (optional), a function of instrument kind.  If not configured, the [default aggregation](#default-aggregation) SHOULD be used.
 * The default output `temporality` (optional), a function of instrument kind.  If not configured, the Cumulative temporality SHOULD be used.
 * **Status**: [Experimental](../document-status.md) - The default aggregation cardinality limit to use, a function of instrument kind.  If not configured, a default value of 2000 SHOULD be used.
+* **Status**: [Experimental](../document-status.md) - Zero of more [MetricProducer](#metricproducer)s (optional) to collect metrics from in addition to metrics from the SDK.
 
 The [MetricReader.Collect](#collect) method allows general-purpose
 `MetricExporter` instances to explicitly initiate collection, commonly
@@ -1102,21 +1102,6 @@ idiomatic approach, for example, as `OnForceFlush` and `OnShutdown` callback
 functions.
 
 ### MetricReader operations
-
-#### RegisterProducer(metricProducer)
-
-**Status**: [Experimental](../document-status.md)
-
-RegisterProducer causes the MetricReader to use the provided
-[MetricProducer](#metricproducer) as a source of aggregated metric data in
-subsequent invocations of Collect. RegisterProducer is expected to be called
-during initialization, but MAY be invoked later. Multiple registrations
-of the same MetricProducer MAY result in duplicate metric data being collected.
-
-If the [MeterProvider](#meterprovider) is an instance of
-[MetricProducer](#metricproducer), this MAY be used to register the
-MeterProvider, but MUST NOT allow multiple [MeterProviders](#meterprovider)
-to be registered with the same MetricReader.
 
 #### Collect
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/3611

## Changes

This change moves the registration of MetricProducers from a RegisterProducer function to a configuration option on the MetricReader.

The only potentially breaking impact of this change is that a user can no longer register new MetricProducers after the MetricReader is created.  For example, it wouldn't be possible to dynamically register new MetricProducers.  I don't know of any use-cases for this.

### Explanation

Since it isn't feasible for JS to implement the spec as currently written, so we need to at least allow passing MetricProducers as config instead of via RegisterProducer.

However, it would be best if we had a consistent implantation across languages, and when I [prototyped using configuration in Go](https://github.com/open-telemetry/opentelemetry-go/pull/4346), it simplified the implementation, and improved the user experience.

Given that both Go and JS would prefer to have them passed as configuration, rather than registration, and no other prototypes or implementations exist, I think it makes more sense to adapt the specification to require using configuration.

### History

The RegisterProducer method was originally proposed and discussed here: https://github.com/open-telemetry/opentelemetry-specification/pull/2722#discussion_r948113827.  I've spoken with the author after reviewing the prototype, and we both agree that configuration is actually a better way to pass MetricProducers.