### PR TITLE
Logs API to have functionality for reusing Standard Attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ release.
 
 ### Logs
 
-- Logs API should have ergonomics for reusing standard attributes.
+- Logs API should have ergonomics for reusing Standard Attributes.
   ([#4373](https://github.com/open-telemetry/opentelemetry-specification/pull/4373))
 
 ### Baggage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ release.
 
 ### Logs
 
-- Logs API should have ergonomics for reusing Standard Attributes.
+- Logs API should have functionality for reusing Standard Attributes.
   ([#4373](https://github.com/open-telemetry/opentelemetry-specification/pull/4373))
 
 ### Baggage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ release.
   ([#4352](https://github.com/open-telemetry/opentelemetry-specification/pull/4352))
 - Make all `Logger` operations user-facing.
   ([#4352](https://github.com/open-telemetry/opentelemetry-specification/pull/4352))
+- Logs API should have ergonimics for reusing standard attributes.
+  ([#4373](https://github.com/open-telemetry/opentelemetry-specification/pull/4373))
 
 ### Events
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ release.
   ([#4352](https://github.com/open-telemetry/opentelemetry-specification/pull/4352))
 - Make all `Logger` operations user-facing.
   ([#4352](https://github.com/open-telemetry/opentelemetry-specification/pull/4352))
-- Logs API should have ergonimics for reusing standard attributes.
+- Logs API should have ergonomics for reusing standard attributes.
   ([#4373](https://github.com/open-telemetry/opentelemetry-specification/pull/4373))
 
 ### Events

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -194,6 +194,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | LoggerProvider.ForceFlush                    |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | Logger.Emit(LogRecord)                       |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | Logger.EmitEvent(LogRecord)                  |          |     |      |     |        |      |        |     |      |     |      |       |
+| Reuse Standard Attributes                    | X        | +   |      |     |        |      |        |     |      |     |      |       |
 | Logger.Enabled                               | X        | +   |      |     |        |      |        |     | +    | +   |      |       |
 | SimpleLogRecordProcessor                     |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
 | BatchLogRecordProcessor                      |          |     | +    |     | +      |      |        | +   |      | +   |      |       |

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -126,7 +126,7 @@ The API MUST accept the following parameters:
 [1]: **Status**: [Development](../document-status.md) -
 The API SHOULD provide ergonomics so that the caller can use
 [Standard Attributes](../common/README.md#standard-attribute)
-along with log attributes of [type `map<string, any>`](/specification/logs/data-model.md#type-mapstring-any).
+along with log attributes of [type `map<string, any>`](./data-model.md#type-mapstring-any).
 This allows the reuse of attributes when emitting telemetry for other signals.
 This can be converting functions, method overloads, etc.
 

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -127,7 +127,7 @@ The API MUST accept the following parameters:
 The API SHOULD provide ergonomics so that the caller can use
 [Standard Attributes](../common/README.md#standard-attribute)
 along with log attributes of [type `map<string, any>`](./data-model.md#type-mapstring-any).
-This allows the reuse of attributes when emitting telemetry for other signals.
+This allows the reuse of attributes across signals.
 This can be converting functions, method overloads, etc.
 
 ### Enabled

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -126,13 +126,11 @@ The API MUST accept the following parameters:
 
 **Status**: [Development](../document-status.md)
 
-The API SHOULD provide functionality so that the caller can use
+The API SHOULD provide functionality for users to convert
 [Standard Attributes](../common/README.md#standard-attribute)
-along with [Log Attributes](./data-model.md#field-attributes)
-of [type `map<string, any>`](./data-model.md#type-mapstring-any).
+so they can be used, or directly accept them, in the log signal.
 This allows the reuse of [Standard Attributes](../common/README.md#standard-attribute)
 across signals.
-This can be converting functions, method overloads, etc.
 
 ### Enabled
 

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -120,8 +120,13 @@ The API MUST accept the following parameters:
 - [Severity Number](./data-model.md#field-severitynumber) (optional)
 - [Severity Text](./data-model.md#field-severitytext) (optional)
 - [Body](./data-model.md#field-body) (optional)
-- [Attributes](./data-model.md#field-attributes) (optional)
+- [Attributes](./data-model.md#field-attributes) (optional) [1]
 - **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
+
+[1]: The API SHOULD provide ergonomics so that the caller can reuse
+[Standard Attributes](../common/README.md#standard-attribute)
+that are used when emitting telemetry for other signals.
+This can be converting functions, method overloads, etc.
 
 ### Enabled
 

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -124,7 +124,7 @@ The API MUST accept the following parameters:
 - **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
 
 [1]: **Status**: [Development](../document-status.md) -
-The API SHOULD provide ergonomics so that the caller can use
+The API SHOULD provide functionality so that the caller can use
 [Standard Attributes](../common/README.md#standard-attribute)
 along with [Log Attributes](./data-model.md#field-attributes)
 of [type `map<string, any>`](./data-model.md#type-mapstring-any).

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -126,8 +126,10 @@ The API MUST accept the following parameters:
 [1]: **Status**: [Development](../document-status.md) -
 The API SHOULD provide ergonomics so that the caller can use
 [Standard Attributes](../common/README.md#standard-attribute)
-along with log attributes of [type `map<string, any>`](./data-model.md#type-mapstring-any).
-This allows the reuse of attributes across signals.
+along with [Log Attributes](./data-model.md#field-attributes)
+of [type `map<string, any>`](./data-model.md#type-mapstring-any).
+This allows the reuse of [Standard Attributes](../common/README.md#standard-attribute)
+across signals.
 This can be converting functions, method overloads, etc.
 
 ### Enabled

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -123,7 +123,7 @@ The API MUST accept the following parameters:
 - [Attributes](./data-model.md#field-attributes) (optional) [1]
 - **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
 
-[1]: The API SHOULD provide ergonomics so that the caller can reuse
+[1]: **Status**: [Development](../document-status.md) - The API SHOULD provide ergonomics so that the caller can reuse
 [Standard Attributes](../common/README.md#standard-attribute)
 that are used when emitting telemetry for other signals.
 This can be converting functions, method overloads, etc.

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -125,7 +125,8 @@ The API MUST accept the following parameters:
 
 [1]: **Status**: [Development](../document-status.md) - The API SHOULD provide ergonomics so that the caller can reuse
 [Standard Attributes](../common/README.md#standard-attribute)
-that are used when emitting telemetry for other signals.
+along with log attributes of [type `map<string, any>`](/specification/logs/data-model.md#type-mapstring-any).
+This allows the reuse of attributes when emitting telemetry for other signals.
 This can be converting functions, method overloads, etc.
 
 ### Enabled

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -121,10 +121,11 @@ The API MUST accept the following parameters:
 - [Severity Number](./data-model.md#field-severitynumber) (optional)
 - [Severity Text](./data-model.md#field-severitytext) (optional)
 - [Body](./data-model.md#field-body) (optional)
-- [Attributes](./data-model.md#field-attributes) (optional) [1]
+- [Attributes](./data-model.md#field-attributes) (optional)
 - **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
 
-[1]: **Status**: [Development](../document-status.md) -
+**Status**: [Development](../document-status.md)
+
 The API SHOULD provide functionality so that the caller can use
 [Standard Attributes](../common/README.md#standard-attribute)
 along with [Log Attributes](./data-model.md#field-attributes)

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -123,7 +123,8 @@ The API MUST accept the following parameters:
 - [Attributes](./data-model.md#field-attributes) (optional) [1]
 - **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
 
-[1]: **Status**: [Development](../document-status.md) - The API SHOULD provide ergonomics so that the caller can reuse
+[1]: **Status**: [Development](../document-status.md) -
+The API SHOULD provide ergonomics so that the caller can use
 [Standard Attributes](../common/README.md#standard-attribute)
 along with log attributes of [type `map<string, any>`](/specification/logs/data-model.md#type-mapstring-any).
 This allows the reuse of attributes when emitting telemetry for other signals.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4201

Reference implementations:
- https://github.com/open-telemetry/opentelemetry-go/pull/6180
- https://github.com/open-telemetry/opentelemetry-java/pull/6983

Related Slack thread: https://cloud-native.slack.com/archives/C062HUREGUV/p1736545245331779