### PR TITLE
Remove docfx

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -68,4 +68,3 @@ jobs:
 
     - name: run misspell
       run: make misspell
-

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -69,16 +69,3 @@ jobs:
     - name: run misspell
       run: make misspell
 
-  docfx:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 6.0.x
-
-    - name: install docfx
-      run: dotnet tool update -g docfx --version "3.0.0-*" --add-source https://docfx.pkgs.visualstudio.com/docfx/_packaging/docs-public-packages/nuget/v3/index.json
-
-    - name: run docfx
-      run: docfx build --dry-run

--- a/docfx.json
+++ b/docfx.json
@@ -1,7 +1,0 @@
-{
-  "files": "**/*.{md,png}",
-  "warningsAsErrors": true,
-  "rules": {
-    "link-out-of-scope": "off"
-  }
-}


### PR DESCRIPTION
DocFx v3 is no longer available and not intended to be used externally.

The feature it provided that we don't have from other tooling is cross-file anchor reference check, see https://github.com/open-telemetry/semantic-conventions/issues/1009 for the details. It seems there is no popular (or even not popular) replacement for it.

DocFx v2 only check anchors within the same file which markdownlint does as well.

Related: https://github.com/open-telemetry/semantic-conventions/pull/1008

Closes #4026.

## Changes

This PR removes docfx since v2 does not provide additional value. We'll need to find a different solution for relative anchor checks.

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
