### PR TITLE
Update spec matrix for cardinality cap - cpp and rust

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -180,9 +180,9 @@ formats is required. Implementing more than one format is optional.
 | A metric Producer accepts an optional metric Filter                                                                                                                    |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers                                                  |          |    |      |     |        |      | -      |     |      |     |      |       |
 | The metric SDK's metric Producer implementations uses the metric Filter                                                                                                |          |    |      |     |        |      | -      |     |      |     |      |       |
-| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |      |     |        |      |        |     |      |     |   +   |       |
-| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |      |     |   -   |       |
-| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |      |     |        |      |        |     |      |     |   +   |       |
+| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |      |     |        |      |        |     |  -   |  +  |   +   |       |
+| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |      |     |        |      |        |     |  -   |  -  |   -   |       |
+| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |      |     |        |      |        |     |  -   |  -  |   +   |       |
 
 ## Logs
 


### PR DESCRIPTION
Otel Rust - does not implement
OTel C++ - implement cardinality capping, but does not allow configuring.