### PR TITLE
Add default_histogram_aggregation configuration option to prometheus exporter

### DIFF
--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -57,3 +57,12 @@ metric, or scope labels. The option MAY be named `without_scope_info`, and MUST 
 
 A Prometheus Exporter MAY support a configuration option to produce metrics without a [target info](../../compatibility/prometheus_and_openmetrics.md#resource-attributes-1)
 metric. The option MAY be named `without_target_info`, and MUST be `false` by default.
+
+A Prometheus Exporter MAY support a configuration option to set the default
+histogram aggregation. The option MAY be named `default_histogram_aggregation`,
+and MUST support the following values:
+
+* `explicit_bucket_histogram`: Use [Explicit Bucket Histogram Aggregation](../sdk.md#explicit-bucket-histogram-aggregation).
+* `base2_exponential_bucket_histogram`: Use [Base2 Exponential Bucket Histogram Aggregation](../sdk.md#base2-exponential-bucket-histogram-aggregation).
+
+By default, `default_histogram_aggregation` MUST be `explicit_bucket_histogram`.


### PR DESCRIPTION
Similar to how its possible to specify that base2 exponential histogram should be the [default histogram aggregation for the otlp metric exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk_exporters/otlp.md#additional-configuration), it should be possible to do so for the prometheus exporter.

This adds a new optional config option to the prometheus exporter called `default_histogram_aggregation`, with the same mechanics as the OTLP-exporter equivalent.

The motivation is that there is a [PR](https://github.com/open-telemetry/opentelemetry-configuration/pull/99) to extend the file configuration schema with this option, and we have a rule that all portions of the file configuration schema should be explicitly defined or implied by language in the spec, since we don't want to add configuration options which could potentially contradict the spec.

cc @open-telemetry/configuration-maintainers, @open-telemetry/wg-prometheus, @Abhishekkr3003
