### PR TITLE
Mark direct usage of Logs API as Development

### DIFF
--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -33,6 +33,7 @@ The Logs API is provided for logging library authors to build
 which use this API to bridge between existing logging libraries and the
 OpenTelemetry log data model.
 
+**Status**: [Development](../document-status.md) - 
 The Logs API can also be directly called by instrumentation libraries
 as well as instrumented libraries or applications.
 


### PR DESCRIPTION
Address https://github.com/open-telemetry/opentelemetry-specification/pull/4382/files#r1925732045

This is a PR that should be approved/reviewed if anyone has a strong opinion that allowing direct use of Logs API should be in Development status instead of Stable.

Notice that a spec release is already out (https://github.com/open-telemetry/opentelemetry-specification/pull/4352) and we could just say that "ship has sailed". On the other side, we can consider this PR as a bugfix.

Side note: If you ask me, I would rather keep it as Stable :wink: 