### PR TITLE
[editorial] Remove use of Object-Oriented term `class` in metric API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,6 @@ release.
   Remove `ExemplarFilter` as an interface, now it is only configuration
   parameter.
   ([#3820](https://github.com/open-telemetry/opentelemetry-specification/pull/3820))
-- Remove use of Object-Oriented term `class` in metric API.
-  ([#3881](https://github.com/open-telemetry/opentelemetry-specification/pull/3881))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ release.
   Remove `ExemplarFilter` as an interface, now it is only configuration
   parameter.
   ([#3820](https://github.com/open-telemetry/opentelemetry-specification/pull/3820))
+- Remove use of Object-Oriented term `class` in metric API.
+  ([#3881](https://github.com/open-telemetry/opentelemetry-specification/pull/3881))
 
 ### Logs
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -68,7 +68,7 @@ The Metrics API consists of these main components:
 
 * [MeterProvider](#meterprovider) is the entry point of the API. It provides
   access to `Meters`.
-* [Meter](#meter) is the class responsible for creating `Instruments`.
+* [Meter](#meter) is responsible for creating `Instruments`.
 * [Instrument](#instrument) is responsible for reporting
   [Measurements](#measurement).
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/1569