### PR TITLE
[editorial] Fix links and switch to table markdown syntax

### DIFF
--- a/specification/entities/data-model.md
+++ b/specification/entities/data-model.md
@@ -36,63 +36,11 @@ also runs on a host, so we say that the `process` entity is related to the
 The data model below defines a logical model for an entity (irrespective of the
 physical format and encoding of how entity data is recorded).
 
-<table>
-   <tr>
-    <td><strong>Field</strong>
-    </td>
-    <td><strong>Type</strong>
-    </td>
-    <td><strong>Description</strong>
-    </td>
-   </tr>
-   <tr>
-    <td>Type
-    </td>
-    <td>string
-    </td>
-    <td>Defines the type of the entity. MUST not change during the
-lifetime of the entity. For example: "service" or "host". This field is
-required and MUST not be empty for valid entities.
-    </td>
-   </tr>
-   <tr>
-    <td>Id
-    </td>
-    <td>map&lt;string, standard attribute value&gt;
-    </td>
-    <td>Attributes that identify the entity.
-<p>
-MUST not change during the lifetime of the entity. The Id must contain
-at least one attribute.
-<p>
-Follows OpenTelemetry <a
-href="../common/README.md#standard-attribute">Standard
-attribute definition</a>. SHOULD follow OpenTelemetry <a
-href="https://github.com/open-telemetry/semantic-conventions">semantic
-conventions</a> for attributes.
-    </td>
-   </tr>
-   <tr>
-    <td>Description
-    </td>
-    <td>map&lt;string, any&gt;
-    </td>
-    <td>Descriptive (non-identifying) attributes of the entity.
-<p>
-MAY change over the lifetime of the entity. MAY be empty. These
-attributes are not part of entity's identity.
-<p>
-Follows <a
-href="../logs/data-model.md#type-any">any</a>
-value definition in the OpenTelemetry spec. Arbitrary deep nesting of values
-for arrays and maps is allowed.
-<p>
-SHOULD follow OpenTelemetry <a
-href="https://github.com/open-telemetry/semantic-conventions">semantic
-conventions</a> for attributes.
-    </td>
-   </tr>
-</table>
+| Field        | Type                                   | Description     |
+|--------------|----------------------------------------|-----------------|
+| Type         | string                                 | Defines the type of the entity. MUST not change during the lifetime of the entity. For example: "service" or "host". This field is required and MUST not be empty for valid entities. |
+| Id           | map<string, standard attribute value>  | Attributes that identify the entity.<p>MUST not change during the lifetime of the entity. The Id must contain at least one attribute.<p>Follows OpenTelemetry [Standard attribute definition](../common/README.md#standard-attribute). SHOULD follow OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions) for attributes. |
+| Description  | map<string, any>                       | Descriptive (non-identifying) attributes of the entity.<p>MAY change over the lifetime of the entity. MAY be empty. These attributes are not part of entity's identity.<p>Follows [any](../logs/data-model.md#type-any) value definition in the OpenTelemetry spec. Arbitrary deep nesting of values for arrays and maps is allowed.<p>SHOULD follow OpenTelemetry [semantic conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/README.md) for attributes. |
 
 ## Minimally Sufficient Identity
 

--- a/specification/entities/data-model.md
+++ b/specification/entities/data-model.md
@@ -66,7 +66,7 @@ MUST not change during the lifetime of the entity. The Id must contain
 at least one attribute.
 <p>
 Follows OpenTelemetry <a
-href="../../specification/common/README.md#standard-attribute">Standard
+href="../common/README.md#standard-attribute">Standard
 attribute definition</a>. SHOULD follow OpenTelemetry <a
 href="https://github.com/open-telemetry/semantic-conventions">semantic
 conventions</a> for attributes.
@@ -83,7 +83,7 @@ MAY change over the lifetime of the entity. MAY be empty. These
 attributes are not part of entity's identity.
 <p>
 Follows <a
-href="../../specification/logs/data-model.md#type-any">any</a>
+href="../logs/data-model.md#type-any">any</a>
 value definition in the OpenTelemetry spec. Arbitrary deep nesting of values
 for arrays and maps is allowed.
 <p>

--- a/specification/resource/data-model.md
+++ b/specification/resource/data-model.md
@@ -56,7 +56,7 @@ The data model below defines a logical model for an Resource (irrespective of th
 MUST not change during the lifetime of the resource.
 <p>
 Follows OpenTelemetry <a
-href="../../specification/common/README.md#standard-attribute">Standard
+href="../common/README.md#standard-attribute">Standard
 attribute definition</a>.
     </td>
    </tr>

--- a/specification/resource/data-model.md
+++ b/specification/resource/data-model.md
@@ -29,8 +29,8 @@ The data model below defines a logical model for an Resource (irrespective of th
 
 | Field      | Type     | Description     |
 |------------|----------|-----------------|
-| Entities   | set\<Entity\> | Defines the set of Entities associated with this resource.<br/><br/>[Entity is defined here](../entities/data-model.md) |
-| Attributes | map\<string, standard attribute value\> | Additional Attributes that identify the resource.<br/><br/>MUST not change during the lifetime of the resource.<br/><br/>Follows OpenTelemetry [Standard attribute definition](../common/README.md#standard-attribute). |
+| Entities   | set\<Entity\> | Defines the set of Entities associated with this resource.<p>[Entity is defined here](../entities/data-model.md) |
+| Attributes | map\<string, standard attribute value\> | Additional Attributes that identify the resource.<p>MUST not change during the lifetime of the resource.<p>Follows OpenTelemetry [Standard attribute definition](../common/README.md#standard-attribute). |
 
 ## Identity
 

--- a/specification/resource/data-model.md
+++ b/specification/resource/data-model.md
@@ -27,40 +27,10 @@ or more attributes not associated with any entity.
 
 The data model below defines a logical model for an Resource (irrespective of the physical format and encoding of how resource data is recorded).
 
-<table>
-   <tr>
-    <td><strong>Field</strong>
-    </td>
-    <td><strong>Type</strong>
-    </td>
-    <td><strong>Description</strong>
-    </td>
-   </tr>
-   <tr>
-    <td>Entities
-    </td>
-    <td>set&lt;Entity&gt;
-    </td>
-    <td>Defines the set of Entities associated with this resource.
-    <p><a href="../entities/data-model.md#entity-data-model">Entity is defined
-    here</a>
-    </td>
-   </tr>
-   <tr>
-    <td>Attributes
-    </td>
-    <td>map&lt;string, standard attribute value&gt;
-    </td>
-    <td>Additional Attributes that identify the resource.
-<p>
-MUST not change during the lifetime of the resource.
-<p>
-Follows OpenTelemetry <a
-href="../common/README.md#standard-attribute">Standard
-attribute definition</a>.
-    </td>
-   </tr>
-</table>
+| Field      | Type     | Description     |
+|------------|----------|-----------------|
+| Entities   | set\<Entity\> | Defines the set of Entities associated with this resource.<br/><br/>[Entity is defined here](../entities/data-model.md) |
+| Attributes | map\<string, standard attribute value\> | Additional Attributes that identify the resource.<br/><br/>MUST not change during the lifetime of the resource.<br/><br/>Follows OpenTelemetry [Standard attribute definition](../common/README.md#standard-attribute). |
 
 ## Identity
 

--- a/specification/trace/tracestate-probability-sampling.md
+++ b/specification/trace/tracestate-probability-sampling.md
@@ -131,7 +131,7 @@ This section defines the behavior for these two categories of samplers.
 
 See [SDK requirements for trace randomness](./sdk.md#sampling-requirements), which covers potentially inserting explicit trace randomness using the OpenTelemetry TraceState `rv` sub-key.
 
-A head Sampler is responsible for computing the `th` value in a new span's [OpenTelemetry TraceState](./tracestate-handling.md#tracestate-handling). The main inputs to that computation include the parent context's TraceState and the TraceID.
+A head Sampler is responsible for computing the `th` value in a new span's [OpenTelemetry TraceState](./tracestate-handling.md). The main inputs to that computation include the parent context's TraceState and the TraceID.
 
 When a span is sampled by in accordance with this specification, the output TraceState SHOULD be set to convey probability sampling:
 


### PR DESCRIPTION
- Converts two new HTML tables into the equivalent Markdown syntax, otherwise the link references inside the tables don't get correctly processed by Hugo
- Fixes links that break when the spec is published to the website.
  **Reminder**: don't link to spec page titles since those link targets don't exist in the published website HTML pages.

/cc @carlosalberto @jsuereth - once this get's merged, I'd like to test the OTel.io build again before you issue a release. So please let me know.