### PR TITLE
Release 1.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ release.
 
 ### Supplementary Guidelines
 
-## v1.36.0 (2024-08-06)
+## v1.36.0 (2024-08-12)
 
 ### Traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ release.
 
 ### Traces
 
+### Metrics
+
+### Logs
+
+### Events
+
+### Baggage
+
+### Resource
+
+### OpenTelemetry Protocol
+
+### Compatibility
+
+### SDK Configuration
+
+### Common
+
+### Supplementary Guidelines
+
+## v1.36.0 (2024-08-06)
+
+### Traces
+
 - Remove restriction that sampler description is immutable.
   ([#4137](https://github.com/open-telemetry/opentelemetry-specification/pull/4137))
 - Add in-development `OnEnding` callback to SDK `SpanProcessor` interface.
@@ -31,19 +55,15 @@ release.
 - The SDK MAY provide an operation that makes a deep clone of a `ReadWriteLogRecord`.
   ([#4090](https://github.com/open-telemetry/opentelemetry-specification/pull/4090))
 
-### Events
+### Baggage
 
-### Resource
-
-### OpenTelemetry Protocol
-
-### Compatibility
-
-### SDK Configuration
+- Clarify no empty string allowed in baggage names.
+  ([#4144](https://github.com/open-telemetry/opentelemetry-specification/pull/4144))
 
 ### Common
 
-### Supplementary Guidelines
+- Require separation of API and SDK artifacts.
+  ([#4125](https://github.com/open-telemetry/opentelemetry-specification/pull/4125))
 
 ## v1.35.0 (2024-07-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,13 @@ release.
 
 ### Metrics
 
-- Clarify prometheus exporter should have `host` and `port` configuration options.
-  ([#4147](https://github.com/open-telemetry/opentelemetry-specification/pull/4147))
 - Clarify metric reader / metric exporter relationship for temporality
   preference and default aggregation. Explicitly define configuration options
   for temporality preference and default aggregation of built-in exporters, and
   make default values explicit.
   ([#4142](https://github.com/open-telemetry/opentelemetry-specification/pull/4142))
+- Add data point flags to the metric data model.
+  ([#4135](https://github.com/open-telemetry/opentelemetry-specification/pull/4135))
 
 ### Logs
 
@@ -59,6 +59,11 @@ release.
 
 - Clarify no empty string allowed in baggage names.
   ([#4144](https://github.com/open-telemetry/opentelemetry-specification/pull/4144))
+
+### Compatibility
+
+- Clarify prometheus exporter should have `host` and `port` configuration options.
+  ([#4147](https://github.com/open-telemetry/opentelemetry-specification/pull/4147))
 
 ### Common
 


### PR DESCRIPTION
August 2024 Release.

Major changes:

- Remove restriction that sampler description is immutable.
  ([#4137](https://github.com/open-telemetry/opentelemetry-specification/pull/4137))
- Require separation of API and SDK artifacts.
  ([#4125](https://github.com/open-telemetry/opentelemetry-specification/pull/4125))
- Clarify no empty string allowed in baggage names.
  ([#4144](https://github.com/open-telemetry/opentelemetry-specification/pull/4144))