### PR TITLE
Describe the use cases for events in greater detail

### DIFF
--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -48,7 +48,7 @@ both their `Attributes` and their `Body`.
 The Events API was designed to allow shared libraries to emit high quality
 logs without needing to depend on a third party logger. Unlike the
 [Logs Bridge API](./bridge-api.md), instrumentation authors and application
-developers and are encouraged to call this API directly. It is appropriate to
+developers are encouraged to call this API directly. It is appropriate to
 use the Event API when these properties fit your requirements:
 
 * Logging from a shared library that must run in many applications.

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -44,7 +44,7 @@ of LogRecord, not a separate concept.
 Events contain all of the features provided by LogRecords, plus one additional
 feature: every event is a semantic convention. All Events have a
 `name`, and all Events with the same `name` MUST conform to the same schema for
-both their `Attributes` and their `Body`. This additional 
+both their `Attributes` and their `Body`.
 
 The Events API was designed to allow shared libraries to emit high quality
 logs without needing to depend on a third party logger. Unlike the

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,17 +9,16 @@
 
 <!-- toc -->
 
-- [Events API](#events-api)
-  - [Event Data model](#event-data-model)
-  - [Event API usecases](#event-api-usecases)
-  - [EventLoggerProvider](#eventloggerprovider)
-    - [EventLoggerProvider operations](#eventloggerprovider-operations)
-      - [Get an EventLogger](#get-an-eventlogger)
-  - [EventLogger](#eventlogger)
-    - [EventLogger Operations](#eventlogger-operations)
-      - [Emit Event](#emit-event)
-  - [Optional and required parameters](#optional-and-required-parameters)
-  - [References](#references)
+- [Event Data model](#event-data-model)
+- [Event API usecases](#event-api-usecases)
+- [EventLoggerProvider](#eventloggerprovider)
+  * [EventLoggerProvider operations](#eventloggerprovider-operations)
+    + [Get an EventLogger](#get-an-eventlogger)
+- [EventLogger](#eventlogger)
+  * [EventLogger Operations](#eventlogger-operations)
+    + [Emit Event](#emit-event)
+- [Optional and required parameters](#optional-and-required-parameters)
+- [References](#references)
 
 <!-- tocstop -->
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -55,7 +55,7 @@ appropriate to use the Event API when these properties fit your requirements:
   conventions for LogRecords that are not Events.
 
 If any of these properties fit your requirements, we recommend using the Event API.
-Events are described in more detail in the[semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
+Events are described in more detail in the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
 
 Please note that Events are sent directly to the OTel Log SDK, which currently lacks a
 number of advanced features present in popular log frameworks. For example: 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -71,10 +71,10 @@ use the Event API when these properties fit your requirements:
 If any of these properties fit your requirements, we recommend using the Event API.
 Events are described in more detail in the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
 
-Please note that Events are sent directly to the OTel Log SDK, which currently
-lacks a number of advanced features present in popular log frameworks. For example:
-pattern logging, file rotation, network appenders, etc. These features cannot be
-used with the Event API at this time.
+Please note that the OpenTelemetry Log SDK currently lacks a number of advanced
+features present in popular log frameworks. For example: pattern logging, file
+rotation, network appenders, etc. These features cannot be used with the
+OpenTelemetry Event SDK at this time.
 
 If a logging library is capable of creating logs which correctly map
 to the Event data model, logging in this manner is also an acceptable way to

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -60,7 +60,9 @@ Events are described in more detail in the [semantic conventions](https://github
 Please note that Events are sent directly to the OTel Log SDK, which currently lacks a
 number of advanced features present in popular log frameworks. For example:
 pattern logging, file rotation, network appenders, etc. These features cannot be
-used with Events at this time.
+used with the Event API at this time. If a log framework is capable of creating
+logs which correctly map to the Event data model, that is also an acceptable
+way to create Events.
 
 ## EventLoggerProvider
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,16 +9,17 @@
 
 <!-- toc -->
 
-- [Event Data model](#event-data-model)
-- [Event API usecases](#event-api-usecases)
-- [EventLoggerProvider](#eventloggerprovider)
-  * [EventLoggerProvider operations](#eventloggerprovider-operations)
-    + [Get an EventLogger](#get-an-eventlogger)
-- [EventLogger](#eventlogger)
-  * [EventLogger Operations](#eventlogger-operations)
-    + [Emit Event](#emit-event)
-- [Optional and required parameters](#optional-and-required-parameters)
-- [References](#references)
+- [Events API](#events-api)
+  - [Event Data model](#event-data-model)
+  - [Event API use cases](#event-api-use-cases)
+  - [EventLoggerProvider](#eventloggerprovider)
+    - [EventLoggerProvider operations](#eventloggerprovider-operations)
+      - [Get an EventLogger](#get-an-eventlogger)
+  - [EventLogger](#eventlogger)
+    - [EventLogger Operations](#eventlogger-operations)
+      - [Emit Event](#emit-event)
+  - [Optional and required parameters](#optional-and-required-parameters)
+  - [References](#references)
 
 <!-- tocstop -->
 
@@ -51,7 +52,7 @@ The Event format is as follows. All Events have a `name` attribute, and all
 Events with the same `name` MUST conform to the same schema for both their
 `Attributes` and their `Body`.
 
-## Event API usecases
+## Event API use cases
 
 The Events API was designed to allow shared libraries to emit high quality
 logs without needing to depend on a third party logger. Unlike the
@@ -75,7 +76,7 @@ lacks a number of advanced features present in popular log frameworks. For examp
 pattern logging, file rotation, network appenders, etc. These features cannot be
 used with the Event API at this time.
 
-If a logging framework is capable of creating logs which correctly map
+If a logging library is capable of creating logs which correctly map
 to the Event data model, logging in this manner is also an acceptable way to
 create Events.
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -41,28 +41,35 @@ using the same [data model](./data-model.md). An Event is a specialized type
 of LogRecord, not a separate concept.
 
 Events contain all of the features provided by LogRecords, plus one additional
-feature. All Events have a `name`.  Events with the same `name` MUST conform to
-the same schema for both their `Attributes` and their `Body`.
+feature: every event is a semantic convention. All Events have a
+`name`, and all Events with the same `name` MUST conform to the same schema for
+both their `Attributes` and their `Body`. This additional 
 
-Unlike the [Logs Bridge API](./bridge-api.md), application developers and
-instrumentation authors are encouraged to call this API directly. It is
-appropriate to use the Event API when these properties fit your requirements:
+The Events API was designed to allow shared libraries to emit high quality
+logs without needing to depend on a third party logger. Unlike the [Logs Bridge API](./bridge-api.md), instrumentation authors and application developers and are encouraged
+to call this API directly. It is appropriate to use the Event API when these properties fit your requirements:
 
-* A consistent schema that can be identified by a name is necessary.
-* Analysis by an Observability platform is the intended use case. For
-  example: statistics, indexing, machine learning, session replay.
+* Logging from a shared library that must run in many applications.
 * A semantic convention needs to be defined. We do not define semantic
   conventions for LogRecords that are not Events.
+* Analysis by an observability platform is the intended use case. For
+  example: statistics, indexing, machine learning, session replay.
+* Normalizing logging and having a consistent schema across a large
+  application is helpful.
 
 If any of these properties fit your requirements, we recommend using the Event API.
 Events are described in more detail in the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
 
-Please note that Events are sent directly to the OTel Log SDK, which currently lacks a
-number of advanced features present in popular log frameworks. For example:
+Please note that Events are sent directly to the OTel Log SDK, which currently
+lacks a number of advanced features present in popular log frameworks. For example:
 pattern logging, file rotation, network appenders, etc. These features cannot be
-used with the Event API at this time. If a log framework is capable of creating
-logs which correctly map to the Event data model, that is also an acceptable
-way to create Events.
+used with the Event API at this time.
+
+If a third party logging framework is capable of creating logs which correctly map
+to the Event data model, loggin in this manner is also an acceptable way to create
+Events. For application developers that need additional logging features, we
+recommend using this approach. For shared libraries and instrumentation, we recommend
+using the Event API directly, to avoid taking a dependecy on a third party logger.
 
 ## EventLoggerProvider
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -26,7 +26,8 @@
 
 The Event API consists of these main components:
 
-* [EventLoggerProvider](#eventloggerprovider) is the entry point of the API. It provides access to `EventLogger`s.
+* [EventLoggerProvider](#eventloggerprovider) is the entry point of the API. It
+  provides access to `EventLogger`s.
 * [EventLogger](#eventlogger) is the component responsible for emitting events.
 
 ## Data model
@@ -46,8 +47,10 @@ feature: every event is a semantic convention. All Events have a
 both their `Attributes` and their `Body`. This additional 
 
 The Events API was designed to allow shared libraries to emit high quality
-logs without needing to depend on a third party logger. Unlike the [Logs Bridge API](./bridge-api.md), instrumentation authors and application developers and are encouraged
-to call this API directly. It is appropriate to use the Event API when these properties fit your requirements:
+logs without needing to depend on a third party logger. Unlike the
+[Logs Bridge API](./bridge-api.md), instrumentation authors and application
+developers and are encouraged to call this API directly. It is appropriate to
+use the Event API when these properties fit your requirements:
 
 * Logging from a shared library that must run in many applications.
 * A semantic convention needs to be defined. We do not define semantic
@@ -65,11 +68,9 @@ lacks a number of advanced features present in popular log frameworks. For examp
 pattern logging, file rotation, network appenders, etc. These features cannot be
 used with the Event API at this time.
 
-If a third party logging framework is capable of creating logs which correctly map
-to the Event data model, logging in this manner is also an acceptable way to create
-Events. For application developers that need additional logging features, we
-recommend using this approach. For shared libraries and instrumentation, we recommend
-using the Event API directly, to avoid taking a dependecy on a third party logger.
+If a logging framework is capable of creating logs which correctly map
+to the Event data model, logging in this manner is also an acceptable way to
+create Events.
 
 ## EventLoggerProvider
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,15 +9,16 @@
 
 <!-- toc -->
 
-- [Data model](#data-model)
-- [EventLoggerProvider](#eventloggerprovider)
-  * [EventLoggerProvider operations](#eventloggerprovider-operations)
-    + [Get an EventLogger](#get-an-eventlogger)
-- [EventLogger](#eventlogger)
-  * [EventLogger Operations](#eventlogger-operations)
-    + [Emit Event](#emit-event)
-- [Optional and required parameters](#optional-and-required-parameters)
-- [References](#references)
+- [Events API](#events-api)
+  - [Data model](#data-model)
+  - [EventLoggerProvider](#eventloggerprovider)
+    - [EventLoggerProvider operations](#eventloggerprovider-operations)
+      - [Get an EventLogger](#get-an-eventlogger)
+  - [EventLogger](#eventlogger)
+    - [EventLogger Operations](#eventlogger-operations)
+      - [Emit Event](#emit-event)
+  - [Optional and required parameters](#optional-and-required-parameters)
+  - [References](#references)
 
 <!-- tocstop -->
 
@@ -36,17 +37,31 @@ Wikipedia’s [definition of log file](https://en.wikipedia.org/wiki/Log_file):
 >operating system or other software runs.
 
 From OpenTelemetry's perspective LogRecords and Events are both represented
-using the same [data model](./data-model.md).
+using the same [data model](./data-model.md). An Event is a specialized type
+of LogRecord, not a seperate concept.
 
-However, OpenTelemetry does recognize a subtle semantic difference between
-LogRecords and Events: Events are LogRecords which have a `name` which uniquely
-defines a particular class or type of event. All events with the same `name`
-have `Body` that conform to the same schema, which assists in analysis in
-observability platforms. Events are described in more detail in
-the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
+Events contain all of the features provided by LogRecords, plus one additional
+feature. All Events have a `name`.  Events with the same `name` MUST conform to
+the same schema for both their `Attributes` and their `Body`.
 
 Unlike the [Logs Bridge API](./bridge-api.md), application developers and
-instrumentation authors are encouraged to call this API directly.
+instrumentation authors are encouraged to call this API directly. It is 
+appropriate to use the Event API when these properties fit your requirements:
+
+* A consistent schema that can be identified by a name is necessary.
+* A semantic convention needs to be defined. We do not define semantic
+  conventions for logs.
+* Analysis by an Observability platform is the intended use case. For
+  example: statistics, indexing, machine learning, session replay.
+
+If any of these properties fit your requirements, we recommend using the Event API.
+Events are described in more detail in the[semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
+
+
+Please note that Events are sent directly to the OTel Log SDK, which currently lacks a
+number of advanced features present in popular log frameworks. For example: 
+pattern logging, file rotation, network appenders, etc. These features cannot be
+used with events at this time.
 
 ## EventLoggerProvider
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -66,7 +66,7 @@ pattern logging, file rotation, network appenders, etc. These features cannot be
 used with the Event API at this time.
 
 If a third party logging framework is capable of creating logs which correctly map
-to the Event data model, loggin in this manner is also an acceptable way to create
+to the Event data model, logging in this manner is also an acceptable way to create
 Events. For application developers that need additional logging features, we
 recommend using this approach. For shared libraries and instrumentation, we recommend
 using the Event API directly, to avoid taking a dependecy on a third party logger.

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -45,7 +45,7 @@ feature. All Events have a `name`.  Events with the same `name` MUST conform to
 the same schema for both their `Attributes` and their `Body`.
 
 Unlike the [Logs Bridge API](./bridge-api.md), application developers and
-instrumentation authors are encouraged to call this API directly. It is 
+instrumentation authors are encouraged to call this API directly. It is
 appropriate to use the Event API when these properties fit your requirements:
 
 * A consistent schema that can be identified by a name is necessary.
@@ -58,7 +58,7 @@ If any of these properties fit your requirements, we recommend using the Event A
 Events are described in more detail in the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
 
 Please note that Events are sent directly to the OTel Log SDK, which currently lacks a
-number of advanced features present in popular log frameworks. For example: 
+number of advanced features present in popular log frameworks. For example:
 pattern logging, file rotation, network appenders, etc. These features cannot be
 used with Events at this time.
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -72,7 +72,7 @@ If any of these properties fit your requirements, we recommend using the Event A
 Events are described in more detail in the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
 
 Please note that the OpenTelemetry Log SDK currently lacks a number of advanced
-features present in popular log frameworks. For example: pattern logging, file
+features present in popular logging libraries. For example: pattern logging, file
 rotation, network appenders, etc. These features cannot be used with the
 OpenTelemetry Event SDK at this time.
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -42,10 +42,15 @@ From OpenTelemetry's perspective LogRecords and Events are both represented
 using the same [data model](./data-model.md). An Event is a specialized type
 of LogRecord, not a separate concept.
 
-Events contain all of the features provided by LogRecords, plus one additional
-feature: every event is a semantic convention. All Events have a
-`name`, and all Events with the same `name` MUST conform to the same schema for
-both their `Attributes` and their `Body`.
+Events are OpenTelemetry's standardized semantic formatting for LogRecords.
+Beyond the structure provided by the LogRecord data model, it is helpful for
+logs to have a common format within that structure. When OpenTelemetry
+instrumentation emits logs, those logs SHOULD be formatted as Events. All
+semantic conventions defined for logs MUST be formatted as Events.
+
+The Event format is as follows. All Events have a `name` attribute, and all
+Events with the same `name` MUST conform to the same schema for both their
+`Attributes` and their `Body`.
 
 ## Event API usecases
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,15 +9,17 @@
 
 <!-- toc -->
 
-- [Data model](#data-model)
-- [EventLoggerProvider](#eventloggerprovider)
-  * [EventLoggerProvider operations](#eventloggerprovider-operations)
-    + [Get an EventLogger](#get-an-eventlogger)
-- [EventLogger](#eventlogger)
-  * [EventLogger Operations](#eventlogger-operations)
-    + [Emit Event](#emit-event)
-- [Optional and required parameters](#optional-and-required-parameters)
-- [References](#references)
+- [Events API](#events-api)
+  - [Event Data model](#event-data-model)
+  - [Event API usecases](#event-api-usecases)
+  - [EventLoggerProvider](#eventloggerprovider)
+    - [EventLoggerProvider operations](#eventloggerprovider-operations)
+      - [Get an EventLogger](#get-an-eventlogger)
+  - [EventLogger](#eventlogger)
+    - [EventLogger Operations](#eventlogger-operations)
+      - [Emit Event](#emit-event)
+  - [Optional and required parameters](#optional-and-required-parameters)
+  - [References](#references)
 
 <!-- tocstop -->
 
@@ -29,7 +31,7 @@ The Event API consists of these main components:
   provides access to `EventLogger`s.
 * [EventLogger](#eventlogger) is the component responsible for emitting events.
 
-## Data model
+## Event Data model
 
 Wikipedia’s [definition of log file](https://en.wikipedia.org/wiki/Log_file):
 
@@ -44,6 +46,8 @@ Events contain all of the features provided by LogRecords, plus one additional
 feature: every event is a semantic convention. All Events have a
 `name`, and all Events with the same `name` MUST conform to the same schema for
 both their `Attributes` and their `Body`.
+
+## Event API usecases
 
 The Events API was designed to allow shared libraries to emit high quality
 logs without needing to depend on a third party logger. Unlike the

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -49,19 +49,18 @@ instrumentation authors are encouraged to call this API directly. It is
 appropriate to use the Event API when these properties fit your requirements:
 
 * A consistent schema that can be identified by a name is necessary.
-* A semantic convention needs to be defined. We do not define semantic
-  conventions for logs.
 * Analysis by an Observability platform is the intended use case. For
   example: statistics, indexing, machine learning, session replay.
+* A semantic convention needs to be defined. We do not define semantic
+  conventions for LogRecords that are not Events.
 
 If any of these properties fit your requirements, we recommend using the Event API.
 Events are described in more detail in the[semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).
 
-
 Please note that Events are sent directly to the OTel Log SDK, which currently lacks a
 number of advanced features present in popular log frameworks. For example: 
 pattern logging, file rotation, network appenders, etc. These features cannot be
-used with events at this time.
+used with Events at this time.
 
 ## EventLoggerProvider
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,16 +9,15 @@
 
 <!-- toc -->
 
-- [Events API](#events-api)
-  - [Data model](#data-model)
-  - [EventLoggerProvider](#eventloggerprovider)
-    - [EventLoggerProvider operations](#eventloggerprovider-operations)
-      - [Get an EventLogger](#get-an-eventlogger)
-  - [EventLogger](#eventlogger)
-    - [EventLogger Operations](#eventlogger-operations)
-      - [Emit Event](#emit-event)
-  - [Optional and required parameters](#optional-and-required-parameters)
-  - [References](#references)
+- [Data model](#data-model)
+- [EventLoggerProvider](#eventloggerprovider)
+  * [EventLoggerProvider operations](#eventloggerprovider-operations)
+    + [Get an EventLogger](#get-an-eventlogger)
+- [EventLogger](#eventlogger)
+  * [EventLogger Operations](#eventlogger-operations)
+    + [Emit Event](#emit-event)
+- [Optional and required parameters](#optional-and-required-parameters)
+- [References](#references)
 
 <!-- tocstop -->
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,17 +9,16 @@
 
 <!-- toc -->
 
-- [Events API](#events-api)
-  - [Event Data model](#event-data-model)
-  - [Event API use cases](#event-api-use-cases)
-  - [EventLoggerProvider](#eventloggerprovider)
-    - [EventLoggerProvider operations](#eventloggerprovider-operations)
-      - [Get an EventLogger](#get-an-eventlogger)
-  - [EventLogger](#eventlogger)
-    - [EventLogger Operations](#eventlogger-operations)
-      - [Emit Event](#emit-event)
-  - [Optional and required parameters](#optional-and-required-parameters)
-  - [References](#references)
+- [Event Data model](#event-data-model)
+- [Event API use cases](#event-api-use-cases)
+- [EventLoggerProvider](#eventloggerprovider)
+  * [EventLoggerProvider operations](#eventloggerprovider-operations)
+    + [Get an EventLogger](#get-an-eventlogger)
+- [EventLogger](#eventlogger)
+  * [EventLogger Operations](#eventlogger-operations)
+    + [Emit Event](#emit-event)
+- [Optional and required parameters](#optional-and-required-parameters)
+- [References](#references)
 
 <!-- tocstop -->
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -38,7 +38,7 @@ Wikipedia’s [definition of log file](https://en.wikipedia.org/wiki/Log_file):
 
 From OpenTelemetry's perspective LogRecords and Events are both represented
 using the same [data model](./data-model.md). An Event is a specialized type
-of LogRecord, not a seperate concept.
+of LogRecord, not a separate concept.
 
 Events contain all of the features provided by LogRecords, plus one additional
 feature. All Events have a `name`.  Events with the same `name` MUST conform to


### PR DESCRIPTION
Resolves #3254 and #4045 

The PR adds clarity to the features provided by Events, as well as guidance on when it is appropriate to use the Event API.

## Changes

* Reorganized the Data Model section for clarity
* Include MUST for the requirement that Event `Body` and `Attributes` fields conform to a schema.
* Include use cases for when Events are appropriate.
* Include a warning that advanced logging features are not currently accessible when using Events.