### PR TITLE
Release 1.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,9 @@ release.
 
 ### Traces
 
-- Clarify STDOUT exporter format is unspecified.
-   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
-
 ### Metrics
 
-- Clarify STDOUT exporter format is unspecified.
-   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
-
 ### Logs
-
-- Clarify STDOUT exporter format is unspecified.
-   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
 
 ### Baggage
 
@@ -40,10 +31,29 @@ release.
 
 ### Supplementary Guidelines
 
+### OTEPs
+
+## v1.43.0 (2025-03-11)
+
+### Traces
+
+- Clarify STDOUT exporter format is unspecified.
+   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
+
+### Metrics
+
+- Clarify STDOUT exporter format is unspecified.
+   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
+
+### Logs
+
+- Clarify STDOUT exporter format is unspecified.
+   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
+
+### Supplementary Guidelines
+
 - Add Advanced Processing to Logs Supplementary Guidelines.
   ([#4407](https://github.com/open-telemetry/opentelemetry-specification/pull/4407))
-
-### OTEPs
 
 ## v1.42.0 (2025-02-18)
 


### PR DESCRIPTION
March 2025 Release.

## v1.43.0 (2025-03-11)

### Traces

- Clarify STDOUT exporter format is unspecified.
   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))

### Metrics

- Clarify STDOUT exporter format is unspecified.
   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))

### Logs

- Clarify STDOUT exporter format is unspecified.
   ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))

### Supplementary Guidelines

- Add Advanced Processing to Logs Supplementary Guidelines.
  ([#4407](https://github.com/open-telemetry/opentelemetry-specification/pull/4407))
