### PR TITLE
Propagation - Extract handles multiple values on carrier using same key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ### Context
 
+- Propagation - Extract handles multiple values on carrier using same key. 
+  [#4295](https://github.com/open-telemetry/opentelemetry-specification/pull/4295)
+
 ### Traces
 
 ### Metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release.
 
 ### Context
 
-- Propagation - Extract handles multiple values on carrier using same key. 
+- Propagation - Extract handles multiple values on carrier using same key.
   [#4295](https://github.com/open-telemetry/opentelemetry-specification/pull/4295)
 
 ### Traces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release.
 
 ### Context
 
-- Propagation - Adds optional GetAll method to Getter, allowing for the retrieval of multiple keys for the same value.
+- Adds optional `GetAll` method to `Getter` in Propagation API, allowing for the retrieval of multiple values for the same key.
   [#4295](https://github.com/open-telemetry/opentelemetry-specification/pull/4295)
 
 ### Traces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release.
 
 ### Context
 
-- Propagation - Extract handles multiple values on carrier using same key.
+- Propagation - Adds optional GetAll method to Getter, allowing for the retrieval of multiple keys for the same value.
   [#4295](https://github.com/open-telemetry/opentelemetry-specification/pull/4295)
 
 ### Traces

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -232,6 +232,8 @@ The Get function is responsible for handling case sensitivity. If the getter is 
 
 ##### GetAll
 
+**Status**: [Development](../document-status.md)
+
 The GetAll function MUST NOT require explicit implementation to satisfy the base `Getter` type.
 Language implementations have the flexibility to incorporate this optional
 functionality in various ways, such as by providing a default GetAll method, or

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -240,7 +240,7 @@ since instrumentation which previously functioned would fail. Language implement
 of this, and add GetAll in a way that retains backwards compatibility. For example, by providing a default
 GetAll implementation based on Get, or by creating an extended Getter type.
 
-If explicitly implemented, the GetAll function MUST return all values of the given propagation key.
+If explicitly implemented, the `GetAll` function MUST return all values of the given propagation key.
 It SHOULD return them in the same order as they appear in the carrier.
 If the key doesn't exist, it SHOULD return an empty collection.
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -249,7 +249,7 @@ Required arguments:
 - the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-The GetAll function is responsible for handling case sensitivity. If the getter is intended to work with an HTTP request object, the getter MUST be case insensitive.
+The `GetAll` function is responsible for handling case sensitivity. If the getter is intended to work with an HTTP request object, the getter MUST be case insensitive.
 
 ## Injectors and Extractors as Separate Interfaces
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -237,7 +237,7 @@ The Get function is responsible for handling case sensitivity. If the getter is 
 For many language implementations, the `GetAll` function will be added after the stable release of `Getter`.
 For these languages, requiring implementations of `Getter` to include `GetAll` constitutes a breaking change
 since instrumentation which previously functioned would fail. Language implementations should be cognizant
-of this, and add GetAll in a way that retains backwards compatibility. For example, by providing a default
+of this, and add `GetAll` in a way that retains backwards compatibility. For example, by providing a default
 `GetAll` implementation based on Get, or by creating an extended `Getter` type.
 
 If explicitly implemented, the `GetAll` function MUST return all values of the given propagation key.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -1,6 +1,6 @@
 # Propagators API
 
-**Status**: [Stable, Feature-Freeze](../document-status.md)
+**Status**: [Stable](../document-status.md), except where otherwise specified.
 
 <details>
 <summary>Table of Contents</summary>

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -234,7 +234,7 @@ The Get function is responsible for handling case sensitivity. If the getter is 
 
 **Status**: [Development](../document-status.md)
 
-For many language implementations, the GetAll function will be added after the stable release of Getter.
+For many language implementations, the `GetAll` function will be added after the stable release of `Getter`.
 For these languages, requiring implementations of Getter to include GetAll constitutes a breaking change
 since instrumentation which previously functioned would fail. Language implementations should be cognizant
 of this, and add GetAll in a way that retains backwards compatibility. For example, by providing a default

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -235,7 +235,7 @@ The Get function is responsible for handling case sensitivity. If the getter is 
 **Status**: [Development](../document-status.md)
 
 For many language implementations, the `GetAll` function will be added after the stable release of `Getter`.
-For these languages, requiring implementations of Getter to include GetAll constitutes a breaking change
+For these languages, requiring implementations of `Getter` to include `GetAll` constitutes a breaking change
 since instrumentation which previously functioned would fail. Language implementations should be cognizant
 of this, and add GetAll in a way that retains backwards compatibility. For example, by providing a default
 `GetAll` implementation based on Get, or by creating an extended `Getter` type.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -22,6 +22,7 @@
     + [Getter argument](#getter-argument)
       - [Keys](#keys)
       - [Get](#get)
+      - [GetAll](#getall)
 - [Injectors and Extractors as Separate Interfaces](#injectors-and-extractors-as-separate-interfaces)
 - [Composite Propagator](#composite-propagator)
   * [Create a Composite Propagator](#create-a-composite-propagator)

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -196,11 +196,11 @@ Returns a new `Context` derived from the `Context` passed as argument.
 
 #### Getter argument
 
-Getter is an argument in `Extract` that get value from given field
+Getter is an argument in `Extract` that gets value(s) from given field.
 
 `Getter` allows a `TextMapPropagator` to read propagated fields from a carrier.
 
-One of the ways to implement it is `Getter` class with `Get` and `Keys` methods
+One of the ways to implement it is `Getter` class with methods `Get`, `Keys`, and `GetAll`
 as described below. Languages may decide on alternative implementations and
 expose corresponding methods as delegates or other ways.
 
@@ -228,6 +228,24 @@ Required arguments:
 - the key of the field.
 
 The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive.
+
+##### GetAll
+
+The GetAll function MUST NOT require explicit implementation to satisfy the base `Getter` type.
+Language implementations have the flexibility to incorporate this optional
+functionality in various ways, such as by providing a default GetAll method, or
+by creating a new type that extends the base `Getter` type.
+
+If explicitly implemented, the GetAll function MUST return all values of the given propagation key.
+It SHOULD return them in the same order as they appear in the carrier.
+If the key doesn't exist, it SHOULD return an empty collection.
+
+Required arguments:
+
+- the carrier of propagation fields, such as an HTTP request.
+- the key of the field.
+
+The GetAll function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive.
 
 ## Injectors and Extractors as Separate Interfaces
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -248,7 +248,7 @@ Required arguments:
 - the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-The GetAll function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive.
+The GetAll function is responsible for handling case sensitivity. If the getter is intended to work with an HTTP request object, the getter MUST be case insensitive.
 
 ## Injectors and Extractors as Separate Interfaces
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -228,7 +228,7 @@ Required arguments:
 - the carrier of propagation fields, such as an HTTP request.
 - the key of the field.
 
-The Get function is responsible for handling case sensitivity. If the getter is intended to work with a HTTP request object, the getter MUST be case insensitive.
+The Get function is responsible for handling case sensitivity. If the getter is intended to work with an HTTP request object, the getter MUST be case insensitive.
 
 ##### GetAll
 

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -238,7 +238,7 @@ For many language implementations, the GetAll function will be added after the s
 For these languages, requiring implementations of Getter to include GetAll constitutes a breaking change
 since instrumentation which previously functioned would fail. Language implementations should be cognizant
 of this, and add GetAll in a way that retains backwards compatibility. For example, by providing a default
-GetAll implementation based on Get, or by creating an extended Getter type.
+`GetAll` implementation based on Get, or by creating an extended `Getter` type.
 
 If explicitly implemented, the `GetAll` function MUST return all values of the given propagation key.
 It SHOULD return them in the same order as they appear in the carrier.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -234,10 +234,11 @@ The Get function is responsible for handling case sensitivity. If the getter is 
 
 **Status**: [Development](../document-status.md)
 
-The GetAll function MUST NOT require explicit implementation to satisfy the base `Getter` type.
-Language implementations have the flexibility to incorporate this optional
-functionality in various ways, such as by providing a default GetAll method, or
-by creating a new type that extends the base `Getter` type.
+For many language implementations, the GetAll function will be added after the stable release of Getter.
+For these languages, requiring implementations of Getter to include GetAll constitutes a breaking change
+since instrumentation which previously functioned would fail. Language implementations should be cognizant
+of this, and add GetAll in a way that retains backwards compatibility. For example, by providing a default
+GetAll implementation based on Get, or by creating an extended Getter type.
 
 If explicitly implemented, the GetAll function MUST return all values of the given propagation key.
 It SHOULD return them in the same order as they appear in the carrier.


### PR DESCRIPTION
Fixes #433

Discussed in 11/5/24 Spec SIG, and prototyped in Java and Go.

## Changes

Adds `GetAll` method to Getter, allowing for the retrieval of multiple keys for the same value. For example, an HTTP request may have multiple `baggage` headers.

As written in the changes, the implementation of `GetAll` is strictly optional. This is for two reasons: 
1. Backwards compatibility with existing types/interfaces
2. Carriers do not necessarily support returning multiple values for a single key

## Links to Prototypes

This includes implementations of `GetAll()` in Java and Go, as well as using the method in the W3C Baggage Propagators (multiple baggage headers are allowed, [spec reference](https://www.w3.org/TR/baggage/#baggage-http-header-format)).

- Java: https://github.com/open-telemetry/opentelemetry-java/pull/6852
- Go: https://github.com/open-telemetry/opentelemetry-go/pull/5973

* [x] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
