### PR TITLE
Release 1.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,6 @@ release.
 
 ### Logs
 
-- Add optional `Event Name` parameter to `Logger.Enabled` and `LogRecordProcessor.Enabled`.
-  ([#4489](https://github.com/open-telemetry/opentelemetry-specification/pull/4489))
-
 ### Baggage
 
 ### Resource
@@ -36,17 +33,27 @@ release.
 
 ### OTEPs
 
-## v1.45.0 (2025-05-07)
+## v1.45.0 (2025-05-14)
 
 ### Context
 
 - Drop reference to binary `Propagator`.
   ([#4490](https://github.com/open-telemetry/opentelemetry-specification/pull/4490))
 
+### Logs
+
+- Add optional `Event Name` parameter to `Logger.Enabled` and `LogRecordProcessor.Enabled`.
+  ([#4489](https://github.com/open-telemetry/opentelemetry-specification/pull/4489))
+
 ### Resource
 
 - Add experimental resource detector name.
   ([#4461](https://github.com/open-telemetry/opentelemetry-specification/pull/4461))
+
+### OTEPs
+
+- OTEP: Span Event API deprecation plan.
+  ([#4430](https://github.com/open-telemetry/opentelemetry-specification/pull/4430))
 
 ## v1.44.0 (2025-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ release.
 
 ### Context
 
-- Drop reference to binary `Propagator`.
-  ([#4490](https://github.com/open-telemetry/opentelemetry-specification/pull/4490))
-
 ### Traces
 
 ### Metrics
@@ -21,9 +18,6 @@ release.
 ### Baggage
 
 ### Resource
-
-- Add experimental resource detector name.
-  ([#4461](https://github.com/open-telemetry/opentelemetry-specification/pull/4461))
 
 ### Profiles
 
@@ -38,6 +32,19 @@ release.
 ### Supplementary Guidelines
 
 ### OTEPs
+
+## v1.45.0 (2025-05-07)
+
+### Context
+
+- Drop reference to binary `Propagator`.
+  ([#4490](https://github.com/open-telemetry/opentelemetry-specification/pull/4490))
+
+### Resource
+
+- Add experimental resource detector name.
+  ([#4461](https://github.com/open-telemetry/opentelemetry-specification/pull/4461))
+
 
 ## v1.44.0 (2025-04-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,6 @@ release.
 
 - Add experimental resource detector name.
   ([#4461](https://github.com/open-telemetry/opentelemetry-specification/pull/4461))
-
-
 ## v1.44.0 (2025-04-15)
 
 ### Context

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ release.
 
 - Add experimental resource detector name.
   ([#4461](https://github.com/open-telemetry/opentelemetry-specification/pull/4461))
+
 ## v1.44.0 (2025-04-15)
 
 ### Context


### PR DESCRIPTION
May 2025 Release.

### Context

- Drop reference to binary `Propagator`.
  ([#4490](https://github.com/open-telemetry/opentelemetry-specification/pull/4490))

### Logs

- Add optional `Event Name` parameter to `Logger.Enabled` and `LogRecordProcessor.Enabled`.
  ([#4489](https://github.com/open-telemetry/opentelemetry-specification/pull/4489))

### Resource

- Add experimental resource detector name.
  ([#4461](https://github.com/open-telemetry/opentelemetry-specification/pull/4461))

### OTEPs

- OTEP: Span Event API deprecation plan.
  ([#4430](https://github.com/open-telemetry/opentelemetry-specification/pull/4430))