### PR TITLE
[editorial] OTLP design & req: redirect to GH & mark as external

### DIFF
--- a/specification/protocol/README.md
+++ b/specification/protocol/README.md
@@ -4,8 +4,13 @@ linkTitle: Protocol
 
 # OpenTelemetry Protocol
 
-The OpenTelemetry protocol (OTLP) specification has moved to
-[github.com/open-telemetry/opentelemetry-proto/docs/README.md](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/README.md).
+The OpenTelemetry protocol (OTLP) design goals, requirements, and
+[specification] have moved to
+[github.com/open-telemetry/opentelemetry-proto/docs](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/).
+
+You can also view the specification from the OpenTelemetry website, see [OTLP][specification].
 
 For additional OTLP implementation requirements in the OpenTelemetry SDKs, see
 [SDK Exporter](exporter.md).
+
+[specification]: https://opentelemetry.io/docs/specs/otlp/

--- a/specification/protocol/design-goals.md
+++ b/specification/protocol/design-goals.md
@@ -1,5 +1,7 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Design Goals
+redirect: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/design-goals.md 301!
+manualLinkTarget: _blank
 --->
 
 # Design Goals for OpenTelemetry Wire Protocol

--- a/specification/protocol/requirements.md
+++ b/specification/protocol/requirements.md
@@ -1,5 +1,7 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Requirements
+redirect: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/requirements.md 301!
+manualLinkTarget: _blank
 --->
 
 # OpenTelemetry Protocol Requirements


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/3799. This PR adds front matter config to the **OTLP** **design-goals** and **requirements** pages so that:
  - Each page automatically redirects to its new GitHub home, and 
  - An "external link" icon is show next to the page links in the left sidenav (see the screenshot below)
-  Clarifies the text of the "OpenTelemetry Protocol" page to indicate that three pages have moved: design-goals, requirements, and the specification; not only the specification.

cc @theletterf @svrnm 

---

### Screenshot

... of the OTel website showing the left side nav section of the OTel sepc:

> <img width=300 src="https://github.com/open-telemetry/opentelemetry-specification/assets/4140793/d2861192-4215-43a7-aed4-4b58bec07b22">
