### PR TITLE
nit: Unpin markdown-link-check version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "markdown-link-check": "3.10.3",
+    "markdown-link-check": "^3.11.2",
     "markdown-toc": "^1.2.0",
     "markdownlint-cli": "0.31.0"
   }


### PR DESCRIPTION
Version was pinned in https://github.com/open-telemetry/opentelemetry-specification/pull/3327 because of a bug in the tool, which is fixed, so we can use latest version again