### PR TITLE
Update the spec compliance matrix for C++.

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -190,8 +190,8 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 |----------------------------------------------|----------|-----|------|-----|--------|------|--------|-----|------|-----|------|-------|
 | LoggerProvider.Get Logger                    |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | LoggerProvider.Get Logger accepts attributes |          |     |      |     | +      |      |        | +   |      | +   |      |       |
-| LoggerProvider.Shutdown                      |          |     | +    |     | +      |      |        | +   |      |     | -    |       |
-| LoggerProvider.ForceFlush                    |          |     | +    |     | +      |      |        | +   |      |     | -    |       |
+| LoggerProvider.Shutdown                      |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
+| LoggerProvider.ForceFlush                    |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | Logger.Emit(LogRecord)                       |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | Logger.Enabled                               | X        | +   |      |     |        |      |        |     | +    | +   |      |       |
 | SimpleLogRecordProcessor                     |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
@@ -199,7 +199,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Can plug custom LogRecordProcessor           |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
 | OTLP/gRPC exporter                           |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
 | OTLP/HTTP exporter                           |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
-| OTLP File exporter                           |          |     | -    |     | -      |      |        |     |      |     | -    |       |
+| OTLP File exporter                           |          |     | -    |     | -      |      |        |     |      | +   | -    |       |
 | Can plug custom LogRecordExporter            |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
 | Trace Context Injection                      |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
 
@@ -252,7 +252,7 @@ Disclaimer: Events are currently in Development status - work in progress.
 | Jaeger Propagator                                                                |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | -    | +     |
 | OT Propagator                                                                    |          | +  | +    | +  | +      |      |        |     |      |     |      |       |
 | OpenCensus Binary Propagator                                                     |          | +  |      |    |        |      |        |     |      |     |      |       |
-| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          | +  | +    |    | +      | +    |        | +   |      |     |      |       |
+| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          | +  | +    |    | +      | +    |        | +   |      | +   |      |       |
 | Fields                                                                           |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
 | Setter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      | +   | N/A  | +   | +    | +     |
 | Getter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      | +   | N/A  | +   | +    | +     |
@@ -270,30 +270,30 @@ Note: Support for environment variables is optional.
 | OTEL_LOG_LEVEL                                           | -  | -    | +  | [-][py1059] | +    | -      | +   |      | -   | -    | -     |
 | OTEL_PROPAGATORS                                         | -  | +    |    | +           | +    | +      | +   | -    | -   | -    | -     |
 | OTEL_BSP_*                                               | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    | -     |
-| OTEL_BLRP_*                                              |    | +    |    |             |      |        |     | +    |     | +    |       |
+| OTEL_BLRP_*                                              |    | +    |    |             |      |        |     | +    | -   | +    |       |
 | OTEL_EXPORTER_OTLP_*                                     | +  | +    |    | +           | +    | +      | +   | +    | +   | +    | -     |
 | OTEL_EXPORTER_ZIPKIN_*                                   | -  | +    |    | +           | +    | -      | +   | -    | -   | +    | -     |
 | OTEL_TRACES_EXPORTER                                     | -  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
 | OTEL_METRICS_EXPORTER                                    | -  | +    |    | +           | -    | -      | +   | -    | -   | -    | -     |
-| OTEL_LOGS_EXPORTER                                       | -  | +    |    | +           |      |        | +   |      |     | -    |       |
+| OTEL_LOGS_EXPORTER                                       | -  | +    |    | +           |      |        | +   |      | -   | -    |       |
 | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT                          | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT                   | +  | +    | +  | +           | +    | +      | +   |      |     | +    |       |
+| OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT                   | +  | +    | +  | +           | +    | +      | +   |      | -   | +    |       |
 | OTEL_SPAN_EVENT_COUNT_LIMIT                              | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
 | OTEL_SPAN_LINK_COUNT_LIMIT                               | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT                         | +  | -    |    | +           | +    | +      | +   |      |     | +    |       |
-| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT                          | +  | -    |    | +           | +    | +      | +   |      |     | +    |       |
-| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT                     |    |      |    |             |      |        | +   |      |     |      |       |
-| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT              |    |      |    |             |      |        | +   |      |     |      |       |
+| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT                         | +  | -    |    | +           | +    | +      | +   |      | -   | +    |       |
+| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT                          | +  | -    |    | +           | +    | +      | +   |      | -   | +    |       |
+| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT                     |    |      |    |             |      |        | +   |      | -   |      |       |
+| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT              |    |      |    |             |      |        | +   |      | -   |      |       |
 | OTEL_TRACES_SAMPLER                                      | +  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
 | OTEL_TRACES_SAMPLER_ARG                                  | +  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                        | +  | +    | +  | +           | +    | -      | +   |      |     | +    |       |
-| OTEL_ATTRIBUTE_COUNT_LIMIT                               | +  | +    | +  | +           | +    | -      | +   |      |     | +    |       |
-| OTEL_METRIC_EXPORT_INTERVAL                              | -  | +    |    | +           |      |        | +   |      |     | +    |       |
-| OTEL_METRIC_EXPORT_TIMEOUT                               | -  | -    |    | +           |      |        | +   |      |     | +    |       |
-| OTEL_METRICS_EXEMPLAR_FILTER                             | -  | +    |    |             |      |        | +   |      |     | +    |       |
-| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | -  | +    | +  | +           |      |        | +   |      |     | +    |       |
-| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |    | +    |    | +           |      |        |     |      |     |      |       |
-| OTEL_EXPERIMENTAL_CONFIG_FILE                            |    |      |    |             |      |        |     |      |     |      |       |
+| OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                        | +  | +    | +  | +           | +    | -      | +   |      | -   | +    |       |
+| OTEL_ATTRIBUTE_COUNT_LIMIT                               | +  | +    | +  | +           | +    | -      | +   |      | -   | +    |       |
+| OTEL_METRIC_EXPORT_INTERVAL                              | -  | +    |    | +           |      |        | +   |      | -   | +    |       |
+| OTEL_METRIC_EXPORT_TIMEOUT                               | -  | -    |    | +           |      |        | +   |      | -   | +    |       |
+| OTEL_METRICS_EXEMPLAR_FILTER                             | -  | +    |    |             |      |        | +   |      | -   | +    |       |
+| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | -  | +    | +  | +           |      |        | +   |      | -   | +    |       |
+| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |    | +    |    | +           |      |        |     |      | -   |      |       |
+| OTEL_EXPERIMENTAL_CONFIG_FILE                            |    |      |    |             |      |        |     |      | -   |      |       |
 
 ## Declarative configuration
 


### PR DESCRIPTION
Update the spec compliance matrix for C++.

## Changes

Please provide a brief description of the changes here.

* Logs section
  * Document that `LoggerProvider.Shutdown` and `LoggerProvider.ForceFlush` are implemented.
    * see https://github.com/open-telemetry/opentelemetry-cpp/blob/6445819fceeb3bfea1444a88418f00a0df69cd2f/sdk/include/opentelemetry/sdk/logs/logger_provider.h#L93-L101
  * Document that the `OTLP File exporter` is supported.
    * see https://github.com/open-telemetry/opentelemetry-cpp/blob/6445819fceeb3bfea1444a88418f00a0df69cd2f/exporters/otlp/include/opentelemetry/exporters/otlp/otlp_file_exporter.h#L26
* Context Propagation section
  * Document that `TextMapPropagator` is supported.
    * see https://github.com/open-telemetry/opentelemetry-cpp/blob/6445819fceeb3bfea1444a88418f00a0df69cd2f/api/include/opentelemetry/context/propagation/text_map_propagator.h#L42
* Environment Variables section
  * Many environment variables are still not supported in C++.
  * Document them explicitly with `-`, which is more informative than a blank.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [X] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
