### PR TITLE
add definition for standard output logging exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ release.
 
 ### Logs
 
+- Add definition for standard output log record exporter.
+  ([#3741](https://github.com/open-telemetry/opentelemetry-specification/pull/3741))
+
 ### Resource
 
 ### OpenTelemetry Protocol

--- a/specification/logs/sdk_exporters/stdout.md
+++ b/specification/logs/sdk_exporters/stdout.md
@@ -1,0 +1,22 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Stdout
+--->
+
+# OpenTelemetry LogRecord Exporter - Standard output
+
+**Status**: [Experimental](../../document-status.md)
+
+"Standard output" LogRecord Exporter is a [LogRecord
+Exporter](../sdk.md#logrecordexporter) which outputs the logs to
+stdout/console.
+
+[OpenTelemetry SDK](../../overview.md#sdk) authors MAY choose the best idiomatic
+name for their language. For example, ConsoleExporter, StdoutExporter,
+StreamExporter, etc.
+
+If a language provides a mechanism to automatically configure a
+[LogRecordProcessor](../sdk.md#logrecordprocessor) to pair with the associated
+exporter (e.g., using the [`OTEL_LOGS_EXPORTER` environment
+variable](../../configuration/sdk-environment-variables.md#exporter-selection)), by
+default the exporter MUST be paired with a [batching
+processor](../sdk.md#batching-processor).

--- a/specification/logs/sdk_exporters/stdout.md
+++ b/specification/logs/sdk_exporters/stdout.md
@@ -18,5 +18,5 @@ If a language provides a mechanism to automatically configure a
 [LogRecordProcessor](../sdk.md#logrecordprocessor) to pair with the associated
 exporter (e.g., using the [`OTEL_LOGS_EXPORTER` environment
 variable](../../configuration/sdk-environment-variables.md#exporter-selection)), by
-default the standard output exporter MUST be paired with a [batching
-processor](../sdk.md#batching-processor).
+default the standard output exporter SHOULD be paired with a [simple
+processor](../sdk.md#simple-processor).

--- a/specification/logs/sdk_exporters/stdout.md
+++ b/specification/logs/sdk_exporters/stdout.md
@@ -18,5 +18,5 @@ If a language provides a mechanism to automatically configure a
 [LogRecordProcessor](../sdk.md#logrecordprocessor) to pair with the associated
 exporter (e.g., using the [`OTEL_LOGS_EXPORTER` environment
 variable](../../configuration/sdk-environment-variables.md#exporter-selection)), by
-default the exporter MUST be paired with a [batching
+default the standard output exporter MUST be paired with a [batching
 processor](../sdk.md#batching-processor).


### PR DESCRIPTION
## Changes

I couldn't find the definition for a standard output exporter for the logging signal, so I'm submitting one. This is mostly a copy of the definition already present for the metrics exporter. It doesn't specify a format for the output itself.

* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes

Similar to https://github.com/open-telemetry/opentelemetry-specification/pull/3740
