### PR TITLE
Add Cardinality Limit to Compliance Matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -180,6 +180,9 @@ formats is required. Implementing more than one format is optional.
 | A metric Producer accepts an optional metric Filter                                                                                                                    |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers                                                  |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric SDK's metric Producer implementations uses the metric Filter                                                                                                |          |    |      |     |        |      | -      |     |      |     |      |       |
+| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                                                |          |    |      |     |        |      |       |     |      |     |      |       |
+| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                |          |    |      |     |        |      |       |     |      |     |      |       |
+| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                                |          |    |      |     |        |      |       |     |      |     |      |       |
 
 ## Logs
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -180,9 +180,9 @@ formats is required. Implementing more than one format is optional.
 | A metric Producer accepts an optional metric Filter                                                                                                                    |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers                                                  |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric SDK's metric Producer implementations uses the metric Filter                                                                                                |          |    |      |     |        |      | -      |     |      |     |      |       |
-| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                                                |          |    |      |     |        |      |       |     |      |     |      |       |
-| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                |          |    |      |     |        |      |       |     |      |     |      |       |
-| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                                |          |    |      |     |        |      |       |     |      |     |      |       |
+| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |      |     |        |      |        |     |      |     |      |       |
+| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |      |     |      |       |
+| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |      |     |        |      |        |     |      |     |      |       |
 
 ## Logs
 


### PR DESCRIPTION
## Changes

Cardinality Limit is a stable feature in Metric SDK spec, but has no entry in the spec compliance matrix, making it hard to know which languages have implemented this.

This PR adds an entry with empty values for each languages; filling with actual status can be follow up work for each languages.