### PR TITLE
[editorial] Spec compliance matrix: optional noted with 'X', not '+'

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -210,16 +210,16 @@ Disclaimer: Events are currently in Development status - work in progress.
 |----------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
 | [EventLoggerProvider](specification/logs/event-api.md#eventloggerprovider) |          |    |      |    |        |      |        |     |      |     |      |       |
 | Get EventLogger                                                            |          |    |      |    |        |      |        |     |      |     |      |       |
-| Get EventLogger accepts version                                            | +        |    |      |    |        |      |        |     |      |     |      |       |
-| Get EventLogger accepts schema_url                                         | +        |    |      |    |        |      |        |     |      |     |      |       |
-| Get EventLogger accepts attributes                                         | +        |    |      |    |        |      |        |     |      |     |      |       |
+| Get EventLogger accepts version                                            | X        |    |      |    |        |      |        |     |      |     |      |       |
+| Get EventLogger accepts schema_url                                         | X        |    |      |    |        |      |        |     |      |     |      |       |
+| Get EventLogger accepts attributes                                         | X        |    |      |    |        |      |        |     |      |     |      |       |
 | [EventLogger](specification/logs/event-api.md#eventlogger)                 |          |    |      |    |        |      |        |     |      |     |      |       |
 | Emit event accepts name                                                    |          |    |      |    |        |      |        |     |      |     |      |       |
-| Emit event accepts AnyValue body                                           | +        |    |      |    |        |      |        |     |      |     |      |       |
-| Emit event accepts severity                                                | +        |    |      |    |        |      |        |     |      |     |      |       |
-| Emit event accepts timestamp                                               | +        |    |      |    |        |      |        |     |      |     |      |       |
-| Emit event accepts attributes                                              | +        |    |      |    |        |      |        |     |      |     |      |       |
-| Emit event accepts context                                                 | +        |    |      |    |        |      |        |     |      |     |      |       |
+| Emit event accepts AnyValue body                                           | X        |    |      |    |        |      |        |     |      |     |      |       |
+| Emit event accepts severity                                                | X        |    |      |    |        |      |        |     |      |     |      |       |
+| Emit event accepts timestamp                                               | X        |    |      |    |        |      |        |     |      |     |      |       |
+| Emit event accepts attributes                                              | X        |    |      |    |        |      |        |     |      |     |      |       |
+| Emit event accepts context                                                 | X        |    |      |    |        |      |        |     |      |     |      |       |
 
 ## Resource
 


### PR DESCRIPTION

## Changes

Please provide a brief description of the changes here.

In the spec compliance matrix, optional entries are to be noted with `X`, not `+`.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [X] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
