### PR TITLE
Probability Samplers based on W3C Trace Context Level 2

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -355,6 +355,42 @@ Additional `Propagator`s implementing vendor-specific protocols such as AWS
 X-Ray trace header protocol MUST NOT be maintained or distributed as part of
 the Core OpenTelemetry repositories.
 
+### W3C Trace Context Requirements
+
+A W3C Trace Context propagator is expected to implement the
+`traceparent` and `tracestate` contexts fields specified in [W3C Trace
+Context Level 2](https://www.w3.org/TR/trace-context-2/).
+
+#### W3C Trace Context Inject and Extract
+
+When injecting and extracting trace context to ro from a carrier, the
+following fields are propagated.
+
+- TraceID (16 bytes)
+- SpanID (8 bytes)
+- TraceFlags (8 bits)
+- TraceState (string)
+
+Propagators SHOULD  all 8 valid bits in the Trace flags field
+from the `traceparent` header, even those not recognized at the time
+the implementation was prepared.  All 8 bits of the trace flags are
+expected to propagate.
+
+#### W3C Trace Context Inject
+
+When injecting trace context into a carrier, the following fields are
+taken from the Context and .
+
+- TraceID (16 bytes)
+- SpanID (8 bytes)
+- TraceFlags (8 bits)
+- Trace
+
+#### W3C Trace Context Fields
+
+Fields MUST return the list of header names containing `traceparent`
+and `tracestate`.
+
 ### B3 Requirements
 
 B3 has both single and multi-header encodings. It also has semantics that do not

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -361,8 +361,6 @@ A W3C Trace Context propagator is expected to implement the
 `traceparent` and `tracestate` contexts fields specified in [W3C Trace
 Context Level 2](https://www.w3.org/TR/trace-context-2/).
 
-#### W3C Trace Context Inject and Extract
-
 When injecting and extracting trace context to ro from a carrier, the
 following fields are propagated.
 
@@ -371,25 +369,7 @@ following fields are propagated.
 - TraceFlags (8 bits)
 - TraceState (string)
 
-Propagators SHOULD  all 8 valid bits in the Trace flags field
-from the `traceparent` header, even those not recognized at the time
-the implementation was prepared.  All 8 bits of the trace flags are
-expected to propagate.
-
-#### W3C Trace Context Inject
-
-When injecting trace context into a carrier, the following fields are
-taken from the Context and .
-
-- TraceID (16 bytes)
-- SpanID (8 bytes)
-- TraceFlags (8 bits)
-- Trace
-
-#### W3C Trace Context Fields
-
-Fields MUST return the list of header names containing `traceparent`
-and `tracestate`.
+Propagators MUST NOT assume that bits 2-7 (6 most significant bits) will be zero.
 
 ### B3 Requirements
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -361,7 +361,7 @@ A W3C Trace Context propagator is expected to implement the
 `traceparent` and `tracestate` contexts fields specified in [W3C Trace
 Context Level 2](https://www.w3.org/TR/trace-context-2/).
 
-When injecting and extracting trace context to ro from a carrier, the
+When injecting and extracting trace context to or from a carrier, the
 following fields are propagated.
 
 - TraceID (16 bytes)
@@ -369,7 +369,9 @@ following fields are propagated.
 - TraceFlags (8 bits)
 - TraceState (string)
 
-Propagators MUST NOT assume that bits 2-7 (6 most significant bits) will be zero.
+Propagators MUST NOT assume that bits 2-7 (6 most significant bits)
+will be zero, as they are reserved for future use and are expected to
+propagate with the context.
 
 ### B3 Requirements
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -221,7 +221,10 @@ byte.
 
 `TraceFlags` contain details about the trace. Unlike TraceState values,
 TraceFlags are present in all traces. The current version of the specification
-only supports a single flag called [sampled](https://www.w3.org/TR/trace-context/#sampled-flag).
+supports two flags:
+
+- [Sampled](https://www.w3.org/TR/trace-context/#sampled-flag)
+- [Random](https://www.w3.org/TR/trace-context-2/#random-trace-id-flag)
 
 `TraceState` carries vendor-specific trace identification data, represented as a list
 of key-value pairs. TraceState allows multiple tracing

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -339,30 +339,23 @@ the `ParentBased` sampler specified below.
 
 ##### `TraceIdRatioBased` sampler implementation overview
 
-SDKs SHOULD use an implementation that is equivalent to the
-specification referenced below as the `TraceIdRatioBased` Sampler,
-which is based on the [W3C Trace Context Level 2 Random TraceID
-flag](https://www.w3.org/TR/trace-context-2/#random-trace-id-flag).
-When a TraceID has the `Random` bit set, samplers are able to use 56
-specific bits of consistent randomness for sampling decisions.
+SDKs SHOULD conform with the [consistent-probability
+`TraceIdRatioBased` Sampler
+requirements](./tracestate-probability-sampling.md).
 
 The implementation has the following steps:
 
-* Ratio values are restricted to the range `2**-56` through 1
+* Sampling probabilities are restricted to the range `2**-56` through 1.
 * A rejection threshold is calculated, expressing as an integer how
-  many out of 2**56 trace IDs should be sampled.
+  many out of 2**56 trace IDs should be selected.
 * The threshold is encoded as a "T-value", expressing the threshold
-  using up to 5 hexadecimal digits of precision.
+  using up to 4 recommended digits of precision.
 * Sampler decisions are made by comparing the Trace ID randomness
   against the rejection threshold.
 * When Sampled, T-value is included in the [OpenTelemetry TraceState
   header](./tracestate-handling.md), identified by sub-key `th`,
   indicating the sampling probability of the associated Context.  See
   [Randomness requirements](#randomness-requirements), below.
-
-For more detailed information, see the
-[tracestate-probability-sampling](./tracestate-probability-sampling.md)
-specification.
 
 When this implementation is used, the Sampler description SHOULD
 return a string of the form `"TraceIdRatioBased{RATIO;tv:TVALUE}"`
@@ -396,7 +389,10 @@ a sampling ratio of 1 to every 10,000 spans it could return
 
 #### ParentBased
 
-* This is a sampler decorator. `ParentBased` helps distinguish between the
+SDKs SHOULD conform with the [consistent-probability `ParentBased`
+Sampler requirements](./tracestate-probability-sampling.md).
+
+This is a sampler decorator. `ParentBased` helps distinguish between the
 following cases:
   * No parent (root span).
   * Remote parent (`SpanContext.IsRemote() == true`) with `SampledFlag` set

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -460,6 +460,30 @@ Additional `IdGenerator` implementing vendor-specific protocols such as AWS
 X-Ray trace id generator MUST NOT be maintained or distributed as part of the
 Core OpenTelemetry repositories.
 
+### Randomness requirement
+
+The SDK SHOULD implement the TraceID randomness requirements specified
+in the W3C [Trace Context Level
+2](https://www.w3.org/TR/trace-context-2/#randomness-of-trace-id)
+Candidate Recommendation.
+
+This states that the SDK should fill least significant 7 bytes (i.e., 56
+bits) of the TraceID are genuinely random or pseudo-random., so they
+can be used for probability sampling.
+
+#### Randomness trace context flag
+
+The Trace Context `Random` flag, having value `0x2`, SHOULD be set in
+the W3C Trace Context that is propagated when the SDK originates a new
+TraceID that meets the Randomness requirement.
+
+#### Randomness requirements for IdGenerators
+
+If the SDK uses an `IdGenerator` extension point, the SDK SHOULD
+enable it to declare whether it meets the Randomness requirement, in
+which case the `Random` flag SHOULD be set in the W3C Trace Context
+that is propagated when the SDK originates a new TraceID.
+
 ## Span processor
 
 Span processor is an interface which allows hooks for span start and end method

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -339,9 +339,9 @@ the `ParentBased` sampler specified below.
 
 ##### `TraceIdRatioBased` sampler implementation overview
 
-SDKs MAY use an implementation that matches the specification
-referenced below as the `TraceIdRatioBased` Sampler, which based on
-the [W3C Trace Context Level 2 Random TraceID
+SDKs SHOULD use an implementation that is equivalent to the
+specification referenced below as the `TraceIdRatioBased` Sampler,
+which is based on the [W3C Trace Context Level 2 Random TraceID
 flag](https://www.w3.org/TR/trace-context-2/#random-trace-id-flag).
 When a TraceID has the `Random` bit set, samplers are able to use 56
 specific bits of consistent randomness for sampling decisions.
@@ -352,7 +352,7 @@ The implementation has the following steps:
 * A rejection threshold is calculated, expressing as an integer how
   many out of 2**56 trace IDs should be sampled.
 * The threshold is encoded as a "T-value", expressing the threshold
-  using 5 hexadecimal digits of precision.
+  using up to 5 hexadecimal digits of precision.
 * Sampler decisions are made by comparing the Trace ID randomness
   against the rejection threshold.
 * When Sampled, T-value is included in the [OpenTelemetry TraceState
@@ -365,8 +365,9 @@ For more detailed information, see the
 specification.
 
 When this implementation is used, the Sampler description SHOULD
-return a string of the form `"TraceIdRatioBased{tv:TVALUE}"` with
-`TVALUE` replaced by the encoded T-Value as the Sampler Description.
+return a string of the form `"TraceIdRatioBased{RATIO;tv:TVALUE}"`
+with `RATIO` the configured probability and `TVALUE` replaced by the
+encoded T-Value, as the Sampler Description.
 
 ##### Former requirements for `TraceIdRatioBased` sampler algorithm
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -333,16 +333,9 @@ The default sampler is `ParentBased(root=AlwaysOn)`.
 
 #### TraceIdRatioBased
 
-* The `TraceIdRatioBased` MUST ignore the parent `SampledFlag`. To respect the
-  parent `SampledFlag`, the `TraceIdRatioBased` should be used as a delegate of
-  the `ParentBased` sampler specified below.
-* Description MAY return a string of the form `"TraceIdRatioBased{RATIO}"`
-  with `RATIO` replaced with the Sampler instance's trace sampling ratio
-  represented as a decimal number. The precision of the number SHOULD follow
-  implementation language standards and SHOULD be high enough to identify when
-  Samplers have different ratios. For example, if a TraceIdRatioBased Sampler
-  had a sampling ratio of 1 to every 10,000 spans it could return
-  `"TraceIdRatioBased{0.000100}"` as its description.
+The `TraceIdRatioBased` MUST ignore the parent `SampledFlag`. To respect the
+parent `SampledFlag`, the `TraceIdRatioBased` should be used as a delegate of
+the `ParentBased` sampler specified below.
 
 ##### `TraceIdRatioBased` sampler implementation overview
 
@@ -390,6 +383,15 @@ Sampler before transitioning to the modern requirements stated above.
   sample. This is important when a backend system may want to run with a higher
   sampling rate than the frontend system, this way all frontend traces will
   still be sampled and extra traces will be sampled on the backend only.
+
+When this implementation is used, Description MAY return a string of
+the form `"TraceIdRatioBased{RATIO}"` with `RATIO` replaced with the
+Sampler instance's trace sampling ratio represented as a decimal
+number. The precision of the number SHOULD follow implementation
+language standards and SHOULD be high enough to identify when Samplers
+have different ratios. For example, if a TraceIdRatioBased Sampler had
+a sampling ratio of 1 to every 10,000 spans it could return
+`"TraceIdRatioBased{0.000100}"` as its description.
 
 #### ParentBased
 

--- a/specification/trace/tracestate-probability-sampling.md
+++ b/specification/trace/tracestate-probability-sampling.md
@@ -369,7 +369,10 @@ and set the Random trace flag, when generating new contexts.
 ##### Requirement: Tail Samplers assume random TraceIDs
 
 Tail Samplers SHOULD ignore the W3C Trace Context Level 2 Random flag
-when interpreting span data.  This is a compromise 
+when interpreting span data.  This is a compromise, based in the fact
+that the W3C Trace Context Level 2 specification selected which
+56-bits would become standard based aiming for compatibility with
+existing tracing systems.
 
 When there is an explicit R-value set, the Sampler will anyway
 disregard the Random flag.  However, when there is no explicit R-value


### PR DESCRIPTION
Fixes #1413.
Fixes #3602.

## Changes

Updates Trace SDK and Propagator specifications with complete support for consistent probability sampling as described in [OTEP 235](https://github.com/open-telemetry/oteps/blob/main/text/trace/0235-sampling-threshold-in-trace-state.md).

* [ ] Related issues #3307, #2253, #2179, #2113, #1947,#1844,
* [ ] OTEP: https://github.com/open-telemetry/oteps/pull/235
* [ ] Links to the prototypes https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29720
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) TODO
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) TODO
