### PR TITLE
Nit fix link to correct shutdown & flush

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -71,7 +71,7 @@ linkTitle: SDK
   * [Push Metric Exporter](#push-metric-exporter)
     + [Interface Definition](#interface-definition)
       - [Export(batch)](#exportbatch)
-      - [ForceFlush()](#forceflush)
+      - [ForceFlush](#forceflush-2)
       - [Shutdown](#shutdown-2)
   * [Pull Metric Exporter](#pull-metric-exporter)
 - [MetricProducer](#metricproducer)
@@ -1545,7 +1545,7 @@ Returns: `ExportResult`
 Note: this result may be returned via an async mechanism or a callback, if that
 is idiomatic for the language implementation.
 
-##### ForceFlush()
+##### ForceFlush
 
 This is a hint to ensure that the export of any `Metrics` the exporter has
 received prior to the call to `ForceFlush` SHOULD be completed as soon as

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -72,7 +72,7 @@ linkTitle: SDK
     + [Interface Definition](#interface-definition)
       - [Export(batch)](#exportbatch)
       - [ForceFlush()](#forceflush)
-      - [Shutdown()](#shutdown)
+      - [Shutdown()](#shutdown-2)
   * [Pull Metric Exporter](#pull-metric-exporter)
 - [MetricProducer](#metricproducer)
   * [Interface Definition](#interface-definition-1)

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -72,7 +72,7 @@ linkTitle: SDK
     + [Interface Definition](#interface-definition)
       - [Export(batch)](#exportbatch)
       - [ForceFlush()](#forceflush)
-      - [Shutdown()](#shutdown-2)
+      - [Shutdown](#shutdown-2)
   * [Pull Metric Exporter](#pull-metric-exporter)
 - [MetricProducer](#metricproducer)
   * [Interface Definition](#interface-definition-1)
@@ -1563,7 +1563,7 @@ implemented as a blocking API or an asynchronous API which notifies the caller
 via a callback or an event. [OpenTelemetry SDK](../overview.md#sdk) authors MAY
 decide if they want to make the flush timeout configurable.
 
-##### Shutdown()
+##### Shutdown
 
 Shuts down the exporter. Called when SDK is shut down. This is an opportunity
 for exporter to do any cleanup required.


### PR DESCRIPTION
## Changes

Shutdown() for Exporter was pointing to Shutdown() for MeterProvider. Fixed to point to the right one. Same for Flush
