### PR TITLE
Propagators API: Update HTTP header RFC reference to 9110

### DIFF
--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -120,7 +120,7 @@ The carrier of propagated data on both the client (injector) and server (extract
 usually an HTTP request.
 
 In order to increase compatibility, the key/value pairs MUST only consist of US-ASCII characters
-that make up valid HTTP header fields as per [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2).
+that make up valid HTTP header fields as per [RFC 9110](https://tools.ietf.org/html/rfc9110/#name-fields).
 
 `Getter` and `Setter` are optional helper components used for extraction and injection respectively,
 and are defined as separate objects from the carrier to avoid runtime allocations,


### PR DESCRIPTION
Fixes #3444 

## Changes

Please provide a brief description of the changes here.

I updated the Propagators API documentation to reference RFC9110 [Section 5](https://tools.ietf.org/html/rfc9110/#name-fields), which specifies the latest HTTP Header Fields specification.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #3444
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
  * No related
* [ ] Links to the prototypes (when adding or changing features)
  * No related
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * This is a trivial change
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
  * No changes
