### PR TITLE
Temporarily remove broken link to fix build

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ For details, see [CONTRIBUTING.md](CONTRIBUTING.md), in particular read
 
 Questions that need additional attention can be brought to the regular
 specifications meeting. EU and US timezone friendly meeting is held every
-Tuesday at 8 AM Pacific time. Meeting notes are held in the [Google
-doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo).
-APAC timezone friendly meetings are held on request. See
-[OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar).
+Tuesday at 8 AM Pacific time. Meeting notes are held in the (TODO: restore link
+to doc when permissions are fixed). APAC timezone friendly meetings are held on
+request.
+See [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar).
 
 Escalations to technical committee may be made over the
 [e-mail](https://github.com/open-telemetry/community#tc-technical-committee).

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ For details, see [CONTRIBUTING.md](CONTRIBUTING.md), in particular read
 
 Questions that need additional attention can be brought to the regular
 specifications meeting. EU and US timezone friendly meeting is held every
-Tuesday at 8 AM Pacific time. Meeting notes are held in the (TODO: restore link
-to doc when permissions are fixed). APAC timezone friendly meetings are held on
-request.
-See [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar).
+Tuesday at 8 AM Pacific time. Meeting notes are held in the [Google
+doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo).
+APAC timezone friendly meetings are held on request. See
+[OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar).
 
 Escalations to technical committee may be made over the
 [e-mail](https://github.com/open-telemetry/community#tc-technical-committee).

--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ For details, see [CONTRIBUTING.md](CONTRIBUTING.md), in particular read
 
 Questions that need additional attention can be brought to the regular
 specifications meeting. EU and US timezone friendly meeting is held every
-Tuesday at 8 AM Pacific time. Meeting notes are held in the [Google
-doc](https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo).
-APAC timezone friendly meetings are held on request. See
-[OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar).
+Tuesday at 8 AM Pacific time. Meeting notes are held in the Google
+doc `https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo` (
+TODO: restore link when document permissions are fixed). APAC timezone friendly
+meetings are held on request.
+See [OpenTelemetry calendar](https://github.com/open-telemetry/community#calendar).
 
 Escalations to technical committee may be made over the
 [e-mail](https://github.com/open-telemetry/community#tc-technical-committee).


### PR DESCRIPTION
Fix build, which is currently failing because the permissions of the spec meetings notes file changed: https://docs.google.com/document/d/1pdvPeKjA8v8w_fGKAN68JjWBmVJtPCpqdi9IZrd6eEo/edit