### PR TITLE
Add SimpleConcurrentProcessor, clarify existing export concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ release.
 
 ### Logs
 
+- Add the in-development Simple Concurrent log record processor.
+  ([#4163](https://github.com/open-telemetry/opentelemetry-specification/pull/4163))
+- Clarify that `Export` should not called by built-in processors concurrently.
+
 ### Events
 
 ### Resource


### PR DESCRIPTION
Fixes #4134 

## Changes
1. Clarifies explicitly that the existing built-in processors should not invoke Export() concurrently. This was already the intention (from what I gather!), but not explicitly listed.
2. Adds SimpleConcurrentProcessor (happy to get alternative name suggestions), which can call Export() concurrently.


.NET, Rust, C++ have their SimpleProcessor already matching this.
Java, Go, Python does not. I believe they can fix the SimpleProcessor implementation to match this. This should be treated as a bug fix. Since SimpleProcessors were meant to be used in test/debug scenarios (stdout exporters), the extra perf hit should not be a concern. If it is indeed a concern, then users can be advised to switch to SimpleConcurrentProcessor.

(I also considered the possibility of adding extra capability to existing SimpleProcessor, but I believe it is better to have a dedicated one to avoid any confusion about "Simple" being in used for high-perf, prod scenarios. Also, adding more capabilities may make SimpleProcessor more complex without much gains.)

**Additional background/context:**
.NET, Rust, C++ had the equivalent of SimpleConcurrentProcessors for quite a while and was used when exporting to OS native tracing systems like [ETW (Windows)](https://learn.microsoft.com/en-us/windows/win32/etw/about-event-tracing), Linux [user_events](https://docs.kernel.org/trace/user_events.html). Exporting to these systems are done for scenarios requiring very high performance, and the existing Simple/Batch processors does not allow such high performance, necessitating the need of an official exporting processor.

(Note: A similar PR can be done for tracing sdk as well, but want to first try out in Log SDK. Once this is done, will make a follow up PR to trace sdk as well.)

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
