### PR TITLE
Remove span name from stability guarantees

### DIFF
--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -186,7 +186,6 @@ Semantic Conventions defines the set of fields in the OTLP data model:
   - Attribute values that are defined in a list of well-known values.
 - [Trace](trace/api.md)
   - The following data on [span](trace/api.md#span):
-    - The span name
     - The span kind
     - The attribute keys provided to the span
       - Whether these attributes must be provided at span start time, due to
@@ -225,6 +224,7 @@ Semantic Conventions defines the set of fields in the OTLP data model:
 Things not listed in the above are not expected to remain stable via semantic
 convention and are allowed (or expected) to change. A few examples:
 
+- The span name
 - The values of attributes
   - An exception are existing values in lists of well-known values. However,
     new values can be added to such lists. Consumers should expect unknown


### PR DESCRIPTION
## Changes

The context: we'd like to update span name for HTTP client spans to include HTTP route/operation name when it's available.
Today span name includes only method (e.g. `GET` and could instead become more useful - `GET users/{user_id}`).
See  https://github.com/open-telemetry/semantic-conventions/pull/675 and https://github.com/open-telemetry/semantic-conventions/issues/923 for more details.

However, even in the general case, span name is not something dashboards and alerts should rely on:
- span name is usually constructed from attributes that would be more reliable for queries, dashboards and alerts
- span names can change depending on the available level of details (e.g. HTTP server span name looks like `{method} {route}` and route availability depends on the web framework).
- span name format, case sensitivity could be hard to enforce and may depend on the language. 

Span name should be fine in queries like "top N longest" or "top N with highest error rate" - then, when span names become more descriptive, such queries would produce even better results.

* [x] Related issues https://github.com/open-telemetry/semantic-conventions/pull/675, https://github.com/open-telemetry/semantic-conventions/issues/923
* ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps)~~
* ~~Links to the prototypes (when adding or changing features)~~
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* ~~[`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary~~
