### PR TITLE
Update spec-compliance-matrix.md for Go temporality preference

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -291,7 +291,7 @@ Note: Support for environment variables is optional.
 | OTEL_METRIC_EXPORT_INTERVAL                              | -  | +    |    | +           |      |        | +   |      |     | +    |       |
 | OTEL_METRIC_EXPORT_TIMEOUT                               | -  | -    |    | +           |      |        | +   |      |     | +    |       |
 | OTEL_METRICS_EXEMPLAR_FILTER                             | -  | +    |    |             |      |        | +   |      |     | +    |       |
-| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | -  | +    | +  | +           |      |        | +   |      |     | +    |       |
+| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | +  | +    | +  | +           |      |        | +   |      |     | +    |       |
 | OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |    | +    |    | +           |      |        |     |      |     |      |       |
 | OTEL_EXPERIMENTAL_CONFIG_FILE                            |    |      |    |             |      |        |     |      |     |      |       |
 


### PR DESCRIPTION
This has been implemented in https://github.com/open-telemetry/opentelemetry-go/pull/4287.

See also https://github.com/open-telemetry/opentelemetry-go/blob/v1.30.0/exporters/otlp/otlpmetric/otlpmetrichttp/doc.go#L61-L67 for docs on it.

cc @open-telemetry/go-maintainers 