### PR TITLE
Metric namespaces should not be pluralized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ release.
   ([#3242](https://github.com/open-telemetry/opentelemetry-specification/pull/3242))
 - Promote MetricProducer specification to feature-freeze.
   ([#3600](https://github.com/open-telemetry/opentelemetry-specification/pull/3600))
+- Metric namespaces SHOULD NOT be pluralized.
+  ([#3663](https://github.com/open-telemetry/opentelemetry-specification/pull/3663))
 
 ### Logs
 

--- a/specification/metrics/semantic_conventions/README.md
+++ b/specification/metrics/semantic_conventions/README.md
@@ -106,6 +106,8 @@ using the OpenMetrics exposition format, use the
 
 ### Pluralization
 
+Metric namespaces SHOULD NOT be pluralized.
+
 Metric names SHOULD NOT be pluralized, unless the value being recorded
 represents discrete instances of a
 [countable quantity](https://en.wikipedia.org/wiki/Count_noun).


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/semantic-conventions/issues/212

## Changes

Metric namespaces SHOULD NOT be pluralized.

This affect these current metric namespaces:

* `system.processes.count` -> `system.process.count`
* `system.processes.created` -> `system.process.created`
* `db.client.connections.*` -> `db.client.connection.*`
* `jvm.threads.count` -> `jvm.thread.count`
* `jvm.classes.count` -> `jvm.class.count`
