### PR TITLE
Define span events to events mapping

### DIFF
--- a/specification/logs/README.md
+++ b/specification/logs/README.md
@@ -449,6 +449,7 @@ standard output.
 * [Logs Data Model](./data-model.md)
 * [Event API](./event-api.md)
 * [Trace Context in non-OTLP Log Formats](../compatibility/logging_trace_context.md)
+* [Span Events to Events mapping](./span-events-mapping.md)
 
 ## References
 

--- a/specification/logs/span-events-mapping.md
+++ b/specification/logs/span-events-mapping.md
@@ -8,7 +8,7 @@ Applications or telemetry consumers MAY transform Span Events to Events inside t
 
 Event API properties:
 
-<!- TODO add link to semantic conventions once https://github.com/open-telemetry/semantic-conventions/pull/954 is merged -->
+<!-- TODO add link to semantic conventions once https://github.com/open-telemetry/semantic-conventions/pull/954 is merged -->
 
 - `Name` SHOULD match the Span Event name
 - `Timestamp` SHOULD match Span Event timestamp

--- a/specification/logs/span-events-mapping.md
+++ b/specification/logs/span-events-mapping.md
@@ -1,0 +1,32 @@
+# Span Event to Events Mapping
+
+**Status**: [Experimental](../document-status.md)
+
+<details>
+<summary>Table of Contents</summary>
+
+<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
+
+<!-- toc -->
+
+<!-- tocstop -->
+
+</details>
+
+[Span Events](../trace/api.md#add-events) represent an event attached to a span and has a different structure than [Events](./event-api.md).
+
+Applications or telemetry consumers MAY transform Span Events to Events inside their span processing pipeline using the mappings defined in the document.
+
+Event API properties:
+
+<!- TODO add link to semantic conventions once https://github.com/open-telemetry/semantic-conventions/pull/954 is merged -->
+
+- `Name` SHOULD match the Span Event name
+- `Timestamp` SHOULD match Span Event timestamp
+- `Context` SHOULD match the context of the span the Span Event is attached to.
+- `SeverityNumber` - no mapping, not set. <!-- TODO define mapping in the semconv -->
+- `Payload` SHOULD be set to the object deserialized from JSON string provided in the Span Event `event.data` attribute (if any). If deserialization fails with an error, the original string value of the `event.data` attribute SHOULD be used.
+- `Attributes` SHOULD match Span Event attributes except those that were used to populate other event properties (`event.data`).
+
+The `EventLogger` used to report mapped Events SHOULD have the same instrumentation scope properties as the
+Span the original Span Event is attached to.

--- a/specification/logs/span-events-mapping.md
+++ b/specification/logs/span-events-mapping.md
@@ -1,17 +1,6 @@
-# Span Event to Events Mapping
+# Span Event to Event Mapping
 
 **Status**: [Experimental](../document-status.md)
-
-<details>
-<summary>Table of Contents</summary>
-
-<!-- Re-generate TOC with `markdown-toc --no-first-h1 -i` -->
-
-<!-- toc -->
-
-<!-- tocstop -->
-
-</details>
 
 [Span Events](../trace/api.md#add-events) represent an event attached to a span and has a different structure than [Events](./event-api.md).
 


### PR DESCRIPTION
## Changes

Introduces mapping from Span Events to Events (along with https://github.com/open-telemetry/semantic-conventions/pull/954).

This mechanism allows
- instrumentations to emit structured events using APIs available now in their language (such as LLM https://github.com/open-telemetry/semantic-conventions/pull/980). 
- to decouple instrumentation from the long-term unification mechanism between different kinds of events
- to provide the backward compatibility story for Span Events (if they are ever deprecated)

The end-to-end case:
1. Instrumentation emits Span Events using existing Trace API. 
    - it provides payload in a dedicated attribute (`event.data`). It's serialized to JSON (Note: `"plain string"` is a valid JSON)
    - we may define a mapping for severity as well
2.  Mapping component (e.g. a span processor or a collector processor) transforms span events to events using the defined mapping. 
     - the current version of this PR defines API-level mapping (for in-process component such as span processor)
     - it should be possible to define a mapping to LogRecords and/or on the OTLP level 
3. [Out of scope of this PR] Such component can be implemented 
    - as a part of OTel SDK Span implementation and used to deprecate Span Events. It can then follow Event sampling rules rather than Span sampling.
    - as an opt-in contrib span processor/collector processor or on the backend. Then it will follow Span sampling decisions

* [ ] Related issues #3406
* ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps)~~
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* ~~[`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary~~
