### PR TITLE
Clarify that unit must be a suffix for metric names for Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ release.
 
 ### Compatibility
 
+- Prometheus: Clarify location of unit suffix within metric names.
+  ([#4057](https://github.com/open-telemetry/opentelemetry-specification/pull/4057))
+
 ### SDK Configuration
 
 ### Common

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -267,9 +267,9 @@ The Unit of an OTLP metric point SHOULD be converted to the equivalent unit in P
 
 The resulting unit SHOULD be added to the metric as
 [UNIT metadata](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily)
-and as a suffix to the metric name unless the metric name already contains the
-unit, or the unit MUST be omitted. The unit suffix comes before any
-type-specific suffixes.
+and as a suffix to the metric name unless the metric name already ends with the
+unit (before type-specific suffixes), or the unit MUST be omitted. The unit
+suffix comes before any type-specific suffixes.
 
 The description of an OTLP metrics point MUST be added as
 [HELP metadata](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information).

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -268,8 +268,8 @@ The Unit of an OTLP metric point SHOULD be converted to the equivalent unit in P
 The resulting unit SHOULD be added to the metric as
 [UNIT metadata](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily)
 and as a suffix to the metric name unless the metric name already ends with the
-unit (before type-specific suffixes), or the unit MUST be omitted. The unit
-suffix comes before any type-specific suffixes.
+unit (before type-specific suffixes), or the unit metadata MUST be omitted. The
+unit suffix comes before any type-specific suffixes.
 
 The description of an OTLP metrics point MUST be added as
 [HELP metadata](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information).


### PR DESCRIPTION
I found this confusion while reviewing https://github.com/open-telemetry/opentelemetry-dotnet/pull/5646#discussion_r1611719896.  The intention is for unit to be added in the same fashion for both OpenMetrics and non-OpenMetrics names.

Before this change, the name `seconds_before_my_birthday` would not have a unit suffix appended.  While this is a conceivable name, it isn't compliant with OpenMetrics, which is the intention of the spec.  Instead, it needs to be changed to `seconds_before_my_birthday_seconds` to be compliant with the OpenMetrics spec.

This change will prevent Exporters from needing to special-case unit handling for OpenMetrics vs non-OpenMetrics.

@open-telemetry/wg-prometheus @reyang @robertcoltheart 
