### PR TITLE
Update status of stdout exporter for logs to stable

### DIFF
--- a/specification/logs/sdk_exporters/stdout.md
+++ b/specification/logs/sdk_exporters/stdout.md
@@ -4,7 +4,7 @@ linkTitle: Stdout
 
 # OpenTelemetry LogRecord Exporter - Standard output
 
-**Status**: [Experimental](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 "Standard output" LogRecord Exporter is a [LogRecord
 Exporter](../sdk.md#logrecordexporter) which outputs the logs to


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-specification/pull/3741/files and  https://github.com/open-telemetry/opentelemetry-specification/pull/3740/files were added together, and it is not clear why one is experimental, and the other is stable.

This PR is marking the logging stdout exporter spec as stable. I couldn't find any reason why it was non-stable in the first place, so I assume it was just an oversight only. Happy to be corrected, if I missed something

Fixes #

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
