### PR TITLE
fix: Improve link to jsonlines.org

### DIFF
--- a/specification/protocol/file-exporter.md
+++ b/specification/protocol/file-exporter.md
@@ -61,7 +61,7 @@ This document describes the serialization of OpenTelemetry data as JSON objects 
 
 #### JSON lines file
 
-This file is a [JSON lines file](jsonlines.org), and therefore follows those requirements:
+This file is a [JSON lines file](https://jsonlines.org), and therefore follows those requirements:
 
 * UTF-8 encoding
 * Each line is a valid JSON value

--- a/specification/protocol/file-exporter.md
+++ b/specification/protocol/file-exporter.md
@@ -61,7 +61,7 @@ This document describes the serialization of OpenTelemetry data as JSON objects 
 
 #### JSON lines file
 
-This file is a JSON lines file (jsonlines.org), and therefore follows those requirements:
+This file is a [JSON lines file](jsonlines.org), and therefore follows those requirements:
 
 * UTF-8 encoding
 * Each line is a valid JSON value


### PR DESCRIPTION
## Changes

Update file-exporter with a clickable link to jsonlines.org.
