### PR TITLE
Fix community contributing hyperlink

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Welcome to OpenTelemetry specifications repository!
 
 Before you start - see OpenTelemetry general
-[contributing](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+[contributing](https://github.com/open-telemetry/community/blob/main/guides/contributor/README.md)
 requirements and recommendations.
 
 ## Sign the CLA


### PR DESCRIPTION
Fix after https://github.com/open-telemetry/community/pull/2051

CC @austinlparker @svrnm 

_May be good checking if this does not affect other repos._