### PR TITLE
add 'create a new gauge' to meter operations

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -171,6 +171,7 @@ The `Meter` MUST provide functions to create new [Instruments](#instrument):
 * [Create a new Counter](#counter-creation)
 * [Create a new Asynchronous Counter](#asynchronous-counter-creation)
 * [Create a new Histogram](#histogram-creation)
++ [Create a new Gauge](#gauge-creation)
 * [Create a new Asynchronous Gauge](#asynchronous-gauge-creation)
 * [Create a new UpDownCounter](#updowncounter-creation)
 * [Create a new Asynchronous UpDownCounter](#asynchronous-updowncounter-creation)

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -171,7 +171,7 @@ The `Meter` MUST provide functions to create new [Instruments](#instrument):
 * [Create a new Counter](#counter-creation)
 * [Create a new Asynchronous Counter](#asynchronous-counter-creation)
 * [Create a new Histogram](#histogram-creation)
-+ [Create a new Gauge](#gauge-creation)
+* [Create a new Gauge](#gauge-creation)
 * [Create a new Asynchronous Gauge](#asynchronous-gauge-creation)
 * [Create a new UpDownCounter](#updowncounter-creation)
 * [Create a new Asynchronous UpDownCounter](#asynchronous-updowncounter-creation)


### PR DESCRIPTION
Adds the missing creation of a sync gauge to the meter operations list of links.

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
