### PR TITLE
Set up merge queue

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
 
 jobs:
   markdownlint:


### PR DESCRIPTION
This will avoid the need to rebase PRs before merging them, which has been a very nice improvement in the semconv repo.

I will follow up with enabling merge queue on this repo if/when this PR is merged.