### PR TITLE
Update Metric Filter proposed spec

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1687,6 +1687,7 @@ operation.
 - `name`: the name of the metric stream
 - `kind`: the metric stream [kind](./data-model.md#point-kinds)
 - `unit`: the metric stream unit
+- `value`: the observed value of the metric
 
 Returns: `MetricFilterResult`
 


### PR DESCRIPTION
Added "value" to the metric filter parameters as a way to filter metrics based on observed values. 

This is very useful to avoid metrics like "You received zero http requests", "Your http queue length is zero", "The GC ran Zero times" and other "default" values.