### PR TITLE
[editorial] Fix link: drop anchor ID to page title

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -283,7 +283,7 @@ non-zero TraceID and a non-zero SpanID, MUST be provided.
 
 An API called `IsRemote`, that returns a boolean value, which is `true` if the SpanContext was
 propagated from a remote parent, MUST be provided.
-When extracting a `SpanContext` through the [Propagators API](../context/api-propagators.md#propagators-api),
+When extracting a `SpanContext` through the [Propagators API](../context/api-propagators.md),
 `IsRemote` MUST return true, whereas for the SpanContext of any child spans it MUST return false.
 
 ### TraceState


### PR DESCRIPTION
- Fix link that is broken when the spec is published to the website. There shouldn't be a hash to the page title.

/cc @open-telemetry/docs-maintainers 