### PR TITLE
Clarify OTEPs are documents of intent.

### DIFF
--- a/oteps/README.md
+++ b/oteps/README.md
@@ -4,8 +4,9 @@
 
 OpenTelemetry uses an "OTEP" (similar to a RFC) process for proposing changes to the OpenTelemetry Specification.
 
-[!IMPORTANT] OTEPs are documents of intent. They become requirements only after their content have been
-[integrated](#integrating-the-otep-into-the-spec) into the actual [Specification](../specification).
+> [!NOTE]
+> OTEPs are documents of intent. They become requirements only after their content have been
+> [integrated](#integrating-the-otep-into-the-spec) into the actual [Specification](../specification).
 
 ### Table of Contents
 

--- a/oteps/README.md
+++ b/oteps/README.md
@@ -4,6 +4,9 @@
 
 OpenTelemetry uses an "OTEP" (similar to a RFC) process for proposing changes to the OpenTelemetry Specification.
 
+[!IMPORTANT] OTEPs are documents of intent. They become requirements only after their content have been
+[integrated](#integrating-the-otep-into-the-spec) into the actual [Specification](../specification).
+
 ### Table of Contents
 
 - [OpenTelemetry Enhancement Proposal (OTEP)](#opentelemetry-enhancement-proposal-otep)

--- a/oteps/README.md
+++ b/oteps/README.md
@@ -5,7 +5,7 @@
 OpenTelemetry uses an "OTEP" (similar to a RFC) process for proposing changes to the OpenTelemetry Specification.
 
 > [!NOTE]
-> OTEPs are documents of intent. They become requirements only after their content have been
+> OTEPs are documents of intent. They become requirements only after their contents have been
 > [integrated](#integrating-the-otep-into-the-spec) into the actual [Specification](../specification).
 
 ### Table of Contents


### PR DESCRIPTION
It was discussed, during the move of OTEPs to the Specification repo, that we want to let users know OTEPs are _not_ part of the Specification _until_ their contents have been actually integrated.

We had mentioned we may want to add this one to every OTEP. Any opinion?