### PR TITLE
logs: Document Flags mapping in Google Cloud logs appendix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ release.
 
 ### Logs
 
+- Update GCP data model to use `Flags` instead of
+  `gcp.trace_sampled`. ([#3629](https://github.com/open-telemetry/opentelemetry-specification/pull/3629))
+
 ### Resource
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ release.
 
 ### Logs
 
-- Update GCP data model to use `Flags` instead of
+- Update GCP data model to use `TraceFlags` instead of
   `gcp.trace_sampled`. ([#3629](https://github.com/open-telemetry/opentelemetry-specification/pull/3629))
 
 ### Resource

--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -495,6 +495,7 @@ trace            | string             | The trace associated with the log entry,
 span_id          | string             | The span ID within the trace associated with the log entry. | SpanId
 labels           | map<string,string> | A set of user-defined (key, value) data that provides additional information about the log entry. | Attributes
 http_request     | HttpRequest        | The HTTP request associated with the log entry, if any. | Attributes["gcp.http_request"]
+trace_sampled    | boolean            | The sampling decision of the trace associated with the log entry. | Flags
 All other fields |                    |                                                         | Attributes["gcp.*"]
 
 ### Elastic Common Schema

--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -495,7 +495,7 @@ trace            | string             | The trace associated with the log entry,
 span_id          | string             | The span ID within the trace associated with the log entry. | SpanId
 labels           | map<string,string> | A set of user-defined (key, value) data that provides additional information about the log entry. | Attributes
 http_request     | HttpRequest        | The HTTP request associated with the log entry, if any. | Attributes["gcp.http_request"]
-trace_sampled    | boolean            | The sampling decision of the trace associated with the log entry. | Flags
+trace_sampled    | boolean            | The sampling decision of the trace associated with the log entry. | TraceFlags.SAMPLED
 All other fields |                    |                                                         | Attributes["gcp.*"]
 
 ### Elastic Common Schema


### PR DESCRIPTION
## Changes

GCP logging exporters should support the IsSampled flag, for example https://github.com/GoogleCloudPlatform/opentelemetry-operations-go/pull/690 adds this support.

Currently, this is supported by the `gcp.trace_sampled` attribute (by way of our [mapping for "All other fields"](https://github.com/open-telemetry/opentelemetry-specification/blob/dc78006c12d9767fd2e35b691706c7572a76fd43/specification/logs/data-model-appendix.md#google-cloud-logging) to a matching `gcp.*` attribute).

Therefore, in the spec this is a breaking change (from `gcp.trace_sampled` to `Flags`), but implementations can continue to support the attribute for backward-compatibility.

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
