### PR TITLE
Fix jaeger propagation link

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -126,7 +126,7 @@ Known values for `OTEL_PROPAGATORS` are:
 - `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
 - `"b3"`: [B3 Single](../context/api-propagators.md#configuration)
 - `"b3multi"`: [B3 Multi](../context/api-propagators.md#configuration)
-- `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.21/client-libraries/#propagation-format)
+- `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.63/client-libraries/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
 - `"ottrace"`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)
 - `"none"`: No automatically configured propagator.

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -126,7 +126,7 @@ Known values for `OTEL_PROPAGATORS` are:
 - `"baggage"`: [W3C Baggage](https://www.w3.org/TR/baggage/)
 - `"b3"`: [B3 Single](../context/api-propagators.md#configuration)
 - `"b3multi"`: [B3 Multi](../context/api-propagators.md#configuration)
-- `"jaeger"`: [Jaeger](https://www.jaegertracing.io/docs/1.63/client-libraries/#propagation-format)
+- `"jaeger"`: [Jaeger](https://www.jaegertracing.io/sdk-migration/#propagation-format)
 - `"xray"`: [AWS X-Ray](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader) (_third party_)
 - `"ottrace"`: [OT Trace](https://github.com/opentracing?q=basic&type=&language=) (_third party_)
 - `"none"`: No automatically configured propagator.

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -338,7 +338,7 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 * [W3C Baggage](https://www.w3.org/TR/baggage). MAY alternatively
   be distributed as part of the OpenTelemetry API.
 * [B3](https://github.com/openzipkin/b3-propagation).
-* [Jaeger](https://www.jaegertracing.io/docs/latest/client-libraries/#propagation-format).
+* [Jaeger](https://www.jaegertracing.io/docs/1.63/client-libraries/#propagation-format).
 
 This is a list of additional propagators that MAY be maintained and distributed
 as OpenTelemetry extension packages:

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -338,7 +338,7 @@ organization and MUST be distributed as OpenTelemetry extension packages:
 * [W3C Baggage](https://www.w3.org/TR/baggage). MAY alternatively
   be distributed as part of the OpenTelemetry API.
 * [B3](https://github.com/openzipkin/b3-propagation).
-* [Jaeger](https://www.jaegertracing.io/docs/1.63/client-libraries/#propagation-format).
+* [Jaeger](https://www.jaegertracing.io/sdk-migration/#propagation-format).
 
 This is a list of additional propagators that MAY be maintained and distributed
 as OpenTelemetry extension packages:


### PR DESCRIPTION
Build is currently failing due to this broken link, which appears to have been removed in the 2.0 version of jaeger docs: https://github.com/open-telemetry/opentelemetry-specification/actions/runs/12041693502/job/33627729557?pr=4295

Maybe @yurishkuro can confirm if there is an equivalent page in the latest version of the docs.