### PR TITLE
Add mTLS client key password and certificate revocation configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ release.
 
 ### OpenTelemetry Protocol
 
+- Add mTLS client key password and certificate revocation configuration options
+  for OTLP exporters. New environment variables: `OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD`,
+  `OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE`, and `OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG`
+  with corresponding per-signal variants.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
+
 ### Compatibility
 
 - Clarify expectations about Prometheus content negotiation for metric names.

--- a/oteps/assets/0225-config.yaml
+++ b/oteps/assets/0225-config.yaml
@@ -60,6 +60,18 @@ sdk:
         #
         # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE
         client_certificate: /app/cert.pem
+        # Sets the password for encrypted client private key file.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD, OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY_PASSWORD
+        client_key_password: mypassword
+        # Sets the certificate revocation mode.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE, OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_REVOCATION_MODE
+        certificate_revocation_mode: Online
+        # Sets the certificate revocation flag.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG, OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_REVOCATION_FLAG
+        certificate_revocation_flag: ExcludeRoot
         # Sets the headers.
         #
         # Environment variable: OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_TRACES_HEADERS
@@ -253,6 +265,18 @@ sdk:
         #
         # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE
         client_certificate: /app/cert.pem
+        # Sets the password for encrypted client private key file.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD, OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY_PASSWORD
+        client_key_password: mypassword
+        # Sets the certificate revocation mode.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE_REVOCATION_MODE
+        certificate_revocation_mode: Online
+        # Sets the certificate revocation flag.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG, OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE_REVOCATION_FLAG
+        certificate_revocation_flag: ExcludeRoot
         # Sets the headers.
         #
         # Environment variable: OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_METRICS_HEADERS
@@ -367,6 +391,18 @@ sdk:
         #
         # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE, OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE
         client_certificate: /app/cert.pem
+        # Sets the password for encrypted client private key file.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD, OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY_PASSWORD
+        client_key_password: mypassword
+        # Sets the certificate revocation mode.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE, OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE_REVOCATION_MODE
+        certificate_revocation_mode: Online
+        # Sets the certificate revocation flag.
+        #
+        # Environment variable: OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG, OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE_REVOCATION_FLAG
+        certificate_revocation_flag: ExcludeRoot
         # Sets the headers.
         #
         # Environment variable: OTEL_EXPORTER_OTLP_HEADERS, OTEL_EXPORTER_OTLP_LOGS_HEADERS

--- a/oteps/assets/0225-schema.json
+++ b/oteps/assets/0225-schema.json
@@ -131,6 +131,17 @@
                 "client_certificate": {
                     "type": "string"
                 },
+                "client_key_password": {
+                    "type": "string"
+                },
+                "certificate_revocation_mode": {
+                    "type": "string",
+                    "enum": ["Online", "Offline", "NoCheck"]
+                },
+                "certificate_revocation_flag": {
+                    "type": "string",
+                    "enum": ["ExcludeRoot", "EntireChain", "EndCertificateOnly"]
+                },
                 "headers": {
                     "$ref": "#/definitions/Headers"
                 },

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -53,6 +53,21 @@ Each configuration option MUST be overridable by a signal specific option.
   - Env vars: `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE` `OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE` `OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE` `OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE`
   - Type: [String][]
 
+- **Client key password**: Password for encrypted client private key file (PEM).
+  - Default: n/a
+  - Env vars: `OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD` `OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY_PASSWORD` `OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY_PASSWORD` `OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY_PASSWORD`
+  - Type: [String][]
+
+- **Certificate revocation mode**: Certificate revocation mode (`Online`, `Offline`, or `NoCheck`).
+  - Default: `Online`
+  - Env vars: `OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE` `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_REVOCATION_MODE` `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE_REVOCATION_MODE` `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE_REVOCATION_MODE`
+  - Type: [Enum][]
+
+- **Certificate revocation flag**: Certificate revocation flag (`ExcludeRoot`, `EntireChain`, or `EndCertificateOnly`).
+  - Default: `ExcludeRoot`
+  - Env vars: `OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG` `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_REVOCATION_FLAG` `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE_REVOCATION_FLAG` `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE_REVOCATION_FLAG`
+  - Type: [Enum][]
+
 - **Headers**: Key-value pairs to be used as headers associated with gRPC or HTTP requests. See [Specifying headers](./exporter.md#specifying-headers-via-environment-variables) for more details.
   - Default: n/a
   - Env vars: `OTEL_EXPORTER_OTLP_HEADERS` `OTEL_EXPORTER_OTLP_TRACES_HEADERS` `OTEL_EXPORTER_OTLP_METRICS_HEADERS` `OTEL_EXPORTER_OTLP_LOGS_HEADERS`


### PR DESCRIPTION
## Changes

This PR adds support for additional mTLS configuration options to enhance security capabilities in OTLP exporters:

### Added Configuration Options

1. **Client Key Password** (`OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD`):
   - Allows specifying a password for encrypted client private key files (PEM format)
   - Supports per-signal configuration for traces, metrics, and logs

2. **Certificate Revocation Mode** (`OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE`):
   - Configures certificate revocation checking mode with options: `Online`, `Offline`, `NoCheck`
   - Default value: `Online`
   - Supports per-signal configuration for traces, metrics, and logs

3. **Certificate Revocation Flag** (`OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG`):
   - Configures certificate revocation checking scope with options: `ExcludeRoot`, `EntireChain`, `EndCertificateOnly`
   - Default value: `ExcludeRoot`
   - Supports per-signal configuration for traces, metrics, and logs

### Motivation

These configuration options provide essential mTLS security capabilities that are commonly required in enterprise environments:

- **Password-protected private keys**: Allows using encrypted private key files for enhanced security
- **Certificate revocation checking**: Enables proper certificate validation by configuring how and when to check for revoked certificates
- **Flexible revocation scope**: Provides control over which certificates in the chain should be checked for revocation

All new environment variables follow the established OpenTelemetry naming conventions and support per-signal configuration (traces, metrics, logs) consistent with existing OTLP exporter options.

### Environment Variables Added

**General and per-signal variants:**

- `OTEL_EXPORTER_OTLP_CLIENT_KEY_PASSWORD`
- `OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY_PASSWORD`
- `OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY_PASSWORD`
- `OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY_PASSWORD`
- `OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_MODE`
- `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_REVOCATION_MODE`
- `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE_REVOCATION_MODE`
- `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE_REVOCATION_MODE`
- `OTEL_EXPORTER_OTLP_CERTIFICATE_REVOCATION_FLAG`
- `OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE_REVOCATION_FLAG`
- `OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE_REVOCATION_FLAG`
- `OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE_REVOCATION_FLAG`

### Checklist

* [x] Related issues #4580 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary (covered by existing `OTEL_EXPORTER_OTLP_*` entry)

### Breaking Changes

None. This PR only adds new optional configuration options and does not modify existing behavior.
