### PR TITLE
update file-based configuration to allow for multiple inputs

### DIFF
--- a/specification/configuration/file-configuration.md
+++ b/specification/configuration/file-configuration.md
@@ -278,12 +278,14 @@ with OpAmp
 
 #### Parse
 
-Parse and validate a [configuration file](#configuration-file).
+Parse and validate one or more [configuration file](#configuration-file)s.
 
 **Parameters:**
 
-* `file`: The [configuration file](#configuration-file) to parse. This MAY be a
+* `file`: The [configuration file](#configuration-file)(s) to parse. This MAY be a
   file path, or language specific file data structure, or a stream of a file's content.
+  If multiple configuration files are provided, implementations SHOULD merge them into
+  one YAML document prior to parsing and validation.
 * `file_format`: The file format of the `file` (e.g. [yaml](#yaml-file-format)).
   Implementations MAY accept a `file_format` parameter, or infer it from
   the `file` extension, or include file format specific overloads of `parse`,
@@ -429,13 +431,13 @@ ContextPropagators propagators = openTelemetry.getPropagators();
 If an SDK
 supports [OTEL_EXPERIMENTAL_CONFIG_FILE](./sdk-environment-variables.md#file-configuration),
 then setting `OTEL_EXPERIMENTAL_CONFIG_FILE` provides a simple way to obtain an
-SDK initialized from the specified config file. The pattern for accessing the
+SDK initialized from the specified config file(s). The pattern for accessing the
 configured SDK components and installing into instrumentation will vary by
 language. For example, the usage in Java might resemble:
 
 ```shell
-# Set the required env var to the location of the configuration file
-export OTEL_EXPERIMENTAL_CONFIG_FILE="/app/sdk-config.yaml"
+# Set the required env var to the location of the configuration files
+export OTEL_EXPERIMENTAL_CONFIG_FILE="/app/sdk-config.yaml,/app/sdk-config.extra.yaml"
 ```
 
 ```java


### PR DESCRIPTION
The [file-configuration examples](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/file-configuration.md#via-file-configuration-api
) suggest that it should be possible to parse multiple configuration files:

> A more complex case might consist of parsing multiple configuration files from different sources, merging them using custom logic, and creating SDK components from the merged configuration model

The `OTEL_EXPERIMENTAL_CONFIG_FILE` and related `configuration.parse` method don't allow for multiple inputs, so I propose to adjust the descriptions of these to allow for multiple inputs.

Also, in PHP SIG's implementation, when we `parse` config, we also apply default values which makes "custom merging" quite difficult, whereas merging the YAML inputs is straightforward. So, I've also proposed that multiple config inputs should be merged prior to parsing.

This is related to https://github.com/open-telemetry/opentelemetry-configuration/issues/102 where I want to apply a custom sampler to a file-based config without breaking other SIGs by providing config they cannot parse.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
