### PR TITLE
feat: handling of histogram min/max in otlp to prometheus conversion

### DIFF
--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -349,7 +349,8 @@ Histogram as follows:
   and `Offset`. Note that Prometheus Native Histograms buckets are indexed by
   upper boundary while Exponential Histograms are indexed by lower boundary, the
   result being that the Offset fields are different-by-one.
-- `Min` and `Max` are not used.
+- `Min` and `Max`, if present, SHOULD be converted to two separate Prometheus Gauge
+  metrics, `{name}_min` and `{name}_max` respectively.
 - `StartTimeUnixNano` is not used.
 
 [OpenTelemetry Exponential Histogram](../metrics/data-model.md#exponentialhistogram)


### PR DESCRIPTION
Fixes #4588

## Changes

Specification how OTLP Histogram min/max should be converted to Prometheus.

Implementation: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/41255

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
