### PR TITLE
Clarify legacy logs format trace context flags and tracestate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ release.
   ([#3884](https://github.com/open-telemetry/opentelemetry-specification/pull/3884))
 - Clarify that logs attributes are a superset of standard attributes.
   ([#3852](https://github.com/open-telemetry/opentelemetry-specification/pull/3852))
+- Clarify how trace context is to be extracted from legacy logs formats.
+  ([#3923](https://github.com/open-telemetry/opentelemetry-specification/pull/3923))
 
 ### Resource
 

--- a/specification/compatibility/logging_trace_context.md
+++ b/specification/compatibility/logging_trace_context.md
@@ -33,10 +33,7 @@ To summarize, the following field names should be used in legacy formats:
 All 3 fields are optional (see the [data model](../logs/data-model.md) for details of
 which combination of fields is considered valid).
 
-Note the `trace_flags` field carries 8 bits of information, while the
-`flags` field is 32-bits wide. When interpreting `trace_flags` from
-non-OTLP Log Formats, receivers SHOULD NOT allow `trace_flags` to
-cause the most-significant 24 bits of the `flags` field to be set.
+Note the `trace_flags` field carries 8 bits of information.
 
 Note that the W3C Trace Context `tracestate` field is not specifically
 meant to be recorded in logs records, and users are not advised to include

--- a/specification/compatibility/logging_trace_context.md
+++ b/specification/compatibility/logging_trace_context.md
@@ -27,10 +27,23 @@ To summarize, the following field names should be used in legacy formats:
 - "trace_id" for [TraceId](../logs/data-model.md#field-traceid), hex-encoded.
 - "span_id" for [SpanId](../logs/data-model.md#field-spanid), hex-encoded.
 - "trace_flags" for [trace flags](../logs/data-model.md#field-traceflags), formatted
-  according to W3C traceflags format.
+  according to [W3C Trace Context flags format](https://www.w3.org/TR/trace-context/#trace-flags),
+  two hex-encoded digits.
 
 All 3 fields are optional (see the [data model](../logs/data-model.md) for details of
 which combination of fields is considered valid).
+
+Note the `trace_flags` field carries 8 bits of information, while the
+`flags` field is 32-bits wide.  When interpreting `trace_flags` from
+non-OTLP Log Formats, receivers SHOULD NOT allow `trace_flags` to
+cause the most-significant 24 bits of the `flags` field to be set.
+
+Note that the W3C Trace Context `tracestate` field is not specifically
+meant to be recorded in logs records, and users are not advised to include
+the trace context's `tracestate` in legacy formats as an attribute.
+OpenTelemetry's definitions for `tracestate` fields SHOULD have
+equivalent semantic conventions defined in case there are meaningful
+attributes that can be recorded from in logs from the `tracestate`.
 
 ### Syslog RFC5424
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -456,16 +456,6 @@ a superset of [standard Attribute](../common/README.md#attribute),
 to preserve the semantics of structured attributes emitted by the applications.
 This field is optional.
 
-### Field: `Flags`
-
-Type: `fixed32`
-
-Description: The 8 least significant bits are the trace flags as
-defined in W3C Trace Context Level 2 specification. 24 most significant bits are reserved
-and must be set to 0. Readers must not assume that 24 most significant bits
-will be zero and must correctly mask the bits when reading 8-bit trace flag (use
-flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK or 0xFF). This field is optional.
-
 #### Errors and Exceptions
 
 Additional information about errors and/or exceptions that are associated with

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -32,6 +32,7 @@
   * [Field: `Resource`](#field-resource)
   * [Field: `InstrumentationScope`](#field-instrumentationscope)
   * [Field: `Attributes`](#field-attributes)
+  * [Field: `Flags`](#field-flags)
     + [Errors and Exceptions](#errors-and-exceptions)
 - [Example Log Records](#example-log-records)
 - [Example Mappings](#example-mappings)

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -238,10 +238,12 @@ is optional.
 
 Type: byte.
 
-Description: Trace flag as defined in
-[W3C Trace Context](https://www.w3.org/TR/trace-context/#trace-flags)
-specification. At the time of writing the specification defines one flag - the
-SAMPLED flag. This field is optional.
+Description: Trace flags as defined in [W3C Trace Context Level
+2](https://www.w3.org/TR/trace-context-2/#trace-flags)
+specification. At the time of writing the specification defines two
+flags - the SAMPLED flag and the RANDOM flag.  This field is logical-OR
+combined into the least-significant 8-bits of the `Flags` field.  This
+field is optional.
 
 ### Severity Fields
 
@@ -452,6 +454,16 @@ The log attribute model MUST support [`any` type](#type-any),
 a superset of [standard Attribute](../common/README.md#attribute),
 to preserve the semantics of structured attributes emitted by the applications.
 This field is optional.
+
+### Field: `Flags`
+
+Type: `fixed32`
+
+Description: The 8 least significant bits are the trace flags as
+defined in W3C Trace Context Level 2 specification. 24 most significant bits are reserved
+and must be set to 0. Readers must not assume that 24 most significant bits
+will be zero and must correctly mask the bits when reading 8-bit trace flag (use
+flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK or 0xFF). This field is optional.
 
 #### Errors and Exceptions
 


### PR DESCRIPTION
Part of #3303.

## Changes

Clarifies how the trace flags are represented when placing trace context in log records.
Clarifies that `tracestate` is not encoded when placing trace context in log records.


* [x] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
