### PR TITLE
Update Attributes field type in Logs Data Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ release.
 
 ### Logs
 
-- Update types of Resource and Attributes fields in Logs Data Model.
+- Update `Attributes` field type in Logs Data Model to reference common attributes collection.
   ([#3814](https://github.com/open-telemetry/opentelemetry-specification/pull/3814))
 
 ### Resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ release.
 
 ## Unreleased
 
+### Context
+
+### Traces
+
+### Metrics
+
+### Logs
+
+### Resource
+
+### OpenTelemetry Protocol
+
+### Compatibility
+
+### SDK Configuration
+
+### Common
+
+### Supplementary Guidelines
+
+## v1.29.0 (2024-01-10)
+
 ### Context & Baggage
 
 - Align definition of Baggage with W3C Specification.
@@ -19,6 +41,10 @@ release.
 
 ### Metrics
 
+- Define experimental MetricFilter as a mechanism to filter collected metrics by the MetricReader
+  ([#3566](https://github.com/open-telemetry/opentelemetry-specification/pull/3566))
+- Add optional configuration for Prometheus exporters to optionally remove unit and type suffixes.
+  ([#3777](https://github.com/open-telemetry/opentelemetry-specification/pull/3777))
 - Add optional configuration for Prometheus exporters to optionally drop `otel_scope_info` metric.
   ([#3796](https://github.com/open-telemetry/opentelemetry-specification/pull/3796))
 
@@ -31,6 +57,9 @@ release.
 ### Compatibility
 
 ### SDK Configuration
+
+- Define file configuration file format and env var substitution
+  ([#3744](https://github.com/open-telemetry/opentelemetry-specification/pull/3744))
 
 ### Common
 
@@ -54,14 +83,10 @@ release.
 
 ### Metrics
 
-- Define experimental MetricFilter as a mechanism to filter collected metrics by the MetricReader
-  ([#3566](https://github.com/open-telemetry/opentelemetry-specification/pull/3566))
 - Add optional configuration for Prometheus exporters to promote resource attributes to metric attributes
   ([#3761](https://github.com/open-telemetry/opentelemetry-specification/pull/3761))
 - Clarifications and flexibility in Exemplar speicification.
   ([#3760](https://github.com/open-telemetry/opentelemetry-specification/pull/3760))
-- Add optional configuration for Prometheus exporters to optionally remove unit and type suffixes.
-  ([#3777](https://github.com/open-telemetry/opentelemetry-specification/pull/3777))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 ### Logs
 
+- Update types of Resource and Attributes fields in Logs Data Model.
+  ([#3814](https://github.com/open-telemetry/opentelemetry-specification/pull/3814))
+
 ### Resource
 
 ### OpenTelemetry Protocol

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -131,11 +131,11 @@ fields:
 
 - Named top-level fields of specific type and meaning.
 
-- Fields stored as `map<string, any>`, which can contain arbitrary values of
-  different types. The keys and values for well-known fields follow semantic
-  conventions for key names and possible values that allow all parties that work
-  with the field to have the same interpretation of the data. See references to
-  semantic conventions for `Resource` and `Attributes` fields and examples in
+- Fields that can contain arbitrary values of different types. The keys and
+  values for well-known fields follow semantic conventions for key names and
+  possible values that allow all parties that work with the field to have the
+  same interpretation of the data. See references to semantic conventions for
+  `Resource` and `Attributes` fields and examples in
   [Appendix A](./data-model-appendix.md#appendix-a-example-mappings).
 
 The reasons for having these 2 kinds of fields are:
@@ -147,9 +147,9 @@ The reasons for having these 2 kinds of fields are:
 - Ability to enforce types of named fields, which is very useful for compiled
   languages with type checks.
 
-- Flexibility to represent less frequent data as `map<string, any>`. This
-  includes well-known data that has standardized semantics as well as arbitrary
-  custom data that the application may want to include in the logs.
+- Flexibility to represent less frequent data. This includes well-known data
+  that has standardized semantics as well as arbitrary custom data that the
+  application may want to include in the logs.
 
 When designing this data model we followed the following reasoning to make a
 decision about when to use a top-level named field:
@@ -402,7 +402,7 @@ corresponding short names).
 
 ### Field: `Body`
 
-Type: any.
+Type: [`any`](#type-any).
 
 Description: A value containing the body of the log record (see the description
 of `any` type above). Can be for example a human-readable string message
@@ -415,7 +415,7 @@ source. This field is optional.
 
 ### Field: `Resource`
 
-Type: `map<string, any>`.
+Type: [Resource](../resource/sdk.md).
 
 Description: Describes the source of the log, aka
 [resource](../overview.md#resources). Multiple occurrences of events coming from
@@ -444,7 +444,7 @@ is optional.
 
 ### Field: `Attributes`
 
-Type: `map<string, any>`.
+Type: [Attribute Collection](../common/README.md#attribute-collections).
 
 Description: Additional information about the specific event occurrence. Unlike
 the `Resource` field, which is fixed for a particular source, `Attributes` can

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -415,7 +415,7 @@ source. This field is optional.
 
 ### Field: `Resource`
 
-Type: [Resource](../resource/sdk.md).
+Type: `map<string, any>`.
 
 Description: Describes the source of the log, aka
 [resource](../overview.md#resources). Multiple occurrences of events coming from


### PR DESCRIPTION
## Changes

Change the type of `Attributes` to reference the common definition of attributes collection.



## Why

None language currently supports "nested values" in log attributes. All of them represent attributes in the same way for all signals.
   - Java (stable logs): [reuses a common attribute type](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/logs/LogRecordBuilder.java) and [a map as value is not supported](https://github.com/open-telemetry/opentelemetry-java/blob/main/api/all/src/main/java/io/opentelemetry/api/common/AttributeType.java)
   - .NET (stable logs): [models attributes](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Logs/LogRecordAttributeList.cs) (for all signals) as [`KeyValuePair<string, object?>`](https://learn.microsoft.com/en-us/dotnet/api/system.collections.generic.keyvaluepair-2) and [a map as value is not supported by OTLP exporter](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/Shared/TagTransformer.cs)
   - C++ (stable logs): [reuses a common attribute type](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/logs/log_record.h) and [a map as value is not supported](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/common/attribute_value.h)
   - Python (experimental logs): [reuses a common attribute type](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py) and [a map as value is not supported](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/util/types.py)

I feel it would be awkward if attributes in different signals would be modeled differently especially that attributes are defined in the specification separately in a "common" directory.  Moreover, the common definition of attributes collection  even mentions logs attributes:

https://github.com/open-telemetry/opentelemetry-specification/blob/12cd1b1a4750a287282c4bfcd713de38d6716700/specification/common/README.md#L128

If we would like to have "nested values" in attributes then I think that it should be addressed as part of https://github.com/open-telemetry/opentelemetry-specification/issues/376.

I think that the most important thing is to handle "nested values" in `Body` so that logs can handle structured log records (events).

EDIT: However, a lot of logging attributes allow adding nested/structured attributes to the log records.

These changes can be seen as breaking. However, there is 100% precedence of how log attributes and resource are currently handled in all languages that have logs marked as stable and experimental (except Erlang which I have not checked).


Related PRs:
- https://github.com/open-telemetry/opentelemetry-specification/pull/2888
- https://github.com/open-telemetry/opentelemetry-go/pull/4809