### PR TITLE
[API.Context] Drop reference to binary propagator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ### Context
 
+- Drop reference to binary `Propagator`.
+  ([#4490](https://github.com/open-telemetry/opentelemetry-specification/pull/4490))
+
 ### Traces
 
 ### Metrics

--- a/specification/context/api-propagators.md
+++ b/specification/context/api-propagators.md
@@ -70,8 +70,6 @@ The Propagators API currently defines one `Propagator` type:
 - `TextMapPropagator` is a type that injects values into and extracts values
   from carriers as string key/value pairs.
 
-A binary `Propagator` type will be added in the future (see [#437](https://github.com/open-telemetry/opentelemetry-specification/issues/437)).
-
 ### Carrier
 
 A carrier is the medium used by `Propagator`s to read values from and write values to.


### PR DESCRIPTION
Handles closed #437

## Changes

[API.Context] Drop reference to binary propagator.

It was closed ~year ago. No progress in couple last years. It can be added when needed. Now, it is misleading.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #437
* ~~[ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #~~
* ~~[ ] Links to the prototypes (when adding or changing features)~~
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* ~~[ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary~~
