### PR TITLE
Fix Resource field type in Logs Data Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 ### Logs
 
+- Fix `Resource` field type in Logs Data Model.
+  ([#3814](https://github.com/open-telemetry/opentelemetry-specification/pull/3814))
+
 ### Resource
 
 ### OpenTelemetry Protocol

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ release.
 ### Logs
 
 - Fix `Resource` field type in Logs Data Model.
-  ([#3814](https://github.com/open-telemetry/opentelemetry-specification/pull/3814))
+  ([#3826](https://github.com/open-telemetry/opentelemetry-specification/pull/3826))
 
 ### Resource
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -415,7 +415,7 @@ source. This field is optional.
 
 ### Field: `Resource`
 
-Type: `map<string, any>`.
+Type: [Resource](../resource/sdk.md).
 
 Description: Describes the source of the log, aka
 [resource](../overview.md#resources). Multiple occurrences of events coming from


### PR DESCRIPTION
## Changes

Change the type of `Resource` to reference the definition in the SDK so that the resource's scheme URL is included in logs data model.

## Why

The Logs Data Model misses scheme URL of resource. All of the languages reuse a common type representing resource.
  - Java (stable logs): [reuses a common resource type](https://github.com/open-telemetry/opentelemetry-java/blob/main/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/data/LogRecordData.java)
  - .NET (stable logs): [reuses a common resource type](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Exporter.OpenTelemetryProtocol/Implementation/OtlpLogRecordTransformer.cs) 
  - C++ (stable logs): [reuses a common resource type](https://github.com/open-telemetry/opentelemetry-cpp/blob/main/sdk/src/logs/read_write_log_record.cc) 
   - Python (experimental logs): [reuses a common resource type](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/_logs/_internal/__init__.py) 

These changes can be seen as breaking. However, there is 100% precedence of how log attributes and resource are currently handled in all languages. I see the current description as a bug because we would miss scheme URL of the resource. AFAIK the intention of the OTel Logs Specification authors was to have only nested values for Body and Attributes.

Related PRs:
- https://github.com/open-telemetry/opentelemetry-specification/pull/2888
- https://github.com/open-telemetry/opentelemetry-go/pull/4809