### PR TITLE
Simplify the name "Logs Instrumentation API" to just "Logs API"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 ### Logs
 
+- Simplify the name "Logs Instrumentation API" to just "Logs API".
+  ([#4258](https://github.com/open-telemetry/opentelemetry-specification/pull/4258))
+
 ### Events
 
 ### Baggage

--- a/specification/logs/bridge-api.md
+++ b/specification/logs/bridge-api.md
@@ -16,7 +16,7 @@
   * [Logger operations](#logger-operations)
     + [Emit a LogRecord](#emit-a-logrecord)
     + [Enabled](#enabled)
-- [Logs Instrumentation API](#logs-instrumentation-api)
+- [Logs API](#logs-api)
 - [Optional and required parameters](#optional-and-required-parameters)
 - [Concurrency requirements](#concurrency-requirements)
 - [Artifact Naming](#artifact-naming)
@@ -146,7 +146,7 @@ SHOULD be documented that instrumentation authors needs to call this API each
 time they [emit a LogRecord](#emit-a-logrecord) to ensure they have the most
 up-to-date response.
 
-## Logs Instrumentation API
+## Logs API
 
 **Status**: [Development](../document-status.md)
 

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -9,7 +9,7 @@
 
 <!-- toc -->
 
-- [Logs Instrumentation API Development](#logs-instrumentation-api-development)
+- [Logs API Development](#logs-api-development)
 - [Event Data model](#event-data-model)
 - [Event API use cases](#event-api-use-cases)
 - [EventLoggerProvider](#eventloggerprovider)
@@ -31,12 +31,12 @@ The Event API consists of these main components:
   provides access to `EventLogger`s.
 * [EventLogger](#eventlogger) is the component responsible for emitting events.
 
-## Logs Instrumentation API Development
+## Logs API Development
 
 > [!NOTE]
-> We are currently in the process of defining a new [Logs Instrumentation API](./bridge-api.md#logs-instrumentation-api).
+> We are currently in the process of defining a new [Logs API](./bridge-api.md#logs-api).
 
-The intent is that this Logs Instrumentation API will incorporate the current functionality of this existing Events API and once it is defined and implemented, the Events API usage will be migrated, deprecated, renamed and eventually removed.
+The intent is that this Logs API will incorporate the current functionality of this existing Events API and once it is defined and implemented, the Events API usage will be migrated, deprecated, renamed and eventually removed.
 
 No further work is scheduled for the current Events API definition at this time.
 

--- a/specification/logs/event-sdk.md
+++ b/specification/logs/event-sdk.md
@@ -9,7 +9,7 @@
 
 <!-- toc -->
 
-- [Logs Instrumentation API Development](#logs-instrumentation-api-development)
+- [Logs API Development](#logs-api-development)
 - [Overview](#overview)
 - [EventLoggerProvider](#eventloggerprovider)
   * [EventLoggerProvider Creation](#eventloggerprovider-creation)
@@ -30,10 +30,10 @@ API that provides users with this functionally.
 
 All implementations of the OpenTelemetry API MUST provide an SDK.
 
-## Logs Instrumentation API Development
+## Logs API Development
 
 > [!NOTE]
-> We are currently in the process of defining a new [Logs Instrumentation API](./bridge-api.md#logs-instrumentation-api).
+> We are currently in the process of defining a new [Logs API](./bridge-api.md#logs-api).
 
 The intent is that Logs SDK will incorporate the current functionality of this existing Events SDK and once it is defined and implemented, the Events SDK usage will be migrated, deprecated, renamed and eventually removed.
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -34,7 +34,7 @@
     + [Export](#export)
     + [ForceFlush](#forceflush-2)
     + [Shutdown](#shutdown-1)
-- [Logs Instrumentation API](#logs-instrumentation-api)
+- [Logs API](#logs-api)
 
 <!-- tocstop -->
 
@@ -539,9 +539,9 @@ return a Failure result.
 and the destination is unavailable). [OpenTelemetry SDK](../overview.md#sdk)
 authors MAY decide if they want to make the shutdown timeout configurable.
 
-## Logs Instrumentation API
+## Logs API
 
 > [!NOTE]
-> We are currently in the process of defining a new [Logs Instrumentation API](./bridge-api.md#logs-instrumentation-api).
+> We are currently in the process of defining a new [Logs API](./bridge-api.md#logs-api).
 
 - [OTEP0150 Logging Library SDK Prototype Specification](https://github.com/open-telemetry/oteps/blob/main/text/logs/0150-logging-library-sdk.md)


### PR DESCRIPTION
This matches "Traces API" and "Metrics API" and can still be differentiated from "Logs Bridge API".

Follow-up from https://github.com/open-telemetry/opentelemetry-specification/pull/4236#pullrequestreview-2352473178
