### PR TITLE
Stabilize the schema file formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ release.
 
 ### Common
 
+### Telemetry Schemas
+
+- Stabilize the `v1.0.0` and `v1.1.0` schema file formats.
+  ([#3845](https://github.com/open-telemetry/opentelemetry-specification/pull/3845))
+
 ### Supplementary Guidelines
 
 ## v1.29.0 (2024-01-10)

--- a/specification/schemas/file_format_v1.0.0.md
+++ b/specification/schemas/file_format_v1.0.0.md
@@ -4,7 +4,7 @@ linkTitle: 1.0.0
 
 # Schema File Format 1.0.0
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 A Schema File is a YAML file that describes the schema of a particular version.
 It defines the transformations that can be used to convert the telemetry data

--- a/specification/schemas/file_format_v1.1.0.md
+++ b/specification/schemas/file_format_v1.1.0.md
@@ -4,7 +4,7 @@ linkTitle: 1.1.0
 
 # Schema File Format 1.1.0
 
-**Status**: [Experimental](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 A Schema File is a YAML file that describes the schema of a particular version.
 It defines the transformations that can be used to convert the telemetry data


### PR DESCRIPTION
Resolve #3844

Both of these files has not changed in two years and are broadly adopted in our semantic conventions. Given they are effectively stabilized as there is likely no desire to change these in any breaking way, make it official by stabilizing both.
