### PR TITLE
Clarify string content must be valid Unicode sequences

### DIFF
--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -39,6 +39,8 @@ An `Attribute` is a key-value pair, which MUST have the following properties:
   - An array of primitive type values. The array MUST be homogeneous,
     i.e., it MUST NOT contain values of different types.
 
+String values SHOULD be valid Unicode sequences (UTF-8).
+
 For protocols that do not natively support non-string values, non-string values SHOULD be represented as JSON-encoded strings.  For example, the expression `int64(100)` will be encoded as `100`, `float64(1.5)` will be encoded as `1.5`, and an empty array of any type will be encoded as `[]`.
 
 Attribute values expressing a numerical value of zero, an empty string, or an

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -39,7 +39,7 @@ An `Attribute` is a key-value pair, which MUST have the following properties:
   - An array of primitive type values. The array MUST be homogeneous,
     i.e., it MUST NOT contain values of different types.
 
-String values MUST be valid Unicode sequences (UTF-8).
+String values MUST be valid Unicode sequences. It do not accept arbitrary bytes.
 
 For protocols that do not natively support non-string values, non-string values SHOULD be represented as JSON-encoded strings.  For example, the expression `int64(100)` will be encoded as `100`, `float64(1.5)` will be encoded as `1.5`, and an empty array of any type will be encoded as `[]`.
 

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -39,7 +39,7 @@ An `Attribute` is a key-value pair, which MUST have the following properties:
   - An array of primitive type values. The array MUST be homogeneous,
     i.e., it MUST NOT contain values of different types.
 
-String values SHOULD be valid Unicode sequences (UTF-8).
+String values MUST be valid Unicode sequences (UTF-8).
 
 For protocols that do not natively support non-string values, non-string values SHOULD be represented as JSON-encoded strings.  For example, the expression `int64(100)` will be encoded as `100`, `float64(1.5)` will be encoded as `1.5`, and an empty array of any type will be encoded as `[]`.
 

--- a/specification/common/attribute-type-mapping.md
+++ b/specification/common/attribute-type-mapping.md
@@ -106,11 +106,7 @@ AnyValue's
 [string_value](https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L31)
 field.
 
-String values which are not valid Unicode sequences SHOULD be converted to
-AnyValue's
-[bytes_value](https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L37)
-with the bytes representing the string in the original order and format of the
-source string.
+String values which are not valid Unicode sequences SHOULD be dropped.
 
 #### Byte Sequences
 


### PR DESCRIPTION
Fixes #3950

## Changes

- Limit primitive string value to UTF-8.
- Drop attribute mapping for non-UTF-8 strings.
