### PR TITLE
Refer to W3C working draft versions

### DIFF
--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -146,7 +146,7 @@ reasons.
 
 The API layer or an extension package MUST include the following `Propagator`s:
 
-* A `TextMapPropagator` implementing the [W3C Baggage Specification](https://w3c.github.io/baggage).
+* A `TextMapPropagator` implementing the [W3C Baggage Specification](https://www.w3.org/TR/baggage).
 
 See [Propagators Distribution](../context/api-propagators.md#propagators-distribution)
 for how propagators are to be distributed.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -333,9 +333,9 @@ Required parameters:
 The official list of propagators that MUST be maintained by the OpenTelemetry
 organization and MUST be distributed as OpenTelemetry extension packages:
 
-* [W3C TraceContext](https://www.w3.org/TR/trace-context/). MAY alternatively
+* [W3C TraceContext](https://www.w3.org/TR/trace-context). MAY alternatively
   be distributed as part of the OpenTelemetry API.
-* [W3C Baggage](https://w3c.github.io/baggage). MAY alternatively
+* [W3C Baggage](https://www.w3.org/TR/baggage). MAY alternatively
   be distributed as part of the OpenTelemetry API.
 * [B3](https://github.com/openzipkin/b3-propagation).
 * [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format).

--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -284,7 +284,7 @@ auto-instrumenting solutions that modify trace logging libraries used by the
 application to automatically output the trace context such as the trace id or
 span id with every log statement. The trace context can be automatically
 extracted from incoming requests if standard compliant request propagation is
-used, e.g. via [W3C TraceContext](https://w3c.github.io/trace-context/). In
+used, e.g. via [W3C TraceContext](https://www.w3.org/TR/trace-context). In
 addition, the requests outgoing from the application may be injected with the
 same trace context data, thus resulting in context propagation through the
 application and creating an opportunity to have full trace context in logs

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -155,7 +155,7 @@ release).
 
 ### Specifying headers via environment variables
 
-The `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXPORTER_OTLP_METRICS_HEADERS` environment variables will contain a list of key value pairs, and these are expected to be represented in a format matching to the [W3C Correlation-Context](https://github.com/w3c/baggage/blob/master/baggage/HTTP_HEADER_FORMAT.md), except that additional semi-colon delimited metadata is not supported, i.e.: key1=value1,key2=value2. All attribute values MUST be considered strings.
+The `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXPORTER_OTLP_METRICS_HEADERS` environment variables will contain a list of key value pairs, and these are expected to be represented in a format matching to the [W3C Baggage](https://www.w3.org/TR/baggage/#header-content), except that additional semi-colon delimited metadata is not supported, i.e.: key1=value1,key2=value2. All attribute values MUST be considered strings.
 
 ## Retry
 

--- a/specification/resource/sdk.md
+++ b/specification/resource/sdk.md
@@ -137,7 +137,7 @@ has higher priority.
 
 The `OTEL_RESOURCE_ATTRIBUTES` environment variable will contain of a list of
 key value pairs, and these are expected to be represented in a format matching
-to the [W3C Baggage](https://w3c.github.io/baggage), except that additional
+to the [W3C Baggage](https://www.w3.org/TR/baggage/#header-content), except that additional
 semi-colon delimited metadata is not supported, i.e.: `key1=value1,key2=value2`.
 All attribute values MUST be considered strings and characters outside the
 `baggage-octet` range MUST be percent-encoded.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/3757

Changes:

- Refer to a W3C "working draft" version instead of "editor's draft" or "master branch" version

I also want to notice that most other hyperlinks is already referring to working draft. On this branch `https://www.w3.org/TR/` is found in 23 places.

I find this change editorial and I do not think it is worth putting an entry in the changelog.
