### PR TITLE
Remove forgotten TODO text inside specification/logs/supplementary-guidelines.md

### DIFF
--- a/specification/logs/supplementary-guidelines.md
+++ b/specification/logs/supplementary-guidelines.md
@@ -91,9 +91,6 @@ calling [emit a LogRecord](./bridge-api.md#emit-a-logrecord). This allows the co
 to be included even when log records are emitted asynchronously, which can
 otherwise lead the Context to be incorrect.
 
-TODO: clarify how works or doesn't work when the log statement call site and the
-log appender are executed on different threads.
-
 #### Explicit Context Injection
 
 In order for `TraceContext` to be recorded in `LogRecord`s in languages where


### PR DESCRIPTION
There is a line with text `TODO: clarify how works or doesn't work when the log statement call site and the
log appender are executed on different threads.` at [supplementary guidelines page of logs specification](https://opentelemetry.io/docs/specs/otel/logs/supplementary-guidelines/#implicit-context-injection). This doesn't seem to explain a concept, but rather seems to be a reminder to the author. This PR removes that text.

## Changes

Removing `TODO: clarify how works or doesn't work when the log statement call site and the
log appender are executed on different threads.` text from specification/logs/supplementary-guidelines.md
