### PR TITLE
[configuration] Add exception for 'false default' when there is a double negation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ release.
 
 ### SDK Configuration
 
+- Add exception for environment variable naming guidance to avoid double negation ([#4351](https://github.com/open-telemetry/opentelemetry-specification/pull/4351)).
+
 ### Common
 
 ### Supplementary Guidelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ release.
 
 ### SDK Configuration
 
-- Add exception for environment variable naming guidance to avoid double negation ([#4351](https://github.com/open-telemetry/opentelemetry-specification/pull/4351)).
+- Add exception for environment variable naming guidance to avoid double negation.
+  ([#4351](https://github.com/open-telemetry/opentelemetry-specification/pull/4351))
 
 ### Common
 

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -72,10 +72,10 @@ here as a true value, including unset and empty values, MUST be interpreted as
 false. If any value other than a true value, case-insensitive string `"false"`,
 empty, or unset is used, a warning SHOULD be logged to inform users about the
 fallback to false being applied. All Boolean environment variables SHOULD be
-named and defined such that false is the expected safe default behavior, unless 
+named and defined such that false is the expected safe default behavior, unless
 the name and false value would produce a double-negation (e.g. 'disabled'). In
 the latter case Boolean environment variables MAY be named and defined such that
-true is the safe default behavior. Renaming or changing the default value MUST 
+true is the safe default behavior. Renaming or changing the default value MUST
 NOT happen without a major version upgrade.
 
 ### Numeric

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -72,9 +72,11 @@ here as a true value, including unset and empty values, MUST be interpreted as
 false. If any value other than a true value, case-insensitive string `"false"`,
 empty, or unset is used, a warning SHOULD be logged to inform users about the
 fallback to false being applied. All Boolean environment variables SHOULD be
-named and defined such that false is the expected safe default behavior.
-Renaming or changing the default value MUST NOT happen without a major version
-upgrade.
+named and defined such that false is the expected safe default behavior, unless 
+the name and false value would produce a double-negation (e.g. 'disabled'). In
+the latter case Boolean environment variables MAY be named and defined such that
+true is the safe default behavior. Renaming or changing the default value MUST 
+NOT happen without a major version upgrade.
 
 ### Numeric
 


### PR DESCRIPTION
Relates to #4344.

## Changes

Adds exception to naming and default value rule for environment variables. 

This is a backwards compatible change since the original statement is phrased as a 'SHOULD'. The `OTEL_SDK_DISABLED` deviates from this new norm (this is not a spec violation but a lack of consistency). 

The wording tries to be similar to the one in footnote [1] here: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/protocol/exporter.md

There are several OpenTelemetry artifacts that are either not bound by the specification or have decided, for usability reasons, to not follow this rule in this case. This change would, I argue, bring more consistency and less confusion to end users.

I plan to submit a follow-up PR to change `MeterConfig.disabled` to `MeterConfig.enabled` if this PR is accepted.
I don't plan to submit a PR to migrate `OTEL_SDK_DISABLED`, but this could be done if there is interest.

Thanks to @pellared for guidance on this :)

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #4344
* [x] ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps) ~~
* [x] ~~Links to the prototypes (when adding or changing features)~~ (not applicable)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
