### PR TITLE
[spec] [entities] Mention entity references in the stability guarantees

### DIFF
--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -208,6 +208,9 @@ Semantic Conventions defines the set of fields in the OTLP data model:
 
 - [Resource](resource/sdk.md)
   - attribute keys. (The key section of attributes key value pairs)
+  - [Entity References](entities/data-model.md#entity-data-model)
+    - Entity type
+    - Identifier (inherits attribute key guarantees from the resource)
 - InstrumentationScope
   - Attribute keys
     - provided to [get a tracer](trace/api.md#get-a-tracer)


### PR DESCRIPTION
Since an entity’s type is part of its identity, we should define stability guarantees for it, considering that the identifying attributes are already covered by resource attribute guarantees.

Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4451