### PR TITLE
Add support for binary protobuf serialization to file exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ release.
 
 ### OpenTelemetry Protocol
 
+- Use `TracesData`, `MetricsData` and `LogsData` proto messages for file exporter.
+
 ### Compatibility
 
 ### SDK Configuration

--- a/specification/protocol/file-exporter.md
+++ b/specification/protocol/file-exporter.md
@@ -48,7 +48,7 @@ This defines the first version of the serialization scheme.
 The data must be encoded according to the format specified in the
 [OTLP JSON Encoding](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#json-protobuf-encoding).
 
-Only top-level objects, `ExportTraceServiceRequest`, `ExportMetricsServiceRequest`, and `ExportLogsServiceRequest` are supported.
+Only top-level objects, `TracesData`, `MetricsData`, and `LogsData` are supported.
 
 Files must contain exactly one type of data: traces, metrics, or logs.
 


### PR DESCRIPTION
Fixes #

## Changes

* Add support for binary protobuf serialization to file exporter;
* Clarify that SDK implementations can expose helpers to serialize data to Binary/JSON protobuf encodings so that other exporters can be easily implemented.
* Restructure the JSON section to reduce number of titles and follow same pattern as binary protobuf.
