### PR TITLE
Prevent stale action from applying to issues

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -13,5 +13,9 @@ jobs:
           stale-pr-message: 'This PR was marked stale due to lack of activity. It will be closed in 7 days.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'release:after-ga'
-          days-before-stale: 7
-          days-before-close: 7
+          # opt out of defaults to avoid marking issues as stale
+          days-before-stale: -1
+          days-before-close: -1
+          # overrides the above only for pull requests
+          days-before-pr-stale: 7
+          days-before-pr-close: 7


### PR DESCRIPTION
The stale action recently started applying to issues after we updated to the latest version.

The solution in this PR seems to have worked in semantic conventions repo: https://github.com/open-telemetry/semantic-conventions/pull/771