### PR TITLE
[editorial] Use canonical link into semconv

### DIFF
--- a/specification/profiles/mappings.md
+++ b/specification/profiles/mappings.md
@@ -14,7 +14,7 @@ This document defines the required attributes of [`Mapping`](../../oteps/profile
 ## Attributes
 
 A message representing a `Mapping` MUST have at least one of the following
-[process attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/process/#process-attributes):
+[process attributes](https://opentelemetry.io/docs/specs/semconv/registry/attributes/process/#process-attributes):
 
 - `process.executable.build_id.gnu`
 - `process.executable.build_id.go`


### PR DESCRIPTION
- Addresses OTel.io link-check failure reported in https://github.com/open-telemetry/opentelemetry.io/pull/6952#issuecomment-2967779704
- I'm not sure how to avoid this in the future. /cc @trask 