### PR TITLE
Add explicit option for SDK otlp exporter to disable retry

### DIFF
--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -169,7 +169,12 @@ The `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_TRACES_HEADERS`, `OTEL_EXP
 
 ## Retry
 
-Transient errors MUST be handled with a retry strategy. This retry strategy MUST implement an exponential back-off with jitter to avoid overwhelming the destination until the network is restored or the destination has recovered.
+Transient errors MUST be handled with a retry strategy. This retry strategy MUST
+implement an exponential back-off with jitter to avoid overwhelming the
+destination until the network is restored or the destination has recovered.
+
+SDKs SHOULD provide a configuration option to disable the retry strategy. This
+option MAY be named `disabled`, AND MUST be `false` by default.
 
 ### Transient errors
 


### PR DESCRIPTION
That have been several attempts at further refining the spec around OTLP retry configuration options. What is clear is that SDK OTLP exporters [MUST handle transient errors with an exponential retry strategy](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#retry). But we failed to align on the details of that strategy and what options should be configurable.

I don't have the ability to drive the answer to all the questions, but believe we can agree on a narrower scope. 

We're trying to add retry configuration to file configuration in https://github.com/open-telemetry/opentelemetry-configuration/pull/97. In `opentelemetry-configuration`, we have a [policy stating](https://github.com/open-telemetry/opentelemetry-configuration?tab=readme-ov-file#what-properties-are-part-of-schema) we only add configuration properties for options described in the spec. This is important for a number of reasons, including that spec'd options have clearly defined default. We use JSON schema to model the schema in `opentelemetry-configuration` and are unable to encode the default value for properties. Because of this, we defer to the default values as defined in the spec.

Coming back to retry. This PR makes it explicit that SDK OTLP exporters SHOULD have an option to disable the retry strategy, and defines that by default retry is enabled (which is most aligned the current wording "Transient errors MUST be handled with a retry strategy.").

Hopefully despite the different implementations of retry, we can all agree that 1. It should be able to be enabled / disabled. 2. It should be enabled by default.