### PR TITLE
Add Enabled method to Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 ### Logs
 
+- Add the `Enabled` API to the `Logger`.
+  ([#4020](https://github.com/open-telemetry/opentelemetry-specification/pull/4020))
+
 ### Events
 
 ### Resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ release.
 
 ### Logs
 
-- Add the `Enabled` API to the `Logger`.
+- Add the experimental `Enabled` API to the `Logger`.
   ([#4020](https://github.com/open-telemetry/opentelemetry-specification/pull/4020))
 
 ### Events

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -191,6 +191,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | LoggerProvider.Shutdown                      |          |     | +    |     |        |      |        | +   |      |     | -    |       |
 | LoggerProvider.ForceFlush                    |          |     | +    |     |        |      |        | +   |      |     | -    |       |
 | Logger.Emit(LogRecord)                       |          |     | +    |     |        |      |        | +   |      | +   | -    |       |
+| Logger.Enabled                               | X        | +   |      |     |        |      |        |     | +    | +   |      |       |
 | SimpleLogRecordProcessor                     |          |     | +    |     |        |      |        | +   |      | +   |      |       |
 | BatchLogRecordProcessor                      |          |     | +    |     |        |      |        | +   |      | +   |      |       |
 | Can plug custom LogRecordProcessor           |          |     | +    |     |        |      |        | +   |      | +   |      |       |

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -141,7 +141,7 @@ generating a `LogRecord`, a `Logger` SHOULD provide this `Enabled` API.
 
 There are currently no required parameters for this API. Parameters can be
 added in the future, therefore, the API MUST be structured in a way for
-parameters to be added. 
+parameters to be added.
 
 This API MUST return a language idiomatic boolean type.
 

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -158,6 +158,10 @@ that want to optimize memory or handle indeterminable states the flexibility
 they need. If an implementation does not need this flexibility, it SHOULD
 return `false` when logging is disabled for the provided arguments.
 
+The returned value is not always static, it can change over time. The API
+SHOULD be documented that users needs to call this API each time they generate
+a `LogRecord` to ensure they have the most up-to-date response.
+
 ## Optional and required parameters
 
 The operations defined include various parameters, some of which are marked

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -15,6 +15,7 @@
 - [Logger](#logger)
   * [Logger operations](#logger-operations)
     + [Emit a LogRecord](#emit-a-logrecord)
+    + [Enabled](#enabled)
 - [Optional and required parameters](#optional-and-required-parameters)
 - [Concurrency requirements](#concurrency-requirements)
 - [Artifact Naming](#artifact-naming)

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -143,11 +143,9 @@ There are currently no required parameters for this API. Parameters can be
 added in the future, therefore, the API MUST be structured in a way for
 parameters to be added.
 
-This API MUST return a language idiomatic boolean type.
-
-Implementations of this API SHALL return `true` when logging is enabled or
-`false` when logging is disabled for the provided arguments. Implementations
-designed for performance that cache the logging state MAY return stale values.
+This API MUST return a language idiomatic boolean type. A returned value of
+`true` means logging is enabled for the provided arguments, and a returned
+value of `false` means the logging is disabled for the provided arguments.
 
 The returned value is not always static, it can change over time. The API
 SHOULD be documented that users needs to call this API each time they generate

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -148,7 +148,7 @@ This API MUST return a language idiomatic boolean type. A returned value of
 value of `false` means the logging is disabled for the provided arguments.
 
 The returned value is not always static, it can change over time. The API
-SHOULD be documented that users needs to call this API each time they generate
+SHOULD be documented that Logs Bridge API developers needs to call this API each time they generate
 a `LogRecord` to ensure they have the most up-to-date response.
 
 ## Optional and required parameters

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -139,15 +139,9 @@ All parameters are optional.
 To help users avoid performing computationally expensive operations when
 generating a `LogRecord`, a `Logger` SHOULD provide this `Enabled` API.
 
-At a minimum, the API MUST accept the following parameters:
-
-- [Context](../context/README.md) (optional): This is the Context associated
-  with the `LogRecord`. The API MAY implicitly use the current Context as a
-  default behavior.
-- [Severity Number](./data-model.md#field-severitynumber)
-
-Users of a language implementation community can have specific needs when using
-this API. Therefore, additional parameters MAY be accepted.
+There are currently no required parameters for this API. Parameters can be
+added in the future, therefore, the API MUST be structured in a way for
+parameters to be added. 
 
 This API MUST return a language idiomatic boolean type.
 

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -145,12 +145,9 @@ parameters to be added.
 
 This API MUST return a language idiomatic boolean type.
 
-The returned value MUST be `true` when logging is enabled for the provided
-arguments. The returned value can be `true` or `false` when logging is disabled
-for the provided arguments. The ambiguity when disabled allows implementation
-that want to optimize memory or handle indeterminable states the flexibility
-they need. If an implementation does not need this flexibility, it SHOULD
-return `false` when logging is disabled for the provided arguments.
+Implementations of this API SHALL return `true` when logging is enabled or
+`false` when logging is disabled for the provided arguments. Implementations
+designed for performance that cache the logging state MAY return stale values.
 
 The returned value is not always static, it can change over time. The API
 SHOULD be documented that users needs to call this API each time they generate

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -108,6 +108,10 @@ The `Logger` MUST provide functions to:
 
 - Emit a `LogRecord`
 
+The `Logger` SHOULD provide functions to:
+
+- Report if `Enabled` for a `LogRecord`
+
 #### Emit a LogRecord
 
 The effect of calling this API is to emit a `LogRecord` to the processing pipeline.
@@ -126,6 +130,30 @@ The API MUST accept the following parameters:
 - [Attributes](./data-model.md#field-attributes)
 
 All parameters are optional.
+
+#### Enabled
+
+To help users avoid performing computationally expensive operations when
+generating a `LogRecord`, a `Logger` SHOULD provide this `Enabled` API.
+
+At a minimum, the API MUST accept the following parameters:
+
+- [Context](../context/README.md) (optional): This is the Context associated
+  with the `LogRecord`. The API MAY implicitly use the current Context as a
+  default behavior.
+- [Severity Number](./data-model.md#field-severitynumber)
+
+Users of a language implementation community can have specific needs when using
+this API. Therefore, additional parameters MAY be accepted.
+
+This API MUST return a language idiomatic boolean type.
+
+The returned value MUST be `true` when logging is enabled for the provided
+arguments. The returned value can be `true` or `false` when logging is disabled
+for the provided arguments. The ambiguity when disabled allows implementation
+that want to optimize memory or handle indeterminable states the flexibility
+they need. If an implementation does not need this flexibility, it SHOULD
+return `false` when logging is disabled for the provided arguments.
 
 ## Optional and required parameters
 

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -1,6 +1,6 @@
 # Logs Bridge API
 
-**Status**: [Stable](../document-status.md)
+**Status**: [Stable](../document-status.md), except where otherwise specified
 
 <details>
 <summary>Table of Contents</summary>
@@ -133,6 +133,8 @@ The API MUST accept the following parameters:
 All parameters are optional.
 
 #### Enabled
+
+**Status**: [Experimental](../document-status.md)
 
 To help users avoid performing computationally expensive operations when
 generating a `LogRecord`, a `Logger` SHOULD provide this `Enabled` API.


### PR DESCRIPTION
Fixes #3917 

Knowing if a `LogRecord` will be dropped prior to performing computationally expensive operations helps developers using the Logs Bridge API avoid wasted and expensive work. This adds and `Enabled` API to the `Logger` to provide this functionality.

This is related to https://github.com/open-telemetry/opentelemetry-specification/pull/3877. In that PR `Loggers` may become entirely disabled. The `Enabled` method included here will help users determine this state.

### Prototypes

- [Go](https://pkg.go.dev/go.opentelemetry.io/otel/log#Logger)
- [Rust](https://github.com/open-telemetry/opentelemetry-rust/pull/1147)
- [C++](https://github.com/open-telemetry/opentelemetry-cpp/blob/07f6cb54ece56691dbd2a94b0cbeec722ff6a631/api/include/opentelemetry/logs/logger.h#L259)
