### PR TITLE
ci: Stop triage-followup workflow from running on forks

### DIFF
--- a/.github/workflows/triage-followup.yml
+++ b/.github/workflows/triage-followup.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   followup:
+    if: ${{ github.repository == 'open-telemetry/opentelemetry-specification' }}
     permissions:
       issues: write # required for adding triage labels to issues
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes

This workflow only seems relevant on the main repository. Add a condition to exclude it from forks.

This came up when I noticed this workflow failed on my fork yesterday and today.