### PR TITLE
ParentBased is a decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- `ParentBased` sampler is a decorator (not a composite).
+  ([#3706](https://github.com/open-telemetry/opentelemetry-specification/pull/3706))
+
 ### Metrics
 
 - Stabilize `ExplicitBucketBoundaries` instrument advisory parameter.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -349,7 +349,7 @@ of the `TraceID`. [#1413](https://github.com/open-telemetry/opentelemetry-specif
 
 #### ParentBased
 
-* This is a composite sampler. `ParentBased` helps distinguish between the
+* This is a sampler decorator. `ParentBased` helps distinguish between the
 following cases:
   * No parent (root span).
   * Remote parent (`SpanContext.IsRemote() == true`) with `SampledFlag` set


### PR DESCRIPTION
ParentBased sampler is decorator (and not a composite).

> The intent of a composite is to "compose" objects into tree structures to represent part-whole hierarchies.

> What problems can the Composite design pattern solve? 
> [...]
> A part-whole hierarchy should be represented as tree structure

`ParentBased` does not produce a tree.  Composite aims to solve a different (but kind of similar) problem.



> decorator pattern [...] that allows behavior to be added to an individual [object](https://en.wikipedia.org/wiki/Object_(computer_science)), dynamically, without affecting the behavior of other objects from the same [class](https://en.wikipedia.org/wiki/Class_(computer_science)).

> What problems can it solve?
> Responsibilities should be added to (and removed from) an object dynamically at run-time.[5]
>>A flexible alternative to subclassing for extending functionality should be provided.

The key feature of the `ParentBased` is how it changes the "behavior" of the wrapped sampler. We decorate the existing sampler so that it handles the sampling based on the parent's span.

References:
- https://en.wikipedia.org/wiki/Decorator_pattern
- https://en.wikipedia.org/wiki/Composite_pattern
- https://sourcemaking.com/design_patterns/composite
- https://sourcemaking.com/design_patterns/decorator
- https://stackoverflow.com/questions/2233952/difference-between-the-composite-pattern-and-decorator-pattern

Related issue https://github.com/open-telemetry/opentelemetry-go/issues/4565