### PR TITLE
[Editorial] suppress MD041 - First line in a file should be a top-level heading

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -6,6 +6,7 @@ default: true
 
 ul-style: false
 line-length: false
+first-line-heading: false
 no-duplicate-header:
   siblings_only: true
 ol-prefix:


### PR DESCRIPTION
The existing specs are already generate warnings (for example, https://github.com/open-telemetry/opentelemetry-specification/blob/cc48e4e555cf7ace212159fddb7d59235a799ee1/specification/metrics/sdk.md?plain=1#L1-L2), this change will make it less noisy.