### PR TITLE
[Editorial] clarify cardinality limit

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -731,8 +731,10 @@ of metrics across successive collections.
 
 **Status**: [Experimental](../document-status.md)
 
-SDKs SHOULD support being configured with a cardinality limit. A cardinality
-limit is the hard limit on the number of metric streams that can be collected.
+SDKs SHOULD support being configured with a cardinality limit. The number of
+unique combinations of attributes is called cardinality. For a given metric
+stream, the cardinality limit is a hard limit on the number of metric points
+that can be collected during a collection cycle.
 
 #### Configuration
 


### PR DESCRIPTION
The current spec is misleading IMO "A cardinality limit is the hard limit on the number of metric streams that can be collected". It should be the limit of cardinality for a given metric stream.