### PR TITLE
[editorial] Adjust exporter page titles in Metrics and Traces

### DIFF
--- a/specification/metrics/sdk_exporters/in-memory.md
+++ b/specification/metrics/sdk_exporters/in-memory.md
@@ -2,7 +2,7 @@
 linkTitle: In-memory
 --->
 
-# OpenTelemetry Metrics Exporter - In-memory
+# Metrics Exporter - In-memory
 
 **Status**: [Stable](../../document-status.md)
 

--- a/specification/metrics/sdk_exporters/otlp.md
+++ b/specification/metrics/sdk_exporters/otlp.md
@@ -2,7 +2,7 @@
 linkTitle: OTLP
 --->
 
-# OpenTelemetry Metrics Exporter - OTLP
+# Metrics Exporter - OTLP
 
 **Status**: [Stable](../../document-status.md)
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -2,7 +2,7 @@
 linkTitle: Prometheus
 --->
 
-# OpenTelemetry Metrics Exporter - Prometheus
+# Metrics Exporter - Prometheus
 
 **Status**: [Experimental](../../document-status.md)
 

--- a/specification/metrics/sdk_exporters/stdout.md
+++ b/specification/metrics/sdk_exporters/stdout.md
@@ -2,7 +2,7 @@
 linkTitle: Stdout
 --->
 
-# OpenTelemetry Metrics Exporter - Standard output
+# Metrics Exporter - Standard output
 
 **Status**: [Stable](../../document-status.md)
 

--- a/specification/trace/sdk_exporters/stdout.md
+++ b/specification/trace/sdk_exporters/stdout.md
@@ -2,7 +2,7 @@
 linkTitle: Stdout
 --->
 
-# OpenTelemetry Span Exporter - Standard output
+# Span Exporter - Standard output
 
 **Status**: [Stable](../../document-status.md)
 


### PR DESCRIPTION
- Followup to #3939
- Drops the leading "OpenTelemetry" in exporter page titles, where relevant.
  - For example, I kept "OpenTelemetry" in titles like "OpenTelemetry to Jaeger Transformation"