### PR TITLE
Fix inconsistent tracestate reference

### DIFF
--- a/specification/overview.md
+++ b/specification/overview.md
@@ -188,7 +188,7 @@ propagated from parent to child **Spans**.
 - **Tracestate** carries tracing-system specific context in a list of key value
   pairs. **Tracestate** allows different vendors propagate additional
   information and inter-operate with their legacy Id formats. For more details
-  see [this](https://w3c.github.io/trace-context/#tracestate-field).
+  see [this](https://www.w3.org/TR/trace-context/#tracestate-header).
 
 ### Links between spans
 


### PR DESCRIPTION
## Changes

I just would like to report that all links to W3C tracestate specifications are either:
* https://www.w3.org/TR/trace-context/#tracestate-header or,
* https://www.w3.org/TR/trace-context/#tracestate-header-field-values 

But `specification/overview.md` is using:
*  https://w3c.github.io/trace-context/#tracestate-field (not the same document/version).

Do you need me to open an issue first?
