### PR TITLE
Allow independent log processing pipelines

### DIFF
--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -274,6 +274,8 @@ The SDK MUST allow users to implement and configure custom processors and
 decorate built-in processors for advanced scenarios such as enriching with
 attributes.
 
+The SDK SHOULD allow users to set up independent log processing pipelines.
+
 The following diagram shows `LogRecordProcessor`'s relationship to other
 components in the SDK:
 
@@ -303,7 +305,7 @@ therefore it SHOULD NOT block or throw exceptions.
 **Parameters:**
 
 * `logRecord` - a [ReadWriteLogRecord](#readwritelogrecord) for the
-  emitted `LogRecord`.
+  emitted `LogRecord`. It is `logRecord` MAY be passed as a 
 * `context` - the resolved `Context` (the explicitly passed `Context` or the
   current `Context`)
 
@@ -312,6 +314,14 @@ therefore it SHOULD NOT block or throw exceptions.
 A `LogRecordProcessor` may freely modify `logRecord` for the duration of
 the `OnEmit` call. If `logRecord` is needed after `OnEmit` returns (i.e. for
 asynchronous processing) only reads are permitted.
+
+It is implementation specific whether `logRecord` modification are
+also applied to the subsequent registered processors.
+For instance, `logRecord` may be passed by value or by reference.
+If `logRecord` modifications are applied the to subsequent registered processors,
+then [ReadWriteLogRecord](#readwritelogrecord) SHOULD offer
+a way to make a copy so that the user can set up independent log processing
+pipelines.
 
 #### ShutDown
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -274,7 +274,10 @@ The SDK MUST allow users to implement and configure custom processors and
 decorate built-in processors for advanced scenarios such as enriching with
 attributes.
 
-The SDK SHOULD allow users to set up independent log processing pipelines.
+The SDK SHOULD allow users to set up independent processing pipelines.
+For instance, the user should be able to make a log record modification in
+a processor that is not visible to and does not affect the behavior of other
+log record processors.
 
 The following diagram shows `LogRecordProcessor`'s relationship to other
 components in the SDK:

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -226,6 +226,9 @@ the following information added to the [LogRecord](data-model.md#log-and-event-r
 * [`SpanId`](./data-model.md#field-spanid)
 * [`TraceFlags`](./data-model.md#field-traceflags)
 
+ReadWriteLogRecord MAY offer a way to make a copy
+so that the user can set up independent log processing pipelines.
+
 ## LogRecord Limits
 
 `LogRecord` attributes MUST adhere to
@@ -321,10 +324,6 @@ asynchronous processing) only reads are permitted.
 It is implementation specific whether `logRecord` modification are
 also applied to the subsequent registered processors.
 For instance, `logRecord` may be passed by value or by reference.
-If `logRecord` modifications are applied the to subsequent registered processors,
-then [ReadWriteLogRecord](#readwritelogrecord) SHOULD offer
-a way to make a copy so that the user can set up independent log processing
-pipelines.
 
 #### ShutDown
 


### PR DESCRIPTION
Fixes #4010 

This PR tries to achieve the following:
- call out the the SDK should offer a way to make independent log processing
- allow something like `Clone` or `Copy` to `ReadWriteRecord` so that a log record processor can make a copy of the record to make sure that any changes are not affect other registered processors (this should be helpful for Java, Python, JavaScript. We already have something like this in Go
- make it explicit that it is not required that that modification in one log record processor are  affecting subsequent processors

