### PR TITLE
Fix Prometheus docs hyperlinks

### DIFF
--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -51,7 +51,7 @@ This document covers OpenTelemetry compatibility with various Prometheus-related
 
 Formats used for Scraping metrics (pull):
 
-* [Prometheus text exposition format](https://github.com/Prometheus/docs/blob/777846211d502a287ab2b304cb515dc779de3474/content/docs/instrumenting/exposition_formats.md)
+* [Prometheus text exposition format](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 * [Prometheus protobuf format](https://github.com/prometheus/client_model/blob/01ca24cafc7877ed5ce091083068cde086b7c3dc/io/prometheus/client/metrics.proto)
 * [OpenMetrics text format](https://github.com/prometheus/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#text-format)
 * (Not yet supported by Prometheus) [OpenMetrics protobuf format](https://github.com/prometheus/OpenMetrics/blob/1386544931307dff279688f332890c31b6c5de36/specification/OpenMetrics.md#protobuf-format)

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -311,7 +311,7 @@ NOT be supported by new implementations.
 Known values for `OTEL_METRICS_EXPORTER` are:
 
 - `"otlp"`: [OTLP](../protocol/otlp.md)
-- `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
+- `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 - `"console"`: [Standard Output](../metrics/sdk_exporters/stdout.md)
 - `"logging"`: [Standard Output](../metrics/sdk_exporters/stdout.md). It is a deprecated value left for backwards compatibility. It SHOULD
 NOT be supported by new implementations.

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -15,7 +15,7 @@ OpenTelemetry metrics MUST be converted to Prometheus metrics according to the
 A Prometheus Exporter SHOULD use
 [Prometheus client libraries](https://prometheus.io/docs/instrumenting/clientlibs/)
 for serving Prometheus metrics. This allows the prometheus client to negotiate
-the [format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md)
+the [format](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 of the response using the `Content-Type` header. If a prometheus client library
 is used, the OpenTelemetry Prometheus Exporter SHOULD be modeled as a
 [custom Collector](https://prometheus.io/docs/instrumenting/writing_clientlibs/#overall-structure)
@@ -23,7 +23,7 @@ so it can be used in conjunction with existing Prometheus instrumentation.
 
 Regardless of whether a Prometheus client library is used, the Prometheus
 Exporter MUST support version `0.0.4` of the
-[Text-based format](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-based-format).
+[Text-based format](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md#text-based-format).
 A Prometheus Exporter MAY support Exemplars and Exponential Histograms,
 which are [not currently supported by the Prometheus text format](../../compatibility/prometheus_and_openmetrics.md#differences-between-prometheus-formats),
 by supporting other Protocols, but is not required to implement them.


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/actions/runs/15411102316/job/43363085461

```
Issues found in 2 inputs. Find details below.

[home/repo/specification/metrics/sdk_exporters/prometheus.md]:
[404] https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#text-based-format | Network error: Not Found
[404] https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md | Network error: Not Found

[home/repo/specification/configuration/sdk-environment-variables.md]:
[404] https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md | Network error: Not Found
```
