### PR TITLE
add rule-based sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ release.
 
 ### Traces
 
+  - Add `RulesBased` sampler. [#4152](https://github.com/open-telemetry/opentelemetry-specification/pull/4152)
+
 ### Metrics
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ release.
 
 ### Traces
 
-  - Add `RulesBased` sampler. [#4152](https://github.com/open-telemetry/opentelemetry-specification/pull/4152)
+- Add `RulesBased` sampler. [#4152](https://github.com/open-telemetry/opentelemetry-specification/pull/4152)
 
 ### Metrics
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -79,7 +79,7 @@ formats is required. Implementing more than one format is optional.
 | [Sampling](specification/trace/sdk.md#sampling)                                                  | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Allow samplers to modify tracestate                                                              |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    | +     |
 | ShouldSample gets full parent Context                                                            |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | -    | +     |
-| Sampler: RulesBasedSampler                                                                       | Optional |     |      |     |        |      |        |     |      |     |      |       |
+| Sampler: [RulesBasedSampler](specification/trace/sdk.md#rulebased)                               | Optional |     |      |     |        |      |        |     |      |     |      |       |
 | Sampler: JaegerRemoteSampler                                                                     |          | +   | +    |     |        |      |        |     | +    |     |      |       |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          | +   | +    |     | +      | +    | +      | +   | +    | +   | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   |      | +     |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -79,6 +79,7 @@ formats is required. Implementing more than one format is optional.
 | [Sampling](specification/trace/sdk.md#sampling)                                                  | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | Allow samplers to modify tracestate                                                              |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    | +     |
 | ShouldSample gets full parent Context                                                            |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | -    | +     |
+| Sampler: RulesBasedSampler                                                                       | Optional |     |      |     |        |      |        |     |      |     |      |       |
 | Sampler: JaegerRemoteSampler                                                                     |          | +   | +    |     |        |      |        |     | +    |     |      |       |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          | +   | +    |     | +      | +    | +      | +   | +    | +   | -    | +     |
 | [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   |      | +     |

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -32,6 +32,7 @@ linkTitle: SDK
     + [TraceIdRatioBased](#traceidratiobased)
       - [Requirements for `TraceIdRatioBased` sampler algorithm](#requirements-for-traceidratiobased-sampler-algorithm)
     + [ParentBased](#parentbased)
+    + [RuleBased](#rulebased)
     + [JaegerRemoteSampler](#jaegerremotesampler)
 - [Span Limits](#span-limits)
 - [Id Generators](#id-generators)


### PR DESCRIPTION
This is based on PHP's implementation of a rules-based sampler, which itself is based on and expands on [Java's rule-based samplers](https://github.com/open-telemetry/opentelemetry-java-contrib/tree/v1.36.0/samplers/src/main/java/io/opentelemetry/contrib/sampler).

Looking through other SIGs repositories, I didn't find any other similar implementations to try to integrate with this.

Related: https://github.com/open-telemetry/opentelemetry-configuration/issues/102#issuecomment-2231694161
Prototype: https://github.com/open-telemetry/opentelemetry-php-contrib/pull/279

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
