### PR TITLE
[editorial] Remove use of Object-Oriented term `class` in log signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ release.
   ([#3827](https://github.com/open-telemetry/opentelemetry-specification/pull/3827))
 - Deconstruct number scalar type to double and signed integer.
   ([#3854](https://github.com/open-telemetry/opentelemetry-specification/pull/3854))
+- Remove use of Object-Oriented term `class` in log signal.
+  ([#3882](https://github.com/open-telemetry/opentelemetry-specification/pull/3882))
 
 ### Resource
 

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -30,10 +30,10 @@ library authors to build
 which use this API to bridge between existing logging libraries and the
 OpenTelemetry log data model.</b>
 
-The Logs Bridge API consist of these main classes:
+The Logs Bridge API consist of these main components:
 
 * [LoggerProvider](#loggerprovider) is the entry point of the API. It provides access to `Logger`s.
-* [Logger](#logger) is the class responsible for emitting logs as
+* [Logger](#logger) is responsible for emitting logs as
   [LogRecords](./data-model.md#log-and-event-record-definition).
 
 ```mermaid

--- a/specification/logs/noop.md
+++ b/specification/logs/noop.md
@@ -28,8 +28,8 @@ so that no telemetry is produced and computation resources are minimized.
 
 All language implementations of OpenTelemetry MUST provide a No-Op.
 
-The [Logs Bridge API](./bridge-api.md) defines classes with various operations.
-All No-Op classes MUST NOT hold configuration or operational state. All No-op
+The [Logs Bridge API](./bridge-api.md) defines components with various operations.
+All No-Op components MUST NOT hold configuration or operational state. All No-op
 operations MUST accept all defined parameters, MUST NOT validate any arguments
 received, and MUST NOT return any non-empty error or log any message.
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/1569
