### PR TITLE
Metric names and namespaces should not be pluralized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ release.
   ([#3636](https://github.com/open-telemetry/opentelemetry-specification/pull/3636))
 - Attribute sets not observed during async callbacks are not exported.
   ([#3242](https://github.com/open-telemetry/opentelemetry-specification/pull/3242))
+- Metric names and namespaces should not be pluralized.
+  ([#3658](https://github.com/open-telemetry/opentelemetry-specification/pull/3658))
 
 ### Logs
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -105,7 +105,7 @@ using the OpenMetrics exposition format, use the
 
 ### Pluralization
 
-Metric names and namespaces SHOULD NOT be pluralized
+Metric names and namespaces SHOULD NOT be pluralized.
 
 ## General Metric Semantic Conventions
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -106,29 +106,7 @@ using the OpenMetrics exposition format, use the
 
 ### Pluralization
 
-Metric names SHOULD NOT be pluralized, unless the value being recorded
-represents discrete instances of a
-[countable quantity](https://en.wikipedia.org/wiki/Count_noun).
-Generally, the name SHOULD be pluralized only if the unit of the metric in
-question is a non-unit (like `{fault}` or `{operation}`).
-
-Examples:
-
-* `system.filesystem.utilization`, `http.server.duration`, and `system.cpu.time`
-should not be pluralized, even if many data points are recorded.
-* `system.paging.faults`, `system.disk.operations`, and `system.network.packets`
-should be pluralized, even if only a single data point is recorded.
-
-#### Use `count` Instead of Pluralization
-
-If the value being recorded represents the count of concepts signified
-by the namespace then the metric should be named `count` (within its namespace).
-The pluralization rule does not apply in this case.
-
-For example if we have a namespace `system.processes` which contains all metrics related
-to the processes then to represent the count of the processes we can have a metric named
-`system.processes.count`. The suffix `count` here indicates that it is the count of
-`system.processes`.
+Metric names and namespaces SHOULD NOT be pluralized
 
 ## General Metric Semantic Conventions
 
@@ -141,6 +119,10 @@ followed for other instruments not explicitly defined in this document.
 ### Instrument Naming
 
 **Status**: [Experimental](../../document-status.md)
+
+- **count** - an instrument that measures the count of concepts signified
+by the namespace should be called `entity.count`. For example,
+`system.process.count`.
 
 - **limit** - an instrument that measures the constant, known total amount of
 something should be called `entity.limit`. For example, `system.memory.limit`

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -18,7 +18,6 @@ No changes to this document are allowed.
   * [Name Reuse Prohibition](#name-reuse-prohibition)
   * [Units](#units)
   * [Pluralization](#pluralization)
-    + [Use `count` Instead of Pluralization](#use-count-instead-of-pluralization)
 - [General Metric Semantic Conventions](#general-metric-semantic-conventions)
   * [Instrument Naming](#instrument-naming)
   * [Instrument Units](#instrument-units)


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/212

## Changes

Metric names and namespaces should not be pluralized.
