### PR TITLE
Fix typo in MetricFilter

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1597,7 +1597,7 @@ The filtering is done at the [MetricProducer](#metricproducer) for performance r
 The `MetricFilter` allows filtering an entire metric stream - dropping or allowing all its attribute sets -
 by its `TestMetric` operation, which accepts the metric stream information
 (scope, name, kind and unit)  and returns an enumeration: `Accept`, `Drop`
-or `Allow_Partial`. If the latter returned, the `TestAttributes` operation
+or `Accept_Partial`. If the latter returned, the `TestAttributes` operation
 is to be called per attribute set of that metric stream, returning an enumeration
 determining if the data point for that (metric stream, attributes) pair is to be
 allowed in the result of the [MetricProducer](#metricproducer) `Produce` operation.


### PR DESCRIPTION
## Changes
Fix the typo in MetricFilter. Except for this line, it says `Accept_Partial` in the metric filter definition. I forgot this line when I renamed it.
