### PR TITLE
Clarify metrics design goal, scope out StatsD clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ release.
 
 - Clarify STDOUT exporter format is unspecified.
    ([#4418](https://github.com/open-telemetry/opentelemetry-specification/pull/4418))
+- Clarify the metrics design goal, scope out StatsD client support.
+   ([#4445](https://github.com/open-telemetry/opentelemetry-specification/pull/4445))
 
 ### Logs
 

--- a/specification/metrics/README.md
+++ b/specification/metrics/README.md
@@ -44,13 +44,17 @@ important to understand the goals of OpenTelemetry’s metrics effort:
   converging OpenCensus and OpenTracing. We will focus on providing the
   semantics and capability, instead of doing a 1-1 mapping of the APIs.
 
-* **Working with existing metrics instrumentation protocols and standards**. The
-  minimum goal is to provide full support for
-  [Prometheus](https://prometheus.io/) and
-  [StatsD](https://github.com/statsd/statsd) - users should be able to use
-  OpenTelemetry clients and [Collector](../overview.md#collector) to collect and
-  export metrics, with the ability to achieve the same functionality as their
-  native clients.
+* **Working with existing metrics instrumentation protocols and standards**.
+  Here is the minimum set of goals:
+  * Providing a data model that can support both cumulative and delta
+    [aggregation temporality](./data-model.md#temporality).
+  * Providing full support for [Prometheus](https://prometheus.io/) - users
+    should be able to use OpenTelemetry clients and
+    [Collector](../overview.md#collector) to collect and export metrics, with
+    the ability to achieve the same functionality as the native Prometheus
+    clients.
+  * Providing the ability to collect [StatsD](https://github.com/statsd/statsd)
+    metrics using the [OpenTelemetry Collector](../overview.md#collector).
 
 ### Concepts
 

--- a/specification/metrics/README.md
+++ b/specification/metrics/README.md
@@ -46,8 +46,6 @@ important to understand the goals of OpenTelemetry’s metrics effort:
 
 * **Working with existing metrics instrumentation protocols and standards**.
   Here is the minimum set of goals:
-  * Providing a data model that can support both cumulative and delta
-    [aggregation temporality](./data-model.md#temporality).
   * Providing full support for [Prometheus](https://prometheus.io/) - users
     should be able to use OpenTelemetry clients and
     [Collector](../overview.md#collector) to collect and export metrics, with


### PR DESCRIPTION
Fixes #4405

## Changes

Updated the metrics design goals to scope out the StatsD client support.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #4405
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
