### PR TITLE
Update spec matrix to indicate go's links can be recorded after span creation

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -67,7 +67,7 @@ formats is required. Implementing more than one format is optional.
 | Unicode support for keys and string values                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
 | [Span linking](specification/trace/api.md#specifying-links)                                      | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Links can be recorded on span creation                                                           |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
-| Links can be recorded after span creation                                                        |          |     |      |     |        |      |        |     |      | +   |      |       |
+| Links can be recorded after span creation                                                        |          | +   |      |     |        |      |        |     |      | +   |      |       |
 | Links order is preserved                                                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
 | [Span events](specification/trace/api.md#add-events)                                             |          |     |      |     |        |      |        |     |      |     |      |       |
 | AddEvent                                                                                         |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |


### PR DESCRIPTION
## Changes

Go recently merged recording links after span creation.
See https://github.com/open-telemetry/opentelemetry-go/pull/5032

Note that this change is not released yet.

cc @open-telemetry/go-approvers 