### PR TITLE
Define prototype for proposed features in development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,14 @@ Smaller changes can follow a shorter process:
   of the change, prototyping in multiple programming languages might be required
   by the [specification
   approvers](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto).
+  When proposing new features, we
+  encounter
+  a [chicken or the egg problem](https://en.wikipedia.org/wiki/Chicken_or_the_egg)
+  in that proposals require prototyping but language implementations require
+  features to be in the specification. For this reason, when adding new features
+  with Development maturity level, a prototype is defined as an unmerged PR to a
+  language implementation which has the support of the implementation's
+  maintainers.
 
 Trivial changes, such as clarifications, wording changes, spelling/grammar
 corrections, etc. can be made directly via pull requests and do not require an associated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,11 @@ Smaller changes can follow a shorter process:
   a [chicken or the egg problem](https://en.wikipedia.org/wiki/Chicken_or_the_egg)
   in that proposals require prototyping but language implementations require
   features to be in the specification. For this reason, when adding new features
-  with Development maturity level, a prototype is defined as an unmerged PR to a
-  language implementation which has the support of the implementation's
-  maintainers.
+  with Development maturity level, a prototype is defined as a working
+  demonstration of the feature in a language implementation which has the
+  support of that language's maintainers. For example, this may be an unmerged
+  PR with an indication of maintainers' intent to merge in the event the
+  corresponding specification PR is merged.
 
 Trivial changes, such as clarifications, wording changes, spelling/grammar
 corrections, etc. can be made directly via pull requests and do not require an associated


### PR DESCRIPTION
In the 10/22/24 spec SIG, we discussed that the prototyping requirement for newly proposed features with development maturity level has a "chicken and the egg" problem.

This resolves by clarifying what counts as a prototype for these cases. 