### PR TITLE
Introduction of log SeverityNumber 0 - "UNDEFINED"

### DIFF
--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -302,7 +302,7 @@ SeverityNumber range|Range name|Meaning
 Smaller numerical values in each range represent less important (less severe)
 events. Larger numerical values in each range represent more important (more
 severe) events. For example `SeverityNumber=17` describes an error that is less
-critical than an error with `SeverityNumber=20`. The exception to this is the zero value (SeverityNumber=0), which, since it means UNDEFINED, cannot be ordered after any importance level.
+critical than an error with `SeverityNumber=20`. The exception to this is the zero value (`SeverityNumber=0`), which, since it means UNDEFINED, cannot be ordered after any importance level.
 
 #### Mapping of `SeverityNumber`
 

--- a/specification/logs/data-model.md
+++ b/specification/logs/data-model.md
@@ -291,6 +291,7 @@ defines the meaning of `SeverityNumber` value:
 
 SeverityNumber range|Range name|Meaning
 --------------------|----------|-------
+0                   |UNDEFINED |An event with unset severity.
 1-4                 |TRACE     |A fine-grained debugging event. Typically disabled in default configurations.
 5-8                 |DEBUG     |A debugging event.
 9-12                |INFO      |An informational event. Indicates that an event happened.
@@ -301,7 +302,7 @@ SeverityNumber range|Range name|Meaning
 Smaller numerical values in each range represent less important (less severe)
 events. Larger numerical values in each range represent more important (more
 severe) events. For example `SeverityNumber=17` describes an error that is less
-critical than an error with `SeverityNumber=20`.
+critical than an error with `SeverityNumber=20`. The exception to this is the zero value (SeverityNumber=0), which, since it means UNDEFINED, cannot be ordered after any importance level.
 
 #### Mapping of `SeverityNumber`
 


### PR DESCRIPTION
This PR introduces a SeverityNumber 0 with the meaning "UNDEFINED", for the cases where there is no severity defined for the log record. 

Fixes #4478

## Changes

A zero row was added to the table. The accompanying following paragraph was also added a text to highlight that the previous ordering of log events by importance according to SeverityNumber is no longer strictly valid in the case of the zero SeverityNumber. The zero severity number, as indicated in the issue #4478, does not mean that it is of less importance than, say, a DEBUG or INFO message. It just means that the severity was not defined. 