### PR TITLE
protocol/exporter: Configuration options MAY be implemented by exporter, SDK, or separate component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ release.
 - New exporter implementations do not need to support
   `OTEL_EXPORTER_OTLP_SPAN_INSECURE` and `OTEL_EXPORTER_OTLP_METRIC_INSECURE`.
   ([#3719](https://github.com/open-telemetry/opentelemetry-specification/pull/3719))
+- Clarify that the configuration options MAY be implemented by the exporter,
+  the SDK, or a seperate component (e.g. environment-based autoconfiguration component).
+  ([#3719](https://github.com/open-telemetry/opentelemetry-specification/pull/3719))
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ release.
   `OTEL_EXPORTER_OTLP_SPAN_INSECURE` and `OTEL_EXPORTER_OTLP_METRIC_INSECURE`.
   ([#3719](https://github.com/open-telemetry/opentelemetry-specification/pull/3719))
 - Clarify that the configuration options MAY be implemented by the exporter,
-  the SDK, or a seperate component (e.g. environment-based autoconfiguration component).
+  the SDK, or a separate component (e.g. environment-based autoconfiguration component).
   ([#3719](https://github.com/open-telemetry/opentelemetry-specification/pull/3719))
 
 ### Compatibility

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -10,7 +10,9 @@ This document specifies the configuration options available to the OpenTelemetry
 
 ## Configuration Options
 
-The following configuration options MUST be available to configure the OTLP exporter. Each configuration option MUST be overridable by a signal specific option.
+The following configuration options MUST be available to configure the OTLP exporter.
+The configuration options MAY be implemented directly in the OTLP exporter, in the SDK, or in a seperate component (e.g. environment-based autoconfiguration component).
+Each configuration option MUST be overridable by a signal specific option.
 
 - **Endpoint (OTLP/HTTP)**: Target URL to which the exporter is going to send spans or metrics. The endpoint MUST be a valid URL with scheme (http or https) and host, MAY contain a port, SHOULD contain a path and MUST NOT contain other parts (such as query string or fragment). A scheme of https indicates a secure connection. When using `OTEL_EXPORTER_OTLP_ENDPOINT`, exporters MUST construct per-signal URLs as  [described below](#endpoint-urls-for-otlphttp). The per-signal endpoint configuration options take precedence and can be used to override this behavior (the URL is used as-is for them, without any modifications). See the [OTLP Specification][otlphttp-req] for more details.
   - Default:  `http://localhost:4318` [1]

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -11,7 +11,7 @@ This document specifies the configuration options available to the OpenTelemetry
 ## Configuration Options
 
 The following configuration options MUST be available to configure the OTLP exporter.
-The configuration options MAY be implemented directly in the OTLP exporter, in the SDK, or in a seperate component (e.g. environment-based autoconfiguration component).
+The configuration options MAY be implemented directly in the OTLP exporter, in the SDK, or in a separate component (e.g. environment-based autoconfiguration component).
 Each configuration option MUST be overridable by a signal specific option.
 
 - **Endpoint (OTLP/HTTP)**: Target URL to which the exporter is going to send spans or metrics. The endpoint MUST be a valid URL with scheme (http or https) and host, MAY contain a port, SHOULD contain a path and MUST NOT contain other parts (such as query string or fragment). A scheme of https indicates a secure connection. When using `OTEL_EXPORTER_OTLP_ENDPOINT`, exporters MUST construct per-signal URLs as  [described below](#endpoint-urls-for-otlphttp). The per-signal endpoint configuration options take precedence and can be used to override this behavior (the URL is used as-is for them, without any modifications). See the [OTLP Specification][otlphttp-req] for more details.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/3721

## Why

The Go SIG is working towards stabilizing the OTLP metrics exporter.

The Go SIG would prefer to manage the exporter environment variables through a distinct package: https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport. This approach is akin to [Java Autoconfigure](https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure). The rationale behind this decision is as follows:

1. If users aim to utilize the `OTEL_EXPORTER_OTLP_PROTOCOL` and `OTEL_TRACES_EXPORTER`, we aim to support all the values documented in the specification. We want to ensure that users are not prone to encountering runtime errors if a protocol driver hasn't been registered in the code.
2. Simultaneously, we wish to avoid applications to depend on all exporter implementations defined in the specification.

Currently, it is not clear of such design is in compliance with the specification.

## What

Define that **configuration options MAY be implemented by exporter, SDK, or separate component**.

While this PR may be seen as a breaking change, because of the way how the languages adopted the specification I would say that this is a "clarification" or "adopting to the reality".

Here is how different languages currently implement the OTLP configuration options.

### .NET

Configuration options implemented by exporter.
Side note: Per-signal endpoint configuration options are not implemented.

Source code: 
- https://github.com/open-telemetry/opentelemetry-dotnet/tree/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol

### C++

Most configuration options implemented by exporter.
However, the `*_PROTOCOL` env vars are not implemented at all. See: https://github.com/open-telemetry/opentelemetry-cpp/issues/971.

Source code: 
- https://github.com/open-telemetry/opentelemetry-cpp/tree/main/exporters/otlp

### Erlang

Configuration options implemented by exporter.

Source code:
- https://github.com/open-telemetry/opentelemetry-erlang/tree/main/apps/opentelemetry_exporter

### Go

Most configuration options implemented by exporter.
However, the `*_PROTOCOL` env vars are implemented by a separate component (autoexport)

Source code (package docs):
- https://pkg.go.dev/go.opentelemetry.io/contrib/exporters/autoexport
- https://pkg.go.dev/go.opentelemetry.io/otel/exporters/otlp/otlptrace

### Java

Configuration options implemented by an autoconfigure component.

Source code:
- https://github.com/open-telemetry/opentelemetry-java/tree/main/sdk-extensions/autoconfigure
- https://github.com/open-telemetry/opentelemetry-java/tree/main/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp

### JavaScript

Most configuration options implemented by exporter.
However, the `*_PROTOCOL` env vars are implemented by a separate component (opentelemetry-sdk-node)

Source code:
- https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/opentelemetry-sdk-node
- https://github.com/open-telemetry/opentelemetry-js/tree/main/experimental/packages/exporter-trace-otlp-http

### PHP

Configuration options implemented by exporter.

Source code:
- https://github.com/open-telemetry/opentelemetry-php/tree/main/src/Contrib/Otlp

### Python

Most configuration options implemented by exporter.
However, the `*_PROTOCOL` env vars are implemented by the SDK.

Source code:
- https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_configuration/__init__.py
- https://github.com/open-telemetry/opentelemetry-python/tree/main/exporter

### Ruby

Most configuration options implemented by exporter.
However, the `*_PROTOCOL` env vars are implemented by the SDK.

Source code:
- https://github.com/open-telemetry/opentelemetry-ruby/blob/main/sdk/lib/opentelemetry/sdk/configurator.rb
- https://github.com/open-telemetry/opentelemetry-ruby/tree/main/exporter/otlp-http

### Rust

Configuration options implemented by exporter.

Source code:
- https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp

### Swift

Env vars not supported.

### Previous work and discussions

- https://github.com/open-telemetry/opentelemetry-specification/issues/3721
- https://github.com/open-telemetry/opentelemetry-specification/pull/3722