### PR TITLE
Stabilize `ExplicitBucketBoundaries` instrument advisory parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Stabilize `ExplicitBucketBoundaries` instrument advisory parameter.
+  ([#3694](https://github.com/open-telemetry/opentelemetry-specification/pull/3694))
+
 ### Logs
 
 ### Resource

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -23,6 +23,8 @@ linkTitle: API
     + [Instrument unit](#instrument-unit)
     + [Instrument description](#instrument-description)
     + [Instrument advisory parameters](#instrument-advisory-parameters)
+      - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
+      - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -246,24 +248,37 @@ instrument. The API MUST treat it as an opaque string.
 
 #### Instrument advisory parameters
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Mixed](../document-status.md)
 
 `advisory` parameters are an optional set of recommendations provided by the
 author of the Instrument, aimed at assisting implementations in providing
 useful output with minimal configuration. They differ from other parameters
 in that Implementations MAY ignore `advisory` parameters.
 
-* OpenTelemetry SDKs MUST handle `advisory` parameters as described
-  [here](./sdk.md#instrument-advisory-parameters).
-* `advisory` parameters may be general, or may be accepted only for specific
-  instrument `kind`s.
-  * `Histogram`:
-    * `ExplicitBucketBoundaries` (`double[]`): The recommended set of bucket
-      boundaries to use if aggregating to
-      [explicit bucket Histogram metric data point](./data-model.md#histogram).
-  * All instruments:
-    * `Attributes` (a list of [attribute keys](../common/README.md#attribute)):
-      The recommended set of attribute keys to be used for the resulting metrics.
+OpenTelemetry SDKs MUST handle `advisory` parameters as described
+[here](./sdk.md#instrument-advisory-parameters).
+
+`advisory` parameters may be general, or may be accepted only for specific
+instrument `kind`s.
+
+##### Instrument advisory parameter: `ExplicitBucketBoundaries`
+
+**Status**: [Stable](../document-status.md)
+
+Applies to Histogram instrument type.
+
+`ExplicitBucketBoundaries` (`double[]`) is the recommended set of bucket
+boundaries to use if aggregating to
+[explicit bucket Histogram metric data point](./data-model.md#histogram).
+
+##### Instrument advisory parameter: `Attributes`
+
+**Status**: [Experimental](../document-status.md)
+
+Applies to all instrument types.
+
+`Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
+the recommended set of attribute keys to be used for the resulting metrics.
 
 #### Synchronous and Asynchronous instruments
 


### PR DESCRIPTION
Fixes #3391

This is a prerequisite for HTTP semconv stability.

## Changes

Stabilizes `ExplicitBucketBoundaries` instrument advisory parameter.

Prototypes in Java, JS, Go, and Erlang:
* https://github.com/open-telemetry/opentelemetry-java/pull/5217
* https://github.com/open-telemetry/opentelemetry-js/pull/3876
* https://github.com/open-telemetry/opentelemetry-go/pull/4341
* https://github.com/open-telemetry/opentelemetry-erlang/pull/628