### PR TITLE
Mark exemplar filter env variable config as stable

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -274,8 +274,6 @@ NOT be supported by new implementations.
 
 ### Exemplar
 
-**Status**: [Development](../document-status.md)
-
 | Name            | Description | Default | Notes |
 |-----------------|---------|-------------|---------|
 | `OTEL_METRICS_EXEMPLAR_FILTER` | Filter for which measurements can become Exemplars. | `"trace_based"` | |


### PR DESCRIPTION
I believe this was accidentally left out in https://github.com/open-telemetry/opentelemetry-specification/pull/3870/files
