### PR TITLE
Fix batch parameter requirements

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -213,7 +213,7 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 | OTEL_BSP_SCHEDULE_DELAY        | Delay interval (in milliseconds) between two consecutive exports | 5000    | [Duration][] |                                                                                   |
 | OTEL_BSP_EXPORT_TIMEOUT        | Maximum allowed time (in milliseconds) to export data            | 30000   | [Timeout][]  |                                                                                   |
 | OTEL_BSP_MAX_QUEUE_SIZE        | Maximum queue size                                               | 2048    | [Integer][]  | Valid values are positive.                                                        |
-| OTEL_BSP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                                               | 512     | [Integer][]  | Must be less than or equal to OTEL_BSP_MAX_QUEUE_SIZE. Valid values are positive. |
+| OTEL_BSP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                                               | 512     | [Integer][]  | Valid values are positive.                                                        |
 
 ## Batch LogRecord Processor
 
@@ -222,7 +222,7 @@ Depending on the value of `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG` may b
 | OTEL_BLRP_SCHEDULE_DELAY        | Delay interval (in milliseconds) between two consecutive exports | 1000    | [Duration][] |                                                                                    |
 | OTEL_BLRP_EXPORT_TIMEOUT        | Maximum allowed time (in milliseconds) to export data            | 30000   | [Timeout][]  |                                                                                    |
 | OTEL_BLRP_MAX_QUEUE_SIZE        | Maximum queue size                                               | 2048    | [Integer][]  | Valid values are positive.                                                         |
-| OTEL_BLRP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                                               | 512     | [Integer][]  | Must be less than or equal to OTEL_BLRP_MAX_QUEUE_SIZE. Valid values are positive. |
+| OTEL_BLRP_MAX_EXPORT_BATCH_SIZE | Maximum batch size                                               | 512     | [Integer][]  | Valid values are positive.                                                         |
 
 ## Attribute Limits
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -430,8 +430,8 @@ to make sure that they are not invoked concurrently.
   consecutive exports. The default value is `1000`.
 * `exportTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
-* `maxExportBatchSize` - the maximum batch size of every export. It must be
-  smaller or equal to `maxQueueSize`. The default value is `512`.
+* `maxExportBatchSize` - the maximum batch size of every export. The default
+  value is `512`.
 
 ## LogRecordExporter
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -733,10 +733,9 @@ an empty batch OR skip the export and consider it to be completed immediately.
   consecutive exports. The default value is `5000`.
 * `exportTimeoutMillis` - how long the export can run before it is cancelled.
   The default value is `30000`.
-* `maxExportBatchSize` - the maximum batch size of every export. It must be
-  smaller or equal to `maxQueueSize`. If the queue reaches `maxExportBatchSize`
-  a batch will be exported even if `scheduledDelayMillis` milliseconds have not
-  elapsed. The default value is `512`.
+* `maxExportBatchSize` - the maximum batch size of every export. If the queue
+  reaches `maxExportBatchSize` a batch will be exported even if `scheduledDelayMillis`
+  milliseconds have not elapsed. The default value is `512`.
 
 ## Span Exporter
 


### PR DESCRIPTION
Fixes a bug which has been present since the original introduction of standard environment variables in #666 and the original trace SDK spec #205.

@breedx-splk [points out](https://github.com/open-telemetry/opentelemetry-java/issues/7024#issuecomment-2617347391) that there's no need for the export batch size to be less than the queue size since an export batch size smaller than the queue can still drain a queue in multiple exports.

On the other side of things, an export batch size large than the queue will always fully drain the queue with each export. And so you could say there's no reason for the export batch size to be larger than the max queue size, but its hardly worth restricting.

