### PR TITLE
[chore] Correct label name

### DIFF
--- a/issue-management.md
+++ b/issue-management.md
@@ -30,7 +30,7 @@ which provide more context. Following are the definitions of each triage label a
 
 These labels are applied to issues when it is unclear yet if they are something the project will take on.
 
-* `triage:deciding:needs-community-feedback` - This issue is open to community discussion. If the community can provide sufficient reasoning, it may be accepted by the project.
+* `triage:deciding:community-feedback` - This issue is open to community discussion. If the community can provide sufficient reasoning, it may be accepted by the project.
 * `triage:deciding:needs-info` - This issue does not provide enough information for the project to accept it. It is left open to provide the author with time to add more details.
 * `triage:deciding:tc-inbox` - This issue needs attention from the TC in order to move forward. It may need TC input for triage, or to unblock a discussion that is deadlocked.
 


### PR DESCRIPTION
Updates label name: it's `triage:deciding:community-feedback`, not `triage:deciding:needs-community-feedback`
