### PR TITLE
Update the link to the semconv attributes naming guideline.

### DIFF
--- a/oteps/logs/0097-log-data-model.md
+++ b/oteps/logs/0097-log-data-model.md
@@ -426,7 +426,7 @@ field, which is fixed for a particular source, `Attributes` can vary for each
 occurrence of the event coming from the same source. Can contain information
 about the request context (other than TraceId/SpanId). SHOULD follow
 OpenTelemetry
-[semantic conventions for Attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-naming.md).
+[semantic conventions for Attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/naming.md#attributes).
 This field is optional.
 
 ## Example Log Records

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -61,7 +61,7 @@ both containing an array of strings to represent a mapping
 
 Attributes are equal when their keys and values are equal.
 
-See [Attribute Naming](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-naming.md) for naming guidelines.
+See [Attribute Naming](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/naming.md#attributes) for naming guidelines.
 
 See [Requirement Level](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attribute-requirement-level.md) for requirement levels guidelines.
 


### PR DESCRIPTION
Recently the semconv docs for attribute naming changed, so this PR updates this.