### PR TITLE
Use a specific markdown-link-check version to fix the build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "markdown-link-check": "^3.11.2",
+    "markdown-link-check": "3.11.2",
     "markdown-toc": "^1.2.0",
     "markdownlint-cli": "0.31.0"
   }


### PR DESCRIPTION
https://github.com/tcort/markdown-link-check/issues/304 is breaking our build (a regression in that library).

It's the second time (at least?) this library break. Can we please pin it instead? See https://github.com/open-telemetry/opentelemetry-specification/pull/3682 