### PR TITLE
Define transient error in OTLP exporter specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ release.
 
 ### Resource
 
+### Protocol
+
+- Fix and clarify definition of "transient error" in the OTLP exporter specification.
+  ([#3653](https://github.com/open-telemetry/opentelemetry-specification/pull/3653))
+
 ### Compatibility
 
 - Prometheus exporters SHOULD provide configuration to disable the addition of `_total` suffixes.

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -167,10 +167,10 @@ Transient errors MUST be handled with a retry strategy. This retry strategy MUST
 Transient errors are defined by the
 [OTLP protocol specification][protocol-spec].
 
-For [OTLP/gRPC](otlp-grpc), transient errors are defined by a set of
+For [OTLP/gRPC][otlp-grpc], transient errors are defined by a set of
 [retryable gRPC status codes][retryable-grpc-status-codes].
 
-For [OTLP/HTTP](otlp-http), transient errors are defined by:
+For [OTLP/HTTP][otlp-http], transient errors are defined by:
 
 1. A set of [retryable HTTP status codes][retryable-http-status-codes] received
    from the server.

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -162,7 +162,17 @@ The `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXP
 
 Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
 
-For OTLP/HTTP, the errors `408 (Request Timeout)` and `5xx (Server Errors)` are defined as transient, detailed information about errors can be found in the [HTTP failures section](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures). For the OTLP/gRPC, the full list of the gRPC retryable status codes can be found in the [gRPC response section](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc-response).
+Transient errors are defined by a set of retryable response status codes
+received from the server. Refer to the
+[protocol specification][protocol-spec] for the set of retryable status codes:
+
+* [OTLP/HTTP retryable status codes][retryable-http-status-codes]
+* [OTLP/gRPC retryable status codes][retryable-grpc-status-codes]
+
+For OTLP/HTTP, the following scenarios are also considered a transient error:
+
+* The server disconnects without returning a response.
+* The exporter cannot connect to the server.
 
 ## User Agent
 
@@ -177,3 +187,6 @@ The format of the header SHOULD follow [RFC 7231][rfc-7231]. The conventions use
 [resource-semconv]: ../resource/semantic_conventions/README.md#telemetry-sdk
 [otlphttp-req]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
 [rfc-7231]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
+[protocol-spec]: (https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md)
+[retryable-grpc-status-codes]: (https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures)
+[retryable-http-status-codes]: (https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1)

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -162,17 +162,22 @@ The `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXP
 
 Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
 
-Transient errors are defined by a set of retryable response status codes
-received from the server. Refer to the
-[protocol specification][protocol-spec] for the set of retryable status codes:
+### Transient errors
 
-* [OTLP/HTTP retryable status codes][retryable-http-status-codes]
-* [OTLP/gRPC retryable status codes][retryable-grpc-status-codes]
+Transient errors are defined by the
+[OTLP protocol specification][protocol-spec].
 
-For OTLP/HTTP, the following scenarios are also considered a transient error:
+For [OTLP/gRPC](otlpgrpc), transient errors are defined by a set of
+[retryable gRPC status codes][retryable-grpc-status-codes].
 
-* The server disconnects without returning a response.
-* The exporter cannot connect to the server.
+For [OTLP/HTTP](otlphttp), transient errors are defined by:
+
+1. A set of [retryable HTTP status codes][retryable-http-status-codes] received
+   from the server.
+2. The scenarios described in:
+   [All other responses](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#all-other-responses)
+   and
+   [OTLP/HTTP Connection](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-connection).
 
 ## User Agent
 
@@ -188,5 +193,7 @@ The format of the header SHOULD follow [RFC 7231][rfc-7231]. The conventions use
 [otlphttp-req]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
 [rfc-7231]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
 [protocol-spec]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
+[oltpgrpc]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc
+[otlphttp]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp
 [retryable-grpc-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures
 [retryable-http-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -187,6 +187,6 @@ The format of the header SHOULD follow [RFC 7231][rfc-7231]. The conventions use
 [resource-semconv]: ../resource/semantic_conventions/README.md#telemetry-sdk
 [otlphttp-req]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
 [rfc-7231]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
-[protocol-spec]: (https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md)
-[retryable-grpc-status-codes]: (https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures)
-[retryable-http-status-codes]: (https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1)
+[protocol-spec]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
+[retryable-grpc-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures
+[retryable-http-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -167,10 +167,10 @@ Transient errors MUST be handled with a retry strategy. This retry strategy MUST
 Transient errors are defined by the
 [OTLP protocol specification][protocol-spec].
 
-For [OTLP/gRPC](otlpgrpc), transient errors are defined by a set of
+For [OTLP/gRPC](otlp-grpc), transient errors are defined by a set of
 [retryable gRPC status codes][retryable-grpc-status-codes].
 
-For [OTLP/HTTP](otlphttp), transient errors are defined by:
+For [OTLP/HTTP](otlp-http), transient errors are defined by:
 
 1. A set of [retryable HTTP status codes][retryable-http-status-codes] received
    from the server.
@@ -193,7 +193,7 @@ The format of the header SHOULD follow [RFC 7231][rfc-7231]. The conventions use
 [otlphttp-req]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
 [rfc-7231]: https://datatracker.ietf.org/doc/html/rfc7231#section-5.5.3
 [protocol-spec]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
-[oltpgrpc]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc
-[otlphttp]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp
+[otlp-grpc]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc
+[otlp-http]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp
 [retryable-grpc-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures
 [retryable-http-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1


### PR DESCRIPTION
Fixes #3652

This PR attempts to clearly define `transient error` in the OTLP exporter specification.

It also fixes a bug in that the set of retryable status codes in the OTLP exporter spec vs. the protocol spec are not aligned.