### PR TITLE
[editorial] Logs > Exporters > Stdout - drop leading "OpenTelemetry" from the page title

### DIFF
--- a/specification/logs/sdk_exporters/stdout.md
+++ b/specification/logs/sdk_exporters/stdout.md
@@ -2,7 +2,7 @@
 linkTitle: Stdout
 --->
 
-# OpenTelemetry LogRecord Exporter - Standard output
+# Logs Exporter - Standard output
 
 **Status**: [Stable](../../document-status.md)
 


### PR DESCRIPTION
I wonder if y'all at the specs SIG would be open to dropping the leading "OpenTelemetry" for this and other exporter pages, in those situations were it is unnecessary?

None of the Log's other subpages start with "OpenTelemetry"; here's the list:

- Data Model Appendix
- Events API Interface
- Logs Bridge API
- Logs Data Model
- Logs SDK
- Logs Bridge API No-Op Implementation
- Supplementary Guidelines

This makes "OpenTelemetry LogRecord Exporter - Standard output" stand out. So, for consistency, the Stdout exporter page probably shouldn't have OTel as the start of the title either. Also, for sake of consistency with the other exporters for Metrics and Traces, I think the title should use "Logs" rather than "LogRecord". WDYT?

/cc @theletterf @svrnm 