### PR TITLE
[Configuration SDK] Rename Config operations to SDK operations

### DIFF
--- a/specification/configuration/sdk.md
+++ b/specification/configuration/sdk.md
@@ -12,7 +12,7 @@
       - [Supported SDK extension plugins](#supported-sdk-extension-plugins)
       - [ComponentsProvider operations](#componentsprovider-operations)
         * [Create Plugin](#create-plugin)
-  * [Config operations](#config-operations)
+  * [SDK operations](#sdk-operations)
     + [Parse](#parse)
     + [Create](#create)
     + [Register ComponentProvider](#register-componentprovider)
@@ -40,7 +40,7 @@ components:
 * [SDK extension components](#sdk-extension-components) defines how users and
   libraries extend file configuration with custom SDK extension plugin
   interfaces (exporters, processors, etc).
-* [Config operations](#config-operations) defines user APIs to parse
+* [SDK operations](#sdk-operations) defines user APIs to parse
   configuration files and produce SDK components from their contents.
 
 ### In-Memory configuration model
@@ -176,7 +176,7 @@ and attempts to extract data according to its configuration schema. If this
 fails (e.g. a required property is not present, a type is mismatches, etc.),
 Create Plugin SHOULD return an error.
 
-### Config operations
+### SDK operations
 
 SDK implementations of configuration MUST provide the following operations.
 


### PR DESCRIPTION
The current term `Config operations` is very confusing. Especially that there is a `ConfigProvider` which is NOT retruning objects that have "Config operations".