### PR TITLE
Release 1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ release.
 
 ### Logs
 
-- Add the in-development isolating log record processor.
-  ([#4062](https://github.com/open-telemetry/opentelemetry-specification/pull/4062))
-
 ### Events
 
 ### Resource
@@ -31,6 +28,53 @@ release.
 ### Common
 
 ### Supplementary Guidelines
+
+## v1.35.0 (2024-07-10)
+
+### Context
+
+- No changes.
+
+### Traces
+
+- No changes.
+
+### Metrics
+
+- No changes.
+
+### Logs
+
+- Add the in-development isolating log record processor.
+  ([#4062](https://github.com/open-telemetry/opentelemetry-specification/pull/4062))
+
+### Events
+
+- No changes.
+
+### Resource
+
+- No changes.
+
+### OpenTelemetry Protocol
+
+- No changes.
+
+### Compatibility
+
+- No changes.
+
+### SDK Configuration
+
+- No changes.
+
+### Common
+
+- No changes.
+
+### Supplementary Guidelines
+
+- No changes.
 
 ## v1.34.0 (2024-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,52 +29,12 @@ release.
 
 ### Supplementary Guidelines
 
-## v1.35.0 (2024-07-10)
-
-### Context
-
-- No changes.
-
-### Traces
-
-- No changes.
-
-### Metrics
-
-- No changes.
+## v1.35.0 (2024-07-12)
 
 ### Logs
 
 - Add the in-development isolating log record processor.
   ([#4062](https://github.com/open-telemetry/opentelemetry-specification/pull/4062))
-
-### Events
-
-- No changes.
-
-### Resource
-
-- No changes.
-
-### OpenTelemetry Protocol
-
-- No changes.
-
-### Compatibility
-
-- No changes.
-
-### SDK Configuration
-
-- No changes.
-
-### Common
-
-- No changes.
-
-### Supplementary Guidelines
-
-- No changes.
 
 ## v1.34.0 (2024-06-11)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ release.
 
 ### Compatibility
 
-- Define casing for hex-encoded IDs and mark the "Trace Context in non-OTLP Log Formats" specification stable.
-  ([#3909](https://github.com/open-telemetry/opentelemetry-specification/pull/3909))
-
 ### SDK Configuration
 
 ### Common
@@ -38,6 +35,11 @@ release.
 
 - Add the in-development isolating log record processor.
   ([#4062](https://github.com/open-telemetry/opentelemetry-specification/pull/4062))
+
+### Compatibility
+
+- Define casing for hex-encoded IDs and mark the "Trace Context in non-OTLP Log Formats" specification stable.
+  ([#3909](https://github.com/open-telemetry/opentelemetry-specification/pull/3909))
 
 ## v1.34.0 (2024-06-11)
 


### PR DESCRIPTION
July 2024 release.

FYI, the only non-editorial changes for this month are:

- (Experimental) Isolating Log Record Processor (#4062)
- Define casing for hex-encoded IDs and mark the "Trace Context in non-OTLP Log Formats" specification stable (#3909 )