### PR TITLE
Editorial - add links to Metric instrument parameters

### DIFF
--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -179,12 +179,12 @@ Also see the respective sections below for more information on instrument creati
 Instruments are used to report [Measurements](#measurement). Each Instrument
 will have the following parameters:
 
-* The `name` of the Instrument
+* The [`name`](#instrument-name-syntax) of the Instrument
 * The `kind` of the Instrument - whether it is a [Counter](#counter) or
   one of the other kinds, whether it is synchronous or asynchronous
-* An optional `unit` of measure
-* An optional `description`
-* Optional `advisory` parameters (**development**)
+* An optional [`unit`](#instrument-unit) of measure
+* An optional [`description`](#instrument-description)
+* Optional [`advisory`](#instrument-advisory-parameters) parameters (**mixed**)
 
 Instruments are associated with the Meter during creation. Instruments
 are identified by the `name`, `kind`, `unit`, and `description`.


### PR DESCRIPTION
## Changes

Editorial - Nit edits to make it easy to navigate the API spec by linking to relevant sections.
