### PR TITLE
Exemplars SHOULD be on by default

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1005,7 +1005,7 @@ While the metric data point for the counter would carry the attributes `X` and
 A Metric SDK MUST provide a mechanism to sample `Exemplar`s from measurements
 via the `ExemplarFilter` and `ExemplarReservoir` hooks.
 
-`Exemplar` sampling SHOULD be turned off by default. If `Exemplar` sampling is
+`Exemplar` sampling SHOULD be turned on by default. If `Exemplar` sampling is
 off, the SDK MUST NOT have overhead related to exemplar sampling.
 
 A Metric SDK MUST allow exemplar sampling to leverage the configuration of


### PR DESCRIPTION
Unblocks #3870

## Changes

Discussed during the [Apr. 10th, 2024 Technical Committee Meeting](https://docs.google.com/document/d/1hOHPCu5TGenqTeWPB9qQB_qd33uITZBcvK1FnWxYJAw/edit#heading=h.qwjvmbli5ooj), we'd like to move Exemplars specification to stable. To address the blocking concern https://github.com/open-telemetry/opentelemetry-specification/pull/3870#pullrequestreview-1952842576, this PR updated the wording to "SHOULD" (instead of "MUST"), if certain SDK implementations have performance concerns, they can decide to ship a stable version with exemplars OFF by default, and switch to ON by default later once the perf issue is solved (which is not a breaking change as exemplars are best efforts).