### PR TITLE
Remove Feature Freeze from document statuses.

### DIFF
--- a/oteps/metrics/0146-metrics-prototype-scenarios.md
+++ b/oteps/metrics/0146-metrics-prototype-scenarios.md
@@ -15,7 +15,7 @@ before end of 2021:
   We might introduce additional features but there should be a high bar.
 
 * By end of 9/30/2021, we should mark the metrics API/SDK specification as
-  [`Feature-freeze`](../../specification/document-status.md#feature-freeze),
+  `Feature-freeze`,
   and focus on bug fixing or editorial changes.
 
 * By end of 11/30/2021, we want to have a stable release of metrics API/SDK

--- a/specification/baggage/api.md
+++ b/specification/baggage/api.md
@@ -1,6 +1,6 @@
 # Baggage API
 
-**Status**: [Stable, Feature-freeze](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 <details>
 <summary>Table of Contents</summary>

--- a/specification/context/README.md
+++ b/specification/context/README.md
@@ -7,7 +7,7 @@ path_base_for_github_subdir:
 
 # Context
 
-**Status**: [Stable, Feature-freeze](../document-status.md).
+**Status**: [Stable](../document-status.md).
 
 <details>
 <summary>Table of Contents</summary>

--- a/specification/document-status.md
+++ b/specification/document-status.md
@@ -24,12 +24,6 @@ The specification follows
 [OTEP 0232](../oteps/0232-maturity-of-otel.md#explanation)
 maturity level definitions.
 
-## Feature freeze
-
-In addition to the maturity levels above, documents may be marked as `Feature-freeze`. These documents are not currently accepting new feature requests, to allow the Technical Committee time to focus on other areas of the specification. Editorial changes are still accepted. Changes that address production issues with existing features are still accepted.
-
-Feature freeze is separate from a maturity level. The maturity level represents the support requirements for the document, feature freeze only indicates the current focus of the specification community. The feature freeze label may be applied to a document at any maturity level. By definition, deprecated documents have a feature freeze in place.
-
 ## Mixed
 
 Some documents have individual sections with different statuses. These documents are marked with the status `Mixed` at the top, for clarity.


### PR DESCRIPTION
Follow up to #4529 

Discussed this recently during the Specification call and there was initial agreement regarding removing Feature Freeze (and potentially restoring it if needed).

PS - embarrassed to realize we had forgotten to remove Feature freeze from the Baggage API and Context documents.