### PR TITLE
[configuration] Fail on unsupported identifiers

### DIFF
--- a/specification/configuration/file-configuration.md
+++ b/specification/configuration/file-configuration.md
@@ -90,6 +90,14 @@ more non line break characters (i.e. any character except `\n`). If a referenced
 environment variable is not defined and does not have a `DEFAULT_VALUE`, it MUST
 be replaced with an empty value.
 
+Configuration files MUST fail to parse if they contain a reference that does not
+match the references regular expression but does match the following PCRE2
+regular expression:
+
+```regexp
+\$\{(?<INVALID_IDENTIFIER>[^}]+)\}
+```
+
 Node types MUST be interpreted after environment variable substitution takes
 place. This ensures the environment string representation of boolean, integer,
 or floating point fields can be properly converted to expected types.
@@ -127,6 +135,7 @@ string_key_with_default: ${UNDEFINED_KEY:-fallback}   # UNDEFINED_KEY is not def
 undefined_key: ${UNDEFINED_KEY}                       # Invalid reference, UNDEFINED_KEY is not defined and is replaced with ""
 ${STRING_VALUE}: value                                # Invalid reference, substitution is not valid in mapping keys and reference is ignored
 recursive_key: ${REPLACE_ME}                          # Valid reference to REPLACE_ME
+# invalid_identifier_key: ${STRING_VALUE:?error}      # If uncommented, this is an invalid identifier, it would fail to parse
 ```
 
 Environment variable substitution results in the following YAML:


### PR DESCRIPTION
Fixes #3981

## Changes

Fail to parse when invalid identifiers are found (this is basically anything that uses the `${...}` syntax but contains an invalid blob in between). The rationale is to allow for changes in a backwards compatible way. Right now it would not be possible to extend the syntax in a non-breaking way to support more sh/POSIX/Bash syntax like the ones [here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_02) or potentially to support other providers (like we support in the Collector e.g. `${file:<something>}`).

As an example both #3974 and #3948 would have been nonbreaking had we done this change first (we would go from "fail to parse" to "do something", instead of going from one way of parsing to a different one).

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #398
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes