### PR TITLE
Add Release Candidate to the lifecycle status table

### DIFF
--- a/specification/document-status.md
+++ b/specification/document-status.md
@@ -9,12 +9,13 @@ documents. The following table describes what the statuses mean.
 
 The support guarantees and allowed changes are governed by the lifecycle of the document.Lifecycle stages are defined in the [Versioning and Stability](versioning-and-stability.md) document.
 
-|Status              |Explanation|
-|--------------------|-----------|
-|No explicit "Status"|Equivalent to Development.|
-|Development        |Breaking changes are allowed.|
-|Stable              |Breaking changes are no longer allowed. See [stability guarantees](versioning-and-stability.md#stable) for details.|
-|Deprecated          |Changes are no longer allowed, except for editorial changes.|
+| Status               | Explanation                                                                                                         |
+|----------------------|---------------------------------------------------------------------------------------------------------------------|
+| No explicit "Status" | Equivalent to Development.                                                                                          |
+| Development          | Breaking changes are allowed.                                                                                       |
+| Release Candidate    | Breaking changes are only allowed under special circumstances.                                                      |
+| Stable               | Breaking changes are no longer allowed. See [stability guarantees](versioning-and-stability.md#stable) for details. |
+| Deprecated           | Changes are no longer allowed, except for editorial changes.                                                        |
 
 The specification follows
 [OTEP 0232](../oteps/0232-maturity-of-otel.md#explanation)


### PR DESCRIPTION
We have started using Release Candidate lifecycle status in the semantic convention repo, and we link to this table.

Borrowed the language from OTEP 232.