### PR TITLE
[editorial] Remove outdated section from Logs SDK

### DIFF
--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -33,7 +33,6 @@
     + [Export](#export)
     + [ForceFlush](#forceflush-2)
     + [Shutdown](#shutdown-1)
-- [Logs API](#logs-api)
 
 <!-- tocstop -->
 
@@ -516,10 +515,5 @@ return a Failure result.
 `Shutdown` SHOULD NOT block indefinitely (e.g. if it attempts to flush the data
 and the destination is unavailable). [OpenTelemetry SDK](../overview.md#sdk)
 authors MAY decide if they want to make the shutdown timeout configurable.
-
-## Logs API
-
-> [!NOTE]
-> We are currently in the process of defining a new [Logs API](./api.md).
 
 - [OTEP0150 Logging Library SDK Prototype Specification](https://github.com/open-telemetry/oteps/blob/main/text/logs/0150-logging-library-sdk.md)


### PR DESCRIPTION
This section is no longer needed after these PR being merged:
- https://github.com/open-telemetry/opentelemetry-specification/pull/4352/

The section was originally created here:
- https://github.com/open-telemetry/opentelemetry-specification/pull/4236
