### PR TITLE
Clarify Body representation in Log Bridge API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 ### Logs
 
+- Clarify Body representation in Log Bridge API.
+  ([#3814](https://github.com/open-telemetry/opentelemetry-specification/pull/3814))
+
 ### Resource
 
 ### OpenTelemetry Protocol

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -120,7 +120,8 @@ The API MUST accept the following parameters:
   behavior.
 - [Severity Number](./data-model.md#field-severitynumber)
 - [Severity Text](./data-model.md#field-severitytext)
-- [Body](./data-model.md#field-body)
+- [Body](./data-model.md#field-body). The API MUST support passing Body as `string`.
+  The API MAY support passing Body as a type representing [`any`](./data-model.md#type-any).
 - [Attributes](./data-model.md#field-attributes)
 
 All parameters are optional.


### PR DESCRIPTION
**Superseded by https://github.com/open-telemetry/opentelemetry-specification/pull/3827**

## Changes

Clarify Body representation in Log Bridge API as to make interpretation of the specification easier.

## Why

I noticed that [the Logs Data Model defines](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#field-body) Body to be [`any`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/data-model.md#type-any) (not a `string`).

However, the spec in the same section later says:
> First-party Applications SHOULD use a string message.

The spec [here](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/README.md#new-first-party-application-logs) says that the application is First-Party App if it is using Bridge API. Therefore, the spec recommends passing Body via Bridge API as `string`.

Here is how the languages are currently representing Body in their Logs Bridge APIs:

- [Java](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java) (stable logs): Defines Body as `string`.
- [.NET](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Logs/LogRecordData.cs) (stable logs): Defines Body as `string`.
- [C++](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Logs/LogRecordData.cs) (stable logs): Defines Body as attribute value (however [a map as value is not supported](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/common/attribute_value.h)).
- [Python](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py) (experimental logs): Defines Body as `Any` (in Python sense which means it can be anything).

However, I think that the Bridge API can still accept a structured body (`any`). This would give more flexibility to the Bridge API consumer and also can be helpful when if we the user would like to pass events (structured logs).

Slack thread: https://cloud-native.slack.com/archives/C01N7PP1THC/p1704907537212259

Related to https://github.com/open-telemetry/opentelemetry-go/pull/4809
