### PR TITLE
[Proposal] Add Entity SIG approvers for Entity specification work.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,10 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
+# Entities SIG, will be owners for Resource + Entity specification.
+# This work will be folded into general Spec Sponsorship once complete
+/specification/resource/   @open-telemetry/technical-committee @open-telemetry/spec-sponsors @open-telemetry/specs-entities-approvers
+/specification/entity/   @open-telemetry/technical-committee @open-telemetry/spec-sponsors @open-telemetry/specs-entities-approvers
+
 # Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md 
 *   @open-telemetry/technical-committee @open-telemetry/spec-sponsors


### PR DESCRIPTION
Generally, our direction for specification sponsorship is to promote general approvers of the specification (see https://github.com/open-telemetry/opentelemetry-specification/issues/3821).

This change proposes having a set of Entity (and Resource) specification approvers from the Entities SIG.  The intention is to give the active specification work this SIG is doing a clear indication of expertise and ownership within OpenTelemetry.

The intention is that this role will be folded back into general Specification Sponsorship role once Entities has completed its work.

- Phase 1 is resource + entity work.  Approval on resource specification would be removed post Phase 1 for general spec sponsors.  At the completion of Phase 1, it is expected that this approver group can be removed and some Entity approvers may be promoted to Spec Sponsor.
- Phase 2 for entities would be a new project proposal.  If this project is accepted, we could then re-create an *entity only* approver delimination in the specification for the same reason.  


This is a proposal to give a clear signal to Specification Maintainers the approval status of PRs coming from the Entities SIG (green check marks and clear ownership of those).


## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
