### PR TITLE
Add "Platform" to Glossary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ release.
 
 ### Supplementary Guidelines
 
+- Add "Platform" to Glossary ([#3897](https://github.com/open-telemetry/opentelemetry-specification/pull/3897))
+
 ## v1.30.0 (2024-02-15)
 
 ### Context

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -191,6 +191,13 @@ application in the scope of which the telemetry is emitted.
 
 An umbrella term for the smallest unit of sequential code execution, used in different concepts of multitasking. Examples are threads, coroutines or fibers.
 
+### Platform
+
+Platforms are environments that provide developers with the tools and resources
+they need to build, deploy, and manage applications. One example of such a
+platform is .NET. Platforms might provide opinionated defaults and tools related
+to how telemetry should be generated and handled.
+
 ## Logs
 
 ### Log Record


### PR DESCRIPTION
## Changes

Add "Platform" to Glossary, as currently used in the Context/Propagators part of the spec.

* [x] Related issues #3896
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary

Fixes #3896

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>