### PR TITLE
Add requirement to allow extending Stable APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ release.
 
 ### Compatibility
 
+- Add requirement to allow extending Stable APIs
+  ([#4270](https://github.com/open-telemetry/opentelemetry-specification/pull/4270))
+
 ### SDK Configuration
 
 ### Common

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -147,7 +147,7 @@ workarounds without incrementing the major version.
 For example, a possible workaround might be to add a new interface instead of extending the existing one and accept the
 new interface in addition to the old one in every place.
 
-Additionally, a Stable signal's API/SDK may be extended by adding new methods to existing
+Additionally, a Stable signal's API/SDK MAY be extended by adding new methods to existing
 Stable APIs. Language implementations SHOULD have a mechanism to do so, such that:
 
 - Adding a new method in Development maturity level is possible and is not a breaking

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -152,7 +152,8 @@ Stable APIs. Language implementations SHOULD have a mechanism to do so, such tha
 
 - Adding a new method in Development maturity level is possible and is not a breaking
   change for users that do not use the new method. It is acceptable that to use the
-  new method the user must opt-in explicitly, provided that such opt-in operation is easy.
+  new method the user must opt-in explicitly, provided that such opt-in operation is 
+  easy and documented.
 - Newly added methods are clearly marked and documented as in Development.
 - Removing (or deprecating) a method that was in Development maturity level but did
   not graduate to Stable level is not a breaking change for users that never used the

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -142,10 +142,22 @@ the plugin interfaces MUST continue to be possible to use with newer versions of
 For languages that commonly share code via binary artifacts, e.g. Java, backwards-compatible means that end user's code that implements plugin interfaces MUST continue to be possible to use with newer minor or patch versions without recompiling the end user's code.
 
 If this backwards compatible addition of methods to interfaces is not possible for a language,
-the language maintainers MAY still implement the addition using backwards-compatible workarounds without incrementing the major version.
+the language maintainers SHOULD still implement the addition using backwards-compatible
+workarounds without incrementing the major version.
 For example, a possible workaround might be to add a new interface instead of extending the existing one and accept the
 new interface in addition to the old one in every place.
 
+Additionally, a Stable signal's API/SDK may be extended by adding new calls to existing
+Stable APIs. Language implementations SHOULD have a mechanism to do so, such that:
+
+- Adding a new method in Development maturity level is possible and is not a breaking
+  change for users that do not use the new method. It is acceptable that to use the
+  new method the user must opt-in explicitly, provided that such opt-in operation is easy.
+- Newly added methods are clearly marked and documented as in Development.
+- Removing (or deprecating) a method that was in Development maturity level but did
+  not graduate to Stable level is not a breaking change for users that never used the
+  method.
+  
 There may be other ways to extend existing API/SDKs in non-breaking manner. Language
 maintainers SHOULD choose the idiomatic way for their language.
 

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -155,7 +155,6 @@ Stable APIs. Language implementations SHOULD have a mechanism to do so, such tha
 - New in Development methods SHOULD require opt-in, so that the user is made aware of
   the risk associated with using the development API. It should be documented that
   the newly added methods are in Development and are subject to breaking changes.
-- Newly added methods are clearly marked and documented as in Development.
 - Removing (or deprecating) a method that was in Development maturity level but did
   not graduate to Stable level is not a breaking change for users that never used the
   method.

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -147,7 +147,7 @@ workarounds without incrementing the major version.
 For example, a possible workaround might be to add a new interface instead of extending the existing one and accept the
 new interface in addition to the old one in every place.
 
-Additionally, a Stable signal's API/SDK may be extended by adding new calls to existing
+Additionally, a Stable signal's API/SDK may be extended by adding new methods to existing
 Stable APIs. Language implementations SHOULD have a mechanism to do so, such that:
 
 - Adding a new method in Development maturity level is possible and is not a breaking

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -151,9 +151,10 @@ Additionally, a Stable signal's API/SDK may be extended by adding new calls to e
 Stable APIs. Language implementations SHOULD have a mechanism to do so, such that:
 
 - Adding a new method in Development maturity level is possible and is not a breaking
-  change for users that do not use the new method. It is acceptable that to use the
-  new method the user must opt-in explicitly, provided that such opt-in operation is 
-  easy and documented.
+  change for users that do not use the new method.
+- New in Development methods SHOULD require opt-in, so that the user is made aware of
+  the risk associated with using the development API. It should be documented that
+  the newly added methods are in Development and are subject to breaking changes.
 - Newly added methods are clearly marked and documented as in Development.
 - Removing (or deprecating) a method that was in Development maturity level but did
   not graduate to Stable level is not a breaking change for users that never used the


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-specification/issues/4257

This issue has been discussed in spec SIG meeting on 22 Oct 2024 and decision was made that we want this to be a requirement for language implementations.

This is a new requirement for implementations, which we believe becomes more and more important now that we have Stable signals that we would like to continue evolving.
