### PR TITLE
[DoNotMerge] ReadableLogRecord is able to access the passed context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ release.
 
 ### Logs
 
+- `ReadableLogRecord` is able to access the passed context.
+  ([#3908](https://github.com/open-telemetry/opentelemetry-specification/pull/3908))
+
 ### Resource
 
 ### OpenTelemetry Protocol

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -135,7 +135,9 @@ following `LogRecord`-like interfaces are defined in the SDK:
 ### ReadableLogRecord
 
 A function receiving this as an argument MUST be able to access all the
-information added to the [LogRecord](data-model.md#log-and-event-record-definition). It MUST also be able to
+information added via [Emit a LogRecord](bridge-api.md#emit-a-logrecord).
+
+It MUST also be able to access the [Instrumentation Scope](./data-model.md#field-instrumentationscope)
 access the [Instrumentation Scope](./data-model.md#field-instrumentationscope)
 and [Resource](./data-model.md#field-resource) information (implicitly)
 associated with the `LogRecord`.


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-specification/pull/3907

## Changes

Clarify that `ReadableLogRecord` is able to access all information added via "Emit a log record". 

This is needed so that the SDK is able to get access to the passed `Context` (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md#emit-a-logrecord) which can contain e.g. some baggage that may want to be used e.g. by custom processors.

I think that the original intention of the spec authors was "Emit a Record" as "LogRecord" data model already defined fields that are later defined in `ReadableLogRecord` (e.g. Instrumentation Scope, Resource).
