### PR TITLE
profiles: MUST NOT use code.*

### DIFF
--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -6,5 +6,11 @@ path_base_for_github_subdir:
 
 # Profiles
 
-The Profiles signal MUST NOT use the Resource["code.*"] attributes as they
-are covered by the Profiles signal itself.
+## Attribute handling exception
+
+The resource attribute within the `code.*` namespace MUST NOT be utilized within the scope of the
+OTel profiles signal. This constraint is imposed to prevent redundancy and maintain data integrity.
+The OTel profiles signal is specifically designed to efficiently encode stacktraces and symbolization
+information, rendering the inclusion of resource attributes within the `code.*` namespace unnecessary
+and potentially duplicative. Consequently, this attribute is explicitly excluded from use within the
+context of OTel profiles.

--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -8,9 +8,9 @@ path_base_for_github_subdir:
 
 ## Attribute handling exception
 
-The resource attribute within the `code.*` namespace MUST NOT be utilized within the scope of the
+Resource attributes within the `code.*` namespace MUST NOT be utilized within the scope of the
 OTel profiles signal. This constraint is imposed to prevent redundancy and maintain data integrity.
 The OTel profiles signal is specifically designed to efficiently encode stacktraces and symbolization
 information, rendering the inclusion of resource attributes within the `code.*` namespace unnecessary
-and potentially duplicative. Consequently, this attribute is explicitly excluded from use within the
+and potentially duplicative. Consequently, this namespace is explicitly excluded from use within the
 context of OTel profiles.

--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -5,3 +5,6 @@ path_base_for_github_subdir:
 --->
 
 # Profiles
+
+The Profiles signal MUST NOT use the Resource["code.*"] attributes as they
+are covered by the Profiles signal itself.


### PR DESCRIPTION
Clarify that the Profiles signal MUST NOT use the Resource["code.*"] attributes.

FYI: @open-telemetry/profiling-maintainers 

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] ~~Related issues #~~ Result from the Profiling SIG discussion and decision on 2025-03-20
* [ ] ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps) #~~
* [ ] ~~Links to the prototypes (when adding or changing features)~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes~~ Change is considered trivial.
* [ ] ~~[`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary~~  Change does not affect compliance.
