### PR TITLE
Pin docfx version to the last working one.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -78,7 +78,7 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: install docfx
-      run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
+      run: dotnet tool update -g docfx --version "3.0.0-beta1-1332-g260405656d" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
 
     - name: run docfx
       run: docfx build --dry-run


### PR DESCRIPTION
In a rather tragic fashion `docfx` just stopped working out of nowhere, and it seems it's because the versions we had been using all along (`3.0.0-beta` fashion) are _somehow_ not installed anymore (even though we specific we want `3.0.0+` versions), and now we get `2.76.` versions, which work well, but not for us. Let's try to get ourselves unblocked for the time being.

cc @reyang 