### PR TITLE
Update the PR merge criteria to allow situational judgement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,10 @@ A PR is considered to be **ready to merge** when:
   people reasonable time to review.
 * Trivial changes (typos, cosmetic changes, CI improvements, etc.) don't have to
   wait for two days.
+* The [spec
+  maintainers](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto)
+  might make situational judgement and put additional requirements (e.g. need
+  more approvals, wait for the next release train, etc.).
 
 Any [spec
 maintainer](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto) can


### PR DESCRIPTION
There was a discussion among TC members about whether we should require 4 approvals for OTEPs.

Given we want to merge OTEPs into the specification repo, I think it'll be good to improve the spec PR merge criteria. Here is the thinking behind this change:

1. Having 2 approvals seem good to me, I haven't seen cases where people try to abuse it.
2. Increasing the number from 2 to 4 will slow down PRs for trivial/editorial changes. Many of the editorial PRs were contributed by first-time contributor to the OpenTelemetry project. I actually think we might want to speed this up rather than slowing it down.
3. Since the project started, I think the spec maintainers (TC members) have been careful about significant changes, so we make sure people have enough time to review, discuss and share their opinions.

## Changes

Clarify that spec maintainers might put additional requirements before merging the PR.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
