### PR TITLE
Remove the recommendation to not synchronize access to Config.disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,22 @@ release.
 
 - Add in-development support for `otlp/stdout` exporter via `OTEL_TRACES_EXPORTER`.
   ([#4183](https://github.com/open-telemetry/opentelemetry-specification/pull/4183))
+- Remove the recommendation to not synchronize access to `TracerConfig.enabled`.
+  ([#4310](https://github.com/open-telemetry/opentelemetry-specification/pull/4310))
 
 ### Metrics
 
 - Add in-development support for `otlp/stdout` exporter via `OTEL_METRICS_EXPORTER`.
   ([#4183](https://github.com/open-telemetry/opentelemetry-specification/pull/4183))
+- Remove the recommendation to not synchronize access to `MeterConfig.enabled`.
+  ([#4310](https://github.com/open-telemetry/opentelemetry-specification/pull/4310))
 
 ### Logs
 
 - Add in-development support for `otlp/stdout` exporter via `OTEL_LOGS_EXPORTER`.
  ([#4183](https://github.com/open-telemetry/opentelemetry-specification/pull/4183))
+- Remove the recommendation to not synchronize access to `LoggerConfig.enabled`.
+  ([#4310](https://github.com/open-telemetry/opentelemetry-specification/pull/4310))
 
 ### Events
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,21 +13,21 @@ release.
 
 - Add in-development support for `otlp/stdout` exporter via `OTEL_TRACES_EXPORTER`.
   ([#4183](https://github.com/open-telemetry/opentelemetry-specification/pull/4183))
-- Remove the recommendation to not synchronize access to `TracerConfig.enabled`.
+- Remove the recommendation to not synchronize access to `TracerConfig.disabled`.
   ([#4310](https://github.com/open-telemetry/opentelemetry-specification/pull/4310))
 
 ### Metrics
 
 - Add in-development support for `otlp/stdout` exporter via `OTEL_METRICS_EXPORTER`.
   ([#4183](https://github.com/open-telemetry/opentelemetry-specification/pull/4183))
-- Remove the recommendation to not synchronize access to `MeterConfig.enabled`.
+- Remove the recommendation to not synchronize access to `MeterConfig.disabled`.
   ([#4310](https://github.com/open-telemetry/opentelemetry-specification/pull/4310))
 
 ### Logs
 
 - Add in-development support for `otlp/stdout` exporter via `OTEL_LOGS_EXPORTER`.
  ([#4183](https://github.com/open-telemetry/opentelemetry-specification/pull/4183))
-- Remove the recommendation to not synchronize access to `LoggerConfig.enabled`.
+- Remove the recommendation to not synchronize access to `LoggerConfig.disabled`.
   ([#4310](https://github.com/open-telemetry/opentelemetry-specification/pull/4310))
 
 ### Events

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -190,9 +190,7 @@ It consists of the following parameters:
   is [Enabled](./api.md#enabled). If `disabled` is `true`, `Enabled`
   returns `false`. If `disabled` is `false`, `Enabled` returns `true`. It is not
   necessary for implementations to ensure that changes to `disabled` are
-  immediately visible to callers of `Enabled`. I.e. atomic, volatile,
-  synchronized, or equivalent memory semantics to avoid stale reads are
-  discouraged to prioritize performance over immediate consistency.
+  immediately visible to callers of `Enabled`.
 
 ## Additional LogRecord interfaces
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -973,9 +973,7 @@ default `MeterConfig.disabled=false` and instruments use the default
 aggregation when no matching views match the instrument.
 
 It is not necessary for implementations to ensure that changes
-to `MeterConfig.disabled` are immediately visible to callers of `Enabled`. I.e.
-atomic, volatile, synchronized, or equivalent memory semantics to avoid stale
-reads are discouraged to prioritize performance over immediate consistency.
+to `MeterConfig.disabled` are immediately visible to callers of `Enabled`.
 
 ## Attribute limits
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -184,9 +184,7 @@ It consists of the following parameters:
   is [Enabled](./api.md#enabled). If `disabled` is `true`, `Enabled`
   returns `false`. If `disabled` is `false`, `Enabled` returns `true`. It is not
   necessary for implementations to ensure that changes to `disabled` are
-  immediately visible to callers of `Enabled`. I.e. atomic, volatile,
-  synchronized, or equivalent memory semantics to avoid stale reads are
-  discouraged to prioritize performance over immediate consistency.
+  immediately visible to callers of `Enabled`.
 
 ## Additional Span Interfaces
 


### PR DESCRIPTION
## Why

> It is not necessary for implementations to ensure that changes to `disabled` are immediately visible to callers of `Enabled`.

I am OK with this statement. The implementation can use things like [`Volatile.Read`](https://learn.microsoft.com/en-us/dotnet/api/system.threading.volatile.read?view=net-9.0) or `volatile` in .NET so that at some point a modified `disabled` value will be returned.

> I.e. atomic, volatile, synchronized, or equivalent memory semantics to avoid stale reads are **discouraged** to prioritize performance over immediate consistency.

I completely disagree with this statement as it encourages that we should never synchronize the memory which leads to data races. If we do not have any mean to synchronize then the user may NEVER get the updated value.

E.g. the program may use the memory from CPU cache and never invalidate it; the actual behavior depends on many things e.g. CPU architecture. It is not a theoretical issue, I was experiencing and fixing such bugs. You can also check: https://www.albahari.com/threading/part4.aspx#_Nonblocking_Synchronization (see: _Do We Really Need Locks and Barriers?_)

"Not immediately" vs "never" is a big difference.



Lack of any synchronization can for sure be an issue for Java and Go:
- https://docs.oracle.com/javase/specs/jls/se8/html/jls-17.html#jls-17.4
- https://go.dev/ref/mem

Besides, the Go race detector would bail if we would not synchronize access e.g. using atomic.

## What

Remove an unsafe recommendation to not synchronize access to Config.disabled.