### PR TITLE
Add notes about the migration from Span Events to the Events API

### DIFF
--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -163,6 +163,14 @@ NOT obligate a user to provide it.
 For each required parameter, the API MUST be structured to obligate a user to
 provide it.
 
+## Supplementary Guildelines
+
+### Migrating from Span Events to the Events API
+
+Instrumentation migrating from Span Events to the Events API must set the event context parameter from a current or explicit
+SpanContext. Otherwise, data exported will be inconsistent with Span Events having traceID and spanID correlation while Events
+do not.
+
 ## References
 
 - [OTEP0202 Introducing Events and Logs API](https://github.com/open-telemetry/oteps/blob/main/text/0202-events-and-logs-api.md)

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -18,6 +18,8 @@
   * [EventLogger Operations](#eventlogger-operations)
     + [Emit Event](#emit-event)
 - [Optional and required parameters](#optional-and-required-parameters)
+- [Supplementary Guildelines](#supplementary-guildelines)
+  * [Migrating from Span Events to the Events API](#migrating-from-span-events-to-the-events-api)
 - [References](#references)
 
 <!-- tocstop -->


### PR DESCRIPTION
Fixes #1294

## Changes

This adds notes about the migration from Span Events to the Events API.

While the Log api has extended guidance about implicit and explicit context, as well diagrams and special guidelines, the new Events API does not, yet.

In particular, I would like to make foreground the migration concern about Span Events to the Events API wrt Span Context. A Span event always has one, where Events only would if you added it explicitly to each event.

If you don't, then in a mixed environment you will have some data linked to spans and others not. I think this is worthwhile calling out somewhere, but happy to move it around.

* [x] Related issues https://github.com/open-telemetry/semantic-conventions/issues/1294
* [x] Related [OTEP(s)](https://github.com/open-telemetry/oteps) https://github.com/open-telemetry/oteps/blob/main/text/0202-events-and-logs-api.md
* [n/a] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [n/a] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
