### PR TITLE
[editorial] Add Hugo front-matter path base

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -5,8 +5,11 @@ cascade:
   body_class: otel-docs-spec
   github_repo: &repo https://github.com/open-telemetry/opentelemetry-specification
   github_subdir: specification
-  path_base_for_github_subdir: content/en/docs/specs/otel/
+  path_base_for_github_subdir: tmp/otel/specification
   github_project_repo: *repo
+path_base_for_github_subdir:
+  from: tmp/otel/specification/_index.md
+  to: README.md
 --->
 
 # OpenTelemetry Specification

--- a/specification/baggage/README.md
+++ b/specification/baggage/README.md
@@ -1,1 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+path_base_for_github_subdir:
+  from: tmp/otel/specification/baggage/_index.md
+  to: baggage/README.md
+--->
+
 # Baggage

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -1,6 +1,9 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Common concepts
 aliases: [/docs/reference/specification/common/common]
+path_base_for_github_subdir:
+  from: tmp/otel/specification/common/_index.md
+  to: common/README.md
 --->
 
 # Common specification concepts

--- a/specification/compatibility/README.md
+++ b/specification/compatibility/README.md
@@ -1,1 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+path_base_for_github_subdir:
+  from: tmp/otel/specification/compatibility/_index.md
+  to: compatibility/README.md
+--->
+
 # Compatibility

--- a/specification/configuration/README.md
+++ b/specification/configuration/README.md
@@ -1,1 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+path_base_for_github_subdir:
+  from: tmp/otel/specification/configuration/_index.md
+  to: configuration/README.md
+--->
+
 # Configuration

--- a/specification/context/README.md
+++ b/specification/context/README.md
@@ -1,5 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 aliases: [/docs/reference/specification/context/context]
+path_base_for_github_subdir:
+  from: tmp/otel/specification/context/_index.md
+  to: context/README.md
 --->
 
 # Context

--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -1,6 +1,9 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Logs
 aliases: [/docs/reference/specification/logs/overview]
+path_base_for_github_subdir:
+  from: tmp/otel/specification/logs/_index.md
+  to: logs/README.md
 --->
 
 # OpenTelemetry Logging

--- a/specification/metrics/README.md
+++ b/specification/metrics/README.md
@@ -1,5 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Metrics
+path_base_for_github_subdir:
+  from: tmp/otel/specification/metrics/_index.md
+  to: metrics/README.md
 --->
 
 # OpenTelemetry Metrics

--- a/specification/metrics/sdk_exporters/README.md
+++ b/specification/metrics/sdk_exporters/README.md
@@ -1,5 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Exporters
+path_base_for_github_subdir:
+  from: tmp/otel/specification/metrics/sdk_exporters/_index.md
+  to: metrics/sdk_exporters/README.md
 --->
 
 # Metrics Exporters

--- a/specification/protocol/README.md
+++ b/specification/protocol/README.md
@@ -1,5 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Protocol
+path_base_for_github_subdir:
+  from: tmp/otel/specification/protocol/_index.md
+  to: protocol/README.md
 --->
 
 # OpenTelemetry Protocol

--- a/specification/resource/README.md
+++ b/specification/resource/README.md
@@ -1,1 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+path_base_for_github_subdir:
+  from: tmp/otel/specification/resource/_index.md
+  to: resource/README.md
+--->
+
 # Resource

--- a/specification/schemas/README.md
+++ b/specification/schemas/README.md
@@ -1,6 +1,9 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Schemas
 aliases: [/docs/reference/specification/schemas/overview]
+path_base_for_github_subdir:
+  from: tmp/otel/specification/schemas/_index.md
+  to: schemas/README.md
 --->
 
 # Telemetry Schemas

--- a/specification/trace/README.md
+++ b/specification/trace/README.md
@@ -1,1 +1,7 @@
+<!--- Hugo front matter used to generate the website version of this page:
+path_base_for_github_subdir:
+  from: tmp/otel/specification/trace/_index.md
+  to: trace/README.md
+--->
+
 # Trace

--- a/specification/trace/sdk_exporters/README.md
+++ b/specification/trace/sdk_exporters/README.md
@@ -1,5 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Exporters
+path_base_for_github_subdir:
+  from: tmp/otel/specification/trace/sdk_exporters/_index.md
+  to: trace/sdk_exporters/README.md
 --->
 
 # Trace Exporters


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/3922
- Either updates or adds `path_base_for_github_subdir` to selected page front matter

/cc @theletterf @svrnm 