### PR TITLE
Remove Object Oriented language from metric SDK

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1042,9 +1042,10 @@ SHOULD provide at least the following:
 
 The [MetricReader.Collect](#collect) method allows general-purpose
 `MetricExporter` instances to explicitly initiate collection, commonly
-used with pull-based metrics collection.  A common sub-class of
-`MetricReader`, the periodic exporting `MetricReader` SHOULD be provided
-to be used typically with push-based metrics collection.
+used with pull-based metrics collection.  A common implementation of
+`MetricReader`, the [periodic exporting
+`MetricReader`](#periodic-exporting-metricreader) SHOULD be provided to be used
+typically with push-based metrics collection.
 
 The `MetricReader` MUST ensure that data points from OpenTelemetry
 [instruments](./api.md#instrument) are output in the configured aggregation


### PR DESCRIPTION
Not all implementations have the concept of classes in their languages. Instead, consistently use the term implementation which is used in the periodic exporting reader section.