### PR TITLE
Editorial: Remove erroneous feature freeze designation

### DIFF
--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -8,7 +8,7 @@ path_base_for_github_subdir:
 
 # Common specification concepts
 
-**Status**: [Stable, Feature-freeze](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 <details>
 <summary>Table of Contents</summary>


### PR DESCRIPTION
There is no section of this document which is called out as "Feature-freeze", so we must assume the whole document is stable.