### PR TITLE
add optional otel_scope_info configuration for prometheus exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Add optional configuration for Prometheus exporters to optionally drop `otel_scope_info` metric.
+  ([#3796](https://github.com/open-telemetry/opentelemetry-specification/pull/3796))
+
 ### Logs
 
 ### Resource
@@ -48,7 +51,7 @@ release.
   ([#3761](https://github.com/open-telemetry/opentelemetry-specification/pull/3761))
 - Clarifications and flexibility in Exemplar speicification.
   ([#3760](https://github.com/open-telemetry/opentelemetry-specification/pull/3760))
-- Add optional configuration for Prometheus exporters to optionally remove unit and type suffixes
+- Add optional configuration for Prometheus exporters to optionally remove unit and type suffixes.
   ([#3777](https://github.com/open-telemetry/opentelemetry-specification/pull/3777))
 
 ### Logs

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -37,3 +37,6 @@ or UNIT metadata. The option MAY be named `without_units`, and MUST be `false` b
 
 A Prometheus Exporter MAY support a configuration option to produce metrics without a [type suffix](../../compatibility/prometheus_and_openmetrics.md#metric-metadata).
 The option MAY be named `without_type_suffix`, and MUST be `false` by default.
+
+A Prometheus Exporter MAY support a configuration option to produce metrics without a [scope info](../../compatibility/prometheus_and_openmetrics.md#instrumentation-scope)
+metric. The option MAY be named `without_scope_info`, and MUST be `false` by default.


### PR DESCRIPTION
## Changes

Adding some more options that are exposed in the OTel Go SDK, but not specified in the prometheus exporter details.

* [x] Related issues https://github.com/open-telemetry/opentelemetry-configuration/issues/59
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
