### PR TITLE
Set attribute on exemplar spans

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -993,6 +993,10 @@ span context and baggage can be inspected at this point.
 The "offer" method does not need to store all measurements it is given and
 MAY further sample beyond the `ExemplarFilter`.
 
+If a span is to be used as an exemplar, the ExemplarReservoir MUST set the
+span attribute `"otel.exemplar"` to the value `true`, otherwise it MUST
+not change the attribute.
+
 The "collect" method MUST return accumulated `Exemplar`s. Exemplars are expected
 to abide by the `AggregationTemporality` of any metric point they are recorded
 with. In other words, Exemplars reported against a metric data point SHOULD have
@@ -1044,7 +1048,7 @@ SHOULD be used.
 #### AlignedHistogramBucketExemplarReservoir
 
 This Exemplar reservoir MUST take a configuration parameter that is the
-configuration of a Histogram.  This implementation MUST keep the last seen
+configuration of a Histogram.  This implementation MUST keep the first seen
 measurement that falls within a histogram bucket.  The reservoir will accept
 measurements using the equivalent of the following naive algorithm:
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -993,9 +993,12 @@ span context and baggage can be inspected at this point.
 The "offer" method does not need to store all measurements it is given and
 MAY further sample beyond the `ExemplarFilter`.
 
-If a span is to be used as an exemplar, the ExemplarReservoir MUST set the
-span attribute `"otel.exemplar"` to the value `true`, otherwise it MUST
-not change the attribute.
+If a span might be used as an exemplar, the ExemplarReservoir MUST set the
+span attribute `otel.exemplar` to the value `true`, otherwise it MUST
+not change the attribute. The number of spans with this annotation
+that are not being used as exemplars SHOULD be kept as small as possible. This
+allows tail-based span sampling to keep spans that are used as exemplars,
+without unnecessarily keeping too many spans.
 
 The "collect" method MUST return accumulated `Exemplar`s. Exemplars are expected
 to abide by the `AggregationTemporality` of any metric point they are recorded

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1032,8 +1032,9 @@ algorithm](https://en.wikipedia.org/wiki/Reservoir_sampling) can be used:
 
   ```
   bucket = random_integer(0, num_measurements_seen)
-  if bucket < num_buckets && reservoir[bucket] == null then
+  if bucket < num_buckets then
     reservoir[bucket] = measurement
+    current_span.set_attribute("otel.example", true)
   end
   ```
 
@@ -1056,6 +1057,7 @@ measurements using the equivalent of the following naive algorithm:
   bucket = find_histogram_bucket(measurement)
   if bucket < num_buckets && reservoir[bucket] == null then
     reservoir[bucket] = measurement
+    current_span.set_attribute("otel.example", true)
   end
 
   def find_histogram_bucket(measurement):

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1032,7 +1032,7 @@ algorithm](https://en.wikipedia.org/wiki/Reservoir_sampling) can be used:
 
   ```
   bucket = random_integer(0, num_measurements_seen)
-  if bucket < num_buckets then
+  if bucket < num_buckets && reservoir[bucket] == null then
     reservoir[bucket] = measurement
   end
   ```
@@ -1054,7 +1054,7 @@ measurements using the equivalent of the following naive algorithm:
 
   ```
   bucket = find_histogram_bucket(measurement)
-  if bucket < num_buckets then
+  if bucket < num_buckets && reservoir[bucket] == null then
     reservoir[bucket] = measurement
   end
 


### PR DESCRIPTION
Proof of Concept for a way to support metric exemplars and tail-based sampling at the same time. Hopefully this will spur discussion on how we want to support this use-case.

## Motivation
(from https://github.com/open-telemetry/opentelemetry-specification/issues/2922)

> Exemplars are used to navigate from metrics to example traces. For example, the screenshot shows latencies from the `http.server.duration` metric as visualized by Grafana. Each little dot represents an Exemplar. If you click on an Exemplar, you can navigate to the corresponding trace.
> 
> ![screenshot_2022-10-05_16:23:20_457465619](https://user-images.githubusercontent.com/330535/200163549-1d4a30b7-b1c4-44eb-8ce3-e75eaa27b43c.png)
> 
> However, this does not work well if traces are sampled in the collector: In many cases the metric library will choose a Span as an exemplar that will be discarded by the collector during sampling.
> 
> It would be good if metric libraries could add a standard Span attribute to indicate that a Span has been selected as an Exemplar. This attribute could be considered by the collector's sampling algorithm to ensure that Exemplars aren't discarded.
> 
> A simple way to implement this is adding a boolean attribute, like `exemplar="true"`.

## Changes

- `HistogramExemplarReservoir` and `RandomFixedSizeExemplarReservoir` now collect the `first` instead of the `last` exemplar sample they see. This lets us know whether or not a span will be used as an exemplar while it is still current.
- Suggest `otel.exemplar` as a potential new attribute that, when set to `true` means the sample is being used as an exemplar.

* Related issues 
  * PoC implementation in java: https://github.com/open-telemetry/opentelemetry-java/pull/5922
  * Relevant issue: https://github.com/open-telemetry/opentelemetry-specification/issues/2922
