### PR TITLE
Add OTLP partial success message handling to compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,8 +325,8 @@ Note: Support for environment variables is optional.
 | SchemaURL in ResourceMetrics and ScopeMetrics                                  |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | SchemaURL in ResourceLogs and ScopeLogs                                        |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent)    |          |    |      |    |             |      |        | +   |      |     | +    |       |
-| [Partial Success](specification/protocol/otlp.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        |    |      |    |             |      |        |     |      |     |      |       |
-| [Partial Success](specification/protocol/otlp.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        |    |      |    |             |      |        |     |      |     |      |       |
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)**                      | Optional | Go  | Java | JS  | Python    | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Zipkin V1 JSON                                                                 | X        | -  | +    |    | +           | -    | -      | -   | -    | -   | -    | -     |
 | Zipkin V1 Thrift                                                               | X        | -  | +    |    | [-][py1174] | -    | -      | -   | -    | -   | -    | -     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,6 +325,9 @@ Note: Support for environment variables is optional.
 | SchemaURL in ResourceMetrics and ScopeMetrics                                  |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | SchemaURL in ResourceLogs and ScopeLogs                                        |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent)    |          |    |      |    |             |      |        | +   |      |     | +    |       |
+| [Partial Success](specification/protocol/exporter.md#partial-success) messages are handled and logged for OTLP/gRPC   |          |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](specification/protocol/exporter.md#partial-success-1) messages are handled and logged for OTLP/HTTP |          |    |      |    |             |      |        |     |      |     |      |       |
+
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)**                      | Optional | Go  | Java | JS  | Python    | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Zipkin V1 JSON                                                                 | X        | -  | +    |    | +           | -    | -      | -   | -    | -   | -    | -     |
 | Zipkin V1 Thrift                                                               | X        | -  | +    |    | [-][py1174] | -    | -      | -   | -    | -   | -    | -     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,8 +325,8 @@ Note: Support for environment variables is optional.
 | SchemaURL in ResourceMetrics and ScopeMetrics                                  |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | SchemaURL in ResourceLogs and ScopeLogs                                        |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent)    |          |    |      |    |             |      |        | +   |      |     | +    |       |
-| [Partial Success](specification/protocol/exporter.md#partial-success) messages are handled and logged for OTLP/gRPC   |          |    |      |    |             |      |        |     |      |     |      |       |
-| [Partial Success](specification/protocol/exporter.md#partial-success-1) messages are handled and logged for OTLP/HTTP |          |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](specification/protocol/exporter.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](specification/protocol/exporter.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        |    |      |    |             |      |        |     |      |     |      |       |
 
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)**                      | Optional | Go  | Java | JS  | Python    | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Zipkin V1 JSON                                                                 | X        | -  | +    |    | +           | -    | -      | -   | -    | -   | -    | -     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,9 +325,8 @@ Note: Support for environment variables is optional.
 | SchemaURL in ResourceMetrics and ScopeMetrics                                  |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | SchemaURL in ResourceLogs and ScopeLogs                                        |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent)    |          |    |      |    |             |      |        | +   |      |     | +    |       |
-| [Partial Success](specification/protocol/exporter.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        |    |      |    |             |      |        |     |      |     |      |       |
-| [Partial Success](specification/protocol/exporter.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        |    |      |    |             |      |        |     |      |     |      |       |
-
+| [Partial Success](specification/protocol/otlp.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](specification/protocol/otlp.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        |    |      |    |             |      |        |     |      |     |      |       |
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)**                      | Optional | Go  | Java | JS  | Python    | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Zipkin V1 JSON                                                                 | X        | -  | +    |    | +           | -    | -      | -   | -    | -   | -    | -     |
 | Zipkin V1 Thrift                                                               | X        | -  | +    |    | [-][py1174] | -    | -      | -   | -    | -   | -    | -     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,8 +325,8 @@ Note: Support for environment variables is optional.
 | SchemaURL in ResourceMetrics and ScopeMetrics                                  |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | SchemaURL in ResourceLogs and ScopeLogs                                        |          |    | +    |    | +           |      | -      | +   |      |     | -    |       |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent)    |          |    |      |    |             |      |        | +   |      |     | +    |       |
-| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        |    |      |    |             |      |        |     |      |     |      |       |
-| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        |    |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        | +  |      |    |             |      |        |     |      |     |      |       |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        | +  |      |    |             |      |        |     |      |     |      |       |
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)**                      | Optional | Go  | Java | JS  | Python    | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Zipkin V1 JSON                                                                 | X        | -  | +    |    | +           | -    | -      | -   | -    | -   | -    | -     |
 | Zipkin V1 Thrift                                                               | X        | -  | +    |    | [-][py1174] | -    | -      | -   | -    | -   | -    | -     |


### PR DESCRIPTION
I noticed that the handling of the partial success message introduced more than a year ago in https://github.com/open-telemetry/opentelemetry-specification/pull/2696 is only implemented in a few SDKs. This adds it to the spec compliance matrix to keep track of adoption.

Related issues:

- https://github.com/open-telemetry/opentelemetry-go/issues/3102
- https://github.com/open-telemetry/opentelemetry-python/issues/2882
- https://github.com/open-telemetry/opentelemetry-js/issues/3183
- https://github.com/open-telemetry/opentelemetry-dotnet/issues/3592
- https://github.com/open-telemetry/opentelemetry-cpp/issues/1577
- https://github.com/open-telemetry/opentelemetry-java/issues/4706
- https://github.com/open-telemetry/opentelemetry-erlang/issues/436
- https://github.com/open-telemetry/opentelemetry-rust/issues/865
- https://github.com/open-telemetry/opentelemetry-ruby/issues/1361
- https://github.com/open-telemetry/opentelemetry-php/issues/802
- https://github.com/open-telemetry/opentelemetry-swift/issues/320
- https://github.com/open-telemetry/opentelemetry-collector/issues/6686

cc @jmacd 