### PR TITLE
Update swift jaeger propagator spec compliance

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -260,7 +260,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Global Propagator                                                                |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | TraceContext Propagator                                                          |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | B3 Propagator                                                                    |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Jaeger Propagator                                                                |          | +  | +    | +  | +      | +    | +      |     | +    | +   | -    | -     |
+| Jaeger Propagator                                                                |          | +  | +    | +  | +      | +    | +      |     | +    | +   | -    | +     |
 | OT Propagator                                                                    |          | +  | +    | +  | +      |      |        |     |      |     |      |       |
 | OpenCensus Binary Propagator                                                     |          | +  |      |    |        |      |        |     |      |     |      |       |
 | [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          | +  | +    |    |        | +    |        | +   |      |     |      |       |


### PR DESCRIPTION
## Changes

Update spec compliance to `+` for Jaeger Propagator in Swift, support was added in https://github.com/open-telemetry/opentelemetry-swift/commit/53fb79ab43411b935f4ed31345051315176ee991
