### PR TITLE
[editorial] Add redirect rules to moved OTLP attribute pages

### DIFF
--- a/specification/common/attribute-naming.md
+++ b/specification/common/attribute-naming.md
@@ -1,4 +1,8 @@
+<!--- Hugo front matter used to generate the website version of this page:
+redirect: /docs/specs/semconv/general/attribute-naming/ 301!
+--->
+
 # Attribute Naming
 
 This page has moved to
-[github.com/open-telemetry/semantic-conventions/docs/general/attribute-naming.md](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-naming.md).
+[Attribute Naming](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).

--- a/specification/common/attribute-requirement-level.md
+++ b/specification/common/attribute-requirement-level.md
@@ -1,4 +1,9 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Attribute Requirement Levels
+redirect: /docs/specs/semconv/general/attribute-requirement-level/ 301!
+--->
+
 # Attribute Requirement Levels for Semantic Conventions
 
 This page has moved to
-[github.com/open-telemetry/semantic-conventions/docs/general/attribute-requirement-level.md](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-requirement-level.md).
+[Attribute Requirement Levels](https://opentelemetry.io/docs/specs/semconv/general/attribute-requirement-level/).


### PR DESCRIPTION
- This is in the same spirit as #3831
- Fixes https://github.com/open-telemetry/opentelemetry.io/issues/3799
- On the OTel website, when a reader visits the attributes page affected by this PR, they'll be automatically redirected to the corresponding semconv page on the OTel.io website

cc @theletterf @svrnm 