### PR TITLE
[DoNotMerge] Define attributes equality and make all fields as identifying for Tracer, Meter, Logger, EventLogger

### DIFF
--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -59,6 +59,8 @@ indices that are kept in sync (e.g., two attributes `header_keys` and `header_va
 both containing an array of strings to represent a mapping
 `header_keys[i] -> header_values[i]`).
 
+Attributes are equal when their keys and values are equal.
+
 See [Attribute Naming](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-naming.md) for naming guidelines.
 
 See [Requirement Level](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-requirement-level.md) for requirement levels guidelines.
@@ -185,3 +187,7 @@ Some other implementations may use a streaming approach where every
 that individual attribute value being exported using a streaming wire protocol.
 In such cases the enforcement of uniqueness will likely be the responsibility of
 the recipient of this data.
+
+Collection of attributes are equal when they contain the same attributes,
+irrespective of the order in which those elements appear
+(unordered collection equality).

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -63,7 +63,7 @@ The `LoggerProvider` MUST provide the following functions:
 This API MUST accept the following [instrumentation scope](data-model.md#field-instrumentationscope)
 parameters:
 
-* `name`: This name uniquely identifies the [instrumentation scope](../glossary.md#instrumentation-scope),
+* `name`: Specifies the name of the [instrumentation scope](../glossary.md#instrumentation-scope),
   such as the [instrumentation library](../glossary.md#instrumentation-library)
   (e.g. `io.opentelemetry.contrib.mongodb`), package, module or class name.
   If an application or library has built-in OpenTelemetry instrumentation, both
@@ -85,19 +85,9 @@ parameters:
   associate with emitted telemetry. This API MUST be structured to accept a
   variable number of attributes, including none.
 
-`Logger`s are identified by `name`, `version`, and `schema_url` fields.  When more
-than one `Logger` of the same `name`, `version`, and `schema_url` is created, it
-is unspecified whether or under which conditions the same or different `Logger`
-instances are returned. It is a user error to create Loggers with different
-`attributes` but the same identity.
-
-The term *identical* applied to `Logger`s describes instances where all
-identifying fields are equal. The term *distinct* applied to `Logger`s describes
-instances where at least one identifying field has a different value.
-
-The effect of associating a Schema URL with a `Logger` MUST be that the telemetry
-emitted using the `Logger` will be associated with the Schema URL, provided that
-the emitted data format is capable of representing such association.
+The term *identical* applied to `Logger`s describes instances where all fields
+are equal. The term *distinct* applied to `Logger`s describes instances where at
+least one field has a different value.
 
 ## Logger
 

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -85,9 +85,9 @@ parameters:
   associate with emitted telemetry. This API MUST be structured to accept a
   variable number of attributes, including none.
 
-The term *identical* applied to `Logger`s describes instances where all fields
-are equal. The term *distinct* applied to `Logger`s describes instances where at
-least one field has a different value.
+The term *identical* applied to `Logger`s describes instances where all
+parameters are equal. The term *distinct* applied to `Logger`s describes
+instances where at least one parameter has a different value.
 
 ## Logger
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -121,7 +121,6 @@ The term *identical* applied to `EventLogger`s describes instances where all
 fields are equal. The term *distinct* applied to `EventLogger`s describes
 instances where at least one field has a different value.
 
-
 ## EventLogger
 
 The `EventLogger` is the entrypoint of the Event API, and is responsible for

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -118,8 +118,8 @@ This API MUST accept the following parameters:
   variable number of attributes, including none.
 
 The term *identical* applied to `EventLogger`s describes instances where all
-fields are equal. The term *distinct* applied to `EventLogger`s describes
-instances where at least one field has a different value.
+parameters are equal. The term *distinct* applied to `EventLogger`s describes
+instances where at least one parameter has a different value.
 
 ## EventLogger
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -98,7 +98,7 @@ The `EventLoggerProvider` MUST provide the following functions:
 
 This API MUST accept the following parameters:
 
-* `name`: This name uniquely identifies the [instrumentation scope](../glossary.md#instrumentation-scope),
+* `name`: Specifies the name of the [instrumentation scope](../glossary.md#instrumentation-scope),
   such as the [instrumentation library](../glossary.md#instrumentation-library)
   (e.g. `io.opentelemetry.contrib.mongodb`), package, module or class name.
   If an application or library has built-in OpenTelemetry instrumentation, both
@@ -117,15 +117,10 @@ This API MUST accept the following parameters:
   associate with emitted telemetry. This API MUST be structured to accept a
   variable number of attributes, including none.
 
-`EventLogger`s are identified by `name`, `version`, and `schema_url` fields.  When more
-than one `EventLogger` of the same `name`, `version`, and `schema_url` is created, it
-is unspecified whether or under which conditions the same or different `EventLogger`
-instances are returned. It is a user error to create `EventLogger`s with different
-`attributes` but the same identity.
+The term *identical* applied to `EventLogger`s describes instances where all
+fields are equal. The term *distinct* applied to `EventLogger`s describes
+instances where at least one field has a different value.
 
-The effect of associating a Schema URL with a `EventLogger` MUST be that the telemetry
-emitted using the `EventLogger` will be associated with the Schema URL, provided that
-the emitted data format is capable of representing such association.
 
 ## EventLogger
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -63,6 +63,10 @@ It SHOULD only be possible to create `Logger` instances through a `LoggerProvide
 
 The `LoggerProvider` MUST implement the [Get a Logger API](bridge-api.md#get-a-logger).
 
+The implementation MUST honor all passed parameters so that that the telemetry
+emitted using the `Logger` will contain the data passed via the parameters,
+provided that the emitted data format is capable of representing such data.
+
 The input provided by the user MUST be used to create
 an [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which
 is stored on the created `Logger`.

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -63,7 +63,7 @@ It SHOULD only be possible to create `Logger` instances through a `LoggerProvide
 
 The `LoggerProvider` MUST implement the [Get a Logger API](bridge-api.md#get-a-logger).
 
-The implementation MUST honor all passed parameters so that that the telemetry
+The implementation MUST honor all passed parameters so that the telemetry
 emitted using the `Logger` will contain the data passed via the parameters,
 provided that the emitted data format is capable of representing such data.
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -149,9 +149,9 @@ This API MUST accept the following parameters:
   it is up to their discretion. Therefore, this API MUST be structured to
   accept a variable number of attributes, including none.
 
-The term *identical* applied to Meters describes instances where all fields are
-equal. The term *distinct* applied to Meters describes instances where at least
-one field has a different value.
+The term *identical* applied to Meters describes instances where all parameters
+are equal. The term *distinct* applied to Meters describes instances where at
+least one parameter has a different value.
 
 ## Meter
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -120,7 +120,7 @@ The `MeterProvider` MUST provide the following functions:
 
 This API MUST accept the following parameters:
 
-* `name`: This name uniquely identifies the [instrumentation
+* `name`: Specifies the name of the [instrumentation
   scope](../glossary.md#instrumentation-scope), such as the
   [instrumentation library](../glossary.md#instrumentation-library) (e.g.
   `io.opentelemetry.contrib.mongodb`), package,
@@ -149,15 +149,9 @@ This API MUST accept the following parameters:
   it is up to their discretion. Therefore, this API MUST be structured to
   accept a variable number of attributes, including none.
 
-Meters are identified by `name`, `version`, and `schema_url` fields.  When more
-than one `Meter` of the same `name`, `version`, and `schema_url` is created, it
-is unspecified whether or under which conditions the same or different `Meter`
-instances are returned. It is a user error to create Meters with different
-attributes but the same identity.
-
-The term *identical* applied to Meters describes instances where all identifying
-fields are equal. The term *distinct* applied to Meters describes instances where
-at least one identifying field has a different value.
+The term *identical* applied to Meters describes instances where all fields are
+equal. The term *distinct* applied to Meters describes instances where at least
+one field has a different value.
 
 ## Meter
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -119,7 +119,7 @@ It SHOULD only be possible to create `Meter` instances through a `MeterProvider`
 
 The `MeterProvider` MUST implement the [Get a Meter API](api.md#get-a-meter).
 
-The implementation MUST honor all passed parameters so that that the telemetry
+The implementation MUST honor all passed parameters so that the telemetry
 emitted using the `Meter` will contain the data passed via the parameters,
 provided that the emitted data format is capable of representing such data.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -119,6 +119,10 @@ It SHOULD only be possible to create `Meter` instances through a `MeterProvider`
 
 The `MeterProvider` MUST implement the [Get a Meter API](api.md#get-a-meter).
 
+The implementation MUST honor all passed parameters so that that the telemetry
+emitted using the `Meter` will contain the data passed via the parameters,
+provided that the emitted data format is capable of representing such data.
+
 The input provided by the user MUST be used to create
 an [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which
 is stored on the created `Meter`.
@@ -127,10 +131,6 @@ In the case where an invalid `name` (null or empty string) is specified, a
 working Meter MUST be returned as a fallback rather than returning null or
 throwing an exception, its `name` SHOULD keep the original invalid value, and a
 message reporting that the specified value is invalid SHOULD be logged.
-
-When a Schema URL is passed as an argument when creating a `Meter` the emitted
-telemetry for that `Meter` MUST be associated with the Schema URL, provided
-that the emitted data format is capable of representing such association.
 
 **Status**: [Development](../document-status.md) - The `MeterProvider` MUST
 compute the relevant [MeterConfig](#meterconfig) using the

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -138,15 +138,9 @@ This API MUST accept the following parameters:
 - [since 1.13.0] `attributes` (optional): Specifies the instrumentation scope attributes
   to associate with emitted telemetry.
 
-Tracers are identified by `name`, `version`, and `schema_url` fields.  When more
-than one `Tracer` of the same `name`, `version`, and `schema_url` is created, it
-is unspecified whether or under which conditions the same or different `Tracer`
-instances are returned. It is a user error to create Tracers with different
-attributes but the same identity.
-
-The term *identical* applied to Tracers describes instances where all
-identifying fields are equal. The term *distinct* applied to Tracers describes
-instances where at least one identifying field has a different value.
+The term *identical* applied to Tracers describes instances where all fields are
+equal. The term *distinct* applied to Tracers describes instances where at least
+one field has a different value.
 
 Implementations MUST NOT require users to repeatedly obtain a `Tracer` again
 with the same identity to pick up configuration changes. This can be
@@ -160,11 +154,6 @@ configuration must be stored per-tracer (such as disabling a certain tracer),
 the tracer could, for example, do a look-up with its identity in a map
 in the `TracerProvider`, or the `TracerProvider` could maintain a registry of
 all returned `Tracer`s and actively update their configuration if it changes.
-
-The effect of associating a Schema URL with a `Tracer` MUST be that the
-telemetry emitted using the `Tracer` will be associated with the Schema URL,
-provided that the emitted data format is capable of representing such
-association.
 
 ## Context Interaction
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -138,9 +138,9 @@ This API MUST accept the following parameters:
 - [since 1.13.0] `attributes` (optional): Specifies the instrumentation scope attributes
   to associate with emitted telemetry.
 
-The term *identical* applied to Tracers describes instances where all fields are
-equal. The term *distinct* applied to Tracers describes instances where at least
-one field has a different value.
+The term *identical* applied to Tracers describes instances where all parameters
+are equal. The term *distinct* applied to Tracers describes instances where at
+least one parameter has a different value.
 
 Implementations MUST NOT require users to repeatedly obtain a `Tracer` again
 with the same identity to pick up configuration changes. This can be

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -67,6 +67,10 @@ It SHOULD only be possible to create `Tracer` instances through a `TracerProvide
 
 The `TracerProvider` MUST implement the [Get a Tracer API](api.md#get-a-tracer).
 
+The implementation MUST honor all passed parameters so that that the telemetry
+emitted using the `Tracer` will contain the data passed via the parameters,
+provided that the emitted data format is capable of representing such data.
+
 The input provided by the user MUST be used to create
 an [`InstrumentationScope`](../glossary.md#instrumentation-scope) instance which
 is stored on the created `Tracer`.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -67,7 +67,7 @@ It SHOULD only be possible to create `Tracer` instances through a `TracerProvide
 
 The `TracerProvider` MUST implement the [Get a Tracer API](api.md#get-a-tracer).
 
-The implementation MUST honor all passed parameters so that that the telemetry
+The implementation MUST honor all passed parameters so that the telemetry
 emitted using the `Tracer` will contain the data passed via the parameters,
 provided that the emitted data format is capable of representing such data.
 


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-specification/issues/4160

[Python SDK](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py), [PHP SDK](https://github.com/open-telemetry/opentelemetry-php/blob/main/src/SDK/Trace/TracerProvider.php) look to be compliant with the proposal. AFAIK these are the only languages which handle scope attributes in their stable releases.

**Additional note:** I do not want to merge it before I prototype it in the Go SDK. However, I want to have some "acceptance" before writing the prototype.

**Remarks:** I do not feel competent to handle similar issue for instruments in metrics. Especially how to refine the [duplicate instrument registration](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/sdk.md#duplicate-instrument-registration) section. I decided to leave this section untouched.
