### PR TITLE
Remove confusing description from Body field in Logs Data Model

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -402,16 +402,13 @@ corresponding short names).
 
 ### Field: `Body`
 
-Type: any.
+Type: [`any`](#type-any).
 
 Description: A value containing the body of the log record (see the description
 of `any` type above). Can be for example a human-readable string message
 (including multi-line) describing the event in a free form or it can be a
-structured data composed of arrays and maps of other values. First-party
-Applications SHOULD use a string message. However, a structured body SHOULD be
-used to preserve the semantics of structured logs emitted by Third-party
-Applications. Can vary for each occurrence of the event coming from the same
-source. This field is optional.
+structured data composed of arrays and maps of other values.
+This field is optional.
 
 ### Field: `Resource`
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-specification/pull/3814

## Changes

Remove confusing description from Body field in Logs Data Model.

The description makes the specification not clear as the language authors may understand that the Bridge API must only accept Body as string in https://github.com/open-telemetry/opentelemetry-specification/pull/3814. The existing description is clear enough.
