### PR TITLE
Release 1.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,31 +11,9 @@ release.
 
 ### Traces
 
-- Make all fields as identifying for Tracer. Previously attributes were omitted from being identifying.
-  ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
-- Clarify that `Export` MUST NOT be called by simple and batching processors concurrently.
-  ([#4205](https://github.com/open-telemetry/opentelemetry-specification/pull/4205))
-
 ### Metrics
 
-- Add support for filtering attribute keys for streams via an exclude list.
-  ([#4188](https://github.com/open-telemetry/opentelemetry-specification/pull/4188))
-- Clarify that `Enabled` only applies to synchronous instruments.
-  ([#4211](https://github.com/open-telemetry/opentelemetry-specification/pull/4211))
-- Make all fields as identifying for Meter. Previously attributes were omitted from being identifying.
-  ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
-- Clarify that applying cardinality limits should be done after attribute filtering.
-  ([#4228](https://github.com/open-telemetry/opentelemetry-specification/pull/4228))
-- Mark cardinality limits as stable.
-  ([#4222](https://github.com/open-telemetry/opentelemetry-specification/pull/4222))
-
 ### Logs
-
-- Define `Enabled` parameters for `Logger`.
-  ([#4203](https://github.com/open-telemetry/opentelemetry-specification/pull/4203))
-  ([#4221](https://github.com/open-telemetry/opentelemetry-specification/pull/4221))
-- Make all fields as identifying for Logger. Previously attributes were omitted from being identifying.
-  ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
 
 ### Events
 
@@ -51,10 +29,42 @@ release.
 
 ### Common
 
+### Supplementary Guidelines
+
+## v1.38.0 (2024-10-09)
+
+### Traces
+
+- Make all fields as identifying for Tracer. Previously attributes were omitted from being identifying.
+  ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
+- Clarify that `Export` MUST NOT be called by simple and batching processors concurrently.
+  ([#4205](https://github.com/open-telemetry/opentelemetry-specification/pull/4205))
+
+### Metrics
+
+- Make all fields as identifying for Meter. Previously attributes were omitted from being identifying.
+  ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
+- Add support for filtering attribute keys for streams via an exclude list.
+  ([#4188](https://github.com/open-telemetry/opentelemetry-specification/pull/4188))
+- Clarify that `Enabled` only applies to synchronous instruments.
+  ([#4211](https://github.com/open-telemetry/opentelemetry-specification/pull/4211))
+- Clarify that applying cardinality limits should be done after attribute filtering.
+  ([#4228](https://github.com/open-telemetry/opentelemetry-specification/pull/4228))
+- Mark cardinality limits as stable.
+  ([#4222](https://github.com/open-telemetry/opentelemetry-specification/pull/4222))
+
+### Logs
+
+- Make all fields as identifying for Logger. Previously attributes were omitted from being identifying.
+  ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
+- Define `Enabled` parameters for `Logger`.
+  ([#4203](https://github.com/open-telemetry/opentelemetry-specification/pull/4203))
+  ([#4221](https://github.com/open-telemetry/opentelemetry-specification/pull/4221))
+
+### Common
+
 - Define equality for attributes and collection of attributes.
   ([#4161](https://github.com/open-telemetry/opentelemetry-specification/pull/4161))
-
-### Supplementary Guidelines
 
 ## v1.37.0 (2024-09-13)
 


### PR DESCRIPTION
October 2024 Release.

Changes of special interest:

* [Mark cardinality limits as Stable](https://github.com/open-telemetry/opentelemetry-specification/pull/4222)