### PR TITLE
Release 1.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ release.
 
 ### Supplementary Guidelines
 
-## v1.33.0 (2024-05-08)
+## v1.33.0 (2024-05-09)
 
 ### Context
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,7 @@ release.
 
 ### Metrics
 
-- Change the exemplar behavior to be on by default.
-  ([#3994](https://github.com/open-telemetry/opentelemetry-specification/pull/3994))
-- Add name suggestion for option to apply resource attributes as metric attributes in Prometheus exporter.
-  ([#3837](https://github.com/open-telemetry/opentelemetry-specification/pull/3837))
-- Mark Exemplars as stable.
-  ([#3870](https://github.com/open-telemetry/opentelemetry-specification/pull/3870))
-- Mark synchronous gauge as stable.
-  ([#4019](https://github.com/open-telemetry/opentelemetry-specification/pull/4019))
-
 ### Logs
-
-- Allow implementations to export duplicate keys in a map as an opt-in option.
-  ([#3938](https://github.com/open-telemetry/opentelemetry-specification/pull/3938))
 
 ### Events
 
@@ -34,6 +22,45 @@ release.
 ### OpenTelemetry Protocol
 
 ### Compatibility
+
+### SDK Configuration
+
+### Common
+
+### Supplementary Guidelines
+
+## v1.33.0 (2024-05-07)
+
+### Context
+
+### Traces
+
+### Metrics
+
+- Change the exemplar behavior to be on by default.
+  ([#3994](https://github.com/open-telemetry/opentelemetry-specification/pull/3994))
+- Use normative language for exemplar default aggregations.
+  ([#4009](https://github.com/open-telemetry/opentelemetry-specification/pull/4009))
+- Mark Exemplars as stable.
+  ([#3870](https://github.com/open-telemetry/opentelemetry-specification/pull/3870))
+- Mark synchronous gauge as stable.
+  ([#4019](https://github.com/open-telemetry/opentelemetry-specification/pull/4019))
+
+### Logs
+
+- Allow implementations to export duplicate keys in a map as an opt-in option.
+  ([#3987](https://github.com/open-telemetry/opentelemetry-specification/pull/3987))
+
+### Events
+
+### Resource
+
+### OpenTelemetry Protocol
+
+### Compatibility
+
+- Add name suggestion for option to apply resource attributes as metric attributes in Prometheus exporter.
+  ([#3837](https://github.com/open-telemetry/opentelemetry-specification/pull/3837))
 
 ### SDK Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ release.
 
 ### Traces
 
-- Links with invalid SpanContext are recorded.
-  ([#3928](https://github.com/open-telemetry/opentelemetry-specification/pull/3928))
-
 ### Metrics
 
 ### Logs
@@ -37,6 +34,9 @@ release.
 ### Context
 
 ### Traces
+
+- Links with invalid SpanContext are recorded.
+  ([#3928](https://github.com/open-telemetry/opentelemetry-specification/pull/3928))
 
 ### Metrics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ release.
 
 ### Supplementary Guidelines
 
-## v1.33.0 (2024-05-07)
+## v1.33.0 (2024-05-08)
 
 ### Context
 


### PR DESCRIPTION
May 2024 release.

Important changes:

* Mark exemplars as stable (#3870)
* Mark synchronous gauge as stable (#4019)
* Record Links with empty/invalid SpanContext (#3928)