### PR TITLE
[editorial] logs/api: add Hugo alias and linkTitle due to file rename

### DIFF
--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -1,3 +1,8 @@
+<!--- Hugo front matter used to generate the website version of this page:
+linkTitle: API
+aliases: [bridge-api]
+--->
+
 # Logs API
 
 **Status**: [Stable](../document-status.md), except where otherwise specified

--- a/specification/logs/event-api.md
+++ b/specification/logs/event-api.md
@@ -34,7 +34,7 @@ The Event API consists of these main components:
 ## Logs API Development
 
 > [!NOTE]
-> We are currently in the process of defining a new [Logs API](./api.md#logs-api).
+> We are currently in the process of defining a new [Logs API](./api.md).
 
 The intent is that this Logs API will incorporate the current functionality of this existing Events API and once it is defined and implemented, the Events API usage will be migrated, deprecated, renamed and eventually removed.
 

--- a/specification/logs/event-sdk.md
+++ b/specification/logs/event-sdk.md
@@ -33,7 +33,7 @@ All implementations of the OpenTelemetry API MUST provide an SDK.
 ## Logs API Development
 
 > [!NOTE]
-> We are currently in the process of defining a new [Logs API](./api.md#logs-api).
+> We are currently in the process of defining a new [Logs API](./api.md).
 
 The intent is that Logs SDK will incorporate the current functionality of this existing Events SDK and once it is defined and implemented, the Events SDK usage will be migrated, deprecated, renamed and eventually removed.
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -542,6 +542,6 @@ authors MAY decide if they want to make the shutdown timeout configurable.
 ## Logs API
 
 > [!NOTE]
-> We are currently in the process of defining a new [Logs API](./api.md#logs-api).
+> We are currently in the process of defining a new [Logs API](./api.md).
 
 - [OTEP0150 Logging Library SDK Prototype Specification](https://github.com/open-telemetry/oteps/blob/main/text/logs/0150-logging-library-sdk.md)


### PR DESCRIPTION
- Followup to #4259. cc @tedsuo 
- Adds an alias due to the file rename
  > <img width="645" alt="image" src="https://github.com/user-attachments/assets/9f99d8d9-8881-4d5c-966c-8ac609a39747">
- Adds a `linkTitle` (to be the same as for the API pages of other signals)
- The rename is the root cause of the initial build failure of https://github.com/open-telemetry/opentelemetry.io/pull/5552.

/cc @open-telemetry/docs-maintainers