### PR TITLE
[editorial] Remove use of Object-Oriented term `class` in trace API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ release.
 
 ### Traces
 
-- Remove use of Object-Oriented term `class` in trace API.
-  ([#3880](https://github.com/open-telemetry/opentelemetry-specification/pull/3880))
-
 ### Metrics
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- Remove use of Object-Oriented term `class` in trace API.
+  ([#3880](https://github.com/open-telemetry/opentelemetry-specification/pull/3880))
+
 ### Metrics
 
 - Expose `ExemplarReservoir` as configuration parameter for views.

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -52,11 +52,11 @@ linkTitle: API
 
 </details>
 
-The Tracing API consist of these main classes:
+The Tracing API consist of these main components:
 
 - [`TracerProvider`](#tracerprovider) is the entry point of the API.
   It provides access to `Tracer`s.
-- [`Tracer`](#tracer) is the class responsible for creating `Span`s.
+- [`Tracer`](#tracer) is responsible for creating `Span`s.
 - [`Span`](#span) is the API to trace an operation.
 
 ## Data types


### PR DESCRIPTION
Part of #1569