### PR TITLE
Move metrics requirement levels moved to semconv repo

### DIFF
--- a/specification/metrics/metric-requirement-level.md
+++ b/specification/metrics/metric-requirement-level.md
@@ -1,40 +1,9 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: Metric Requirement Levels
+redirect: /docs/specs/semconv/general/metric-requirement-level/ 301!
+--->
+
 # Metric Requirement Levels for Semantic Conventions
 
-**Status**: [Stable](../document-status.md)
-
-<details>
-<summary>Table of Contents</summary>
-
-<!-- toc -->
-
-- [Required](#required)
-- [Recommended](#recommended)
-- [Opt-In](#opt-in)
-
-<!-- tocstop -->
-
-</details>
-
-The following metric requirement levels are specified:
-
-- [Required](#required)
-- [Recommended](#recommended)
-- [Opt-In](#opt-in)
-
-## Required
-
-All instrumentations MUST emit the metric.
-A semantic convention defining a Required metric expects that an absolute majority of instrumentation libraries and applications are able to efficiently emit it.
-
-## Recommended
-
-Instrumentations SHOULD emit the metric by default if it's readily available and can be efficiently emitted. Instrumentations MAY offer a configuration option to disable Recommended metrics.
-
-Instrumentations that decide not to emit `Recommended` metrics due to performance, security, privacy, or other consideration by default, SHOULD allow for opting in to emitting them as defined for the `Opt-In` requirement level if the metrics are logically applicable.
-
-## Opt-In
-
-Instrumentations SHOULD emit the metric if and only if the user configures the instrumentation to do so.
-Instrumentation that doesn't support configuration MUST NOT emit `Opt-In` metrics.
-
-This attribute requirement level is recommended for metrics that are particularly expensive to retrieve or might pose a security or privacy risk. These should therefore only be enabled deliberately by a user making an informed decision.
+This page has moved to
+[Metric Requirement Levels](https://opentelemetry.io/docs/specs/semconv/general/metric-requirement-level/).


### PR DESCRIPTION
Follow up from https://github.com/open-telemetry/semantic-conventions/issues/822

## Changes

Changes to page for metric requirements levels to the Semantic conventions repo (or better, the Website).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
