### PR TITLE
Promote MetricProducer specification to feature-freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ release.
   ([#3636](https://github.com/open-telemetry/opentelemetry-specification/pull/3636))
 - Attribute sets not observed during async callbacks are not exported.
   ([#3242](https://github.com/open-telemetry/opentelemetry-specification/pull/3242))
+- Promote MetricProducer specification to feature-freeze.
+  ([#3600](https://github.com/open-telemetry/opentelemetry-specification/pull/3600))
 
 ### Logs
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1058,7 +1058,6 @@ measurements using the equivalent of the following naive algorithm:
 common configurable aspects of the OpenTelemetry Metrics SDK and
 determines the following capabilities:
 
-* Registering [MetricProducer](#metricproducer)(s)
 * Collecting metrics from the SDK and any registered
   [MetricProducers](#metricproducer) on demand.
 * Handling the [ForceFlush](#forceflush) and [Shutdown](#shutdown) signals from
@@ -1071,7 +1070,7 @@ SHOULD provide at least the following:
 * The default output `aggregation` (optional), a function of instrument kind.  If not configured, the [default aggregation](#default-aggregation) SHOULD be used.
 * The default output `temporality` (optional), a function of instrument kind.  If not configured, the Cumulative temporality SHOULD be used.
 * **Status**: [Experimental](../document-status.md) - The default aggregation cardinality limit to use, a function of instrument kind.  If not configured, a default value of 2000 SHOULD be used.
-* **Status**: [Experimental](../document-status.md) - Zero of more [MetricProducer](#metricproducer)s (optional) to collect metrics from in addition to metrics from the SDK.
+* **Status**: [Feature-freeze](../document-status.md) - Zero of more [MetricProducer](#metricproducer)s (optional) to collect metrics from in addition to metrics from the SDK.
 
 The [MetricReader.Collect](#collect) method allows general-purpose
 `MetricExporter` instances to explicitly initiate collection, commonly
@@ -1430,7 +1429,7 @@ modeled to interact with other components in the SDK:
 
 ## MetricProducer
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Feature-freeze](../document-status.md)
 
 `MetricProducer` defines the interface which bridges to third-party metric
 sources MUST implement so they can be plugged into an OpenTelemetry


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-specification/pull/3600
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/3599.

All outstanding issues with MetricProducer have been resolved:

* https://github.com/open-telemetry/opentelemetry-specification/issues/3615
* https://github.com/open-telemetry/opentelemetry-specification/issues/3611
* https://github.com/open-telemetry/opentelemetry-specification/issues/3601

There are compliant implementations in Go and JS:

* https://github.com/open-telemetry/opentelemetry-go/blob/10d9038059c237fe1805c1439fde04aa39113d45/sdk/metric/reader.go#L121
* https://github.com/open-telemetry/opentelemetry-js/pull/4007

There is a prototype in Java:

* https://github.com/open-telemetry/opentelemetry-java/pull/5678

cc @aabmass @jmacd @MrAlias @reyang @jack-berg