### PR TITLE
Make the end timestamp as a requirement in OnEnd

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -624,7 +624,7 @@ are only allowed synchronously from within the invoked `OnEnding` callbacks.  Al
 
 #### OnEnd(Span)
 
-`OnEnd` is called after a span is ended (i.e., the end timestamp is already set).
+`OnEnd` is called after a span is ended. The end timestamp MUST have been set.
 This method MUST be called synchronously within the [`Span.End()` API](api.md#end),
 therefore it should not block or throw an exception.
 


### PR DESCRIPTION
## Changes

This does the same change as in #4240, but for `OnEnd`.
