### PR TITLE
Clarify map representation in Logs Data Model

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -120,7 +120,9 @@ Value of type `any` can be one of the following:
 
 Value of type `map<string, any>` is a map of string keys to `any` values. The
 keys in the map are unique (duplicate keys are not allowed). The representation
-of the map is language-dependent.
+of the map is language-dependent. The SDKs MAY allow duplicated keys (represent
+the map as an array/list of key-values) as long as the OTLP exporters by default
+handle deduplication.
 
 Arbitrary deep nesting of values for arrays and maps is allowed (essentially
 allows to represent an equivalent of a JSON object).

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -121,8 +121,8 @@ Value of type `any` can be one of the following:
 Value of type `map<string, any>` is a map of string keys to `any` values. The
 keys in the map are unique (duplicate keys are not allowed). The representation
 of the map is language-dependent. The SDKs MAY allow duplicated keys (represent
-the map as an array/list of key-values) as long as the OTLP exporters by default
-handle deduplication.
+the map as an array/list of key-values) as long as they provide means to have
+them deduplicated when log records are exported.
 
 Arbitrary deep nesting of values for arrays and maps is allowed (essentially
 allows to represent an equivalent of a JSON object).


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/3931

Per https://github.com/open-telemetry/opentelemetry-specification/pull/3938#discussion_r1526685159

> I think it is fine to do the deduplication anywhere you want as long as externally observable data complies with this document.

Related to https://github.com/open-telemetry/opentelemetry-go/issues/5086