### PR TITLE
[editorial] Normalized intra-spec link in protocol/file-exporter.md

### DIFF
--- a/specification/protocol/file-exporter.md
+++ b/specification/protocol/file-exporter.md
@@ -4,7 +4,7 @@ linkTitle: File Exporter
 
 # OpenTelemetry Protocol File Exporter
 
-**Status**: [Development](../../specification/document-status.md)
+**Status**: [Development](../document-status.md)
 
 This document provides a placeholder for specifying an OTLP exporter capable of
 exporting to either a file or stdout.


### PR DESCRIPTION
- Contributes to https://github.com/open-telemetry/opentelemetry.io/issues/5935
- Normalized intra-spec link in `file-exporter.md`: there is no need to have the path step out of the spec only to step back into it

/cc @arminru @svrnm 