### PR TITLE
Define OTEL_CONFIG_FILE with environment variable merge semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ release.
 
 ### SDK Configuration
 
+- Define `OTEL_CONFIG_FILE` environment variable.
+   ([#3805](https://github.com/open-telemetry/opentelemetry-specification/pull/3805))
+
 ### Common
 
 - Clarify that attribute keys are case-sensitive.

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -276,37 +276,38 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 
 Note: Support for environment variables is optional.
 
-| Feature                                                  | Go  | Java | JS  | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|----------------------------------------------------------|-----|------|-----|-------------|------|--------|-----|------|-----|------|-------|
-| OTEL_SDK_DISABLED                                        | -   | +    | -   | -           | -    | -      | +   | -    | -   | -    | -     |
-| OTEL_RESOURCE_ATTRIBUTES                                 | +   | +    | +   | +           | +    | +      | +   | +    | +   | +    | -     |
-| OTEL_SERVICE_NAME                                        | +   | +    | +   | +           | +    | +      | +   |      |     | +    |       |
-| OTEL_LOG_LEVEL                                           | -   | -    | +   | [-][py1059] | +    | -      | +   |      | -   | -    | -     |
-| OTEL_PROPAGATORS                                         | -   | +    |     | +           | +    | +      | +   | -    | -   | -    | -     |
-| OTEL_BSP_*                                               | +   | +    | +   | +           | +    | +      | +   | +    | -   | +    | -     |
-| OTEL_BLRP_*                                              |     | +    |     |             |      |        |     |      |     | +    |       |
-| OTEL_EXPORTER_OTLP_*                                     | +   | +    |     | +           | +    | +      | +   | +    | +   | +    | -     |
-| OTEL_EXPORTER_ZIPKIN_*                                   | -   | +    |     | +           | +    | -      | +   | -    | -   | +    | -     |
-| OTEL_TRACES_EXPORTER                                     | -   | +    | +   | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_METRICS_EXPORTER                                    | -   | +    |     | +           | -    | -      | +   | -    | -   | -    | -     |
-| OTEL_LOGS_EXPORTER                                       | -   | +    |     | +           |      |        | +   |      |     | -    |       |
-| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT                          | +   | +    | +   | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT                   | +   | +    | +   | +           | +    | +      | +   |      |     | +    |       |
-| OTEL_SPAN_EVENT_COUNT_LIMIT                              | +   | +    | +   | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_SPAN_LINK_COUNT_LIMIT                               | +   | +    | +   | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT                         | +   | -    |     | +           | +    | +      | +   |      |     | +    |       |
-| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT                          | +   | -    |     | +           | +    | +      | +   |      |     | +    |       |
-| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT                     |     |      |     |             |      |        | +   |      |     |      |       |
-| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT              |     |      |     |             |      |        | +   |      |     |      |       |
-| OTEL_TRACES_SAMPLER                                      | +   | +    | +   | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_TRACES_SAMPLER_ARG                                  | +   | +    | +   | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                        | +   | +    | +   | +           | +    | -      | +   |      |     | +    |       |
-| OTEL_ATTRIBUTE_COUNT_LIMIT                               | +   | +    | +   | +           | +    | -      | +   |      |     | +    |       |
-| OTEL_METRIC_EXPORT_INTERVAL                              | -   | +    |     |             |      |        | +   |      |     | +    |       |
-| OTEL_METRIC_EXPORT_TIMEOUT                               | -   | -    |     |             |      |        | +   |      |     | +    |       |
-| OTEL_METRICS_EXEMPLAR_FILTER                             | -   | +    |     |             |      |        | +   |      |     | -    |       |
-| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | -   | +    | +   | +           |      |        | +   |      |     | +    |       |
-| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |     | +    |     |             |      |        |     |      |     |      |       |
+| Feature                                                  | Go | Java | JS | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+|----------------------------------------------------------|----|------|----|-------------|------|--------|-----|------|-----|------|-------|
+| OTEL_SDK_DISABLED                                        | -  | +    | -  | -           | -    | -      | +   | -    | -   | -    | -     |
+| OTEL_RESOURCE_ATTRIBUTES                                 | +  | +    | +  | +           | +    | +      | +   | +    | +   | +    | -     |
+| OTEL_SERVICE_NAME                                        | +  | +    | +  | +           | +    | +      | +   |      |     | +    |       |
+| OTEL_LOG_LEVEL                                           | -  | -    | +  | [-][py1059] | +    | -      | +   |      | -   | -    | -     |
+| OTEL_PROPAGATORS                                         | -  | +    |    | +           | +    | +      | +   | -    | -   | -    | -     |
+| OTEL_BSP_*                                               | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    | -     |
+| OTEL_BLRP_*                                              |    | +    |    |             |      |        |     |      |     | +    |       |
+| OTEL_EXPORTER_OTLP_*                                     | +  | +    |    | +           | +    | +      | +   | +    | +   | +    | -     |
+| OTEL_EXPORTER_ZIPKIN_*                                   | -  | +    |    | +           | +    | -      | +   | -    | -   | +    | -     |
+| OTEL_TRACES_EXPORTER                                     | -  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
+| OTEL_METRICS_EXPORTER                                    | -  | +    |    | +           | -    | -      | +   | -    | -   | -    | -     |
+| OTEL_LOGS_EXPORTER                                       | -  | +    |    | +           |      |        | +   |      |     | -    |       |
+| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT                          | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
+| OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT                   | +  | +    | +  | +           | +    | +      | +   |      |     | +    |       |
+| OTEL_SPAN_EVENT_COUNT_LIMIT                              | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
+| OTEL_SPAN_LINK_COUNT_LIMIT                               | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
+| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT                         | +  | -    |    | +           | +    | +      | +   |      |     | +    |       |
+| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT                          | +  | -    |    | +           | +    | +      | +   |      |     | +    |       |
+| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT                     |    |      |    |             |      |        | +   |      |     |      |       |
+| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT              |    |      |    |             |      |        | +   |      |     |      |       |
+| OTEL_TRACES_SAMPLER                                      | +  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
+| OTEL_TRACES_SAMPLER_ARG                                  | +  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
+| OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                        | +  | +    | +  | +           | +    | -      | +   |      |     | +    |       |
+| OTEL_ATTRIBUTE_COUNT_LIMIT                               | +  | +    | +  | +           | +    | -      | +   |      |     | +    |       |
+| OTEL_METRIC_EXPORT_INTERVAL                              | -  | +    |    |             |      |        | +   |      |     | +    |       |
+| OTEL_METRIC_EXPORT_TIMEOUT                               | -  | -    |    |             |      |        | +   |      |     | +    |       |
+| OTEL_METRICS_EXEMPLAR_FILTER                             | -  | +    |    |             |      |        | +   |      |     | -    |       |
+| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | -  | +    | +  | +           |      |        | +   |      |     | +    |       |
+| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |    | +    |    |             |      |        |     |      |     |      |       |
+| OTEL_CONFIG_FILE                                         |    |      |    |             |      |        |     |      |     |      |       |
 
 ## File Configuration
 

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -302,9 +302,9 @@ that use [periodic exporting MetricReader](../metrics/sdk.md#periodic-exporting-
 
 Environment variables involved in [file configuration](file-configuration.md).
 
-| Name             | Description                                                   | Default | Notes     |
-|------------------|---------------------------------------------------------------|---------|-----------|
-| OTEL_CONFIG_FILE | The path of the configuration file used to configure the SDK. |         | See below |
+| Name             | Description                                                                                                                                                                   | Default | Notes     |
+|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-----------|
+| OTEL_CONFIG_FILE | The path of the configuration file used to configure the SDK. If set, the configuration in this file takes precedence over all other SDK configuration environment variables. |         | See below |
 
 If `OTEL_CONFIG_FILE` is set, the file at the specified path is used to
 call [Parse](file-configuration.md#parse). The

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -8,7 +8,39 @@ aliases:
 
 # OpenTelemetry Environment Variable Specification
 
-**Status**: [Mixed](../document-status.md)
+**Status**: [Stable](../document-status.md) except where otherwise specified
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- toc -->
+
+- [Implementation guidelines](#implementation-guidelines)
+- [Parsing empty value](#parsing-empty-value)
+- [Special configuration types](#special-configuration-types)
+  * [Boolean value](#boolean-value)
+  * [Numeric value](#numeric-value)
+  * [Enum value](#enum-value)
+  * [Duration](#duration)
+- [General SDK Configuration](#general-sdk-configuration)
+- [Batch Span Processor](#batch-span-processor)
+- [Batch LogRecord Processor](#batch-logrecord-processor)
+- [Attribute Limits](#attribute-limits)
+- [Span Limits](#span-limits)
+- [LogRecord Limits](#logrecord-limits)
+- [OTLP Exporter](#otlp-exporter)
+- [Zipkin Exporter](#zipkin-exporter)
+- [Prometheus Exporter](#prometheus-exporter)
+- [Exporter Selection](#exporter-selection)
+- [Metrics SDK Configuration](#metrics-sdk-configuration)
+  * [Exemplar](#exemplar)
+  * [Periodic exporting MetricReader](#periodic-exporting-metricreader)
+- [File Configuration](#file-configuration)
+- [Language Specific Environment Variables](#language-specific-environment-variables)
+
+<!-- tocstop -->
+
+</details>
 
 The goal of this specification is to unify the environment variable names between different OpenTelemetry implementations.
 
@@ -17,21 +49,15 @@ If they do, they SHOULD use the names listed in this document.
 
 ## Implementation guidelines
 
-**Status**: [Stable](../document-status.md)
-
 Environment variables MAY be handled (implemented) directly by a component, in the SDK, or in a separate component (e.g. environment-based autoconfiguration component).
 
 The environment-based configuration MUST have a direct code configuration equivalent.
 
 ## Parsing empty value
 
-**Status**: [Stable](../document-status.md)
-
 The SDK MUST interpret an empty value of an environment variable the same way as when the variable is unset.
 
 ## Special configuration types
-
-**Status**: [Stable](../document-status.md)
 
 ### Boolean value
 
@@ -47,9 +73,9 @@ Renaming or changing the default value MUST NOT happen without a major version u
 If an implementation chooses to support an integer-valued environment variable, it SHOULD support nonnegative values between 0 and 2³¹ − 1 (inclusive). Individual SDKs MAY choose to support a larger range of values.
 
 > The following paragraph was added after stabilization and the requirements are
-thus qualified as "SHOULD" to allow implementations to avoid breaking changes.
-For new
-implementations, these should be treated as MUST requirements.
+> thus qualified as "SHOULD" to allow implementations to avoid breaking changes.
+> For new
+> implementations, these should be treated as MUST requirements.
 
 For variables accepting a numeric value, if the user provides a value the implementation cannot parse,
 or which is outside the valid range for the configuration item, the implementation SHOULD
@@ -82,8 +108,6 @@ gracefully ignore the setting and use the default value if it is defined.
 For example, the value `12000` indicates 12000 milliseconds, i.e., 12 seconds.
 
 ## General SDK Configuration
-
-**Status**: [Stable](../document-status.md)
 
 | Name                     | Description                                                                                                   | Default                                                                                                                                          | Notes                                                                                                                                                                                                                                                                                    |
 |--------------------------|---------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -129,8 +153,6 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 
 ## Batch Span Processor
 
-**Status**: [Stable](../document-status.md)
-
 | Name                           | Description                                                      | Default  | Notes                                                 |
 | ------------------------------ | ---------------------------------------------------------------- | -------  | ----------------------------------------------------- |
 | OTEL_BSP_SCHEDULE_DELAY        | Delay interval (in milliseconds) between two consecutive exports | 5000     |                                                       |
@@ -139,8 +161,6 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 | OTEL_BSP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                                               | 512      | Must be less than or equal to OTEL_BSP_MAX_QUEUE_SIZE |
 
 ## Batch LogRecord Processor
-
-**Status**: [Stable](../document-status.md)
 
 | Name                            | Description                                                      | Default  | Notes                                                  |
 | ------------------------------- | ---------------------------------------------------------------- | -------  | ------------------------------------------------------ |
@@ -163,8 +183,6 @@ See the SDK [Attribute Limits](../common/README.md#attribute-limits) section for
 
 ## Span Limits
 
-**Status**: [Stable](../document-status.md)
-
 See the SDK [Span Limits](../trace/sdk.md#span-limits) section for the definition of the limits.
 
 | Name                                   | Description                                    | Default | Notes |
@@ -178,8 +196,6 @@ See the SDK [Span Limits](../trace/sdk.md#span-limits) section for the definitio
 
 ## LogRecord Limits
 
-**Status**: [Stable](../document-status.md)
-
 See the SDK [LogRecord Limits](../logs/sdk.md#logrecord-limits) section for the definition of the limits.
 
 | Name                                        | Description                                | Default  | Notes |
@@ -192,8 +208,6 @@ See the SDK [LogRecord Limits](../logs/sdk.md#logrecord-limits) section for the 
 See [OpenTelemetry Protocol Exporter Configuration Options](../protocol/exporter.md).
 
 ## Zipkin Exporter
-
-**Status**: [Stable](../document-status.md)
 
 | Name                          | Description                                                                        | Default                              |
 | ----------------------------- | ---------------------------------------------------------------------------------- |------------------------------------- |
@@ -219,8 +233,6 @@ _is no specified default, or configuration via environment variables_.
 | OTEL_EXPORTER_PROMETHEUS_PORT | Port used by the Prometheus exporter | 9464                    |
 
 ## Exporter Selection
-
-**Status**: [Stable](../document-status.md)
 
 We define environment variables for setting one or more exporters per signal.
 
@@ -260,8 +272,6 @@ NOT be supported by new implementations.
 
 ## Metrics SDK Configuration
 
-**Status**: [Mixed](../document-status.md)
-
 ### Exemplar
 
 **Status**: [Experimental](../document-status.md)
@@ -278,8 +288,6 @@ Known values for `OTEL_METRICS_EXEMPLAR_FILTER` are:
 
 ### Periodic exporting MetricReader
 
-**Status**: [Stable](../document-status.md)
-
 Environment variables specific for the push metrics exporters (OTLP, stdout, in-memory)
 that use [periodic exporting MetricReader](../metrics/sdk.md#periodic-exporting-metricreader).
 
@@ -287,6 +295,35 @@ that use [periodic exporting MetricReader](../metrics/sdk.md#periodic-exporting-
 | ----------------------------- | ----------------------------------------------------------------------------- | ------- | ----- |
 | `OTEL_METRIC_EXPORT_INTERVAL` | The time interval (in milliseconds) between the start of two export attempts. | 60000   |       |
 | `OTEL_METRIC_EXPORT_TIMEOUT`  | Maximum allowed time (in milliseconds) to export data.                        | 30000   |       |
+
+## File Configuration
+
+**Status**: [Experimental](../document-status.md)
+
+Environment variables involved in [file configuration](file-configuration.md).
+
+| Name             | Description                                                   | Default | Notes     |
+|------------------|---------------------------------------------------------------|---------|-----------|
+| OTEL_CONFIG_FILE | The path of the configuration file used to configure the SDK. |         | See below |
+
+If `OTEL_CONFIG_FILE` is set, the file at the specified path is used to
+call [Parse](file-configuration.md#parse). The
+resulting [configuration model](./file-configuration.md#configuration-model) is
+used to call [Create](file-configuration.md#create) to produce fully configured
+SDK components.
+
+When `OTEL_CONFIG_FILE` is set, all other environment variables besides those
+reference in the configuration file
+for [environment variable substitution](file-configuration.md#environment-variable-substitution)
+MUST be ignored. Ignoring the environment variables is necessary because
+there is no intuitive way to merge the flat environment variable scheme with the
+structured file configuration scheme in all cases. Users that require merging
+multiple sources of configuration are encouraged to customize the configuration
+model returned by `Parse` before `Create` is called. For example, a user may
+call `Parse` on multiple files and define logic from merging the resulting
+configuration models, or overlay values from environment variables on top of a
+configuration model. Implementations MAY provide a mechanism to customize the
+configuration model parsed from `OTEL_CONFIG_FILE`.
 
 ## Language Specific Environment Variables
 

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -313,7 +313,7 @@ used to call [Create](file-configuration.md#create) to produce fully configured
 SDK components.
 
 When `OTEL_CONFIG_FILE` is set, all other environment variables besides those
-reference in the configuration file
+referenced in the configuration file
 for [environment variable substitution](file-configuration.md#environment-variable-substitution)
 MUST be ignored. Ignoring the environment variables is necessary because
 there is no intuitive way to merge the flat environment variable scheme with the

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -302,28 +302,37 @@ that use [periodic exporting MetricReader](../metrics/sdk.md#periodic-exporting-
 
 Environment variables involved in [file configuration](file-configuration.md).
 
-| Name             | Description                                                                                                                                                                   | Default | Notes     |
-|------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-----------|
-| OTEL_CONFIG_FILE | The path of the configuration file used to configure the SDK. If set, the configuration in this file takes precedence over all other SDK configuration environment variables. |         | See below |
+| Name             | Description                                                   | Default | Notes     |
+|------------------|---------------------------------------------------------------|---------|-----------|
+| OTEL_CONFIG_FILE | The path of the configuration file used to configure the SDK. |         | See below |
 
 If `OTEL_CONFIG_FILE` is set, the file at the specified path is used to
-call [Parse](file-configuration.md#parse). The
-resulting [configuration model](./file-configuration.md#configuration-model) is
-used to call [Create](file-configuration.md#create) to produce fully configured
-SDK components.
+call [Parse](file-configuration.md#parse), [Merge Environment](./file-configuration#merge-environment), [Create](file-configuration.md#create).
+The implementation SHOULD log a warning if calling Merge Environment results in
+changes to
+the [configuration model](./file-configuration.md#configuration-model).
+Implementations MAY provide a mechanism to further customize the configuration
+model parsed from `OTEL_CONFIG_FILE`. It SHOULD be possible to opt-in to logging
+the resolved configuration model.
 
-When `OTEL_CONFIG_FILE` is set, all other environment variables besides those
-referenced in the configuration file
-for [environment variable substitution](file-configuration.md#environment-variable-substitution)
-MUST be ignored. Ignoring the environment variables is necessary because
-there is no intuitive way to merge the flat environment variable scheme with the
-structured file configuration scheme in all cases. Users that require merging
-multiple sources of configuration are encouraged to customize the configuration
-model returned by `Parse` before `Create` is called. For example, a user may
-call `Parse` on multiple files and define logic from merging the resulting
-configuration models, or overlay values from environment variables on top of a
-configuration model. Implementations MAY provide a mechanism to customize the
-configuration model parsed from `OTEL_CONFIG_FILE`.
+An example Java implementation:
+
+```java
+OpenTelemetryConfiguration parsedModel = parse("/path/to/config.yaml");
+OpenTelemetryConfiguration modelWithEnvironment = mergeEnvironment(parsedModel);
+if (parsedModel.equals(modelWithEnvironment)) {
+    logger.warn("Environment variables were set that overrode the configuration specified at /path/to/config.yaml");
+}
+// Log at debug level so user has to opt-in to logging effective configuration
+logger.debug("Effective configuration: \n" + toString(modelWithEnvironment));
+OpenTelemetrySdk sdk = create(modelWithEnvironment);
+```
+
+Users with complex configuration requirements (e.g. merging multiple
+configuration files or non-standard merging of environment variables) are
+encouraged to directly use [Parse](./file-configuration.md#parse) and
+programmatically manipulate the configuration model before
+calling [Create](./file-configuration.md#create).
 
 ## Language Specific Environment Variables
 


### PR DESCRIPTION
An alternative to #3805 which merges the environment variable configuration scheme instead of ignoring it.

The merge semantics are messy. As discussed in #3805, there are no merge rules that will satisfy everyone in all use cases. The rules in this PR reflect @trask's [proposal](https://github.com/open-telemetry/opentelemetry-specification/issues/3752#issuecomment-1905004136), which aims to be the least surprising. 

Resolves #3752.