### PR TITLE
Update Instrumentation Scope glossary entry with correct identifying fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ release.
 - Update Instrumentation Scope glossary entry with correct identifying fields
   ([#4244](https://github.com/open-telemetry/opentelemetry-specification/pull/4244))
 
-
 ### Supplementary Guidelines
 
 ## v1.37.0 (2024-09-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ release.
 
 - Define equality for attributes and collection of attributes.
   ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
+- Update Instrumentation Scope glossary entry with correct identifying fields
+  ([#4244](https://github.com/open-telemetry/opentelemetry-specification/pull/4244))
+
 
 ### Supplementary Guidelines
 

--- a/specification/glossary.md
+++ b/specification/glossary.md
@@ -172,15 +172,19 @@ reasonable instrumentation scope. The most common approach is to use the
 scopes are also common, e.g. a module, a package, or a class can be chosen as
 the instrumentation scope.
 
-If the unit of code has a version then the instrumentation scope is defined by
-the (name,version) pair otherwise the version is omitted and only the name is
-used. The name or (name,version) pair uniquely identify the logical unit of the
-code that emits the telemetry. A typical approach to ensure uniqueness is to use
-fully qualified name of the emitting code (e.g. fully qualified library name or
-fully qualified class name).
+The instrumentation scope is defined by the
+(name,version,schema_url,attributes) tuple where version, schema_url, and
+attributes are optional. This tuple uniquely identifies the logical unit of the
+code that emits the telemetry. A typical approach to ensure uniqueness is to
+use the fully qualified name of the emitting code (e.g. fully qualified library
+name or fully qualified class name).
 
 The instrumentation scope is used to obtain a
 [Tracer, Meter, or Logger](#tracer-name--meter-name--logger-name).
+
+The instrumentation scope's optional Schema URL identifies the [Telemetry
+Schema](schemas/README.md) that the instrumentation's emitted
+telemetry conforms to.
 
 The instrumentation scope may have zero or more additional attributes that provide
 additional information about the scope. For example for a scope that specifies an


### PR DESCRIPTION
Small follow up to https://github.com/open-telemetry/opentelemetry-specification/pull/4161

## Changes

Updates the glossary to indicate that instrumentation scope's schema url and attributes are also identifying. I simplified the language a bit.


* [x] Related issues #4160
