### PR TITLE
Remove guidance about when users should call ForceFlush from the specification

### DIFF
--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -285,11 +285,6 @@ it has made to achieve this goal.
 `ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
 failed or timed out.
 
-`ForceFlush` SHOULD only be called in cases where it is absolutely necessary,
-such as when using some FaaS providers that may suspend the process after an
-invocation, but before the `LogRecordProcessor` exports the
-emitted `LogRecord`s.
-
 `ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
 implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. OpenTelemetry SDK authors can decide if they want to
@@ -400,10 +395,6 @@ soon as possible, preferably before returning from this method.
 
 `ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
 failed or timed out.
-
-`ForceFlush` SHOULD only be called in cases where it is absolutely necessary,
-such as when using some FaaS providers that may suspend the process after an
-invocation, but before the exporter exports the `ReadlableLogRecords`.
 
 `ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
 implemented as a blocking API or an asynchronous API which notifies the caller

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1317,10 +1317,6 @@ possible, preferably before returning from this method.
 `ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
 failed or timed out.
 
-`ForceFlush` SHOULD only be called in cases where it is absolutely necessary,
-such as when using some FaaS providers that may suspend the process after an
-invocation, but before the exporter exports the completed metrics.
-
 `ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
 implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. [OpenTelemetry SDK](../overview.md#sdk) authors MAY

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -567,10 +567,6 @@ calls it has made to achieve this goal.
 `ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
 failed or timed out.
 
-`ForceFlush` SHOULD only be called in cases where it is absolutely necessary,
-such as when using some FaaS providers that may suspend the process after an
-invocation, but before the `SpanProcessor` exports the completed spans.
-
 `ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
 implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. OpenTelemetry client authors can decide if they want to
@@ -716,10 +712,6 @@ returning from this method.
 
 `ForceFlush` SHOULD provide a way to let the caller know whether it succeeded,
 failed or timed out.
-
-`ForceFlush` SHOULD only be called in cases where it is absolutely necessary,
-such as when using some FaaS providers that may suspend the process after an
-invocation, but before the exporter exports the completed spans.
 
 `ForceFlush` SHOULD complete or abort within some timeout. `ForceFlush` can be
 implemented as a blocking API or an asynchronous API which notifies the caller


### PR DESCRIPTION
## Changes

The spec for metric exporter's ForceFlush method doesn't currently have any guidance for the SDK authors.  Instead, it appears to provide guidance to users about when they should call ForceFlush.

This PR removes that guidance because it is not relevant to the specification of the SDK.

As an alternative, we could keep the guidance, but clarify that SDK authors SHOULD document ForceFlush with it.  This was rejected in https://github.com/open-telemetry/opentelemetry-specification/pull/3620#pullrequestreview-1544241954

Originally raised here: https://github.com/open-telemetry/opentelemetry-go/pull/4359#pullrequestreview-1544123236
