### PR TITLE
Update link to semconv attribute naming guidance

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -5,6 +5,9 @@ accept = ["200..=299", "403"]
 exclude = [
     # excluding links to pull requests and issues is done for performance
     "^https://github.com/open-telemetry/opentelemetry-specification/(issue|pull)/\\d+$",
+    # TODO (trask) remove this exclusion after next semconv release
+    #  see https://github.com/open-telemetry/opentelemetry-specification/pull/4376
+    "^https://opentelemetry.io/docs/specs/semconv/general/naming/$",
     # TODO (trask) look into this
     "^https://docs.google.com/document/d/1d0afxe3J6bQT-I6UbRXeIYNcTIyBQv4axfjKF4yvAPA/edit"
 ]

--- a/specification/common/attribute-naming.md
+++ b/specification/common/attribute-naming.md
@@ -1,8 +1,8 @@
 <!--- Hugo front matter used to generate the website version of this page:
-redirect: /docs/specs/semconv/general/attribute-naming/ 301!
+redirect: /docs/specs/semconv/general/naming/ 301!
 --->
 
 # Attribute Naming
 
 This page has moved to
-[Attribute Naming](https://opentelemetry.io/docs/specs/semconv/general/attribute-naming/).
+[Naming](https://opentelemetry.io/docs/specs/semconv/general/naming/).


### PR DESCRIPTION
Leaving as draft for now because probably need to wait until after the next semconv release to merge it (when this link will exist https://opentelemetry.io/docs/specs/semconv/general/naming/).

cc @open-telemetry/docs-approvers 