### PR TITLE
[editorial] Add redirect rule to published OTLP page

### DIFF
--- a/specification/protocol/otlp.md
+++ b/specification/protocol/otlp.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Specification
+redirect: /docs/specs/otlp/ 301!
 --->
 
 # OpenTelemetry Protocol Specification
 
-This page has moved to
-[github.com/open-telemetry/opentelemetry-proto/docs/specification.md](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md).
+This page has moved to [OTLP](https://opentelemetry.io/docs/specs/otlp/).


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/3799
- On the OTel website, when a reader visits the `specification/protocol/otlp` page, they'll be automatically redirected to the website's OTLP spec page.

cc @theletterf @svrnm 