### PR TITLE
compliance-matrix: Rust implements LogRecordProcessor.Enabled

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -203,7 +203,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | SimpleLogRecordProcessor                     |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
 | BatchLogRecordProcessor                      |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
 | Can plug custom LogRecordProcessor           |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
-| LogRecordProcessor.Enabled                   | X        | +   |      |     |        |      |        |     |      |     |      |       |
+| LogRecordProcessor.Enabled                   | X        | +   |      |     |        |      |        |     | +    |     |      |       |
 | OTLP/gRPC exporter                           |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
 | OTLP/HTTP exporter                           |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
 | OTLP File exporter                           |          |     | -    |     | -      |      |        |     |      | +   | -    |       |


### PR DESCRIPTION
Rust looks to already implement `LogRecordProcessor.Enabled`: https://github.com/open-telemetry/opentelemetry-rust/blob/b2de6cc5a3dc271fffee45f050e894fba57508ba/opentelemetry-sdk/src/logs/log_processor.rs#L61-L65

Also https://github.com/open-telemetry/opentelemetry-specification/issues/4363#issuecomment-2660164716:

> OTel Rust also has this capability. Here's an example where it is leveraged to improve performance by dropping unwanted log early.
>
> https://github.com/open-telemetry/opentelemetry-rust/blob/88cae2cf7d0ff54a042d281a0df20f096d18bf82/opentelemetry-appender-tracing/benches/logs.rs#L78-L85

CC @cijothomas @open-telemetry/rust-maintainers 

