### PR TITLE
Clarify the trace SDK should log discarded events and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- Clarify the trace SDK should log discarded events and links.
+  ([#4064](https://github.com/open-telemetry/opentelemetry-specification/pull/4064))
+
 ### Metrics
 
 ### Logs

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -495,7 +495,7 @@ public final class SpanLimits {
 * `AttributePerLinkCountLimit` (Default=128) - Maximum allowed attribute per span link count;
 
 There SHOULD be a message printed in the SDK's log to indicate to the user
-that an attribute was discarded due to such a limit.
+that an attribute, event, or link was discarded due to such a limit.
 To prevent excessive logging, the message MUST be printed at most once per
 span (i.e., not per discarded attribute, event, or link).
 


### PR DESCRIPTION
The current language implies only discarded attributes should be logged. However, the following sentence indicates that discarded events and links should also be logged. This updates the first sentence to included the omitted types.