### PR TITLE
[chore] Remove implicit title anchor from versioning-and-stability.md

### DIFF
--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -208,7 +208,7 @@ Semantic Conventions defines the set of fields in the OTLP data model:
 
 - [Resource](resource/sdk.md)
   - attribute keys. (The key section of attributes key value pairs)
-  - [Entity References](entities/data-model.md#entity-data-model)
+  - [Entity References](entities/data-model.md)
     - Entity type
     - Identifier (inherits attribute key guarantees from the resource)
 - InstrumentationScope


### PR DESCRIPTION
This should fix the failing link check in the https://github.com/open-telemetry/opentelemetry.io repo:

```
docs/specs/otel/versioning-and-stability/index.html
  hash does not exist --- docs/specs/otel/versioning-and-stability/index.html --> /docs/specs/otel/entities/data-model/#entity-data-model
```
https://github.com/open-telemetry/opentelemetry.io/actions/runs/16885034448/job/47830450540