### PR TITLE
add definition for standard output span exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ release.
 
 - Add a new AddLink() operation to Span (experimental).
   ([#3678](https://github.com/open-telemetry/opentelemetry-specification/pull/3678))
-- Add definition for standard output trace exporter.
+- Add definition for standard output span exporter.
   ([#3740](https://github.com/open-telemetry/opentelemetry-specification/pull/3740))
 
 ### Metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ release.
 
 - Add a new AddLink() operation to Span (experimental).
   ([#3678](https://github.com/open-telemetry/opentelemetry-specification/pull/3678))
+- Add definition for standard output trace exporter.
+  ([#3740](https://github.com/open-telemetry/opentelemetry-specification/pull/3740))
 
 ### Metrics
 

--- a/specification/trace/sdk_exporters/stdout.md
+++ b/specification/trace/sdk_exporters/stdout.md
@@ -18,5 +18,5 @@ If a language provides a mechanism to automatically configure a
 [Span processor](../sdk.md#span-processor) to pair with the associated
 exporter (e.g., using the [`OTEL_TRACES_EXPORTER` environment
 variable](../../configuration/sdk-environment-variables.md#exporter-selection)), by
-default the standard output exporter MUST be paired with a [batching
-processor](../sdk.md#batching-processor).
+default the standard output exporter SHOULD be paired with a [simple
+processor](../sdk.md#simple-processor).

--- a/specification/trace/sdk_exporters/stdout.md
+++ b/specification/trace/sdk_exporters/stdout.md
@@ -12,7 +12,7 @@ stdout/console.
 
 [OpenTelemetry SDK](../../overview.md#sdk) authors MAY choose the best idiomatic
 name for their language. For example, ConsoleExporter, StdoutExporter,
-StreamExporter, etc.
+StreamExporter, LoggingExporter etc.
 
 If a language provides a mechanism to automatically configure a
 [Span processor](../sdk.md#span-processor) to pair with the associated

--- a/specification/trace/sdk_exporters/stdout.md
+++ b/specification/trace/sdk_exporters/stdout.md
@@ -18,5 +18,5 @@ If a language provides a mechanism to automatically configure a
 [Span processor](../sdk.md#span-processor) to pair with the associated
 exporter (e.g., using the [`OTEL_TRACES_EXPORTER` environment
 variable](../../configuration/sdk-environment-variables.md#exporter-selection)), by
-default the exporter MUST be paired with a [batching
+default the standard output exporter MUST be paired with a [batching
 processor](../sdk.md#batching-processor).

--- a/specification/trace/sdk_exporters/stdout.md
+++ b/specification/trace/sdk_exporters/stdout.md
@@ -1,0 +1,22 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Stdout
+--->
+
+# OpenTelemetry Span Exporter - Standard output
+
+**Status**: [Stable](../../document-status.md)
+
+"Standard output" Span Exporter is a [Span
+Exporter](../sdk.md#span-exporter) which outputs the metrics to
+stdout/console.
+
+[OpenTelemetry SDK](../../overview.md#sdk) authors MAY choose the best idiomatic
+name for their language. For example, ConsoleExporter, StdoutExporter,
+StreamExporter, etc.
+
+If a language provides a mechanism to automatically configure a
+[Span processor](../sdk.md#span-processor) to pair with the associated
+exporter (e.g., using the [`OTEL_TRACES_EXPORTER` environment
+variable](../../configuration/sdk-environment-variables.md#exporter-selection)), by
+default the exporter MUST be paired with a [batching
+processor](../sdk.md#batching-processor).

--- a/specification/trace/sdk_exporters/stdout.md
+++ b/specification/trace/sdk_exporters/stdout.md
@@ -7,7 +7,7 @@ linkTitle: Stdout
 **Status**: [Stable](../../document-status.md)
 
 "Standard output" Span Exporter is a [Span
-Exporter](../sdk.md#span-exporter) which outputs the metrics to
+Exporter](../sdk.md#span-exporter) which outputs the spans to
 stdout/console.
 
 [OpenTelemetry SDK](../../overview.md#sdk) authors MAY choose the best idiomatic


### PR DESCRIPTION
## Changes

I couldn't find the definition for a standard output exporter for the trace signal, so I'm submitting one. This is mostly a copy of the definition already present for the metrics exporter. It doesn't specify a format for the output itself.

* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
