### PR TITLE
metrics: Define name syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
   ([#3546](https://github.com/open-telemetry/opentelemetry-specification/pull/3546))
 - Revise the exemplar default reservoirs.
   ([#3627](https://github.com/open-telemetry/opentelemetry-specification/pull/3627))
+- Have the same name syntax for meter name and instrument name.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-specification/pull/TODO))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ release.
 - Revise the exemplar default reservoirs.
   ([#3627](https://github.com/open-telemetry/opentelemetry-specification/pull/3627))
 - Have the same name syntax for meter name and instrument name.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-specification/pull/TODO))
+  ([#3643](https://github.com/open-telemetry/opentelemetry-specification/pull/3643))
 
 ### Logs
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -19,7 +19,6 @@ linkTitle: API
   * [Meter operations](#meter-operations)
 - [Instrument](#instrument)
   * [General characteristics](#general-characteristics)
-    + [Instrument name syntax](#instrument-name-syntax)
     + [Instrument unit](#instrument-unit)
     + [Instrument description](#instrument-description)
     + [Instrument advice](#instrument-advice)
@@ -49,6 +48,7 @@ linkTitle: API
     + [Asynchronous UpDownCounter operations](#asynchronous-updowncounter-operations)
 - [Measurement](#measurement)
   * [Multiple-instrument callbacks](#multiple-instrument-callbacks)
+- [Name syntax](#name-syntax)
 - [Compatibility requirements](#compatibility-requirements)
 - [Concurrency requirements](#concurrency-requirements)
 
@@ -124,6 +124,10 @@ This API MUST accept the following parameters:
   library](../glossary.md#instrumentation-library) can refer to the same
   library. In that scenario, the `name` denotes a module name or component name
   within that library or application.
+
+  The API SHOULD be documented in a way to communicate to users that the `name`
+  parameter needs to conform to the [name syntax](#name-syntax). The API SHOULD
+  NOT validate the `name`; that is left to implementations of the API.
 * `version`: Specifies the version of the instrumentation scope if the scope
   has a version (e.g. a library version). Example value: `1.0.0`.
   
@@ -195,25 +199,6 @@ The term *identical* applied to an Instrument describes instances where all
 identifying fields are equal.
 
 ### General characteristics
-
-#### Instrument name syntax
-
-The instrument name syntax is defined below using the [Augmented Backus-Naur
-Form](https://tools.ietf.org/html/rfc5234):
-
-```abnf
-instrument-name = ALPHA 0*62 ("_" / "." / "-" / ALPHA / DIGIT)
-
-ALPHA = %x41-5A / %x61-7A; A-Z / a-z
-DIGIT = %x30-39 ; 0-9
-```
-
-* They are not null or empty strings.
-* They are case-insensitive, ASCII strings.
-* The first character must be an alphabetic character.
-* Subsequent characters must belong to the alphanumeric characters, '_', '.',
-  and '-'.
-* They can have a maximum length of 63 characters.
 
 #### Instrument unit
 
@@ -294,9 +279,8 @@ The API to construct synchronous instruments MUST accept the following parameter
   in a way to communicate to users that this parameter is needed.
   
   The API SHOULD be documented in a way to communicate to users that the `name`
-  parameter needs to conform to the [instrument name
-  syntax](#instrument-name-syntax). The API SHOULD NOT validate the `name`;
-  that is left to implementations of the API.
+  parameter needs to conform to the [name syntax](#name-syntax). The API SHOULD
+  NOT validate the `name`; that is left to implementations of the API.
 * A `unit` of measure.
   
   Users can provide a `unit`, but it is up to their discretion. Therefore, this
@@ -347,9 +331,8 @@ The API to construct asynchronous instruments MUST accept the following paramete
   in a way to communicate to users that this parameter is needed.
   
   The API SHOULD be documented in a way to communicate to users that the `name`
-  parameter needs to conform to the [instrument name
-  syntax](#instrument-name-syntax). The API SHOULD NOT validate the `name`,
-  that is left to implementations of the API.
+  parameter needs to conform to the [name syntax](#name-syntax). The API SHOULD
+  NOT validate the `name`; that is left to implementations of the API.
 * A `unit` of measure.
   
   Users can provide a `unit`, but it is up to their discretion. Therefore, this
@@ -1188,6 +1171,25 @@ class Device:
         result.observe(self.usage, usage, {'property', self.property})
         result.observe(self.pressure, pressure, {'property', self.property})
 ```
+
+## Name syntax
+
+The meter and instrument name syntax is defined below using the
+[Augmented Backus-Naur Form](https://tools.ietf.org/html/rfc5234):
+
+```abnf
+name = ALPHA 0*62 ("_" / "." / "-" / ALPHA / DIGIT)
+
+ALPHA = %x41-5A / %x61-7A; A-Z / a-z
+DIGIT = %x30-39 ; 0-9
+```
+
+* They are not null or empty strings.
+* They are case-insensitive, ASCII strings.
+* The first character must be an alphabetic character.
+* Subsequent characters must belong to the alphanumeric characters, '_', '.',
+  and '-'.
+* They can have a maximum length of 63 characters.
 
 ## Compatibility requirements
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -114,10 +114,13 @@ The input provided by the user MUST be used to create
 an [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which
 is stored on the created `Meter`.
 
-In the case where an invalid `name` (null or empty string) is specified, a
-working Meter MUST be returned as a fallback rather than returning null or
-throwing an exception, its `name` SHOULD keep the original invalid value, and a
-message reporting that the specified value is invalid SHOULD be logged.
+When a MeterProvider creates a Meter, it SHOULD validate the meter name
+conforms to the [name syntax](./api.md#name-syntax).
+
+If the instrument name does not conform to this syntax, a working Meter MUST be
+returned as a fallback rather than returning null or throwing an exception,
+its `name` SHOULD keep the original invalid value, and a message reporting that
+the specified value is invalid SHOULD be logged.
 
 When a Schema URL is passed as an argument when creating a `Meter` the emitted
 telemetry for that `Meter` MUST be associated with the Schema URL, provided
@@ -804,7 +807,7 @@ information for the user on how to resolve the conflict, if possible.
 ### Instrument name
 
 When a Meter creates an instrument, it SHOULD validate the instrument name
-conforms to the [instrument name syntax](./api.md#instrument-name-syntax)
+conforms to the [name syntax](./api.md#name-syntax).
 
 If the instrument name does not conform to this syntax, the Meter SHOULD emit
 an error notifying the user about the invalid name. It is left unspecified if a


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/3579

## Changes

The existing meter name validation is "underpowered" compared to instrument name validation. 

I propose to align and use the same syntax and behavior for both names.

## Why 

I am not sure what are the exact reasons that are behind the existing instrument name syntax, but I guess the same reasons could be applies to meter name syntax. I think it would make the specification more consistent.