### PR TITLE
Fix description of OTEL_ATTRIBUTE_COUNT_LIMIT

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -148,7 +148,7 @@ See the SDK [Attribute Limits](../common/README.md#attribute-limits) section for
 | Name                              | Description                          | Default | Notes |
 | --------------------------------- | ------------------------------------ | ------- | ----- |
 | OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT | Maximum allowed attribute value size | no limit|       |
-| OTEL_ATTRIBUTE_COUNT_LIMIT        | Maximum allowed span attribute count | 128     |       |
+| OTEL_ATTRIBUTE_COUNT_LIMIT        | Maximum allowed attribute count      | 128     |       |
 
 ## Span Limits
 


### PR DESCRIPTION
## Changes

The OTEL_ATTRIBUTE_COUNT_LIMIT variable was described in the SDK environment variables document as the "maximum allowed _span_ attribute count" (emphasis added). The "span" in that sentence was likely a mistake, since this variable applies to attributes in general, and not only to span attributes. These are more appropriately controlled with the OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT, which is probably where this description was accidentally copied from.

This is a trivial change, so it follows the expedited process.