### PR TITLE
chore: fix broken link

### DIFF
--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -1014,7 +1014,7 @@ If this flag is set on a data point, then this data point reflects explicitly
 missing data in a series. It serves as an indicator that a previously present
 timeseries was removed and that this timeseries SHOULD NOT be returned in
 queries after such an indicator was received. It is an equivalent of the
-[Prometheus staleness marker](https://prometheus.io/docs/prometheus/2.52/querying/basics/#staleness).
+[Prometheus staleness marker](https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness).
 
 If this flag is set, all other data point properties except attributes, time
 stamps, or time windows, SHOULD be ignored.


### PR DESCRIPTION
The doc for 2.52 is no longer available on the prometheus website, switching to use latest.

Saw the check failure [here](https://github.com/open-telemetry/opentelemetry-specification/actions/runs/10799406554/job/29955075935?pr=4188)