### PR TITLE
Check that opentelemetry.io links are canonical

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,6 @@ markdown-link-check:
 		-v \
 		home/repo
 
-# --max-redirects 0
-
 # This target runs markdown-toc on all files that contain
 # a comment <!-- tocstop -->.
 #


### PR DESCRIPTION
Resolves @chalin's #4554 "how to avoid this in the future"