### PR TITLE
[editorial] Set 'configuration' as title for configuration/README.md

### DIFF
--- a/specification/configuration/README.md
+++ b/specification/configuration/README.md
@@ -4,7 +4,7 @@ path_base_for_github_subdir:
   to: configuration/README.md
 --->
 
-# Overview
+# Configuration
 
 OpenTelemetry SDK components are highly configurable. This specification
 outlines the mechanisms by which OpenTelemetry components can be configured. It


### PR DESCRIPTION
for https://github.com/open-telemetry/opentelemetry.io/pull/5195

## Changes

If rendered on the opentelemetry.io
![Screenshot 2024-09-16 at 13 51 34](https://github.com/user-attachments/assets/3250b96f-b0a4-48f4-bf93-db4f577391ca)
 website the link title for the configuration index page is "Overview", this sets the title to "Configuration to address that"
