### PR TITLE
[editorial] Normalized intra-spec link in trace/api.md

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -759,7 +759,7 @@ Note: A `CLIENT` span may have a child that is also a `CLIENT` span, or a
 depending on how the various components that are providing the functionality
 are built and instrumented.
 
-[Semantic conventions](../../specification/overview.md#semantic-conventions) for
+[Semantic conventions](../overview.md#semantic-conventions) for
 specific technologies should document kind for each span they define.
 
 For instance, [Database Client Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md)


### PR DESCRIPTION
- Similar fix to #4366, in support of https://github.com/open-telemetry/opentelemetry.io/issues/5935. The `trace/api.md` page also has a stray `)` when published to the OTel website
- Normalizes path to intra-spec overview page.

/cc @arminru @svrnm

Apologies for the separate PRs, but I don't have my usual dev env setup so it was easier to fix these separately via the GH web interface.