### PR TITLE
Add context propagation guideline for SQL Server

### DIFF
--- a/supplementary-guidelines/compatibility/sql_server.md
+++ b/supplementary-guidelines/compatibility/sql_server.md
@@ -1,0 +1,34 @@
+Compatibility Considerations for SQL Server
+
+**Status**: [Development](../../specification/document-status.md)
+
+This document highlights compatibility considerations for OpenTelemetry instrumentations when interacting with SQL Server.
+
+## Context Propagation
+
+### SET CONTEXT_INFO
+
+Instrumentations MAY make use of [SET CONTEXT_INFO](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-context-info-transact-sql?view=sql-server-ver16) to add text format of [`traceparent`](https://www.w3.org/TR/trace-context/#traceparent-header) before executing a query. This is an opt-in behavior that should be explicitly enabled by the user.
+
+`SET CONTEXT_INFO` must be executed on the same physical connection as the SQL statement (or reuse its transaction).
+
+Note that `SET CONTEXT_INFO` requires binary input according to its syntax: `SET CONTEXT_INFO { binary_str | @binary_var }` and has a maximum size of 128 bytes.
+
+Example:
+
+For a query `SELECT * FROM songs` where `traceparent` is `00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01`:
+
+Run the following command on the same physical connection as the SQL statement:
+
+```sql
+-- The binary conversion may be done by the application or the driver.
+DECLARE @BinVar varbinary(55);
+SET @BinVar = CAST('00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01' AS varbinary(55));
+SET CONTEXT_INFO @BinVar; 
+```
+
+Then run the query:
+
+```sql
+SELECT * FROM songs;
+```


### PR DESCRIPTION
Part of https://github.com/open-telemetry/semantic-conventions/issues/2162, copied from https://github.com/open-telemetry/semantic-conventions/pull/2363, as the OTel spec may be the best place to host this guideline.

https://github.com/XSAM/otelsql/pull/508 is the prototype to demonstrate how `SET CONTEXT_INFO` works. You can run the example on your local Docker environment.

## Changes

It proposes a way to propagate the context for SQL Server.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary

cc @jsuereth @lmolkova 
