### PR TITLE
Editorial: Remove TODO for JSON file format

### DIFF
--- a/specification/configuration/file-configuration.md
+++ b/specification/configuration/file-configuration.md
@@ -64,8 +64,6 @@ revision >= 1.2.
 
 YAML configuration files MUST use file extensions `.yaml` or `.yml`.
 
-TODO: decide if JSON file format is required
-
 ### Environment variable substitution
 
 Configuration files support environment variables substitution for references


### PR DESCRIPTION
Resolves #3466.

Supporting a JSON file format would be problematic:
- Env var substitution syntax is hard
- JSON doesn't allow comments
- We couldn't mandate JSON support across languages so supporting would be bad from an interoperability standpoint

Also, nobody has expressed interested in a JSON file format. Removing the TODO as it makes it seem imminent / likely which is not the case. This doesn't close the door on a JSON file format - just removes clutter.