### PR TITLE
Define conversion of prometheus native histograms to OpenTelemetry exponential histograms

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,4 +12,5 @@ ol-prefix:
   style: ordered
 no-inline-html: false
 fenced-code-language: false
+no-duplicate-heading: false
 descriptive-link-text: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ release.
 
 - Clarify expectations about Prometheus content negotiation for metric names.
   ([#4543](https://github.com/open-telemetry/opentelemetry-specification/pull/4543))
+- Define conversion of Prometheus native histograms to OpenTelemetry exponential histograms.
+  ([#4561](https://github.com/open-telemetry/opentelemetry-specification/pull/4561))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -143,7 +143,7 @@ MUST be converted to an OTLP Exponential Histogram as follows:
 - The `NoRecordedValue` flag is set to `true` if the `Sum` is equal to the
   Stale NaN value. Otherwise,
   - `Count` is converted to Exponential Histogram `Count`.
-  - `Sum` is converted to the Exponential Histogram `Sum` if `Sum` is set.
+  - `Sum` is converted to the Exponential Histogram `Sum`.
 - `Timestamp` is converted to the Exponential Histogram `TimeUnixNano` after
   converting milliseconds to nanoseconds.
 - `ZeroCount` is converted directly to the Exponential Histogram `ZeroCount`.

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -134,8 +134,7 @@ Multiple Prometheus histogram metrics MUST be merged together into a single OTLP
 
 ### Native Histograms
 
-A [Prometheus Native Histogram](https://prometheus.io/docs/specs/native_histograms/)
-MUST be converted to an OTLP Exponential Histogram as follows:
+A [Prometheus Native Histogram](https://prometheus.io/docs/specs/native_histograms/) with standard (exponential) schema, that is schemas -4 to 8, MUST be converted to an OTLP Exponential Histogram as follows:
 
 - `Schema` is converted to the Exponential Histogram `Scale`.
 - The `NoRecordedValue` flag is set to `true` if either the `Sum` or `Count`

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -158,7 +158,9 @@ MUST be converted to an OTLP Exponential Histogram as follows:
 - `StartTimeUnixNano` is set to the `Created` timestamp, if available.
 - `AggregationTemporality` is set to `cumulative`.
 
-Native histograms of the float or gauge flavors MUST be dropped. Native Histograms with `Schema` outside of the range [-4, 8] MUST be dropped.
+Native histograms of the float or gauge flavors MUST be dropped.
+
+Native Histograms with `Schema` outside of the range [-4, 8] MUST be dropped.
 
 ### Summaries
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -156,7 +156,6 @@ MUST be converted to an OTLP Exponential Histogram as follows:
   result being that the Offset fields are different-by-one.
 - `Min` and `Max` are not set.
 - `StartTimeUnixNano` is set to the `Created` timestamp, if available.
-- `IsMonotonic` is set to `true`.
 - `AggregationTemporality` is set to `cumulative`.
 
 Native histograms of the float or gauge flavors MUST be dropped.

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -134,11 +134,14 @@ Multiple Prometheus histogram metrics MUST be merged together into a single OTLP
 
 ### Native Histograms
 
-A [Prometheus Native Histogram](https://prometheus.io/docs/specs/native_histograms/) with standard (exponential) schema, that is schemas -4 to 8, MUST be converted to an OTLP Exponential Histogram as follows:
+A [Prometheus Native Histogram](https://prometheus.io/docs/specs/native_histograms/)
+with standard (exponential) schema (i.e. schemas -4 to 8) and which are
+of the integer and counter [flavor](https://prometheus.io/docs/specs/native_histograms/#flavors)
+MUST be converted to an OTLP Exponential Histogram as follows:
 
 - `Schema` is converted to the Exponential Histogram `Scale`.
-- The `NoRecordedValue` flag is set to `true` if either the `Sum` or `Count`
-  are equal to the Stale NaN value. Otherwise,
+- The `NoRecordedValue` flag is set to `true` if the `Sum` is equal to the
+  Stale NaN value. Otherwise,
   - `Count` is converted to Exponential Histogram `Count`.
   - `Sum` is converted to the Exponential Histogram `Sum` if `Sum` is set.
 - `Timestamp` is converted to the Exponential Histogram `TimeUnixNano` after
@@ -147,12 +150,16 @@ A [Prometheus Native Histogram](https://prometheus.io/docs/specs/native_histogra
 - `ZeroThreshold`, is converted to the Exponential Histogram `ZeroThreshold`.
 - The sparse bucket layout represented by `PositiveSpans` and `PositiveDeltas` is
   converted to the Exponential Histogram dense layout represented by `Positive`
-  bucket counts and `Offset`. The same holds for `PositiveSpans` and
-  `PositiveDeltas`. Note that Prometheus Native Histograms buckets are indexed by
+  bucket counts and `Offset`. The same holds for `NegativeSpans` and
+  `NegativeDeltas`. Note that Prometheus Native Histograms buckets are indexed by
   upper boundary while Exponential Histograms are indexed by lower boundary, the
   result being that the Offset fields are different-by-one.
 - `Min` and `Max` are not set.
 - `StartTimeUnixNano` is set to the `Created` timestamp, if available.
+- `IsMonotonic` is set to `true`.
+- `AggregationTemporality` is set to `cumulative`.
+
+Native histograms of the float or gauge flavors MUST be dropped.
 
 ### Summaries
 
@@ -170,6 +177,7 @@ Multiple Prometheus metrics are merged together into a single OTLP Summary:
 The following Prometheus types MUST be dropped:
 
 * [Prometheus GaugeHistogram](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#gaugehistogram)
+* [Prometheus Native GaugeHistogram](https://prometheus.io/docs/specs/native_histograms/#gauge-histograms-vs-counter-histograms)
 
 ### Start Time
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/4494

## Changes

This conversion is the inverse of the exp -> native conversion defined here: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/compatibility/prometheus_and_openmetrics.md#exponential-histograms.

* [x] Links to the prototypes: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28663
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes

@open-telemetry/prometheus-interoperability @ywwg @krajorama