### PR TITLE
Add Context parameter to Enabled for synchronous metrics instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Add `Context` parameter to `Enabled` for synchronous instruments.
+  ([#4262](https://github.com/open-telemetry/opentelemetry-specification/pull/4262))
+
 ### Logs
 
 ### Events

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -483,9 +483,12 @@ To help users avoid performing computationally expensive operations when
 recording measurements, [synchronous Instruments](#synchronous-instrument-api)
 SHOULD provide this `Enabled` API.
 
-There are currently no required parameters for this API. Parameters can be
-added in the future, therefore, the API MUST be structured in a way for
-parameters to be added.
+The API SHOULD accept the following parameters:
+
+- The [Context](../context/README.md) to be associated with the measurement.
+  When implicit Context is supported, then this parameter SHOULD be optional and
+  if unspecified then MUST use current Context.
+  When only explicit Context is supported, accepting this parameter is REQUIRED.
 
 This API MUST return a language idiomatic boolean type. A returned value of
 `true` means the instrument is enabled for the provided arguments, and a returned


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4256

Towards https://github.com/open-telemetry/opentelemetry-specification/issues/4215

Other methods with `Context` parameter:
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#context-interaction
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#span-creation
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#synchronous-and-asynchronous-instruments
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md#emit-a-logrecord
- https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/logs/bridge-api.md#enabled