### PR TITLE
clarify that enabled applies to synchronous instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ release.
 
 ### Metrics
 
+- Clarify that `Enabled` only applies to synchronous instruments.
+
 ### Logs
 
 - Clarify that log record mutations are visible in next registered processors.

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -486,7 +486,8 @@ All instruments SHOULD provide functions to:
 **Status**: [Development](../document-status.md)
 
 To help users avoid performing computationally expensive operations when
-recording measurements, instruments SHOULD provide this `Enabled` API.
+recording measurements, [synchronous Instrument](#synchronous-instrument-api)
+SHOULD provide this `Enabled` API.
 
 There are currently no required parameters for this API. Parameters can be
 added in the future, therefore, the API MUST be structured in a way for


### PR DESCRIPTION
Fix #4200

## Changes

The Enabled API is only to be applied to synchronous instruments.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #4200
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
