### PR TITLE
Fix lychee (markdown link check) toml config

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,8 +1,8 @@
-include-fragments = true
+include_fragments = true
 
 accept = ["200..=299", "403"]
 
-exclude  = [
+exclude = [
     # excluding links to pull requests and issues is done for performance
     "^https://github.com/open-telemetry/opentelemetry-specification/(issue|pull)/\\d+$",
     # TODO (trask) look into this
@@ -10,4 +10,4 @@ exclude  = [
 ]
 
 # better to be safe and avoid failures
-max-retries = 6
+max_retries = 6


### PR DESCRIPTION
Just discovered a bug I introduced when switching from command-line config to toml config