### PR TITLE
Update cardinality cap spec matrix for OTel .NET

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -180,9 +180,9 @@ formats is required. Implementing more than one format is optional.
 | A metric Producer accepts an optional metric Filter                                                                                                                    |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers                                                  |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric SDK's metric Producer implementations uses the metric Filter                                                                                                |          |    |      |     |        |      | -      |     |      |     |      |       |
-| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |      |     |        |      |        |     |      |     |      |       |
-| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |      |     |      |       |
-| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |      |     |        |      |        |     |      |     |      |       |
+| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |      |     |        |      |        |     |      |     |   +   |       |
+| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |      |     |  -    |       |
+| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |      |     |        |      |        |     |      |     |   +   |       |
 
 ## Logs
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -181,7 +181,7 @@ formats is required. Implementing more than one format is optional.
 | The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers                                                  |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric SDK's metric Producer implementations uses the metric Filter                                                                                                |          |    |      |     |        |      | -      |     |      |     |      |       |
 | Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |      |     |        |      |        |     |      |     |   +   |       |
-| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |      |     |  -    |       |
+| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |      |     |   -   |       |
 | Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |      |     |        |      |        |     |      |     |   +   |       |
 
 ## Logs


### PR DESCRIPTION
Otel .NET supports capping by default, and supports changing at Metric level using Views, but not at MeterReader level.