### PR TITLE
Refactor description of span kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ release.
 
 ### Traces
 
+- Clarify `SpanKind` description, extend it to cover links, add examples of
+  nested client spans.
+  ([#4178](https://github.com/open-telemetry/opentelemetry-specification/pull/4178))
+
 ### Metrics
 
 ### Logs

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -753,26 +753,36 @@ This functionality MUST be fully implemented in the API, and SHOULD NOT be overr
 parent/child relationships or span links. `SpanKind` describes two independent
 properties that benefit tracing systems during analysis:
 
-1. Whether span represents an outgoing request to a remote service (CLIENT and PRODUCER spans)
-   or a processing of request initiated externally (SERVER and CONSUMER spans).
-2. Whether a Span represents a synchronous call. Spans that describe synchronous operations
-   (SERVER and CLIENT) end after all its children complete under ordinary circumstances.
-   It can be useful for tracing systems to know this property, since synchronous Spans may
-   contribute to the overall trace latency. Asynchronous scenarios can be remote or local.
+1. Whether span represents an outgoing call a remote service (`CLIENT` and
+   `PRODUCER` spans) or a processing of request initiated externally (`SERVER`
+   and `CONSUMER` spans).
+2. Whether a Span represents a synchronous call. Spans that describe synchronous
+   operations (`SERVER` and `CLIENT`) end after all its children complete under
+   ordinary circumstances. It can be useful for tracing systems to know this
+   property, since synchronous Spans may contribute to the overall trace
+   latency. Asynchronous scenarios can be remote or local.
 
 In order for `SpanKind` to be meaningful, callers SHOULD arrange that
 a single Span does not serve more than one purpose.  For example, a
 server-side span SHOULD NOT be used to describe outgoing remote procedure call.
 As a simple guideline, instrumentation should create a
-new Span prior to injecting the SpanContext for a remote outgoing call.
+new Span prior to injecting the `SpanContext` for a remote outgoing call.
 
-Note: A CLIENT span may have a child that is also a CLIENT span,
-or a PRODUCER span might have a local child that is a CLIENT span,
-depending on how the various libraries that are providing the functionality
-are built and instrumented. These scenarios, when they occur, should be
-detailed in the semantic conventions appropriate to the relevant libraries.
+Note: A `CLIENT` span may have a child that is also a `CLIENT` span, or a
+`PRODUCER` span might have a local child that is a `CLIENT` span,
+depending on how the various components that are providing the functionality
+are built and instrumented.
 
-These are the possible SpanKinds:
+For instance, a database client instrumentations create `CLIENT` span that
+describes database calls. If the database client communicate to the server over
+HTTP, the HTTP instrumentation (when enabled) creates nested `CLIENT` spans to
+track individual HTTP calls performed in the scope of logical database `CLIENT`
+operation.
+
+Such scenarios, when they occur, should be detailed in the semantic conventions
+appropriate to the relevant technologies.
+
+These are the possible `SpanKind`s:
 
 * `SERVER` Indicates that the span covers server-side handling of a
   synchronous RPC or other remote request.
@@ -781,10 +791,11 @@ These are the possible SpanKinds:
   When the context of a `CLIENT` span is propagated, `CLIENT` span usually
   becomes a parent of a remote `SERVER` span and ends after the `SERVER` span
   completes.
-* `PRODUCER` span describes the initiation of an asynchronous request. This initiating
-  span will often end before the correlated `CONSUMER` span, possibly even before the
-  `CONSUMER` span starts. In messaging scenarios with batching, tracing
-  individual messages requires a new `PRODUCER` span per message to be created.
+* `PRODUCER` span describes the initiation of an asynchronous request. This
+  initiating span will often end before the correlated `CONSUMER` span,
+  possibly even before the `CONSUMER` span starts. In messaging scenarios with
+  batching, tracing individual messages requires a new `PRODUCER` span per
+  message to be created.
 * `CONSUMER` Indicates that the span describes the receiving or handling of an
   asynchronous request.
 * `INTERNAL` Default value. Indicates that the span represents an

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -751,17 +751,14 @@ This functionality MUST be fully implemented in the API, and SHOULD NOT be overr
 
 `SpanKind` clarifies the relationship between Spans that are correlated via
 parent/child relationships or span links. `SpanKind` describes two independent
-properties that benefit tracing systems during analysis.
+properties that benefit tracing systems during analysis:
 
-The first property described by `SpanKind` reflects whether span describes an
-outgoing request to a remote service (CLIENT and PRODUCER spans) or whether
-it handles request from an external service (SERVER and CONSUMER spans).
-
-The second property described by `SpanKind` reflects whether a Span represents a
-synchronous call. Spans that describe synchronous operations (SERVER and CLIENT),
-under ordinary circumstances, end after all its children complete. It can be
-useful for tracing systems to know this property, since synchronous Spans may
-contribute to the overall trace latency. Asynchronous scenarios can be remote or local.
+1. Whether span represents an outgoing request to a remote service (CLIENT and PRODUCER spans)
+   or a processing of request initiated externally (SERVER and CONSUMER spans).
+2. Whether a Span represents a synchronous call. Spans that describe synchronous operations
+   (SERVER and CLIENT) end after all its children complete under ordinary circumstances.
+   It can be useful for tracing systems to know this property, since synchronous Spans may
+   contribute to the overall trace latency. Asynchronous scenarios can be remote or local.
 
 In order for `SpanKind` to be meaningful, callers SHOULD arrange that
 a single Span does not serve more than one purpose.  For example, a
@@ -781,14 +778,14 @@ These are the possible SpanKinds:
   synchronous RPC or other remote request.
 * `CLIENT` Indicates that the span describes a synchronous request to
   a remote service.
-  When the context of a `CLIENT` span is propagated, `CLIENT`  span usually
-  becomes a parent of a remote `SERVER` span and ends after `SERVER` span
+  When the context of a `CLIENT` span is propagated, `CLIENT` span usually
+  becomes a parent of a remote `SERVER` span and ends after the `SERVER` span
   completes.
 * `PRODUCER` span describes the initiation of an asynchronous request. This initiating
   span will often end before the correlated `CONSUMER` span, possibly even before the
   `CONSUMER` span starts. In messaging scenarios with batching, tracing
   individual messages requires a new `PRODUCER` span per message to be created.
-* `CONSUMER` Indicates that the span describes the receiving or handling on an
+* `CONSUMER` Indicates that the span describes the receiving or handling of an
   asynchronous request.
 * `INTERNAL` Default value. Indicates that the span represents an
   internal operation within an application, as opposed to an

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -758,10 +758,6 @@ properties that benefit tracing systems during analysis:
    and `CONSUMER` spans).
 2. Whether a Span represents a request/response operation (`CLIENT` and `SERVER`
    spans) or a deferred execution (`PRODUCER` and `CONSUMER` spans).
-   Spans that describe request/response operations typically end after all their
-   child spans have completed.
-   It can be beneficial for tracing systems to be aware of this property to make
-   assumptions about overall trace latency.
 
 In order for `SpanKind` to be meaningful, callers SHOULD arrange that
 a single Span does not serve more than one purpose.  For example, a

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -770,14 +770,14 @@ Note: A `CLIENT` span may have a child that is also a `CLIENT` span, or a
 depending on how the various components that are providing the functionality
 are built and instrumented.
 
-For instance, a database client instrumentations create `CLIENT` span that
-describes database calls. If the database client communicate to the server over
-HTTP, the HTTP instrumentation (when enabled) creates nested `CLIENT` spans to
-track individual HTTP calls performed in the scope of logical database `CLIENT`
-operation.
+[Semantic conventions](../../specification/overview.md#semantic-conventions) for
+specific technologies should document kind for each span they define.
 
-Such scenarios, when they occur, should be detailed in the semantic conventions
-appropriate to the relevant technologies.
+For instance, [Database Client Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md)
+recommend using `CLIENT` span kind to describes database calls.
+If the database client communicate to the server over HTTP, the HTTP
+instrumentation (when enabled) creates nested `CLIENT` spans to track individual
+HTTP calls performed in the scope of logical database `CLIENT` operation.
 
 These are the possible `SpanKind`s:
 

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -784,7 +784,7 @@ These are the possible `SpanKind`s:
 * `SERVER` indicates that the span covers server-side handling of a remote
   request while the client awaits a response.
 * `CLIENT` indicates that the span describes a request to a remote service where
-  the client await a response.
+  the client awaits a response.
   When the context of a `CLIENT` span is propagated, `CLIENT` span usually
   becomes a parent of a remote `SERVER` span.
 * `PRODUCER` indicates that the span describes the initiation or scheduling

--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -753,8 +753,8 @@ This functionality MUST be fully implemented in the API, and SHOULD NOT be overr
 parent/child relationships or span links. `SpanKind` describes two independent
 properties that benefit tracing systems during analysis:
 
-1. Whether span represents an outgoing call a remote service (`CLIENT` and
-   `PRODUCER` spans) or a processing of request initiated externally (`SERVER`
+1. Whether span represents an outgoing call to a remote service (`CLIENT` and
+   `PRODUCER` spans) or a processing of an incoming request initiated externally (`SERVER`
    and `CONSUMER` spans).
 2. Whether a Span represents a synchronous call. Spans that describe synchronous
    operations (`SERVER` and `CLIENT`) end after all its children complete under
@@ -785,13 +785,13 @@ appropriate to the relevant technologies.
 These are the possible `SpanKind`s:
 
 * `SERVER` Indicates that the span covers server-side handling of a
-  synchronous RPC or other remote request.
+  remote request.
 * `CLIENT` Indicates that the span describes a synchronous request to
   a remote service.
   When the context of a `CLIENT` span is propagated, `CLIENT` span usually
   becomes a parent of a remote `SERVER` span and ends after the `SERVER` span
   completes.
-* `PRODUCER` span describes the initiation of an asynchronous request. This
+* `PRODUCER` span describes the initiation of a one-way request. This
   initiating span will often end before the correlated `CONSUMER` span,
   possibly even before the `CONSUMER` span starts. In messaging scenarios with
   batching, tracing individual messages requires a new `PRODUCER` span per


### PR DESCRIPTION
Fixes #3172

(Built on top of #4088)

## Changes

- Explains kinds without assuming presence of parent/children 
- Adds links as another correlation mechanism
- Normalizes nested client spans even further - database, messaging, RPC, and LLM semantic conventions require CLIENT kind for logical client operation.
- Does not touch INTERNAL kind yet - https://github.com/open-telemetry/opentelemetry-specification/issues/4179

* [x] Related issues #3172, https://github.com/open-telemetry/semantic-conventions/issues/674, https://github.com/open-telemetry/oteps/pull/172, https://github.com/open-telemetry/semantic-conventions/issues/1315
* ~~[ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #~~
* ~~[ ] Links to the prototypes (when adding or changing features)~~
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* ~~[ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary~~
