### PR TITLE
Make the end timestamp and mutable span as requirements in onending

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -608,7 +608,7 @@ are invoked in the order they have been registered.
 **Status**: [Development](../document-status.md)
 
 `OnEnding` is called during the span `End()` operation.
-The end timestamp MUST have been computed (the method duration is not included
+The end timestamp MUST have been computed (the `OnEnding` method duration is not included
 in the span duration).
 The Span object MUST still be mutable (i.e., `SetAttribute`, `AddLink`, `AddEvent` can be called) while `OnEnding` is called.
 This method MUST be called synchronously within the [`Span.End()` API](api.md#end),

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -607,7 +607,9 @@ are invoked in the order they have been registered.
 
 **Status**: [Development](../document-status.md)
 
-`OnEnding` is called during the span `End()` operation. The end timestamp MUST have been set.
+`OnEnding` is called during the span `End()` operation.
+The end timestamp MUST have been computed (the method duration is not included
+in the span duration).
 The Span object MUST still be mutable (i.e., `SetAttribute`, `AddLink`, `AddEvent` can be called) while `OnEnding` is called.
 This method MUST be called synchronously within the [`Span.End()` API](api.md#end),
 therefore it should not block or throw an exception.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -607,7 +607,8 @@ are invoked in the order they have been registered.
 
 **Status**: [Development](../document-status.md)
 
-`OnEnding` is called during the span `End()` operation, after the end timestamp has been set. The Span object is still mutable (i.e., `SetAttribute`, `AddLink`, `AddEvent` can be called) while `OnEnding` is called.
+`OnEnding` is called during the span `End()` operation. The end timestamp MUST have been set.
+The Span object MUST still be mutable (i.e., `SetAttribute`, `AddLink`, `AddEvent` can be called) while `OnEnding` is called.
 This method MUST be called synchronously within the [`Span.End()` API](api.md#end),
 therefore it should not block or throw an exception.
 If multiple `SpanProcessors` are registered, their `OnEnding` callbacks


### PR DESCRIPTION
## Changes

`OnEnding` specifies that the ending timestamp should be set when the callback runs, and the span should be mutable.
These are requirements, so it seems like they should be marked as so.
