### PR TITLE
Introduce "extended attributes" term

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ release.
   ([#4439](https://github.com/open-telemetry/opentelemetry-specification/pull/4439))
 - Document `Extended Attributes` as the recommended term for new types representing 
   extended attributes.
-  ([#TODO](https://github.com/open-telemetry/opentelemetry-specification/pull/TODO))
+  ([#4462](https://github.com/open-telemetry/opentelemetry-specification/pull/4462))
 
 ### Baggage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ release.
 
 - Add `Enabled` opt-in operation to the `LogRecordProcessor`.
   ([#4439](https://github.com/open-telemetry/opentelemetry-specification/pull/4439))
+- Document `Extended Attributes` as the recommended term for new types representing 
+  extended attributes.
+  ([#TODO](https://github.com/open-telemetry/opentelemetry-specification/pull/TODO))
 
 ### Baggage
 

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -121,7 +121,7 @@ The API MUST accept the following parameters:
 - [Severity Number](./data-model.md#field-severitynumber) (optional)
 - [Severity Text](./data-model.md#field-severitytext) (optional)
 - [Body](./data-model.md#field-body) (optional)
-- [Attributes](./data-model.md#field-attributes) (optional)
+- [Extended Attributes](./data-model.md#field-attributes) (optional)
 - **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
 
 **Status**: [Development](../document-status.md)

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -462,6 +462,9 @@ they all have the same value of `InstrumentationScope`. This field is optional.
 
 Type: [`map<string, any>`](#type-mapstring-any).
 
+Implementations that define a new type to represent extended attributes SHOULD use
+ the term `Extended Attributes`.
+
 Description: Additional information about the specific event occurrence. Unlike
 the `Resource` field, which is fixed for a particular source, `Attributes` can
 vary for each occurrence of the event coming from the same source. Can contain


### PR DESCRIPTION
## Changes

Document that `Extended Attribute`  term should be used to represent an extended set of standard attributes (if introduced by SDK).
This leaves the door open for reusing the same type on other signals and  helps to align the type name across implementations.

See Java prototype: https://github.com/open-telemetry/opentelemetry-java/pull/7123
* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
