### PR TITLE
Stabilize EventName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ release.
   ([#4439](https://github.com/open-telemetry/opentelemetry-specification/pull/4439))
 - Stabilize `Logger.Enabled`.
   ([#4463](https://github.com/open-telemetry/opentelemetry-specification/pull/4463))
+- Stabilize `EventName`.
+  ([#4475](https://github.com/open-telemetry/opentelemetry-specification/pull/4475))
 
 ### Baggage
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -199,7 +199,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | LoggerProvider.ForceFlush                    |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | Logger.Emit(LogRecord)                       |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
 | Reuse Standard Attributes                    | X        | +   |      |     |        |      |        |     |      |     |      |       |
-| LogRecord.Set EventName                      |          |     |      |     |        |      |        |     |      |     |      |       |
+| LogRecord.Set EventName                      |          | +   |      |     |        |      |        |     | +    | +   |      |       |
 | Logger.Enabled                               | X        | +   |      |     |        |      |        |     | +    | +   |      |       |
 | SimpleLogRecordProcessor                     |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
 | BatchLogRecordProcessor                      |          |     | +    |     | +      |      |        | +   |      | +   |      |       |

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -122,7 +122,7 @@ The API MUST accept the following parameters:
 - [Severity Text](./data-model.md#field-severitytext) (optional)
 - [Body](./data-model.md#field-body) (optional)
 - [Attributes](./data-model.md#field-attributes) (optional)
-- **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
+- [Event Name](./data-model.md#field-eventname) (optional)
 
 **Status**: [Development](../document-status.md)
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -1,6 +1,6 @@
 # Logs Data Model
 
-**Status**: [Stable](../document-status.md), except where otherwise specified
+**Status**: [Stable](../document-status.md)
 
 <details>
 <summary>Table of Contents</summary>
@@ -100,8 +100,6 @@ The Data Model aims to successfully represent 3 sorts of logs and events:
   application if needed.
 
 ### Events
-
-**Status**: [Development](../document-status.md)
 
 Events are OpenTelemetry's standardized format for LogRecords. All semantic
 conventions defined for logs SHOULD be formatted as Events. Requirements and details for the Event format can be found in the [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events.md).

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -209,7 +209,7 @@ Body           |The body of the log record.
 Resource       |Describes the source of the log.
 InstrumentationScope|Describes the scope that emitted the log.
 Attributes     |Additional information about the event.
-**Status**: [Development](../document-status.md) - EventName | Name that identifies the class / type of event.
+EventName      |Name that identifies the class / type of event.
 
 Below is the detailed description of each field.
 
@@ -480,8 +480,6 @@ If included, they MUST follow the OpenTelemetry
 [semantic conventions for exception-related attributes](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/exceptions/exceptions-logs.md).
 
 ### Field: `EventName`
-
-**Status**: [Development](../document-status.md)
 
 Type: string.
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -247,7 +247,7 @@ the following information added to the [LogRecord](data-model.md#log-and-event-r
 * [`TraceId`](./data-model.md#field-traceid)
 * [`SpanId`](./data-model.md#field-spanid)
 * [`TraceFlags`](./data-model.md#field-traceflags)
-* **Status**: [Development](../document-status.md) - [`EventName`](./data-model.md#field-eventname)
+* [`EventName`](./data-model.md#field-eventname)
 
 The SDK MAY provide an operation that makes a deep clone of a `ReadWriteLogRecord`.
 The operation can be used by asynchronous processors (e.g. [Batching processor](#batching-processor))


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4459

From the issue comments:

> `EventName` looks to be already supported by:
> - [Collector](https://github.com/open-telemetry/opentelemetry-collector/blob/ced2880d495cb48503d337fb8971d1cee5d2fe13/pdata/plog/generated_logrecord.go#L105-L108)
> - [Go](https://pkg.go.dev/go.opentelemetry.io/otel/log#Record.EventName)
> - [Java](https://github.com/open-telemetry/opentelemetry-java/blob/e6f90f58ce82c861f91fdf7474914ac66939b28f/sdk/logs/src/main/java/io/opentelemetry/sdk/logs/ExtendedSdkLogRecordBuilder.java#L26-L30)
> - [C++](https://github.com/open-telemetry/opentelemetry-cpp/blob/a6779d8e21c008204ea4b62affbec177f931ede9/sdk/include/opentelemetry/sdk/logs/read_write_log_record.h#L100-L104)
> - [Rust](https://github.com/open-telemetry/opentelemetry-rust/blob/297146701d483397432323c6e6cdef86e9da9999/opentelemetry/src/logs/record.rs#L10)

See also: https://github.com/open-telemetry/opentelemetry-proto/pull/643