### PR TITLE
reduce service detector requirement for instance id

### DIFF
--- a/specification/resource/sdk.md
+++ b/specification/resource/sdk.md
@@ -165,7 +165,7 @@ reserved for built-in resource detectors published with language SDKs:
   attributes.
 * `service`: Populates `service.name` based
   on [OTEL_SERVICE_NAME](../configuration/sdk-environment-variables.md#general-sdk-configuration)
-  environment variable; populates `service.instance.id`
+  environment variable; SHOULD populate `service.instance.id`
   as [defined here](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/service.md#service-attributes).
 
 ### Specifying resource information via an environment variable


### PR DESCRIPTION
Fixes #

## Changes

The service resource detector SHOULD populate service.instance.id, however some runtimes (notably those frequently used for PHP) use a shared-nothing approach. This leads to a new instance id for each request, eg https://github.com/open-telemetry/opentelemetry-php/issues/1643
Changing the requirement from an implied MUST to SHOULD allows implementations to deviate when necessary, which I plan to do for PHP SIG.


For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
