### PR TITLE
Deprecate `exception.escaped` attribute, update exception example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ release.
 
 ### Traces
 
+- Deprecate `exception.escaped` attribute, add link to in-development semantic-conventions
+  on how to record errors across signals.
+  ([#4368](https://github.com/open-telemetry/opentelemetry-specification/pull/4368))
+
 ### Metrics
 
 ### Logs

--- a/specification/semantic-conventions.md
+++ b/specification/semantic-conventions.md
@@ -11,27 +11,27 @@ OpenTelemetry defines its semantic conventions in a separate repository:
 
 Semantic conventions MUST provide the following attributes:
 
-- [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/error.md#error-type)
-- [`exception.message`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/exception.md#exception-message)
-- [`exception.stacktrace`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/exception.md#exception-stacktrace)
-- [`exception.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/exception.md#exception-type)
-- [`server.address`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/server.md#server-address)
-- [`server.port`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/server.md#server-port)
-- [`service.name`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/service.md#service-name)
-- [`telemetry.sdk.language`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/telemetry.md#telemetry-sdk-language)
-- [`telemetry.sdk.name`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/telemetry.md#telemetry-sdk-name)
-- [`telemetry.sdk.version`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/telemetry.md#telemetry-sdk-version)
-- [`url.scheme`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/url.md#url-scheme)
+- [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/error.md#error-type)
+- [`exception.message`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/exception.md#exception-message)
+- [`exception.stacktrace`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/exception.md#exception-stacktrace)
+- [`exception.type`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/exception.md#exception-type)
+- [`server.address`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/server.md#server-address)
+- [`server.port`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/server.md#server-port)
+- [`service.name`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/service.md#service-name)
+- [`telemetry.sdk.language`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/telemetry.md#telemetry-sdk-language)
+- [`telemetry.sdk.name`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/telemetry.md#telemetry-sdk-name)
+- [`telemetry.sdk.version`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/telemetry.md#telemetry-sdk-version)
+- [`url.scheme`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/url.md#url-scheme)
 
 Semantic conventions MUST provide the following events:
 
-- [`exception`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/exceptions/exceptions-spans.md)
+- [`exception`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-spans.md)
 
 ## In-development Reserved Attributes
 
 Semantic conventions MUST provide the following attributes:
 
-- [`service.instance.id`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/service.md#service-instance-id)
+- [`service.instance.id`](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/attributes-registry/service.md#service-instance-id)
 
 ## Reserved Namespace
 

--- a/specification/semantic-conventions.md
+++ b/specification/semantic-conventions.md
@@ -11,28 +11,29 @@ OpenTelemetry defines its semantic conventions in a separate repository:
 
 Semantic conventions MUST provide the following attributes:
 
-- Resource
-  - `service.name`
-  - `telemetry.sdk.language`
-  - `telemetry.sdk.name`
-  - `telemetry.sdk.version`
-- Event
-  - `exception.escaped`
-  - `exception.message`
-  - `exception.stacktrace`
-  - `exception.type`
+- [`error.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/error.md#error-type)
+- [`exception.message`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/exception.md#exception-message)
+- [`exception.stacktrace`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/exception.md#exception-stacktrace)
+- [`exception.type`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/exception.md#exception-type)
+- [`server.address`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/server.md#server-address)
+- [`server.port`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/server.md#server-port)
+- [`service.name`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/service.md#service-name)
+- [`telemetry.sdk.language`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/telemetry.md#telemetry-sdk-language)
+- [`telemetry.sdk.name`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/telemetry.md#telemetry-sdk-name)
+- [`telemetry.sdk.version`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/telemetry.md#telemetry-sdk-version)
+- [`url.scheme`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/url.md#url-scheme)
+
+Semantic conventions MUST provide the following events:
+
+- [`exception`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/exceptions/exceptions-spans.md)
 
 ## In-development Reserved Attributes
 
 Semantic conventions MUST provide the following attributes:
 
-- Resource
-  - `server.address`
-  - `server.port`
-  - `service.instance.id`
-  - `url.scheme`
+- [`service.instance.id`](https://github.com/open-telemetry/semantic-conventions/blob/v1.29.0/docs/attributes-registry/service.md#service-instance-id)
 
 ## Reserved Namespace
 
 The `otel.*` namespace is reserved for defining compatibility with
-non-opentelemetry technologies.
+non-OpenTelemetry technologies.

--- a/specification/trace/exceptions.md
+++ b/specification/trace/exceptions.md
@@ -1,9 +1,8 @@
 # Exceptions
 
-**Status**: [Stable](../document-status.md)
+**Status**: [Stable](../document-status.md), Unless otherwise specified.
 
-This document defines how to record exceptions and
-their required attributes.
+This document defines how to record exceptions and their attributes.
 
 <!-- toc -->
 
@@ -17,6 +16,9 @@ their required attributes.
 An exception SHOULD be recorded as an `Event` on the span during which it occurred.
 The name of the event MUST be `"exception"`.
 
+<!-- TODO: update to semconv tag once merged and released  -->
+**Status**: [Development](../document-status.md) - Refer to the [Recording Errors](https://github.com/open-telemetry/semantic-conventions/blob/c77c7d7866c943b357d1d26ffa2fa89b092f2b9f/docs/general/recording-errors.md) document for the details on how to report errors across signals.
+
 A typical template for an auto-instrumentation implementing this semantic convention
 using an [API-provided `recordException` method](api.md#record-exception)
 could look like this (pseudo-Java):
@@ -26,7 +28,9 @@ Span span = myTracer.startSpan(/*...*/);
 try {
   // Code that does the actual work which the Span represents
 } catch (Throwable e) {
-  span.recordException(e, Attributes.of("exception.escaped", true));
+  span.recordException(e);
+  span.setAttribute(AttributeKey.stringKey("error.type"), e.getClass().getCanonicalName())
+  span.setStatus(StatusCode.ERROR, e.getMessage());
   throw e;
 } finally {
   span.end();
@@ -41,7 +45,7 @@ event name `exception`.
 Additionally, the following attributes SHOULD be
 filled out:
 
-- `exception.escaped`
+- [Deprecated](../document-status.md) `exception.escaped`
 - `exception.message`
 - `exception.stacktrace`
 - `exception.type`

--- a/specification/trace/exceptions.md
+++ b/specification/trace/exceptions.md
@@ -16,8 +16,7 @@ This document defines how to record exceptions and their attributes.
 An exception SHOULD be recorded as an `Event` on the span during which it occurred.
 The name of the event MUST be `"exception"`.
 
-<!-- TODO: update to semconv tag once merged and released  -->
-**Status**: [Development](../document-status.md) - Refer to the [Recording Errors](https://github.com/open-telemetry/semantic-conventions/blob/v1.30.0/docs/general/recording-errors.md) document for the details on how to report errors across signals.
+**Status**: [Development](../document-status.md) - Refer to the [Recording Errors](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/recording-errors.md) document for the details on how to report errors across signals.
 
 A typical template for an auto-instrumentation implementing this semantic convention
 using an [API-provided `recordException` method](api.md#record-exception)
@@ -45,7 +44,6 @@ event name `exception`.
 Additionally, the following attributes SHOULD be
 filled out:
 
-- [Deprecated](../document-status.md) `exception.escaped`
 - `exception.message`
 - `exception.stacktrace`
 - `exception.type`

--- a/specification/trace/exceptions.md
+++ b/specification/trace/exceptions.md
@@ -13,7 +13,10 @@ This document defines how to record exceptions and their attributes.
 
 ## Recording an Exception
 
-An exception SHOULD be recorded as an `Event` on the span during which it occurred.
+An exception SHOULD be recorded as an `Event` on the span during which it occurred
+if and only if it remains unhandled when the span ends and causes the span status
+to be set to ERROR.
+
 The name of the event MUST be `"exception"`.
 
 **Status**: [Development](../document-status.md) - Refer to the [Recording Errors](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/recording-errors.md) document for the details on how to report errors across signals.

--- a/specification/trace/exceptions.md
+++ b/specification/trace/exceptions.md
@@ -17,7 +17,7 @@ An exception SHOULD be recorded as an `Event` on the span during which it occurr
 The name of the event MUST be `"exception"`.
 
 <!-- TODO: update to semconv tag once merged and released  -->
-**Status**: [Development](../document-status.md) - Refer to the [Recording Errors](https://github.com/open-telemetry/semantic-conventions/blob/c77c7d7866c943b357d1d26ffa2fa89b092f2b9f/docs/general/recording-errors.md) document for the details on how to report errors across signals.
+**Status**: [Development](../document-status.md) - Refer to the [Recording Errors](https://github.com/open-telemetry/semantic-conventions/blob/v1.30.0/docs/general/recording-errors.md) document for the details on how to report errors across signals.
 
 A typical template for an auto-instrumentation implementing this semantic convention
 using an [API-provided `recordException` method](api.md#record-exception)


### PR DESCRIPTION
This is follow up on https://github.com/open-telemetry/semantic-conventions/pull/1716 - cross signal guidance on how to record errors (and exceptions) in instrumentations. 

## Changes

Follow up for https://github.com/open-telemetry/semantic-conventions/pull/1716

`exception.escaped` attribute is not used in practice within OTel instrumentations (checked Java, .NET, JS. Python, Go, C++ and Rust including contrib repos).
OTel instrumentations, in general, don't record handled exceptions, i.e. virtually all exceptions we're recording in non-native instrumentations are expected to escape span scope.

The litmus test whether to record exception on spans is whether the instrumentation is going to set span status to `ERROR` due to this exception.

A way to record all sorts of exceptions is being introduced in https://github.com/open-telemetry/opentelemetry-specification/pull/4333 and leverages logs along with severity that conveys how critical the exception is in more expressive way than `exception.escaped` flag.

* [x] Related issues https://github.com/open-telemetry/semantic-conventions/issues/1536, https://github.com/open-telemetry/semantic-conventions/issues/1516
* [x] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #4333
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
