### PR TITLE
Update README.md

### DIFF
--- a/specification/README.md
+++ b/specification/README.md
@@ -28,7 +28,7 @@ path_base_for_github_subdir:
   - [Baggage](baggage/api.md)
   - [Tracing](trace/api.md)
   - [Metrics](metrics/api.md)
-  - Logs
+  - [Logs](logs/README.md)
     - [Bridge API](logs/bridge-api.md)
     - [Event API](logs/event-api.md)
 - SDK Specification


### PR DESCRIPTION
content index in https://opentelemetry.io/docs/specs/otel/ didn't correctly navigate to page https://opentelemetry.io/docs/specs/otel/logs/