### PR TITLE
[Logs] Add optional Event Name parameter to Logger.Enabled and LogRecordProcessor.Enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 
 ### Logs
 
+- Add optional `Event Name` parameter to `Logger.Enabled`.
+  ([#0000](https://github.com/open-telemetry/opentelemetry-specification/pull/0000))
+
 ### Baggage
 
 ### Resource

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ release.
 
 ### Logs
 
-- Add optional `Event Name` parameter to `Logger.Enabled`.
+- Add optional `Event Name` parameter to `Logger.Enabled` and `LogRecordProcessor.Enabled`.
   ([#4489](https://github.com/open-telemetry/opentelemetry-specification/pull/4489))
 
 ### Baggage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ release.
 ### Logs
 
 - Add optional `Event Name` parameter to `Logger.Enabled`.
-  ([#0000](https://github.com/open-telemetry/opentelemetry-specification/pull/0000))
+  ([#4489](https://github.com/open-telemetry/opentelemetry-specification/pull/4489))
 
 ### Baggage
 

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -143,6 +143,7 @@ The API SHOULD accept the following parameters:
   if unspecified then MUST use current Context.
   When only explicit Context is supported, accepting this parameter is REQUIRED.
 - [Severity Number](./data-model.md#field-severitynumber) (optional)
+- **Status**: [Development](../document-status.md) - [Event Name](./data-model.md#field-eventname) (optional)
 
 This API MUST return a language idiomatic boolean type. A returned value of
 `true` means the `Logger` is enabled for the provided arguments, and a returned

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -368,6 +368,7 @@ in order to support filtering via [`Logger.Enabled`](api.md#enabled).
 * [Instrumentation Scope](./data-model.md#field-instrumentationscope) associated
   with the `Logger`
 * [Severity Number](./data-model.md#field-severitynumber) passed by the caller
+* [Event Name](./data-model.md#field-eventname) passed by the caller
 
 **Returns:** `Boolean`
 


### PR DESCRIPTION
Fixes #4220

Already used by Rust; https://github.com/open-telemetry/opentelemetry-specification/issues/4220#issuecomment-2828399052: 

> Yes. Otel Rust already has [more parameters for the Enabled()](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/src/logs/logger.rs#L57) check.
> 
> We expect to use that in Etw/user_events exporters scenarios, where we ask the OSKernel about whether a given event is interesting or not. Its [currently leveraging severity ](https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/opentelemetry-user-events-logs/src/logs/exporter.rs#L391-L392) only, but we expect to leverage EventName(and scope too) in the future.

OTel Go prototype: https://github.com/open-telemetry/opentelemetry-go/pull/6702
