### PR TITLE
[metrics] Allow setting ExemplarFilter via View API

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -382,6 +382,13 @@ The SDK MUST accept the following stream configuration parameters:
   user does not provide an `aggregation` value, the `MeterProvider` MUST apply
   a [default aggregation](#default-aggregation) configurable on the basis of
   instrument type according to the [MetricReader](#metricreader) instance.
+* **Status**: [Experimental](../document-status.md) - `exemplar_filter`: The
+  `exemplar_filter` configuration allows users to select between one of the
+  built-in [ExemplarFilters](#exemplarfilter). The list of acceptable values for
+  `exemplar_filter` MUST match those available to be set on the `MeterProvider`
+  for the SDK. Users MUST NOT be required to specify `exemplar_filter` but if
+  specified it MUST override the `MeterProvider` value (if set) or the default
+  SDK behavior if not explicitly set for the `MeterProvider`.
 * `exemplar_reservoir`: A
   functional type that generates an exemplar reservoir a `MeterProvider` will
   use when storing exemplars. This functional type needs to be a factory or


### PR DESCRIPTION
## Changes

* Allow setting `ExemplarFilter` via the View API

## Details

In .NET we have decided to NOT enable `Exemplar`s by default due to performance considerations. If users want `Exemplar`s they can set an `ExemplarFilter` at the `MeterProvider` level. This will carry a performance hit for all measurements.

We feel users may only want to pay for the performance hit on critical metrics. With the current specification design, users don't have a lot of options to accomplish this. Really the only thing which may be done is enable `Exemplar`s for the `MeterProvider` and then use the View API to set an `ExemplarReservoir` which drops `Exemplar`s for any/all metrics where they aren't desired.

The proposed addition here is seeking to make it easier to selectively enable or disable `Exemplar`s at the instrument-level.

## For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [X] Links to the prototypes (when adding or changing features): https://github.com/open-telemetry/opentelemetry-dotnet/compare/main...CodeBlanch:sdk-metrics-view-exemplarfilter?expand=1
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
