### PR TITLE
Yamlify the spec compliance matrix

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,4 @@ For non-trivial changes, follow the [change proposal process](https://github.com
 * [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
 * [ ] Links to the prototypes (when adding or changing features)
 * [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
-* [ ] [`spec-compliance-matrix.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix.md) updated if necessary
+* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary

--- a/.github/scripts/compliance_matrix.py
+++ b/.github/scripts/compliance_matrix.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Generate spec-compliance-matrix.md from YAML files.
+"""
+
+import re
+import yaml
+from pathlib import Path
+from typing import Dict, Any, Optional, List
+
+class MarkdownGenerator:
+    def __init__(self):
+        self.template_data = None
+        self.language_data = {}
+        self.languages = []
+
+    def load_yaml_files(self, yaml_dir: Path):
+        """Load template.yaml and all language-specific YAML files."""
+        template_file = yaml_dir / 'template.yaml'
+
+        with open(template_file, 'r', encoding='utf-8') as f:
+            self.template_data = yaml.safe_load(f)
+
+        for lang_config in self.template_data['languages']:
+            lang_name = lang_config['name']
+            lang_file_path = yaml_dir / lang_config['location']
+
+            if not lang_file_path.exists():
+                raise FileNotFoundError(f"Language file {lang_file_path} not found for {lang_name}")
+
+            with open(lang_file_path, 'r', encoding='utf-8') as f:
+                self.language_data[lang_name] = yaml.safe_load(f)
+
+        self.languages = [lang['name'] for lang in self.template_data['languages']]
+
+    def update_markdown_content(self, md_file_path: Path) -> str:
+        """Update the markdown content with new tables generated from YAML data."""
+        with open(md_file_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+
+        for section in self.template_data['sections']:
+            section_name = section['name']
+            new_table = self._generate_table(section_name, section)
+            content = self._replace_section_table(content, section_name, new_table)
+
+        return content
+
+    def _generate_table(self, section_name: str, section_data: Dict[str, Any]) -> str:
+        """Generate markdown table for a section."""
+        features = section_data['features']
+        if not features:
+            raise ValueError(f"Section '{section_name}' has no features defined")
+
+        # Use section-specific languages if available, otherwise fall back to global
+        languages = section_data.get('languages', self.languages)
+        
+        has_optional_column = not section_data.get('hide_optional_column', False)
+
+        # Build header
+        header_columns = ['Feature']
+        if has_optional_column:
+            header_columns.append('Optional')
+        header_columns.extend(languages)
+
+        rows = self._create_table_header(header_columns)
+
+        # Process features
+        for feature in features:
+            if 'features' in feature:
+                # Subsection header
+                heading = feature['heading']
+                cells = [heading]
+                if has_optional_column:
+                    cells.append('Optional')
+                cells.extend(languages)
+                rows.append(self._create_table_row(cells))
+                
+                for sub_feature in feature['features']:
+                    rows.append(self._build_feature_row(sub_feature, languages, has_optional_column, section_name, heading))
+            else:
+                rows.append(self._build_feature_row(feature, languages, has_optional_column, section_name))
+
+        return '\n'.join(rows)
+
+    def _replace_section_table(self, content: str, section_name: str, new_table: str) -> str:
+        """Replace the table in a specific section."""
+        # Pattern to match a section header and its content until the next section or end
+        section_pattern = rf'(## {re.escape(section_name)}.*?\n)(.*?)(?=\n## |\Z)'
+        
+        def replace_section(match):
+            section_header = match.group(1)
+            existing_content = match.group(2)
+
+            # Pattern to match markdown tables (lines starting and ending with |)
+            table_pattern = r'\|[^\n]+\|(?:\n\|[^\n]+\|)*'
+            
+            if re.search(table_pattern, existing_content):
+                # Replace existing table
+                new_content = re.sub(table_pattern, new_table, existing_content, count=1)
+            else:
+                # Add new table if none exists
+                new_content = existing_content.rstrip() + '\n\n' + new_table + '\n'
+
+            return section_header + new_content
+
+        return re.sub(section_pattern, replace_section, content, flags=re.DOTALL)
+
+    def _build_feature_row(self, feature: Dict, languages: List[str], has_optional_column: bool, section_name: str, heading_name: str = None) -> str:
+        """Build a single feature row."""
+        cells = [feature['name']]
+        
+        if has_optional_column:
+            cells.append(self._get_optional_marker(feature))
+        
+        for lang in languages:
+            cells.append(self._get_language_status(lang, section_name, feature['name'], heading_name))
+        
+        return self._create_table_row(cells)
+
+    def _create_table_header(self, header_columns: List[str]) -> List[str]:
+        """Create markdown table header with both header row and separator row."""
+        header_row = self._create_table_row(header_columns)
+        separators = ['-' * len(col) for col in header_columns] # Sized to match header column widths
+        separator_row = self._create_table_row(separators)
+        return [header_row, separator_row]
+
+    def _create_table_row(self, cells: List[str]) -> str:
+        """Create a markdown table row from cells."""
+        joined_cells = ' | '.join(cells)
+        return f"| {joined_cells} |"
+
+    def _get_language_status(self, lang: str, section_name: str, feature_name: str, heading_name: str = None) -> str:
+        """Get the status of a feature for a specific language."""
+        lang_sections = self.language_data[lang]['sections']
+        
+        # Find the section with matching name
+        lang_section = None
+        for sect in lang_sections:
+            if sect['name'] == section_name:
+                lang_section = sect
+                break
+        
+        if lang_section:
+            status = self._find_feature_status(lang_section['features'], feature_name, heading_name)
+            return status if status is not None else ''
+
+        return ''
+
+    def _find_feature_status(self, features: List[Dict], feature_name: str, heading_name: str = None) -> Optional[str]:
+        """Search for a feature status in a flat or one-level hierarchical structure."""
+        
+        for feature in features:
+            if feature.get('name') == feature_name:
+                # Direct feature match (for top-level features or when no heading specified)
+                if heading_name is None:
+                    status = feature['status']
+                    return self._convert_status_to_symbol(status)
+            elif 'features' in feature and feature.get('heading'):
+                # This is a heading with nested features
+                if heading_name is None or feature.get('heading') == heading_name:
+                    # Search within this heading if it matches or if no specific heading required
+                    for nested_feature in feature['features']:
+                        if nested_feature.get('name') == feature_name:
+                            status = nested_feature['status']
+                            return self._convert_status_to_symbol(status)
+        
+        # If we were looking for a specific heading but didn't find it, try without heading constraint
+        if heading_name is not None:
+            return self._find_feature_status(features, feature_name, None)
+            
+        return None  # Return None when not found
+
+    def _get_optional_marker(self, feature_item: Dict) -> str:
+        """Get the optional marker for a feature."""
+        if feature_item.get('optional') is True:
+            return 'X'
+        elif feature_item.get('optional_one_of_group_is_required') is True:
+            return '*'
+        elif 'optional' in feature_item:
+            return str(feature_item['optional'])
+        return ''
+
+    def _convert_status_to_symbol(self, status) -> str:
+        """Convert status values to markdown symbols."""
+        if status == '?':
+            return ''
+        else:
+            return status
+
+def main():
+    """Main function to regenerate markdown from YAML files."""
+    # Get the repository root (3 levels up from this script)
+    repo_root = Path(__file__).parent.parent.parent
+    yaml_dir = repo_root / 'spec-compliance-matrix'
+    md_file = repo_root / 'spec-compliance-matrix.md'
+
+    generator = MarkdownGenerator()
+    generator.load_yaml_files(yaml_dir)
+    
+    # Generate the updated markdown content and write to file
+    updated_content = generator.update_markdown_content(md_file)
+    with open(md_file, 'w', encoding='utf-8') as f:
+        f.write(updated_content)
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -67,6 +67,21 @@ jobs:
     - name: validate markdown-toc
       run: git diff --exit-code ':*.md' || (echo 'Generated markdown Table of Contents is out of date, please run "make markdown-toc" and commit the changes in this PR.' && exit 1)
 
+  compliance-matrix-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: check out code
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+    - name: install dependencies
+      run: npm install
+
+    - name: run compliance-matrix
+      run: make compliance-matrix
+
+    - name: validate compliance-matrix
+      run: git diff --exit-code spec-compliance-matrix.md || (echo 'Generated compliance matrix is out of date, please run "make compliance-matrix" and commit the changes in this PR.' && exit 1)
+
   misspell:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -73,9 +73,6 @@ jobs:
     - name: check out code
       uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
-    - name: install dependencies
-      run: npm install
-
     - name: run compliance-matrix
       run: make compliance-matrix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,16 @@ To quickly fix typos, use
 make misspell-correction
 ```
 
+## Updating the Compliance Matrix
+
+To update the [compliance matrix](./spec-compliance-matrix.md), edit the
+language YAML file in `spec-compliance-matrix/` (e.g., `go.yaml`, `java.yaml`, etc.)
+and regenerate the matrix:
+
+```bash
+make compliance-matrix
+```
+
 ## Issue Triaging
 
 The following diagram shows the initial triaging of new issues.

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ fix: misspell-correction
 # Generate spec compliance matrix from YAML source
 .PHONY: compliance-matrix
 compliance-matrix:
+	pip install -U PyYAML
 	python .github/scripts/compliance_matrix.py
 	@echo "Compliance matrix generation complete"
 

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,12 @@ check: misspell markdownlint markdown-link-check
 fix: misspell-correction
 	@echo "All autofixes complete"
 
+# Generate spec compliance matrix from YAML source
+.PHONY: compliance-matrix
+compliance-matrix:
+	python .github/scripts/compliance_matrix.py
+	@echo "Compliance matrix generation complete"
+
 .PHONY: install-tools
 install-tools: $(MISSPELL)
 	npm install

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -14,275 +14,275 @@ formats is required. Implementing more than one format is optional.
 
 ## Traces
 
-| Feature                                                                                          | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|--------------------------------------------------------------------------------------------------|----------|-----|------|-----|--------|------|--------|-----|------|-----|------|-------|
-| [TracerProvider](specification/trace/api.md#tracerprovider-operations)                           | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Create TracerProvider                                                                            |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Get a Tracer                                                                                     |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Get a Tracer with schema_url                                                                     |          | +   | +    |     | +      |      |        | +   |      | +   |      |       |
-| Get a Tracer with scope attributes                                                               |          |     |      |     | +      |      |        | +   |      | +   |      |       |
-| Associate Tracer with InstrumentationScope                                                       |          |     |      |     | +      |      |        | +   |      |     |      |       |
-| Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Shutdown (SDK only required)                                                                     |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| ForceFlush (SDK only required)                                                                   |          | +   | +    | -   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Trace / Context interaction](specification/trace/api.md#context-interaction)                    | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Set active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Tracer](specification/trace/api.md#tracer-operations)                                           | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Create a new Span                                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Documentation defines adding attributes at span creation as preferred                            |          |     |      |     | +      | +    |        | +   |      |     | +    |       |
-| Get active Span                                                                                  |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Mark Span active                                                                                 |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [SpanContext](specification/trace/api.md#spancontext)                                            | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| IsValid                                                                                          |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| IsRemote                                                                                         |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Conforms to the W3C TraceContext spec                                                            |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Span](specification/trace/api.md#span)                                                          | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Create root span                                                                                 |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Create with default parent (active span)                                                         |          | N/A | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Create with parent from Context                                                                  |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| No explicit parent Span/SpanContext allowed                                                      |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | -    | +     |
-| SpanProcessor.OnStart receives parent Context                                                    |          | +   | +    | +   | +      | +    | +      | +   | +    | -   | -    | +     |
-| UpdateName                                                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| User-defined start timestamp                                                                     |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| End                                                                                              |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| End with timestamp                                                                               |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| IsRecording                                                                                      |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| IsRecording becomes false after End                                                              |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | -    | +     |
-| Set status with StatusCode (Unset, Ok, Error)                                                    |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| events collection size limit                                                                     |          | +   | +    | +   | +      | +    | +      | +   | +    | -   | -    | +     |
-| attribute collection size limit                                                                  |          | +   | +    | +   | +      | +    | +      | +   | +    | -   | -    | +     |
-| links collection size limit                                                                      |          | +   | +    | +   | +      | +    | +      | +   | +    | -   | -    | +     |
-| [SpanProcessor.OnEnding](specification/trace/sdk.md#onending)                                    | X        | -   | -    | -   | -      | -    | -      | -   | -    | -   | -    | -     |
-| [Span attributes](specification/trace/api.md#set-attributes)                                     | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| SetAttribute                                                                                     |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Set order preserved                                                                              | X        | +   | -    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| String type                                                                                      |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Boolean type                                                                                     |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Double floating-point type                                                                       |          | +   | +    | +   | +      | +    | +      | -   | +    | +   | +    | +     |
-| Signed int64 type                                                                                |          | +   | +    | +   | +      | +    | +      | -   | +    | +   | +    | +     |
-| Array of primitives (homogeneous)                                                                |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| `null` values documented as invalid/undefined                                                    |          | +   | +    | +   | +      | +    | N/A    | +   |      | +   |      | N/A   |
-| Unicode support for keys and string values                                                       |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Span linking](specification/trace/api.md#specifying-links)                                      | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Links can be recorded on span creation                                                           |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
-| Links can be recorded after span creation                                                        |          | +   |      |     | +      |      |        |     |      | +   | +    |       |
-| Links order is preserved                                                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
-| [Span events](specification/trace/api.md#add-events)                                             | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| AddEvent                                                                                         |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Add order preserved                                                                              |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| Safe for concurrent calls                                                                        |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Span exceptions](specification/trace/api.md#record-exception)                                   | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| RecordException                                                                                  |          | -   | +    | +   | +      | +    | +      | +   | +    | -   | +    | -     |
-| RecordException with extra parameters                                                            |          | -   | +    | +   | +      | +    | +      | +   | +    | -   | +    | -     |
-| [Sampling](specification/trace/sdk.md#sampling)                                                  | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Allow samplers to modify tracestate                                                              |          | +   | +    |     | +      | +    | +      | +   | +    | +   | +    | +     |
-| ShouldSample gets full parent Context                                                            |          | +   | +    | +   | +      | +    | +      | +   | +    | +   | -    | +     |
-| Sampler: JaegerRemoteSampler                                                                     |          | +   | +    |     |        |      |        |     | +    |     |      |       |
-| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |          | +   | +    |     | +      | +    | +      | +   | +    | +   | -    | +     |
-| [IdGenerators](specification/trace/sdk.md#id-generators)                                         |          | +   | +    |     | +      | +    | +      | +   | +    | +   |      | +     |
-| [SpanLimits](specification/trace/sdk.md#span-limits)                                             | X        | +   | +    |     | +      | +    | +      | +   |      | -   |      | +     |
-| [Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1) |          |     | +    |     | +      | +    | +      | +   | +    | +   | +    |       |
-| [Attribute Limits](specification/common/README.md#attribute-limits)                              | X        |     | +    |     | +      | +    | +      | +   |      |     |      |       |
-| Fetch InstrumentationScope from ReadableSpan                                                     |          |     | +    |     | +      |      |        | +   |      |     |      |       |
-| [Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)                            | X        |     |      |     |        |      |        |     |      |     |      |       |
-| [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X        |     |      |     |        |      |        |     |      |     |      |       |
-| [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)                          | X        |     |      |     |        |      |        |     |      |     |      |       |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| [TracerProvider](specification/trace/api.md#tracerprovider-operations) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Create TracerProvider |  | + | + | + | + | + | + | + | + | + | + | + |
+| Get a Tracer |  | + | + | + | + | + | + | + | + | + | + | + |
+| Get a Tracer with schema_url |  | + | + |  | + |  |  | + |  | + |  |  |
+| Get a Tracer with scope attributes |  |  |  |  | + |  |  | + |  | + |  |  |
+| Associate Tracer with InstrumentationScope |  |  |  |  | + |  |  | + |  |  |  |  |
+| Safe for concurrent calls |  | + | + | + | + | + | + | + | + | + | + | + |
+| Shutdown (SDK only required) |  | + | + | + | + | + | + | + | + | + | + | + |
+| ForceFlush (SDK only required) |  | + | + | - | + | + | + | + | + | + | + | + |
+| [Trace / Context interaction](specification/trace/api.md#context-interaction) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Get active Span |  | N/A | + | + | + | + | + | + | + | + | + | + |
+| Set active Span |  | N/A | + | + | + | + | + | + | + | + | + | + |
+| [Tracer](specification/trace/api.md#tracer-operations) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Create a new Span |  | + | + | + | + | + | + | + | + | + | + | + |
+| Documentation defines adding attributes at span creation as preferred |  |  |  |  | + | + |  | + |  |  | + |  |
+| Get active Span |  | N/A | + | + | + | + | + | + | + | + | + | + |
+| Mark Span active |  | N/A | + | + | + | + | + | + | + | + | + | + |
+| Safe for concurrent calls |  | + | + | + | + | + | + | + | + | + | + | + |
+| [SpanContext](specification/trace/api.md#spancontext) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| IsValid |  | + | + | + | + | + | + | + | + | + | + | + |
+| IsRemote |  | + | + | + | + | + | + | + | + | + | + | + |
+| Conforms to the W3C TraceContext spec |  | + | + | + | + | + | + | + | + | + | + | + |
+| [Span](specification/trace/api.md#span) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Create root span |  | + | + | + | + | + | + | + | + | + | + | + |
+| Create with default parent (active span) |  | N/A | + | + | + | + | + | + | + | + | + | + |
+| Create with parent from Context |  | + | + | + | + | + | + | + | + | + | + | + |
+| No explicit parent Span/SpanContext allowed |  | + | + | + | + | + | + | + | + | + | - | + |
+| SpanProcessor.OnStart receives parent Context |  | + | + | + | + | + | + | + | + | - | - | + |
+| UpdateName |  | + | + | + | + | + | + | + | + | + | + | + |
+| User-defined start timestamp |  | + | + | + | + | + | + | + | + | + | + | + |
+| End |  | + | + | + | + | + | + | + | + | + | + | + |
+| End with timestamp |  | + | + | + | + | + | + | + | + | + | + | + |
+| IsRecording |  | + | + | + | + | + | + | + | + | + | + | + |
+| IsRecording becomes false after End |  | + | + | + | + | + | + | + | + | + | - | + |
+| Set status with StatusCode (Unset, Ok, Error) |  | + | + | + | + | + | + | + | + | + | + | + |
+| Safe for concurrent calls |  | + | + | + | + | + | + | + | + | + | + | + |
+| events collection size limit |  | + | + | + | + | + | + | + | + | - | - | + |
+| attribute collection size limit |  | + | + | + | + | + | + | + | + | - | - | + |
+| links collection size limit |  | + | + | + | + | + | + | + | + | - | - | + |
+| [SpanProcessor.OnEnding](specification/trace/sdk.md#onending) | X | - | - | - | - | - | - | - | - | - | - | - |
+| [Span attributes](specification/trace/api.md#set-attributes) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| SetAttribute |  | + | + | + | + | + | + | + | + | + | + | + |
+| Set order preserved | X | + | - | + | + | + | + | + | + | + | + | + |
+| String type |  | + | + | + | + | + | + | + | + | + | + | + |
+| Boolean type |  | + | + | + | + | + | + | + | + | + | + | + |
+| Double floating-point type |  | + | + | + | + | + | + | - | + | + | + | + |
+| Signed int64 type |  | + | + | + | + | + | + | - | + | + | + | + |
+| Array of primitives (homogeneous) |  | + | + | + | + | + | + | + | + | + | + | + |
+| `null` values documented as invalid/undefined |  | + | + | + | + | + | N/A | + |  | + |  | N/A |
+| Unicode support for keys and string values |  | + | + | + | + | + | + | + | + | + | + | + |
+| [Span linking](specification/trace/api.md#specifying-links) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Links can be recorded on span creation |  | + | + |  | + | + | + | + | + | + | + |  |
+| Links can be recorded after span creation |  | + |  |  | + |  |  |  |  | + | + |  |
+| Links order is preserved |  | + | + |  | + | + | + | + | + | + | + |  |
+| [Span events](specification/trace/api.md#add-events) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| AddEvent |  | + | + | + | + | + | + | + | + | + | + | + |
+| Add order preserved |  | + | + | + | + | + | + | + | + | + | + | + |
+| Safe for concurrent calls |  | + | + | + | + | + | + | + | + | + | + | + |
+| [Span exceptions](specification/trace/api.md#record-exception) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| RecordException |  | - | + | + | + | + | + | + | + | - | + | - |
+| RecordException with extra parameters |  | - | + | + | + | + | + | + | + | - | + | - |
+| [Sampling](specification/trace/sdk.md#sampling) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Allow samplers to modify tracestate |  | + | + |  | + | + | + | + | + | + | + | + |
+| ShouldSample gets full parent Context |  | + | + | + | + | + | + | + | + | + | - | + |
+| Sampler: JaegerRemoteSampler |  | + | + |  |  |  |  |  | + |  |  |  |
+| [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |  | + | + |  | + | + | + | + | + | + | - | + |
+| [IdGenerators](specification/trace/sdk.md#id-generators) |  | + | + |  | + | + | + | + | + | + |  | + |
+| [SpanLimits](specification/trace/sdk.md#span-limits) | X | + | + |  | + | + | + | + |  | - |  | + |
+| [Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1) |  |  | + |  | + | + | + | + | + | + | + |  |
+| [Attribute Limits](specification/common/README.md#attribute-limits) | X |  | + |  | + | + | + | + |  |  |  |  |
+| Fetch InstrumentationScope from ReadableSpan |  |  | + |  | + |  |  | + |  |  |  |  |
+| [Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness) | X |  |  |  |  |  |  |  |  |  |  |  |
+| [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X |  |  |  |  |  |  |  |  |  |  |  |
+| [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X |  |  |  |  |  |  |  |  |  |  |  |
 
 ## Baggage
 
-| Feature                            | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
-| Basic support                      |          | +  | +    | +  | +      | +    | +      | +   | +    |  +  | +    | +     |
-| Use official header name `baggage` |          | +  | +    | +  | +      | +    | +      | +   | +    |  +  | +    | +     |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| Basic support |  | + | + | + | + | + | + | + | + | + | + | + |
+| Use official header name `baggage` |  | + | + | + | + | + | + | + | + | + | + | + |
 
 ## Metrics
 
-| Feature                                                                                                                                                                | Optional | Go | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----|------|-----|--------|------|--------|-----|------|-----|------|-------|
-| The API provides a way to set and get a global default `MeterProvider`.                                                                                                | X        | +  | +    | +   | +      |      | +      | +   |  +   | +   | -    |       |
-| It is possible to create any number of `MeterProvider`s.                                                                                                               | X        | +  | +    | +   | +      |      | +      | +   | +    | +   | +    |       |
-| `MeterProvider` provides a way to get a `Meter`.                                                                                                                       |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | -    |       |
-| `get_meter` accepts name, `version` and `schema_url`.                                                                                                                  |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | -    |       |
-| `get_meter` accepts `attributes`.                                                                                                                                      |          |    |      |     | +      |      |        | +   |  +   | +   |      |       |
-| When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.                                                                        |          | +  | +    | +   | +      |      | +      |     |  +   | +   | -    |       |
-| The fallback `Meter` `name` property keeps its original invalid value.                                                                                                 | X        | -  | -    | +   | +      |      | +      |     |  +   | -   | -    |       |
-| Associate `Meter` with `InstrumentationScope`.                                                                                                                         |          |    | +    | +   | +      |      | +      |     |  +   | +   |      |       |
-| `Counter` instrument is supported.                                                                                                                                     |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| `AsynchronousCounter` instrument is supported.                                                                                                                         |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| `Histogram` instrument is supported.                                                                                                                                   |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| `AsynchronousGauge` instrument is supported.                                                                                                                           |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| `Gauge` instrument is supported.                                                                                                                                       |          | -  | -    | -   | +      |      | -      | -   |  +   | -   | -    |       |
-| `UpDownCounter` instrument is supported.                                                                                                                               |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| `AsynchronousUpDownCounter` instrument is supported.                                                                                                                   |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| Instruments have `name`                                                                                                                                                |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| Instruments have kind.                                                                                                                                                 |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| Instruments have an optional unit of measure.                                                                                                                          |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| Instruments have an optional description.                                                                                                                              |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`.                |          |    | +    | +   | +      |      | +      |     |      |     |      |       |
-| Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.                                                             |          |    | +    |     |        |      | +      |     |      |     |      |       |
-| It is possible to register two instruments with same `name` under different `Meter`s.                                                                                  |          | +  | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| Instrument names conform to the specified syntax.                                                                                                                      |          | +  | +    | +   | +      |      | +      |     |      | +   |      |       |
-| Instrument units conform to the specified syntax.                                                                                                                      |          | -  | +    |     | +      |      | -      |     | +    | +   | +    |       |
-| Instrument descriptions conform to the specified syntax.                                                                                                               |          | -  | +    |     | -      |      | -      |     |      | -   | +    |       |
-| Instrument supports the advisory ExplicitBucketBoundaries parameter.                                                                                                   |          |    | +    |     |        |      | +      |     |      |     |      |       |
-| Instrument supports the advisory Attributes parameter.                                                                                                                 |          |    | +    |     |        |      | -      |     |      |     |      |       |
-| All methods of `MeterProvider` are safe to be called concurrently.                                                                                                     |          | +  | +    | +   | -      |      | +      |     |      | +   | +    |       |
-| All methods of `Meter` are safe to be called concurrently.                                                                                                             |          | +  | +    | +   | -      |      | +      |     |      | +   | +    |       |
-| All methods of any instrument are safe to be called concurrently.                                                                                                      |          | +  | +    | +   | -      |      | +      |     |      | +   | +    |       |
-| `MeterProvider` allows a `Resource` to be specified.                                                                                                                   |          | +  | +    | +   | +      |      |        | +   |  +   | +   | +    |       |
-| A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.                                                      |          | +  | +    | +   | +      |      |        | +   |  +   | +   | +    |       |
-| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary` instance stored in the `Meter`. |          | +  | -    |     | +      |      |        |     | +    | +   | -    |       |
-| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`.   |          |    | +    | +   | +     |      | +      | +   |  +   | +   |      |       |
-| Configuration is managed solely by the `MeterProvider`.                                                                                                                |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The `MeterProvider` provides methods to update the configuration                                                                                                       | X        | -  | -    | -   | +      |      | -      |     |      | -   | +    |       |
-| The updated configuration applies to all already returned `Meter`s.                                                                                                    | if above | -  | -    | -   | -      |      | -      |     |      | -   | +    |       |
-| There is a way to register `View`s with a `MeterProvider`.                                                                                                             |          | -  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The `View` instrument selection criteria is as specified.                                                                                                              |          |    | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The `View` instrument selection criteria supports wildcards.                                                                                                           | X        |    | +    | +   | +      |      | -      |     |  +   | +   | +    |       |
-| The `View` instrument selection criteria supports the match-all wildcard.                                                                                              |          |    | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| The name of the `View` can be specified.                                                                                                                               |          |    | +    | +   | +      |      | +      | +   |      | +   | +    |       |
-| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.                                                   |          |    | +    | +   | +      |      | +      | +   |  +   | +   | -    |       |
-| The `View` allows configuring excluded attribute keys of resulting metric stream.                                                                                      |          | +  |      |     |        |      |        |     |      |     |      |       |
-| The `View` allows configuring the exemplar reservoir of resulting metric stream.                                                                                       | X        |    | -    |     | -      |      | -      |     |      |     | -    |       |
-| The SDK allows more than one `View` to be specified per instrument.                                                                                                    | X        |    | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| The `Drop` aggregation is available.                                                                                                                                   |          | +  | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| The `Default` aggregation is available.                                                                                                                                |          | +  | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| The `Default` aggregation uses the specified aggregation by instrument.                                                                                                |          | +  | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| The `Sum` aggregation is available.                                                                                                                                    |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The `LastValue` aggregation is available.                                                                                                                              |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The `ExplicitBucketHistogram` aggregation is available.                                                                                                                |          | -  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The `ExponentialBucketHistogram` aggregation is available.                                                                                                             |          |    |      |     | +      |      |        |     |      |     | +    |       |
-| The metrics Reader implementation supports registering metric Exporters                                                                                                |          |    | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.                                                        |          |    | +    |     | +      |      | +      |     |      | -   | -    |       |
-| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.                                                        |          |    | +    | +   | +      |      | +      |     |  +   | +   |      |       |
-| The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).                                                              |          | +  | +    | +   | +      |      | +      |     |  +   | +   | +    |       |
-| The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.                                                                 |          | +  | +    | +   | -      |      | +      |     |      | +   | +    |       |
-| The metrics Exporter `export` function does not block indefinitely.                                                                                                    |          | +  | +    | +   | -      |      | +      |     |      | +   | +    |       |
-| The metrics Exporter `export` function receives a batch of metrics.                                                                                                    |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The metrics Exporter `export` function returns `Success` or `Failure`.                                                                                                 |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The metrics Exporter provides a `ForceFlush` function.                                                                                                                 |          | -  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.                                                                     |          |    | +    | +   | +      |      | +      | +   |      | +   | +    |       |
-| The metrics Exporter provides a `shutdown` function.                                                                                                                   |          | +  | +    | +   | +      |      | +      | +   |  +   | +   | +    |       |
-| The metrics Exporter `shutdown` function do not block indefinitely.                                                                                                    |          | +  | +    | +   | -      |      | +      |     |      | +   | +    |       |
-| The metrics SDK samples `Exemplar`s from measurements.                                                                                                                 |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| Exemplar sampling can be disabled.                                                                                                                                     |          |    | -    |     | -      |      | +      |     |      |     | +    |       |
-| The metrics SDK supports SDK-wide exemplar filter configuration                                                                                                        |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| The metrics SDK supports `TraceBased` exemplar filter                                                                                                                  |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| The metrics SDK supports `AlwaysOn` exemplar filter                                                                                                                    |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| The metrics SDK supports `AlwaysOff` exemplar filter                                                                                                                   |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.                                              |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken.                                                |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| Exemplars contain the timestamp when the measurement was taken.                                                                                                        |          |    | +    |     | -      |      | +      |     |      |     | +    |       |
-| The metrics SDK provides an `ExemplarReservoir` interface or extension point.                                                                                          |          |    | -    |     | -      |      | +      | +   |      |     | -    |       |
-| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.                                                |          |    | -    |     | -      |      | +      | +   |      |     | -    |       |
-| The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`.                           |          |    | +    |     | -      |      | +      | +   |      |     | -    |       |
-| The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation.                               |          |    | +    |     | -      |      | +      |     |      |     | -    |       |
-| A metric Producer accepts an optional metric Filter                                                                                                                    |          |    |      |     |        |      | -      |     |      |     |      |       |
-| The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers                                                  |          |    |      |     |        |      | -      |     |      |     |      |       |
-| The metric SDK's metric Producer implementations uses the metric Filter                                                                                                |          |    |      |     |        |      | -      |     |      |     |      |       |
-| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)                                                                           |          |    |  +   |  +   |   -    |     |        |     |  -   |  +  |   +   |       |
-| Metric SDK supports configuring cardinality limit at MeterReader level                                                                                                 |          |    |  +   |  +   |   -    |     |        |     |  -   |  -  |   -   |       |
-| Metric SDK supports configuring cardinality limit per metric (using Views)                                                                                             |          |    |  +   |  +   |   -    |     |        |     |  -   |  -  |   +   |       |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + |  | + | + | + | + | - |  |
+| It is possible to create any number of `MeterProvider`s. | X | + | + | + | + |  | + | + | + | + | + |  |
+| `MeterProvider` provides a way to get a `Meter`. |  | + | + | + | + |  | + | + | + | + | - |  |
+| `get_meter` accepts name, `version` and `schema_url`. |  | + | + | + | + |  | + | + | + | + | - |  |
+| `get_meter` accepts `attributes`. |  |  |  |  | + |  |  | + | + | + |  |  |
+| When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + |  | + |  | + | + | - |  |
+| The fallback `Meter` `name` property keeps its original invalid value. | X | - | - | + | + |  | + |  | + | - | - |  |
+| Associate `Meter` with `InstrumentationScope`. |  |  | + | + | + |  | + |  | + | + |  |  |
+| `Counter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
+| `AsynchronousCounter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
+| `Histogram` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
+| `AsynchronousGauge` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
+| `Gauge` instrument is supported. |  | - | - | - | + |  | - | - | + | - | - |  |
+| `UpDownCounter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
+| `AsynchronousUpDownCounter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
+| Instruments have `name` |  | + | + | + | + |  | + | + | + | + | + |  |
+| Instruments have kind. |  | + | + | + | + |  | + | + | + | + | + |  |
+| Instruments have an optional unit of measure. |  | + | + | + | + |  | + | + | + | + | + |  |
+| Instruments have an optional description. |  | + | + | + | + |  | + | + | + | + | + |  |
+| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  |  | + | + | + |  | + |  |  |  |  |  |
+| Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name. |  |  | + |  |  |  | + |  |  |  |  |  |
+| It is possible to register two instruments with same `name` under different `Meter`s. |  | + | + | + | + |  | + |  | + | + | + |  |
+| Instrument names conform to the specified syntax. |  | + | + | + | + |  | + |  |  | + |  |  |
+| Instrument units conform to the specified syntax. |  | - | + |  | + |  | - |  | + | + | + |  |
+| Instrument descriptions conform to the specified syntax. |  | - | + |  | - |  | - |  |  | - | + |  |
+| Instrument supports the advisory ExplicitBucketBoundaries parameter. |  |  | + |  |  |  | + |  |  |  |  |  |
+| Instrument supports the advisory Attributes parameter. |  |  | + |  |  |  | - |  |  |  |  |  |
+| All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
+| All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
+| All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
+| `MeterProvider` allows a `Resource` to be specified. |  | + | + | + | + |  |  | + | + | + | + |  |
+| A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`. |  | + | + | + | + |  |  | + | + | + | + |  |
+| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary` instance stored in the `Meter`. |  | + | - |  | + |  |  |  | + | + | - |  |
+| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`. |  |  | + | + | + |  | + | + | + | + |  |  |
+| Configuration is managed solely by the `MeterProvider`. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The `MeterProvider` provides methods to update the configuration | X | - | - | - | + |  | - |  |  | - | + |  |
+| The updated configuration applies to all already returned `Meter`s. | if above | - | - | - | - |  | - |  |  | - | + |  |
+| There is a way to register `View`s with a `MeterProvider`. |  | - | + | + | + |  | + | + | + | + | + |  |
+| The `View` instrument selection criteria is as specified. |  |  | + | + | + |  | + | + | + | + | + |  |
+| The `View` instrument selection criteria supports wildcards. | X |  | + | + | + |  | - |  | + | + | + |  |
+| The `View` instrument selection criteria supports the match-all wildcard. |  |  | + | + | + |  | + |  | + | + | + |  |
+| The name of the `View` can be specified. |  |  | + | + | + |  | + | + |  | + | + |  |
+| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  |  | + | + | + |  | + | + | + | + | - |  |
+| The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + |  |  |  |  |  |  |  |  |  |  |
+| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X |  | - |  | - |  | - |  |  |  | - |  |
+| The SDK allows more than one `View` to be specified per instrument. | X |  | + | + | + |  | + |  | + | + | + |  |
+| The `Drop` aggregation is available. |  | + | + | + | + |  | + |  | + | + | + |  |
+| The `Default` aggregation is available. |  | + | + | + | + |  | + |  | + | + | + |  |
+| The `Default` aggregation uses the specified aggregation by instrument. |  | + | + | + | + |  | + |  | + | + | + |  |
+| The `Sum` aggregation is available. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The `LastValue` aggregation is available. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The `ExplicitBucketHistogram` aggregation is available. |  | - | + | + | + |  | + | + | + | + | + |  |
+| The `ExponentialBucketHistogram` aggregation is available. |  |  |  |  | + |  |  |  |  |  | + |  |
+| The metrics Reader implementation supports registering metric Exporters |  |  | + | + | + |  | + | + | + | + | + |  |
+| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  |  | + |  | + |  | + |  |  | - | - |  |
+| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  |  | + | + | + |  | + |  | + | + |  |  |
+| The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements). |  | + | + | + | + |  | + |  | + | + | + |  |
+| The metrics Exporter `export` function can not be called concurrently from the same Exporter instance. |  | + | + | + | - |  | + |  |  | + | + |  |
+| The metrics Exporter `export` function does not block indefinitely. |  | + | + | + | - |  | + |  |  | + | + |  |
+| The metrics Exporter `export` function receives a batch of metrics. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The metrics Exporter `export` function returns `Success` or `Failure`. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The metrics Exporter provides a `ForceFlush` function. |  | - | + | + | + |  | + | + | + | + | + |  |
+| The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out. |  |  | + | + | + |  | + | + |  | + | + |  |
+| The metrics Exporter provides a `shutdown` function. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The metrics Exporter `shutdown` function do not block indefinitely. |  | + | + | + | - |  | + |  |  | + | + |  |
+| The metrics SDK samples `Exemplar`s from measurements. |  |  | + |  | - |  | + |  |  |  | + |  |
+| Exemplar sampling can be disabled. |  |  | - |  | - |  | + |  |  |  | + |  |
+| The metrics SDK supports SDK-wide exemplar filter configuration |  |  | + |  | - |  | + |  |  |  | + |  |
+| The metrics SDK supports `TraceBased` exemplar filter |  |  | + |  | - |  | + |  |  |  | + |  |
+| The metrics SDK supports `AlwaysOn` exemplar filter |  |  | + |  | - |  | + |  |  |  | + |  |
+| The metrics SDK supports `AlwaysOff` exemplar filter |  |  | + |  | - |  | + |  |  |  | + |  |
+| Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration. |  |  | + |  | - |  | + |  |  |  | + |  |
+| Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken. |  |  | + |  | - |  | + |  |  |  | + |  |
+| Exemplars contain the timestamp when the measurement was taken. |  |  | + |  | - |  | + |  |  |  | + |  |
+| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  |  | - |  | - |  | + | + |  |  | - |  |
+| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  |  | - |  | - |  | + | + |  |  | - |  |
+| The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`. |  |  | + |  | - |  | + | + |  |  | - |  |
+| The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation. |  |  | + |  | - |  | + |  |  |  | - |  |
+| A metric Producer accepts an optional metric Filter |  |  |  |  |  |  | - |  |  |  |  |  |
+| The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers |  |  |  |  |  |  | - |  |  |  |  |  |
+| The metric SDK's metric Producer implementations uses the metric Filter |  |  |  |  |  |  | - |  |  |  |  |  |
+| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits) |  |  | + | + | - |  |  |  | - | + | + |  |
+| Metric SDK supports configuring cardinality limit at MeterReader level |  |  | + | + | - |  |  |  | - | - | - |  |
+| Metric SDK supports configuring cardinality limit per metric (using Views) |  |  | + | + | - |  |  |  | - | - | + |  |
 
 ## Logs
 
 Features for the [Logging SDK](specification/logs/sdk.md).
 Disclaimer: this list of features is still a work in progress, please refer to the specification if in any doubt.
 
-| Feature                                      | Optional | Go  | Java | JS  | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|----------------------------------------------|----------|-----|------|-----|--------|------|--------|-----|------|-----|------|-------|
-| LoggerProvider.Get Logger                    |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
-| LoggerProvider.Get Logger accepts attributes |          |     |      |     | +      |      |        | +   |      | +   |      |       |
-| LoggerProvider.Shutdown                      |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
-| LoggerProvider.ForceFlush                    |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
-| Logger.Emit(LogRecord)                       |          |     | +    |     | +      |      |        | +   |      | +   | -    |       |
-| Reuse Standard Attributes                    | X        | +   |      |     |        |      |        |     |      |     |      |       |
-| LogRecord.Set EventName                      |          | +   |      |     |        |      |        |     | +    | +   |      |       |
-| Logger.Enabled                               | X        | +   |      |     |        |      |        |     | +    | +   |      |       |
-| SimpleLogRecordProcessor                     |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
-| BatchLogRecordProcessor                      |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
-| Can plug custom LogRecordProcessor           |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
-| LogRecordProcessor.Enabled                   | X        | +   |      |     |        |      |        |     | +    |     |      |       |
-| OTLP/gRPC exporter                           |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
-| OTLP/HTTP exporter                           |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
-| OTLP File exporter                           |          |     | -    |     | -      |      |        |     |      | +   | -    |       |
-| Can plug custom LogRecordExporter            |          |     | +    |     | +      |      |        | +   |      | +   |      |       |
-| Trace Context Injection                      |          |     | +    |     | +      |      |        | +   |      | +   | +    |       |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| LoggerProvider.Get Logger |  |  | + |  | + |  |  | + |  | + | - |  |
+| LoggerProvider.Get Logger accepts attributes |  |  |  |  | + |  |  | + |  | + |  |  |
+| LoggerProvider.Shutdown |  |  | + |  | + |  |  | + |  | + | - |  |
+| LoggerProvider.ForceFlush |  |  | + |  | + |  |  | + |  | + | - |  |
+| Logger.Emit(LogRecord) |  |  | + |  | + |  |  | + |  | + | - |  |
+| Reuse Standard Attributes | X | + |  |  |  |  |  |  |  |  |  |  |
+| LogRecord.Set EventName |  | + |  |  |  |  |  |  | + | + |  |  |
+| Logger.Enabled | X | + |  |  |  |  |  |  | + | + |  |  |
+| SimpleLogRecordProcessor |  |  | + |  | + |  |  | + |  | + |  |  |
+| BatchLogRecordProcessor |  |  | + |  | + |  |  | + |  | + |  |  |
+| Can plug custom LogRecordProcessor |  |  | + |  | + |  |  | + |  | + |  |  |
+| LogRecordProcessor.Enabled | X | + |  |  |  |  |  |  | + |  |  |  |
+| OTLP/gRPC exporter |  |  | + |  | + |  |  | + |  | + | + |  |
+| OTLP/HTTP exporter |  |  | + |  | + |  |  | + |  | + | + |  |
+| OTLP File exporter |  |  | - |  | - |  |  |  |  | + | - |  |
+| Can plug custom LogRecordExporter |  |  | + |  | + |  |  | + |  | + |  |  |
+| Trace Context Injection |  |  | + |  | + |  |  | + |  | + | + |  |
 
 ## Resource
 
-| Feature                                                                                                                                     | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|---------------------------------------------------------------------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
-| Create from Attributes                                                                                                                      |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Create empty                                                                                                                                |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Merge (v2)](specification/resource/sdk.md#merge)                                                                                           |          | +  | +    |    | +      | +    | +      | +   | +    | +   | +    |       |
-| Retrieve attributes                                                                                                                         |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable) for service.name |          | +  | +    |    | +      | +    | +      | +   |      | +   | +    |       |
-| [Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism                  |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| [Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)                 |          | +  | +    |    |        |      | -      | +   |      |     | -    |       |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| Create from Attributes |  | + | + | + | + | + | + | + | + | + | + | + |
+| Create empty |  | + | + | + | + | + | + | + | + | + | + | + |
+| [Merge (v2)](specification/resource/sdk.md#merge) |  | + | + |  | + | + | + | + | + | + | + |  |
+| Retrieve attributes |  | + | + | + | + | + | + | + | + | + | + | + |
+| [Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable) for service.name |  | + | + |  | + | + | + | + |  | + | + |  |
+| [Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism |  | + | + | + | + | + | + | + | + | + | + | + |
+| [Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment) |  | + | + |  |  |  | - | + |  |  | - |  |
 
 ## Context Propagation
 
-| Feature                                                                          | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|----------------------------------------------------------------------------------|----------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
-| Create Context Key                                                               |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Get value from Context                                                           |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Set value for Context                                                            |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Attach Context                                                                   |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
-| Detach Context                                                                   |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | -    | -     |
-| Get current Context                                                              |          | N/A| +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Composite Propagator                                                             |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Global Propagator                                                                |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| TraceContext Propagator                                                          |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| B3 Propagator                                                                    |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Jaeger Propagator                                                                |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | -    | +     |
-| OT Propagator                                                                    |          | +  | +    | +  | +      |      |        |     |      |     |      |       |
-| OpenCensus Binary Propagator                                                     |          | +  |      |    |        |      |        |     |      |     |      |       |
-| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |          | +  | +    |    | +      | +    |        | +   |      | +   |      |       |
-| Fields                                                                           |          | +  | +    | +  | +      | +    | +      | +   | +    | +   | +    | +     |
-| Setter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      | +   | N/A  | +   | +    | +     |
-| Getter argument                                                                  | X        | N/A| +    | +  | +      | +    | +      | +   | N/A  | +   | +    | +     |
-| Getter argument returning Keys                                                   | X        | N/A| +    | +  | +      | +    | +      | +   | N/A  | +   | -    | +     |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| Create Context Key |  | + | + | + | + | + | + | + | + | + | + | + |
+| Get value from Context |  | + | + | + | + | + | + | + | + | + | + | + |
+| Set value for Context |  | + | + | + | + | + | + | + | + | + | + | + |
+| Attach Context |  | N/A | + | + | + | + | + | + | + | + | - | - |
+| Detach Context |  | N/A | + | + | + | + | + | + | + | + | - | - |
+| Get current Context |  | N/A | + | + | + | + | + | + | + | + | + | + |
+| Composite Propagator |  | + | + | + | + | + | + | + | + | + | + | + |
+| Global Propagator |  | + | + | + | + | + | + | + | + | + | + | + |
+| TraceContext Propagator |  | + | + | + | + | + | + | + | + | + | + | + |
+| B3 Propagator |  | + | + | + | + | + | + | + | + | + | + | + |
+| Jaeger Propagator |  | + | + | + | + | + | + | + | + | + | - | + |
+| OT Propagator |  | + | + | + | + |  |  |  |  |  |  |  |
+| OpenCensus Binary Propagator |  | + |  |  |  |  |  |  |  |  |  |  |
+| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |  | + | + |  | + | + |  | + |  | + |  |  |
+| Fields |  | + | + | + | + | + | + | + | + | + | + | + |
+| Setter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + |
+| Getter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + |
+| Getter argument returning Keys | X | N/A | + | + | + | + | + | + | N/A | + | - | + |
 
 ## Environment Variables
 
 Note: Support for environment variables is optional.
 
-| Feature                                                  | Go | Java | JS | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|----------------------------------------------------------|----|------|----|-------------|------|--------|-----|------|-----|------|-------|
-| OTEL_SDK_DISABLED                                        | -  | +    | -  | +           | -    | -      | +   | -    | -   | -    | -     |
-| OTEL_RESOURCE_ATTRIBUTES                                 | +  | +    | +  | +           | +    | +      | +   | +    | +   | +    | -     |
-| OTEL_SERVICE_NAME                                        | +  | +    | +  | +           | +    | +      | +   |      | +   | +    |       |
-| OTEL_LOG_LEVEL                                           | -  | -    | +  | [-][py1059] | +    | -      | +   |      | -   | -    | -     |
-| OTEL_PROPAGATORS                                         | -  | +    |    | +           | +    | +      | +   | -    | -   | -    | -     |
-| OTEL_BSP_*                                               | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    | -     |
-| OTEL_BLRP_*                                              |    | +    |    |             |      |        |     | +    | -   | +    |       |
-| OTEL_EXPORTER_OTLP_*                                     | +  | +    |    | +           | +    | +      | +   | +    | +   | +    | -     |
-| OTEL_EXPORTER_ZIPKIN_*                                   | -  | +    |    | +           | +    | -      | +   | -    | -   | +    | -     |
-| OTEL_TRACES_EXPORTER                                     | -  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_METRICS_EXPORTER                                    | -  | +    |    | +           | -    | -      | +   | -    | -   | -    | -     |
-| OTEL_LOGS_EXPORTER                                       | -  | +    |    | +           |      |        | +   |      | -   | -    |       |
-| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT                          | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT                   | +  | +    | +  | +           | +    | +      | +   |      | -   | +    |       |
-| OTEL_SPAN_EVENT_COUNT_LIMIT                              | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_SPAN_LINK_COUNT_LIMIT                               | +  | +    | +  | +           | +    | +      | +   | +    | -   | +    |       |
-| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT                         | +  | -    |    | +           | +    | +      | +   |      | -   | +    |       |
-| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT                          | +  | -    |    | +           | +    | +      | +   |      | -   | +    |       |
-| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT                     |    |      |    |             |      |        | +   |      | -   |      |       |
-| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT              |    |      |    |             |      |        | +   |      | -   |      |       |
-| OTEL_TRACES_SAMPLER                                      | +  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_TRACES_SAMPLER_ARG                                  | +  | +    | +  | +           | +    | +      | +   | -    | -   | -    |       |
-| OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT                        | +  | +    | +  | +           | +    | -      | +   |      | -   | +    |       |
-| OTEL_ATTRIBUTE_COUNT_LIMIT                               | +  | +    | +  | +           | +    | -      | +   |      | -   | +    |       |
-| OTEL_METRIC_EXPORT_INTERVAL                              | -  | +    |    | +           |      |        | +   |      | -   | +    |       |
-| OTEL_METRIC_EXPORT_TIMEOUT                               | -  | -    |    | +           |      |        | +   |      | -   | +    |       |
-| OTEL_METRICS_EXEMPLAR_FILTER                             | -  | +    |    |             |      |        | +   |      | -   | +    |       |
-| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE        | +  | +    | +  | +           |      |        | +   |      | -   | +    |       |
-| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |    | +    |    | +           |      |        |     |      | -   |      |       |
-| OTEL_EXPERIMENTAL_CONFIG_FILE                            |    |      |    |             |      |        |     |      | -   |      |       |
+| Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| OTEL_SDK_DISABLED | - | + | - | + | - | - | + | - | - | - | - |
+| OTEL_RESOURCE_ATTRIBUTES | + | + | + | + | + | + | + | + | + | + | - |
+| OTEL_SERVICE_NAME | + | + | + | + | + | + | + |  | + | + |  |
+| OTEL_LOG_LEVEL | - | - | + | [-][py1059] | + | - | + |  | - | - | - |
+| OTEL_PROPAGATORS | - | + |  | + | + | + | + | - | - | - | - |
+| OTEL_BSP_* | + | + | + | + | + | + | + | + | - | + | - |
+| OTEL_BLRP_* |  | + |  |  |  |  |  | + | - | + |  |
+| OTEL_EXPORTER_OTLP_* | + | + |  | + | + | + | + | + | + | + | - |
+| OTEL_EXPORTER_ZIPKIN_* | - | + |  | + | + | - | + | - | - | + | - |
+| OTEL_TRACES_EXPORTER | - | + | + | + | + | + | + | - | - | - |  |
+| OTEL_METRICS_EXPORTER | - | + |  | + | - | - | + | - | - | - | - |
+| OTEL_LOGS_EXPORTER | - | + |  | + |  |  | + |  | - | - |  |
+| OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  |
+| OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | + | + | + | + | + | + |  | - | + |  |
+| OTEL_SPAN_EVENT_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  |
+| OTEL_SPAN_LINK_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  |
+| OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT | + | - |  | + | + | + | + |  | - | + |  |
+| OTEL_LINK_ATTRIBUTE_COUNT_LIMIT | + | - |  | + | + | + | + |  | - | + |  |
+| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT |  |  |  |  |  |  | + |  | - |  |  |
+| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT |  |  |  |  |  |  | + |  | - |  |  |
+| OTEL_TRACES_SAMPLER | + | + | + | + | + | + | + | - | - | - |  |
+| OTEL_TRACES_SAMPLER_ARG | + | + | + | + | + | + | + | - | - | - |  |
+| OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | + | + | + | + | - | + |  | - | + |  |
+| OTEL_ATTRIBUTE_COUNT_LIMIT | + | + | + | + | + | - | + |  | - | + |  |
+| OTEL_METRIC_EXPORT_INTERVAL | - | + |  | + |  |  | + |  | - | + |  |
+| OTEL_METRIC_EXPORT_TIMEOUT | - | - |  | + |  |  | + |  | - | + |  |
+| OTEL_METRICS_EXEMPLAR_FILTER | - | + |  |  |  |  | + |  | - | + |  |
+| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | + | + | + | + |  |  | + |  | - | + |  |
+| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |  | + |  | + |  |  |  |  | - |  |  |
+| OTEL_EXPERIMENTAL_CONFIG_FILE |  |  |  |  |  |  |  |  | - |  |  |
 
 ## Declarative configuration
 
@@ -290,109 +290,109 @@ See [declarative configuration](./specification/configuration/README.md#declarat
 for details.
 Disclaimer: Declarative configuration is currently in Development status - work in progress.
 
-| Feature                                                                                                                 | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|-------------------------------------------------------------------------------------------------------------------------|----|------|----|--------|------|--------|-----|------|-----|------|-------|
-| `Parse` a configuration file                                                                                            |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Parse` operation accepts the configuration YAML file format                                                        |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Parse` operation performs environment variable substitution                                                        |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Parse` operation returns configuration model                                                                       |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Parse` operation resolves extension component configuration to `properties`                                        |    | x    |    |        |      |        |     |      |     |      |       |
-| `Create` SDK components                                                                                                 |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Create` operation accepts configuration model                                                                      |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Create` operation returns `TracerProvider`                                                                         |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Create` operation returns `MeterProvider`                                                                          |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Create` operation returns `LoggerProvider`                                                                         |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Create` operation returns `Propagators`                                                                            |    | x    |    |        |      |        |     |      |     |      |       |
-| The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components |    | x    |    |        |      |        |     |      |     |      |       |
-| Register a `ComponentProvider`                                                                                          |    | x    |    |        |      |        |     |      |     |      |       |
+| Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| `Parse` a configuration file |  | x |  |  |  |  |  |  |  |  |  |
+| The `Parse` operation accepts the configuration YAML file format |  | x |  |  |  |  |  |  |  |  |  |
+| The `Parse` operation performs environment variable substitution |  | x |  |  |  |  |  |  |  |  |  |
+| The `Parse` operation returns configuration model |  | x |  |  |  |  |  |  |  |  |  |
+| The `Parse` operation resolves extension component configuration to `properties` |  | x |  |  |  |  |  |  |  |  |  |
+| `Create` SDK components |  | x |  |  |  |  |  |  |  |  |  |
+| The `Create` operation accepts configuration model |  | x |  |  |  |  |  |  |  |  |  |
+| The `Create` operation returns `TracerProvider` |  | x |  |  |  |  |  |  |  |  |  |
+| The `Create` operation returns `MeterProvider` |  | x |  |  |  |  |  |  |  |  |  |
+| The `Create` operation returns `LoggerProvider` |  | x |  |  |  |  |  |  |  |  |  |
+| The `Create` operation returns `Propagators` |  | x |  |  |  |  |  |  |  |  |  |
+| The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components |  | x |  |  |  |  |  |  |  |  |  |
+| Register a `ComponentProvider` |  | x |  |  |  |  |  |  |  |  |  |
 
 ## Exporters
 
-| Feature                                                                                                                                                                  | Optional | Go  | Java | JS | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----|------|----|-------------|------|--------|-----|------|-----|------|-------|
-| [Exporter interface](specification/trace/sdk.md#span-exporter)                                                                                                           |          |     | +    |    | +           | +    | +      | +   | +    | +   | +    |       |
-| [Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)                                                                                           |          |     | +    |    | +           | +    | +      | +   | -    |     | +    |       |
-| Standard output (logging)                                                                                                                                                |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| In-memory (mock exporter)                                                                                                                                                |          | +   | +    | +  | +           | +    | +      | +   | -    | +   | +    | +     |
-| **[OTLP](specification/protocol/otlp.md)**                                                                                                                               | Optional | Go  | Java | JS | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| OTLP/gRPC Exporter                                                                                                                                                       | *        | +   | +    | +  | +           |      | +      | +   | +    | +   | +    | +     |
-| OTLP/HTTP binary Protobuf Exporter                                                                                                                                       | *        | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | -     |
-| OTLP/HTTP JSON Protobuf Exporter                                                                                                                                         |          | +   | -    | +  | [-][py1003] |      | -      | +   |      | +   | -    | -     |
-| OTLP/HTTP gzip Content-Encoding support                                                                                                                                  | X        | +   | +    | +  | +           | +    | -      | +   |      | -   | -    | -     |
-| Concurrent sending                                                                                                                                                       |          | -   | +    | +  | [-][py1108] |      | -      |     | +    | -   | -    | -     |
-| Honors retryable responses with backoff                                                                                                                                  | X        | +   | -    | +  | +           | +    | -      |     |      | -   | -    | -     |
-| Honors non-retryable responses                                                                                                                                           | X        | +   | -    | -  | +           | +    | -      |     |      | -   | -    | -     |
-| Honors throttling response                                                                                                                                               | X        | +   | -    | -  | +           | +    | -      |     |      | -   | -    | -     |
-| Multi-destination spec compliance                                                                                                                                        | X        | +   | -    |    | [-][py1109] |      | -      |     |      | -   | -    | -     |
-| SchemaURL in ResourceSpans and ScopeSpans                                                                                                                                |          | +   | +    |    | +           |      | +      | +   |      |     | -    |       |
-| SchemaURL in ResourceMetrics and ScopeMetrics                                                                                                                            |          |     | +    |    | +           |      | -      | +   |      |     | -    |       |
-| SchemaURL in ResourceLogs and ScopeLogs                                                                                                                                  |          |     | +    |    | +           |      | -      | +   |      |     | -    |       |
-| Honors the [user agent spec](specification/protocol/exporter.md#user-agent)                                                                                              |          |     |      |    |             |      |        | +   |      |     | +    |       |
-| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC   | X        | +   |      |    |             |      |        | +   |      |     |      |       |
-| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X        | +   |      |    |             |      |        | +   |      |     |      |       |
-| Metric Exporter configurable temporality preference                                                                                                                      |          |     | +    |    | +           |      |        |     |      |     |      |       |
-| Metric Exporter configurable default aggregation                                                                                                                         |          |     | +    |    | +           |      |        |     |      |     |      |       |
-| **[Zipkin](specification/trace/sdk_exporters/zipkin.md)**                                                                                                                | Optional | Go  | Java | JS | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| Zipkin V1 JSON                                                                                                                                                           | X        | -   | +    |    | +           | -    | -      | -   | -    | -   | -    | -     |
-| Zipkin V1 Thrift                                                                                                                                                         | X        | -   | +    |    | [-][py1174] | -    | -      | -   | -    | -   | -    | -     |
-| Zipkin V2 JSON                                                                                                                                                           | *        | +   | +    |    | +           | +    | -      | +   | +    | +   | +    | +     |
-| Zipkin V2 Protobuf                                                                                                                                                       | *        | -   | +    |    | +           | -    | +      | -   | -    | -   | -    | -     |
-| Service name mapping                                                                                                                                                     |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| SpanKind mapping                                                                                                                                                         |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| InstrumentationLibrary mapping                                                                                                                                           |          | +   | +    | -  | +           | +    | -      | +   | +    | +   | +    | +     |
-| InstrumentationScope mapping                                                                                                                                             |          |     | +    |    |             |      |        |     |      |     |      |       |
-| Boolean attributes                                                                                                                                                       |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| Array attributes                                                                                                                                                         |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| Status mapping                                                                                                                                                           |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| Error Status mapping                                                                                                                                                     |          | +   | +    |    | +           | +    | -      | +   | +    | +   | +    | -     |
-| Event attributes mapping to Annotations                                                                                                                                  |          | +   | +    | +  | +           | +    | +      | +   | +    | +   | +    | +     |
-| Integer microseconds in timestamps                                                                                                                                       |          | N/A | +    |    | +           | +    | -      | +   | +    | +   | +    | +     |
-| **Prometheus**                                                                                                                                                           | Optional | Go  | Java | JS | Python      | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| [Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                    |          | +   | +    | -  | -           | -    | -      | -   | +    | -   | -    | -     |
-| [Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                         |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | +     |
-| [UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                             | X        | -   | -    | +  | +           | -    | -      | -   | -    | -   | +    | -     |
-| [Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                             | X        | +   | +    | -  | +           | -    | -      | -   | +    | +   | +    | -     |
-| [Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                           | X        | +   | +    | -  | -           | -    | -      | -   | +    | -   | -    | -     |
-| [HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                             |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | +     |
-| [TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)                                                                             |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | +     |
-| [otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)                        |          | +   | +    | -  | -           | -    | -      | -   | +    | -   | -    | -     |
-| [otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)                                        |          | +   | -    | -  | -           | -    | -      | -   | -    | -   | -    | -     |
-| [otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)                                                   | X        | +   | -    | -  | -           | -    | -      | -   | +    | -   | -    | -     |
-| [Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)                                                                    |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | -     |
-| [Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)                                                   |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | +     |
-| [Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)                                                      |          | +   | +    | +  | +           | -    | -      | -   | +    | -   | -    | -     |
-| [Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)                                                   | X        | +   | -    | -  | -           | -    | -      | -   | -    | -   | -    | -     |
-| [Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)                                                 |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | -     |
-| [Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)                                         | X        | -   | -    | -  | -           | -    | -      | -   | -    | -   | -    | -     |
-| [Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)                                             |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | +     |
-| [Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)                                       | X        | -   | -    | -  | -           | -    | -      | -   | -    | -   | -    | -     |
-| [Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)                                                             |          | +   | +    | +  | +           | -    | -      | -   | +    | +   | +    | +     |
-| [Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)                                             |          | +   | +    | -  | -           | -    | -      | -   | +    | -   | -    | -     |
-| [Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)                                                     | X        | -   | -    | -  | -           | -    | -      | -   | -    | -   | -    | -     |
-| [`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)                                                    | X        | +   | +    | +  | +           | -    | -      | -   | +    | -   | -    | -     |
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| [Exporter interface](specification/trace/sdk.md#span-exporter) |  |  | + |  | + | + | + | + | + | + | + |  |
+| [Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2) |  |  | + |  | + | + | + | + | - |  | + |  |
+| Standard output (logging) |  | + | + | + | + | + | + | + | + | + | + | + |
+| In-memory (mock exporter) |  | + | + | + | + | + | + | + | - | + | + | + |
+| **[OTLP](specification/protocol/otlp.md)** | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| OTLP/gRPC Exporter | * | + | + | + | + |  | + | + | + | + | + | + |
+| OTLP/HTTP binary Protobuf Exporter | * | + | + | + | + | + | + | + | + | + | + | - |
+| OTLP/HTTP JSON Protobuf Exporter |  | + | - | + | [-][py1003] |  | - | + |  | + | - | - |
+| OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | - | - |
+| Concurrent sending |  | - | + | + | [-][py1108] |  | - |  | + | - | - | - |
+| Honors retryable responses with backoff | X | + | - | + | + | + | - |  |  | - | - | - |
+| Honors non-retryable responses | X | + | - | - | + | + | - |  |  | - | - | - |
+| Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - |
+| Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - |
+| SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | - |  |
+| SchemaURL in ResourceMetrics and ScopeMetrics |  |  | + |  | + |  | - | + |  |  | - |  |
+| SchemaURL in ResourceLogs and ScopeLogs |  |  | + |  | + |  | - | + |  |  | - |  |
+| Honors the [user agent spec](specification/protocol/exporter.md#user-agent) |  |  |  |  |  |  |  | + |  |  | + |  |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC | X | + |  |  |  |  |  | + |  |  |  |  |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X | + |  |  |  |  |  | + |  |  |  |  |
+| Metric Exporter configurable temporality preference |  |  | + |  | + |  |  |  |  |  |  |  |
+| Metric Exporter configurable default aggregation |  |  | + |  | + |  |  |  |  |  |  |  |
+| **[Zipkin](specification/trace/sdk_exporters/zipkin.md)** | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| Zipkin V1 JSON | X | - | + |  | + | - | - | - | - | - | - | - |
+| Zipkin V1 Thrift | X | - | + |  | [-][py1174] | - | - | - | - | - | - | - |
+| Zipkin V2 JSON | * | + | + |  | + | + | - | + | + | + | + | + |
+| Zipkin V2 Protobuf | * | - | + |  | + | - | + | - | - | - | - | - |
+| Service name mapping |  | + | + | + | + | + | + | + | + | + | + | + |
+| SpanKind mapping |  | + | + | + | + | + | + | + | + | + | + | + |
+| InstrumentationLibrary mapping |  | + | + | - | + | + | - | + | + | + | + | + |
+| InstrumentationScope mapping |  |  | + |  |  |  |  |  |  |  |  |  |
+| Boolean attributes |  | + | + | + | + | + | + | + | + | + | + | + |
+| Array attributes |  | + | + | + | + | + | + | + | + | + | + | + |
+| Status mapping |  | + | + | + | + | + | + | + | + | + | + | + |
+| Error Status mapping |  | + | + |  | + | + | - | + | + | + | + | - |
+| Event attributes mapping to Annotations |  | + | + | + | + | + | + | + | + | + | + | + |
+| Integer microseconds in timestamps |  | N/A | + |  | + | + | - | + | + | + | + | + |
+| **Prometheus** | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| [Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | - | - | - | - | - | + | - | - | - |
+| [Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | + | + | - | - | - | + | + | + | + |
+| [UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) | X | - | - | + | + | - | - | - | - | - | + | - |
+| [Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) | X | + | + | - | + | - | - | - | + | + | + | - |
+| [Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) | X | + | + | - | - | - | - | - | + | - | - | - |
+| [HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | + | + | - | - | - | + | + | + | + |
+| [TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | + | + | - | - | - | + | + | + | + |
+| [otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) |  | + | + | - | - | - | - | - | + | - | - | - |
+| [otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) |  | + | - | - | - | - | - | - | - | - | - | - |
+| [otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) | X | + | - | - | - | - | - | - | + | - | - | - |
+| [Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1) |  | + | + | + | + | - | - | - | + | + | + | - |
+| [Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | + | + | + |
+| [Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | - | - | - |
+| [Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums) | X | + | - | - | - | - | - | - | - | - | - | - |
+| [Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | + | + | - |
+| [Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums) | X | - | - | - | - | - | - | - | - | - | - | - |
+| [Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1) |  | + | + | + | + | - | - | - | + | + | + | + |
+| [Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1) | X | - | - | - | - | - | - | - | - | - | - | - |
+| [Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes) |  | + | + | + | + | - | - | - | + | + | + | + |
+| [Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes) |  | + | + | - | - | - | - | - | + | - | - | - |
+| [Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1) | X | - | - | - | - | - | - | - | - | - | - | - |
+| [`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1) | X | + | + | + | + | - | - | - | + | - | - | - |
 
 ## OpenCensus Compatibility
 
 Languages not covered by the OpenCensus project, or that did not reach Alpha, are not listed here.
 
-| Feature                                                                                                 |Go |Java|JS |Python|C++|.NET|Erlang|
-|---------------------------------------------------------------------------------------------------------|---|----|---|------|----|---|----|
-| [Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)   |  + |  +  | +  |   +   |  -  | -  |  -  |
-| [Metric Bridge](specification/compatibility/opencensus.md#metrics--stats) |  + |  +  | -  |   -   |  -  | -  |  -  |
+| Feature | Go | Java | JS | Python | C++ | .NET | Erlang |
+| ------- | -- | ---- | -- | ------ | --- | ---- | ------ |
+| [Trace Bridge](specification/compatibility/opencensus.md#trace-bridge) | + | + | + | + | - | - | - |
+| [Metric Bridge](specification/compatibility/opencensus.md#metrics--stats) | + | + | - | - | - | - | - |
 
 ## OpenTracing Compatibility
 
 Languages not covered by the OpenTracing project do not need to be listed here, e.g. Erlang.
 
-| Feature                                                                                                 |Go |Java|JS |Python|Ruby|PHP|Rust|C++|.NET|Swift|
-|---------------------------------------------------------------------------------------------------------|---|----|---|------|----|---|----|---|----|-----|
-| [Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim) |   |    |   |      |    | + |    |   |    |     |
-| [Tracer](specification/compatibility/opentracing.md#tracer-shim)                                        |   |    |   |      |    | + |    |   |    |     |
-| [Span](specification/compatibility/opentracing.md#span-shim)                                            |   |    |   |      |    | + |    |   |    |     |
-| [SpanContext](specification/compatibility/opentracing.md#spancontext-shim)                              |   |    |   |      |    | + |    |   |    |     |
-| [ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)                            |   |    |   |      |    | + |    |   |    |     |
-| Error mapping for attributes/events                                                                     |   |    |   |      |    | + |    |   |    |     |
-| Migration to OpenTelemetry guide                                                                        |   |    |   |      |    |   |    |   |    |     |
+| Feature | Go | Java | JS | Python | Ruby | PHP | Rust | C++ | .NET | Swift |
+| ------- | -- | ---- | -- | ------ | ---- | --- | ---- | --- | ---- | ----- |
+| [Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim) |  |  |  |  |  | + |  |  |  |  |
+| [Tracer](specification/compatibility/opentracing.md#tracer-shim) |  |  |  |  |  | + |  |  |  |  |
+| [Span](specification/compatibility/opentracing.md#span-shim) |  |  |  |  |  | + |  |  |  |  |
+| [SpanContext](specification/compatibility/opentracing.md#spancontext-shim) |  |  |  |  |  | + |  |  |  |  |
+| [ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim) |  |  |  |  |  | + |  |  |  |  |
+| Error mapping for attributes/events |  |  |  |  |  | + |  |  |  |  |
+| Migration to OpenTelemetry guide |  |  |  |  |  |  |  |  |  |  |
 
 [py1003]: https://github.com/open-telemetry/opentelemetry-python/issues/1003
 [py1059]: https://github.com/open-telemetry/opentelemetry-python/issues/1059

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -1,0 +1,677 @@
+# Implementation status for C++
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '+'
+          - name: Get a Tracer with scope attributes
+            status: '+'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '-'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '-'
+          - name: attribute collection size limit
+            status: '-'
+          - name: links collection size limit
+            status: '-'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '+'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '-'
+          - name: RecordException with extra parameters
+            status: '-'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '-'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '?'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '+'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '-'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '+'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '+'
+      - name: Instrument units conform to the specified syntax.
+        status: '+'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '-'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '+'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '-'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '-'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '+'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '-'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '+'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '+'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '+'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '?'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '?'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '?'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '+'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '-'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '-'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '+'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '+'
+      - name: LoggerProvider.Shutdown
+        status: '+'
+      - name: LoggerProvider.ForceFlush
+        status: '+'
+      - name: Logger.Emit(LogRecord)
+        status: '+'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '+'
+      - name: Logger.Enabled
+        status: '+'
+      - name: SimpleLogRecordProcessor
+        status: '+'
+      - name: BatchLogRecordProcessor
+        status: '+'
+      - name: Can plug custom LogRecordProcessor
+        status: '+'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '+'
+      - name: OTLP/HTTP exporter
+        status: '+'
+      - name: OTLP File exporter
+        status: '+'
+      - name: Can plug custom LogRecordExporter
+        status: '+'
+      - name: Trace Context Injection
+        status: '+'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '?'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '+'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '-'
+      - name: OTEL_PROPAGATORS
+        status: '-'
+      - name: OTEL_BSP_*
+        status: '-'
+      - name: OTEL_BLRP_*
+        status: '-'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '-'
+      - name: OTEL_TRACES_EXPORTER
+        status: '-'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '-'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '-'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '-'
+      - name: OTEL_TRACES_SAMPLER
+        status: '-'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '-'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '-'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '-'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '-'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '-'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '-'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '-'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '-'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '?'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '-'
+          - name: Concurrent sending
+            status: '-'
+          - name: Honors retryable responses with backoff
+            status: '-'
+          - name: Honors non-retryable responses
+            status: '-'
+          - name: Honors throttling response
+            status: '-'
+          - name: Multi-destination spec compliance
+            status: '-'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '?'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '?'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '?'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '-'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '-'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '-'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -1,0 +1,677 @@
+# Implementation status for .NET
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '?'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '+'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '-'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '-'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '-'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '-'
+          - name: attribute collection size limit
+            status: '-'
+          - name: links collection size limit
+            status: '-'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '?'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '+'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '-'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '-'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '?'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '?'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '?'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '-'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '-'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '-'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '-'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '-'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '?'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '?'
+      - name: Instrument units conform to the specified syntax.
+        status: '+'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '+'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '+'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '-'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '?'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '+'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '+'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '+'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '-'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '-'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '-'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '+'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '+'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '+'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '+'
+      - name: Exemplar sampling can be disabled.
+        status: '+'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '+'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '+'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '+'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '+'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '+'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '+'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '+'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '-'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '-'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '-'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '-'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '+'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '-'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '+'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '-'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '-'
+      - name: LoggerProvider.ForceFlush
+        status: '-'
+      - name: Logger.Emit(LogRecord)
+        status: '-'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '+'
+      - name: OTLP/HTTP exporter
+        status: '+'
+      - name: OTLP File exporter
+        status: '-'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '+'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '-'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '-'
+      - name: Detach Context
+        status: '-'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '-'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '?'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '-'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '-'
+      - name: OTEL_PROPAGATORS
+        status: '-'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '+'
+      - name: OTEL_TRACES_EXPORTER
+        status: '-'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '-'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '-'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '-'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '+'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '+'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '-'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '-'
+          - name: Concurrent sending
+            status: '-'
+          - name: Honors retryable responses with backoff
+            status: '-'
+          - name: Honors non-retryable responses
+            status: '-'
+          - name: Honors throttling response
+            status: '-'
+          - name: Multi-destination spec compliance
+            status: '-'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '-'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '-'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '-'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '+'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '-'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '-'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '-'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Erlang/Elixir
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '?'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: 'N/A'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '+'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '+'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '+'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '+'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '+'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '+'
+      - name: Instrument units conform to the specified syntax.
+        status: '-'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '-'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '+'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '-'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '+'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '?'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '-'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '-'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '-'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '-'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '+'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '+'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '+'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '+'
+      - name: Exemplar sampling can be disabled.
+        status: '+'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '+'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '+'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '+'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '+'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '+'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '+'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '+'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '+'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '+'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '+'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '+'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '-'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '-'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '-'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '?'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '?'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '?'
+      - name: LoggerProvider.ForceFlush
+        status: '?'
+      - name: Logger.Emit(LogRecord)
+        status: '?'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '?'
+      - name: OTLP/HTTP exporter
+        status: '?'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '?'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '-'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '?'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '-'
+      - name: OTEL_PROPAGATORS
+        status: '+'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '-'
+      - name: OTEL_TRACES_EXPORTER
+        status: '+'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '?'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '-'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '?'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '+'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '-'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '-'
+          - name: Concurrent sending
+            status: '-'
+          - name: Honors retryable responses with backoff
+            status: '-'
+          - name: Honors non-retryable responses
+            status: '-'
+          - name: Honors throttling response
+            status: '-'
+          - name: Multi-destination spec compliance
+            status: '-'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '+'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '-'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '-'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '-'
+          - name: Zipkin V2 Protobuf
+            status: '+'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '-'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '-'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '-'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '-'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '-'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '-'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '-'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Go
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '+'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: 'N/A'
+          - name: Set active Span
+            status: 'N/A'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: 'N/A'
+          - name: Mark Span active
+            status: 'N/A'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: 'N/A'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '+'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '-'
+          - name: RecordException with extra parameters
+            status: '-'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '+'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '?'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '?'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '-'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '?'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '+'
+      - name: Instrument units conform to the specified syntax.
+        status: '-'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '-'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '+'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '?'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '-'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '-'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '-'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '?'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '?'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '?'
+      - name: The name of the `View` can be specified.
+        status: '?'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '?'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '-'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '+'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '+'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '-'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '?'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '+'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '?'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '?'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '?'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '?'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '?'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '?'
+      - name: LoggerProvider.ForceFlush
+        status: '?'
+      - name: Logger.Emit(LogRecord)
+        status: '?'
+      - name: Reuse Standard Attributes
+        status: '+'
+      - name: LogRecord.Set EventName
+        status: '+'
+      - name: Logger.Enabled
+        status: '+'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '+'
+      - name: OTLP/gRPC exporter
+        status: '?'
+      - name: OTLP/HTTP exporter
+        status: '?'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '?'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '+'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: 'N/A'
+      - name: Detach Context
+        status: 'N/A'
+      - name: Get current Context
+        status: 'N/A'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '+'
+      - name: OpenCensus Binary Propagator
+        status: '+'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '+'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: 'N/A'
+      - name: Getter argument
+        status: 'N/A'
+      - name: Getter argument returning Keys
+        status: 'N/A'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '-'
+      - name: OTEL_PROPAGATORS
+        status: '-'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '-'
+      - name: OTEL_TRACES_EXPORTER
+        status: '-'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '-'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '-'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '-'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '-'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '?'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '?'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '+'
+          - name: Concurrent sending
+            status: '-'
+          - name: Honors retryable responses with backoff
+            status: '+'
+          - name: Honors non-retryable responses
+            status: '+'
+          - name: Honors throttling response
+            status: '+'
+          - name: Multi-destination spec compliance
+            status: '+'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '+'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '?'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '?'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '+'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '+'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: 'N/A'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '+'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '+'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '+'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '+'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '+'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '+'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Java
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '+'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '-'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '+'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '+'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '+'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '-'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '+'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '+'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '+'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '+'
+      - name: Instrument units conform to the specified syntax.
+        status: '+'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '+'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '+'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '+'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '+'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '-'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '-'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '-'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '+'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '-'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '+'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '+'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '+'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '+'
+      - name: Exemplar sampling can be disabled.
+        status: '-'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '+'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '+'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '+'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '+'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '+'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '+'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '+'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '-'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '-'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '+'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '+'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '+'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '+'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '+'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '+'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '+'
+      - name: LoggerProvider.ForceFlush
+        status: '+'
+      - name: Logger.Emit(LogRecord)
+        status: '+'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '+'
+      - name: BatchLogRecordProcessor
+        status: '+'
+      - name: Can plug custom LogRecordProcessor
+        status: '+'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '+'
+      - name: OTLP/HTTP exporter
+        status: '+'
+      - name: OTLP File exporter
+        status: '-'
+      - name: Can plug custom LogRecordExporter
+        status: '+'
+      - name: Trace Context Injection
+        status: '+'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '+'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '+'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '+'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '+'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '-'
+      - name: OTEL_PROPAGATORS
+        status: '+'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '+'
+      - name: OTEL_TRACES_EXPORTER
+        status: '+'
+      - name: OTEL_METRICS_EXPORTER
+        status: '+'
+      - name: OTEL_LOGS_EXPORTER
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '-'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '-'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '+'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: x
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: x
+      - name: The `Parse` operation performs environment variable substitution
+        status: x
+      - name: The `Parse` operation returns configuration model
+        status: x
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: x
+      - name: '`Create` SDK components'
+        status: x
+      - name: The `Create` operation accepts configuration model
+        status: x
+      - name: The `Create` operation returns `TracerProvider`
+        status: x
+      - name: The `Create` operation returns `MeterProvider`
+        status: x
+      - name: The `Create` operation returns `LoggerProvider`
+        status: x
+      - name: The `Create` operation returns `Propagators`
+        status: x
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: x
+      - name: Register a `ComponentProvider`
+        status: x
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '+'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '-'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '+'
+          - name: Concurrent sending
+            status: '+'
+          - name: Honors retryable responses with backoff
+            status: '-'
+          - name: Honors non-retryable responses
+            status: '-'
+          - name: Honors throttling response
+            status: '-'
+          - name: Multi-destination spec compliance
+            status: '-'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '+'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '+'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '+'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '+'
+          - name: Metric Exporter configurable default aggregation
+            status: '+'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '+'
+          - name: Zipkin V1 Thrift
+            status: '+'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '+'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '+'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '+'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '+'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '+'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '+'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -1,0 +1,677 @@
+# Implementation status for JavaScript
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '?'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '-'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '?'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '?'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '?'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '?'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '?'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '?'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '?'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '?'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '+'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '+'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '+'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '+'
+      - name: Instrument units conform to the specified syntax.
+        status: '?'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '?'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '+'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '+'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '-'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '-'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '+'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '+'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '+'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '+'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '?'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '?'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '?'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '+'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '+'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '+'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '?'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '?'
+      - name: LoggerProvider.ForceFlush
+        status: '?'
+      - name: Logger.Emit(LogRecord)
+        status: '?'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '?'
+      - name: OTLP/HTTP exporter
+        status: '?'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '?'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '?'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '?'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '?'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '+'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '?'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '+'
+      - name: OTEL_PROPAGATORS
+        status: '?'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '?'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '?'
+      - name: OTEL_TRACES_EXPORTER
+        status: '+'
+      - name: OTEL_METRICS_EXPORTER
+        status: '?'
+      - name: OTEL_LOGS_EXPORTER
+        status: '?'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '?'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '?'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '?'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '+'
+          - name: Concurrent sending
+            status: '+'
+          - name: Honors retryable responses with backoff
+            status: '+'
+          - name: Honors non-retryable responses
+            status: '-'
+          - name: Honors throttling response
+            status: '-'
+          - name: Multi-destination spec compliance
+            status: '?'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '?'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '?'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '?'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '?'
+          - name: Zipkin V1 Thrift
+            status: '?'
+          - name: Zipkin V2 JSON
+            status: '?'
+          - name: Zipkin V2 Protobuf
+            status: '?'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '-'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '?'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '?'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '+'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '+'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '-'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -1,0 +1,677 @@
+# Implementation status for PHP
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '+'
+          - name: Get a Tracer with scope attributes
+            status: '+'
+          - name: Associate Tracer with InstrumentationScope
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '+'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '-'
+          - name: Signed int64 type
+            status: '-'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '+'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '+'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '+'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '?'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '?'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '?'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '-'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '?'
+      - name: Instrument names conform to the specified syntax.
+        status: '?'
+      - name: Instrument units conform to the specified syntax.
+        status: '?'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '?'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '?'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '?'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '?'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '?'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '?'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '?'
+      - name: The `Drop` aggregation is available.
+        status: '?'
+      - name: The `Default` aggregation is available.
+        status: '?'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '?'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '?'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '?'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '?'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '?'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '+'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '+'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '+'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '?'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '+'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '+'
+      - name: LoggerProvider.Shutdown
+        status: '+'
+      - name: LoggerProvider.ForceFlush
+        status: '+'
+      - name: Logger.Emit(LogRecord)
+        status: '+'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '+'
+      - name: BatchLogRecordProcessor
+        status: '+'
+      - name: Can plug custom LogRecordProcessor
+        status: '+'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '+'
+      - name: OTLP/HTTP exporter
+        status: '+'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '+'
+      - name: Trace Context Injection
+        status: '+'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '+'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '+'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '+'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '+'
+      - name: OTEL_PROPAGATORS
+        status: '+'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '+'
+      - name: OTEL_TRACES_EXPORTER
+        status: '+'
+      - name: OTEL_METRICS_EXPORTER
+        status: '+'
+      - name: OTEL_LOGS_EXPORTER
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '+'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '+'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '+'
+          - name: Concurrent sending
+            status: '?'
+          - name: Honors retryable responses with backoff
+            status: '?'
+          - name: Honors non-retryable responses
+            status: '?'
+          - name: Honors throttling response
+            status: '?'
+          - name: Multi-destination spec compliance
+            status: '?'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '+'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '+'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '+'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '+'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '+'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '+'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '-'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '-'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '?'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '?'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '+'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '+'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '+'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '+'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '+'
+      - name: Error mapping for attributes/events
+        status: '+'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Python
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '+'
+          - name: Get a Tracer with scope attributes
+            status: '+'
+          - name: Associate Tracer with InstrumentationScope
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '+'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '+'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '+'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '+'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '+'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '+'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '+'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '+'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '+'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '+'
+      - name: Instrument units conform to the specified syntax.
+        status: '+'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '-'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '-'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '-'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '-'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '+'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '-'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '+'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '+'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '-'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '-'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '-'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '+'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '-'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '-'
+      - name: Exemplar sampling can be disabled.
+        status: '-'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '-'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '-'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '-'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '-'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '-'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '-'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '-'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '-'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '-'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '-'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '-'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '-'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '-'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '-'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '+'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '+'
+      - name: LoggerProvider.Shutdown
+        status: '+'
+      - name: LoggerProvider.ForceFlush
+        status: '+'
+      - name: Logger.Emit(LogRecord)
+        status: '+'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '+'
+      - name: BatchLogRecordProcessor
+        status: '+'
+      - name: Can plug custom LogRecordProcessor
+        status: '+'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '+'
+      - name: OTLP/HTTP exporter
+        status: '+'
+      - name: OTLP File exporter
+        status: '-'
+      - name: Can plug custom LogRecordExporter
+        status: '+'
+      - name: Trace Context Injection
+        status: '+'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '?'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '+'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '+'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '+'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '[-][py1059]'
+      - name: OTEL_PROPAGATORS
+        status: '+'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '+'
+      - name: OTEL_TRACES_EXPORTER
+        status: '+'
+      - name: OTEL_METRICS_EXPORTER
+        status: '+'
+      - name: OTEL_LOGS_EXPORTER
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '+'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '+'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '+'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '[-][py1003]'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '+'
+          - name: Concurrent sending
+            status: '[-][py1108]'
+          - name: Honors retryable responses with backoff
+            status: '+'
+          - name: Honors non-retryable responses
+            status: '+'
+          - name: Honors throttling response
+            status: '+'
+          - name: Multi-destination spec compliance
+            status: '[-][py1109]'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '+'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '+'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '+'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '+'
+          - name: Metric Exporter configurable default aggregation
+            status: '+'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '+'
+          - name: Zipkin V1 Thrift
+            status: '[-][py1174]'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '+'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '+'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '+'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '-'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Ruby
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '?'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '+'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '+'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '+'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '?'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '?'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '?'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '?'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '?'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '?'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '?'
+      - name: '`Counter` instrument is supported.'
+        status: '?'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '?'
+      - name: '`Histogram` instrument is supported.'
+        status: '?'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '?'
+      - name: '`Gauge` instrument is supported.'
+        status: '?'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '?'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '?'
+      - name: Instruments have `name`
+        status: '?'
+      - name: Instruments have kind.
+        status: '?'
+      - name: Instruments have an optional unit of measure.
+        status: '?'
+      - name: Instruments have an optional description.
+        status: '?'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '?'
+      - name: Instrument names conform to the specified syntax.
+        status: '?'
+      - name: Instrument units conform to the specified syntax.
+        status: '?'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '?'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '?'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '?'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '?'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '?'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '?'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '?'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '?'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '?'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '?'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '?'
+      - name: The name of the `View` can be specified.
+        status: '?'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '?'
+      - name: The `Drop` aggregation is available.
+        status: '?'
+      - name: The `Default` aggregation is available.
+        status: '?'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '?'
+      - name: The `Sum` aggregation is available.
+        status: '?'
+      - name: The `LastValue` aggregation is available.
+        status: '?'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '?'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '?'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '?'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '?'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '?'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '?'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '?'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '?'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '?'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '?'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '?'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '?'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '?'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '?'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '?'
+      - name: LoggerProvider.ForceFlush
+        status: '?'
+      - name: Logger.Emit(LogRecord)
+        status: '?'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '?'
+      - name: OTLP/HTTP exporter
+        status: '?'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '?'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '+'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '?'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '+'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '+'
+      - name: OTEL_LOG_LEVEL
+        status: '+'
+      - name: OTEL_PROPAGATORS
+        status: '+'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '+'
+      - name: OTEL_TRACES_EXPORTER
+        status: '+'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '?'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '+'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '+'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '+'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '?'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '+'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '?'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '?'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '+'
+          - name: Concurrent sending
+            status: '?'
+          - name: Honors retryable responses with backoff
+            status: '+'
+          - name: Honors non-retryable responses
+            status: '+'
+          - name: Honors throttling response
+            status: '+'
+          - name: Multi-destination spec compliance
+            status: '?'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '?'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '?'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '?'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '-'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '-'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '?'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '?'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Rust
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '?'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: '?'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '+'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '+'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '+'
+          - name: RecordException with extra parameters
+            status: '+'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '+'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '?'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '+'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '?'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '+'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '+'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '+'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '+'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '+'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '+'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '+'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '+'
+      - name: '`Counter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '+'
+      - name: '`Histogram` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '+'
+      - name: '`Gauge` instrument is supported.'
+        status: '+'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '+'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '+'
+      - name: Instruments have `name`
+        status: '+'
+      - name: Instruments have kind.
+        status: '+'
+      - name: Instruments have an optional unit of measure.
+        status: '+'
+      - name: Instruments have an optional description.
+        status: '+'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '+'
+      - name: Instrument names conform to the specified syntax.
+        status: '?'
+      - name: Instrument units conform to the specified syntax.
+        status: '+'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '?'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '?'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '+'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '+'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '+'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '+'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '?'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '?'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '+'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '+'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '+'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '+'
+      - name: The name of the `View` can be specified.
+        status: '?'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '+'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '+'
+      - name: The `Drop` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation is available.
+        status: '+'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '+'
+      - name: The `Sum` aggregation is available.
+        status: '+'
+      - name: The `LastValue` aggregation is available.
+        status: '+'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '+'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '+'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '+'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '+'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '?'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '?'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '+'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '+'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '+'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '?'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '+'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '?'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '?'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '?'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '?'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '-'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '-'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '-'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '?'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '?'
+      - name: LoggerProvider.ForceFlush
+        status: '?'
+      - name: Logger.Emit(LogRecord)
+        status: '?'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '+'
+      - name: Logger.Enabled
+        status: '+'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '+'
+      - name: OTLP/gRPC exporter
+        status: '?'
+      - name: OTLP/HTTP exporter
+        status: '?'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '?'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '+'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '?'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '?'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '+'
+      - name: Detach Context
+        status: '+'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '?'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: 'N/A'
+      - name: Getter argument
+        status: 'N/A'
+      - name: Getter argument returning Keys
+        status: 'N/A'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '+'
+      - name: OTEL_SERVICE_NAME
+        status: '?'
+      - name: OTEL_LOG_LEVEL
+        status: '?'
+      - name: OTEL_PROPAGATORS
+        status: '-'
+      - name: OTEL_BSP_*
+        status: '+'
+      - name: OTEL_BLRP_*
+        status: '+'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '+'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '-'
+      - name: OTEL_TRACES_EXPORTER
+        status: '-'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '?'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '+'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '-'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '-'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '?'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '+'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '-'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '-'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '+'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '?'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '?'
+          - name: Concurrent sending
+            status: '+'
+          - name: Honors retryable responses with backoff
+            status: '?'
+          - name: Honors non-retryable responses
+            status: '?'
+          - name: Honors throttling response
+            status: '?'
+          - name: Multi-destination spec compliance
+            status: '?'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '?'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '?'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '?'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '+'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '+'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '+'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '+'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '+'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '?'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '?'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -1,0 +1,677 @@
+# Implementation status for Swift
+#
+# Legend:
+#   '+'     Implemented
+#   '-'     Not implemented
+#   '?'     Unknown
+#   'N/A'   Not applicable to this language
+#
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+            status: '+'
+          - name: Get a Tracer
+            status: '+'
+          - name: Get a Tracer with schema_url
+            status: '?'
+          - name: Get a Tracer with scope attributes
+            status: '?'
+          - name: Associate Tracer with InstrumentationScope
+            status: '?'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: Shutdown (SDK only required)
+            status: '+'
+          - name: ForceFlush (SDK only required)
+            status: '+'
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+            status: '+'
+          - name: Set active Span
+            status: '+'
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+            status: '+'
+          - name: Documentation defines adding attributes at span creation as preferred
+            status: '?'
+          - name: Get active Span
+            status: '+'
+          - name: Mark Span active
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+            status: '+'
+          - name: IsRemote
+            status: '+'
+          - name: Conforms to the W3C TraceContext spec
+            status: '+'
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+            status: '+'
+          - name: Create with default parent (active span)
+            status: '+'
+          - name: Create with parent from Context
+            status: '+'
+          - name: No explicit parent Span/SpanContext allowed
+            status: '+'
+          - name: SpanProcessor.OnStart receives parent Context
+            status: '+'
+          - name: UpdateName
+            status: '+'
+          - name: User-defined start timestamp
+            status: '+'
+          - name: End
+            status: '+'
+          - name: End with timestamp
+            status: '+'
+          - name: IsRecording
+            status: '+'
+          - name: IsRecording becomes false after End
+            status: '+'
+          - name: Set status with StatusCode (Unset, Ok, Error)
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+          - name: events collection size limit
+            status: '+'
+          - name: attribute collection size limit
+            status: '+'
+          - name: links collection size limit
+            status: '+'
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            status: '-'
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+            status: '+'
+          - name: Set order preserved
+            status: '+'
+          - name: String type
+            status: '+'
+          - name: Boolean type
+            status: '+'
+          - name: Double floating-point type
+            status: '+'
+          - name: Signed int64 type
+            status: '+'
+          - name: Array of primitives (homogeneous)
+            status: '+'
+          - name: '`null` values documented as invalid/undefined'
+            status: 'N/A'
+          - name: Unicode support for keys and string values
+            status: '+'
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+            status: '?'
+          - name: Links can be recorded after span creation
+            status: '?'
+          - name: Links order is preserved
+            status: '?'
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+            status: '+'
+          - name: Add order preserved
+            status: '+'
+          - name: Safe for concurrent calls
+            status: '+'
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+            status: '-'
+          - name: RecordException with extra parameters
+            status: '-'
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+            status: '+'
+          - name: ShouldSample gets full parent Context
+            status: '+'
+          - name: 'Sampler: JaegerRemoteSampler'
+            status: '?'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+            status: '+'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+            status: '+'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            status: '+'
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+            status: '?'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            status: '?'
+          - name: Fetch InstrumentationScope from ReadableSpan
+            status: '?'
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            status: '?'
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            status: '?'
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            status: '?'
+  - name: Baggage
+    features:
+      - name: Basic support
+        status: '+'
+      - name: Use official header name `baggage`
+        status: '+'
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        status: '?'
+      - name: It is possible to create any number of `MeterProvider`s.
+        status: '?'
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+        status: '?'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+        status: '?'
+      - name: '`get_meter` accepts `attributes`.'
+        status: '?'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+        status: '?'
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        status: '?'
+      - name: Associate `Meter` with `InstrumentationScope`.
+        status: '?'
+      - name: '`Counter` instrument is supported.'
+        status: '?'
+      - name: '`AsynchronousCounter` instrument is supported.'
+        status: '?'
+      - name: '`Histogram` instrument is supported.'
+        status: '?'
+      - name: '`AsynchronousGauge` instrument is supported.'
+        status: '?'
+      - name: '`Gauge` instrument is supported.'
+        status: '?'
+      - name: '`UpDownCounter` instrument is supported.'
+        status: '?'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+        status: '?'
+      - name: Instruments have `name`
+        status: '?'
+      - name: Instruments have kind.
+        status: '?'
+      - name: Instruments have an optional unit of measure.
+        status: '?'
+      - name: Instruments have an optional description.
+        status: '?'
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+        status: '?'
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+        status: '?'
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+        status: '?'
+      - name: Instrument names conform to the specified syntax.
+        status: '?'
+      - name: Instrument units conform to the specified syntax.
+        status: '?'
+      - name: Instrument descriptions conform to the specified syntax.
+        status: '?'
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+        status: '?'
+      - name: Instrument supports the advisory Attributes parameter.
+        status: '?'
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of `Meter` are safe to be called concurrently.
+        status: '?'
+      - name: All methods of any instrument are safe to be called concurrently.
+        status: '?'
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+        status: '?'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+        status: '?'
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+        status: '?'
+      - name: Configuration is managed solely by the `MeterProvider`.
+        status: '?'
+      - name: The `MeterProvider` provides methods to update the configuration
+        status: '?'
+      - name: The updated configuration applies to all already returned `Meter`s.
+        status: '?'
+      - name: There is a way to register `View`s with a `MeterProvider`.
+        status: '?'
+      - name: The `View` instrument selection criteria is as specified.
+        status: '?'
+      - name: The `View` instrument selection criteria supports wildcards.
+        status: '?'
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+        status: '?'
+      - name: The name of the `View` can be specified.
+        status: '?'
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+        status: '?'
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        status: '?'
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        status: '?'
+      - name: The `Drop` aggregation is available.
+        status: '?'
+      - name: The `Default` aggregation is available.
+        status: '?'
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+        status: '?'
+      - name: The `Sum` aggregation is available.
+        status: '?'
+      - name: The `LastValue` aggregation is available.
+        status: '?'
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+        status: '?'
+      - name: The metrics Reader implementation supports registering metric Exporters
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+        status: '?'
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+        status: '?'
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+        status: '?'
+      - name: The metrics Exporter `export` function does not block indefinitely.
+        status: '?'
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+        status: '?'
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+        status: '?'
+      - name: The metrics Exporter provides a `ForceFlush` function.
+        status: '?'
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+        status: '?'
+      - name: The metrics Exporter provides a `shutdown` function.
+        status: '?'
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+        status: '?'
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+        status: '?'
+      - name: Exemplar sampling can be disabled.
+        status: '?'
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+        status: '?'
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+        status: '?'
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+        status: '?'
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+        status: '?'
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+        status: '?'
+      - name: Exemplars contain the timestamp when the measurement was taken.
+        status: '?'
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+        status: '?'
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+        status: '?'
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+        status: '?'
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+        status: '?'
+      - name: A metric Producer accepts an optional metric Filter
+        status: '?'
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+        status: '?'
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+        status: '?'
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+        status: '?'
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+        status: '?'
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+        status: '?'
+      - name: LoggerProvider.Get Logger accepts attributes
+        status: '?'
+      - name: LoggerProvider.Shutdown
+        status: '?'
+      - name: LoggerProvider.ForceFlush
+        status: '?'
+      - name: Logger.Emit(LogRecord)
+        status: '?'
+      - name: Reuse Standard Attributes
+        status: '?'
+      - name: LogRecord.Set EventName
+        status: '?'
+      - name: Logger.Enabled
+        status: '?'
+      - name: SimpleLogRecordProcessor
+        status: '?'
+      - name: BatchLogRecordProcessor
+        status: '?'
+      - name: Can plug custom LogRecordProcessor
+        status: '?'
+      - name: LogRecordProcessor.Enabled
+        status: '?'
+      - name: OTLP/gRPC exporter
+        status: '?'
+      - name: OTLP/HTTP exporter
+        status: '?'
+      - name: OTLP File exporter
+        status: '?'
+      - name: Can plug custom LogRecordExporter
+        status: '?'
+      - name: Trace Context Injection
+        status: '?'
+  - name: Resource
+    features:
+      - name: Create from Attributes
+        status: '+'
+      - name: Create empty
+        status: '+'
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+        status: '?'
+      - name: Retrieve attributes
+        status: '+'
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+        status: '?'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+        status: '+'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+        status: '?'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+        status: '+'
+      - name: Get value from Context
+        status: '+'
+      - name: Set value for Context
+        status: '+'
+      - name: Attach Context
+        status: '-'
+      - name: Detach Context
+        status: '-'
+      - name: Get current Context
+        status: '+'
+      - name: Composite Propagator
+        status: '+'
+      - name: Global Propagator
+        status: '+'
+      - name: TraceContext Propagator
+        status: '+'
+      - name: B3 Propagator
+        status: '+'
+      - name: Jaeger Propagator
+        status: '+'
+      - name: OT Propagator
+        status: '?'
+      - name: OpenCensus Binary Propagator
+        status: '?'
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+        status: '?'
+      - name: Fields
+        status: '+'
+      - name: Setter argument
+        status: '+'
+      - name: Getter argument
+        status: '+'
+      - name: Getter argument returning Keys
+        status: '+'
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+        status: '-'
+      - name: OTEL_RESOURCE_ATTRIBUTES
+        status: '-'
+      - name: OTEL_SERVICE_NAME
+        status: '?'
+      - name: OTEL_LOG_LEVEL
+        status: '-'
+      - name: OTEL_PROPAGATORS
+        status: '-'
+      - name: OTEL_BSP_*
+        status: '-'
+      - name: OTEL_BLRP_*
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_*
+        status: '-'
+      - name: OTEL_EXPORTER_ZIPKIN_*
+        status: '-'
+      - name: OTEL_TRACES_EXPORTER
+        status: '?'
+      - name: OTEL_METRICS_EXPORTER
+        status: '-'
+      - name: OTEL_LOGS_EXPORTER
+        status: '?'
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER
+        status: '?'
+      - name: OTEL_TRACES_SAMPLER_ARG
+        status: '?'
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+        status: '?'
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+        status: '?'
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+        status: '?'
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+        status: '?'
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+        status: '?'
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+        status: '?'
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+        status: '?'
+      - name: The `Parse` operation accepts the configuration YAML file format
+        status: '?'
+      - name: The `Parse` operation performs environment variable substitution
+        status: '?'
+      - name: The `Parse` operation returns configuration model
+        status: '?'
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+        status: '?'
+      - name: '`Create` SDK components'
+        status: '?'
+      - name: The `Create` operation accepts configuration model
+        status: '?'
+      - name: The `Create` operation returns `TracerProvider`
+        status: '?'
+      - name: The `Create` operation returns `MeterProvider`
+        status: '?'
+      - name: The `Create` operation returns `LoggerProvider`
+        status: '?'
+      - name: The `Create` operation returns `Propagators`
+        status: '?'
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+        status: '?'
+      - name: Register a `ComponentProvider`
+        status: '?'
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+        status: '?'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+        status: '?'
+      - name: Standard output (logging)
+        status: '+'
+      - name: In-memory (mock exporter)
+        status: '+'
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            status: '+'
+          - name: OTLP/HTTP binary Protobuf Exporter
+            status: '-'
+          - name: OTLP/HTTP JSON Protobuf Exporter
+            status: '-'
+          - name: OTLP/HTTP gzip Content-Encoding support
+            status: '-'
+          - name: Concurrent sending
+            status: '-'
+          - name: Honors retryable responses with backoff
+            status: '-'
+          - name: Honors non-retryable responses
+            status: '-'
+          - name: Honors throttling response
+            status: '-'
+          - name: Multi-destination spec compliance
+            status: '-'
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+            status: '?'
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+            status: '?'
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+            status: '?'
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            status: '?'
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            status: '?'
+          - name: Metric Exporter configurable temporality preference
+            status: '?'
+          - name: Metric Exporter configurable default aggregation
+            status: '?'
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            status: '-'
+          - name: Zipkin V1 Thrift
+            status: '-'
+          - name: Zipkin V2 JSON
+            status: '+'
+          - name: Zipkin V2 Protobuf
+            status: '-'
+          - name: Service name mapping
+            status: '+'
+          - name: SpanKind mapping
+            status: '+'
+          - name: InstrumentationLibrary mapping
+            status: '+'
+          - name: InstrumentationScope mapping
+            status: '?'
+          - name: Boolean attributes
+            status: '+'
+          - name: Array attributes
+            status: '+'
+          - name: Status mapping
+            status: '+'
+          - name: Error Status mapping
+            status: '-'
+          - name: Event attributes mapping to Annotations
+            status: '+'
+          - name: Integer microseconds in timestamps
+            status: '+'
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '-'
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            status: '+'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            status: '-'
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+            status: '-'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '+'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            status: '-'
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '+'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            status: '-'
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '+'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+            status: '-'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            status: '-'
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            status: '-'
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+        status: '?'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+        status: '?'
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+        status: '?'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+        status: '?'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+        status: '?'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+        status: '?'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+        status: '?'
+      - name: Error mapping for attributes/events
+        status: '?'
+      - name: Migration to OpenTelemetry guide
+        status: '?'

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -1,0 +1,459 @@
+# This template contains feature definitions only.
+# Language-specific implementation status is stored in individual language YAML files.
+languages:
+  - name: Go
+    location: ./go.yaml
+  - name: Java
+    location: ./java.yaml
+  - name: JS
+    location: ./js.yaml
+  - name: Python
+    location: ./python.yaml
+  - name: Ruby
+    location: ./ruby.yaml
+  - name: Erlang
+    location: ./erlang.yaml
+  - name: PHP
+    location: ./php.yaml
+  - name: Rust
+    location: ./rust.yaml
+  - name: C++
+    location: ./cpp.yaml
+  - name: .NET
+    location: ./dotnet.yaml
+  - name: Swift
+    location: ./swift.yaml
+sections:
+  - name: Traces
+    features:
+      - heading: '[TracerProvider](specification/trace/api.md#tracerprovider-operations)'
+        features:
+          - name: Create TracerProvider
+          - name: Get a Tracer
+          - name: Get a Tracer with schema_url
+          - name: Get a Tracer with scope attributes
+          - name: Associate Tracer with InstrumentationScope
+          - name: Safe for concurrent calls
+          - name: Shutdown (SDK only required)
+          - name: ForceFlush (SDK only required)
+      - heading: '[Trace / Context interaction](specification/trace/api.md#context-interaction)'
+        features:
+          - name: Get active Span
+          - name: Set active Span
+      - heading: '[Tracer](specification/trace/api.md#tracer-operations)'
+        features:
+          - name: Create a new Span
+          - name: Documentation defines adding attributes at span creation as preferred
+          - name: Get active Span
+          - name: Mark Span active
+          - name: Safe for concurrent calls
+      - heading: '[SpanContext](specification/trace/api.md#spancontext)'
+        features:
+          - name: IsValid
+          - name: IsRemote
+          - name: Conforms to the W3C TraceContext spec
+      - heading: '[Span](specification/trace/api.md#span)'
+        features:
+          - name: Create root span
+          - name: Create with default parent (active span)
+          - name: Create with parent from Context
+          - name: No explicit parent Span/SpanContext allowed
+          - name: SpanProcessor.OnStart receives parent Context
+          - name: UpdateName
+          - name: User-defined start timestamp
+          - name: End
+          - name: End with timestamp
+          - name: IsRecording
+          - name: IsRecording becomes false after End
+          - name: Set status with StatusCode (Unset, Ok, Error)
+          - name: Safe for concurrent calls
+          - name: events collection size limit
+          - name: attribute collection size limit
+          - name: links collection size limit
+          - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
+            optional: true
+      - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
+        features:
+          - name: SetAttribute
+          - name: Set order preserved
+            optional: true
+          - name: String type
+          - name: Boolean type
+          - name: Double floating-point type
+          - name: Signed int64 type
+          - name: Array of primitives (homogeneous)
+          - name: '`null` values documented as invalid/undefined'
+          - name: Unicode support for keys and string values
+      - heading: '[Span linking](specification/trace/api.md#specifying-links)'
+        features:
+          - name: Links can be recorded on span creation
+          - name: Links can be recorded after span creation
+          - name: Links order is preserved
+      - heading: '[Span events](specification/trace/api.md#add-events)'
+        features:
+          - name: AddEvent
+          - name: Add order preserved
+          - name: Safe for concurrent calls
+      - heading: '[Span exceptions](specification/trace/api.md#record-exception)'
+        features:
+          - name: RecordException
+          - name: RecordException with extra parameters
+      - heading: '[Sampling](specification/trace/sdk.md#sampling)'
+        features:
+          - name: Allow samplers to modify tracestate
+          - name: ShouldSample gets full parent Context
+          - name: 'Sampler: JaegerRemoteSampler'
+          - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
+          - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
+          - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
+            optional: true
+          - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
+          - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
+            optional: true
+          - name: Fetch InstrumentationScope from ReadableSpan
+          - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
+            optional: true
+          - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
+            optional: true
+          - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
+            optional: true
+  - name: Baggage
+    features:
+      - name: Basic support
+      - name: Use official header name `baggage`
+  - name: Metrics
+    features:
+      - name: The API provides a way to set and get a global default `MeterProvider`.
+        optional: true
+      - name: It is possible to create any number of `MeterProvider`s.
+        optional: true
+      - name: '`MeterProvider` provides a way to get a `Meter`.'
+      - name: '`get_meter` accepts name, `version` and `schema_url`.'
+      - name: '`get_meter` accepts `attributes`.'
+      - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
+      - name: The fallback `Meter` `name` property keeps its original invalid value.
+        optional: true
+      - name: Associate `Meter` with `InstrumentationScope`.
+      - name: '`Counter` instrument is supported.'
+      - name: '`AsynchronousCounter` instrument is supported.'
+      - name: '`Histogram` instrument is supported.'
+      - name: '`AsynchronousGauge` instrument is supported.'
+      - name: '`Gauge` instrument is supported.'
+      - name: '`UpDownCounter` instrument is supported.'
+      - name: '`AsynchronousUpDownCounter` instrument is supported.'
+      - name: Instruments have `name`
+      - name: Instruments have kind.
+      - name: Instruments have an optional unit of measure.
+      - name: Instruments have an optional description.
+      - name:
+          A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
+          the same `Meter` using the same `name`.
+      - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
+      - name: It is possible to register two instruments with same `name` under different `Meter`s.
+      - name: Instrument names conform to the specified syntax.
+      - name: Instrument units conform to the specified syntax.
+      - name: Instrument descriptions conform to the specified syntax.
+      - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
+      - name: Instrument supports the advisory Attributes parameter.
+      - name: All methods of `MeterProvider` are safe to be called concurrently.
+      - name: All methods of `Meter` are safe to be called concurrently.
+      - name: All methods of any instrument are safe to be called concurrently.
+      - name: '`MeterProvider` allows a `Resource` to be specified.'
+      - name: A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`.
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary`
+          instance stored in the `Meter`.
+      - name:
+          The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
+          instance stored in the `Meter`.
+      - name: Configuration is managed solely by the `MeterProvider`.
+      - name: The `MeterProvider` provides methods to update the configuration
+        optional: true
+      - name: The updated configuration applies to all already returned `Meter`s.
+        optional: if above
+      - name: There is a way to register `View`s with a `MeterProvider`.
+      - name: The `View` instrument selection criteria is as specified.
+      - name: The `View` instrument selection criteria supports wildcards.
+        optional: true
+      - name: The `View` instrument selection criteria supports the match-all wildcard.
+      - name: The name of the `View` can be specified.
+      - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
+      - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
+      - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
+        optional: true
+      - name: The SDK allows more than one `View` to be specified per instrument.
+        optional: true
+      - name: The `Drop` aggregation is available.
+      - name: The `Default` aggregation is available.
+      - name: The `Default` aggregation uses the specified aggregation by instrument.
+      - name: The `Sum` aggregation is available.
+      - name: The `LastValue` aggregation is available.
+      - name: The `ExplicitBucketHistogram` aggregation is available.
+      - name: The `ExponentialBucketHistogram` aggregation is available.
+      - name: The metrics Reader implementation supports registering metric Exporters
+      - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
+      - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
+      - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
+      - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
+      - name: The metrics Exporter `export` function does not block indefinitely.
+      - name: The metrics Exporter `export` function receives a batch of metrics.
+      - name: The metrics Exporter `export` function returns `Success` or `Failure`.
+      - name: The metrics Exporter provides a `ForceFlush` function.
+      - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
+      - name: The metrics Exporter provides a `shutdown` function.
+      - name: The metrics Exporter `shutdown` function do not block indefinitely.
+      - name: The metrics SDK samples `Exemplar`s from measurements.
+      - name: Exemplar sampling can be disabled.
+      - name: The metrics SDK supports SDK-wide exemplar filter configuration
+      - name: The metrics SDK supports `TraceBased` exemplar filter
+      - name: The metrics SDK supports `AlwaysOn` exemplar filter
+      - name: The metrics SDK supports `AlwaysOff` exemplar filter
+      - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+      - name:
+          Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
+          taken.
+      - name: Exemplars contain the timestamp when the measurement was taken.
+      - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
+      - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
+      - name:
+          The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
+          `ExplicitBucketHistogram`.
+      - name:
+          The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
+          aggregation.
+      - name: A metric Producer accepts an optional metric Filter
+      - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
+      - name: The metric SDK's metric Producer implementations uses the metric Filter
+      - name: Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits)
+      - name: Metric SDK supports configuring cardinality limit at MeterReader level
+      - name: Metric SDK supports configuring cardinality limit per metric (using Views)
+  - name: Logs
+    features:
+      - name: LoggerProvider.Get Logger
+      - name: LoggerProvider.Get Logger accepts attributes
+      - name: LoggerProvider.Shutdown
+      - name: LoggerProvider.ForceFlush
+      - name: Logger.Emit(LogRecord)
+      - name: Reuse Standard Attributes
+        optional: true
+      - name: LogRecord.Set EventName
+      - name: Logger.Enabled
+        optional: true
+      - name: SimpleLogRecordProcessor
+      - name: BatchLogRecordProcessor
+      - name: Can plug custom LogRecordProcessor
+      - name: LogRecordProcessor.Enabled
+        optional: true
+      - name: OTLP/gRPC exporter
+      - name: OTLP/HTTP exporter
+      - name: OTLP File exporter
+      - name: Can plug custom LogRecordExporter
+      - name: Trace Context Injection
+  - name: Resource
+    features:
+      - name: Create from Attributes
+      - name: Create empty
+      - name: '[Merge (v2)](specification/resource/sdk.md#merge)'
+      - name: Retrieve attributes
+      - name:
+          '[Default value](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource#semantic-attributes-with-dedicated-environment-variable)
+          for service.name'
+      - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
+      - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
+  - name: Context Propagation
+    features:
+      - name: Create Context Key
+      - name: Get value from Context
+      - name: Set value for Context
+      - name: Attach Context
+      - name: Detach Context
+      - name: Get current Context
+      - name: Composite Propagator
+      - name: Global Propagator
+      - name: TraceContext Propagator
+      - name: B3 Propagator
+      - name: Jaeger Propagator
+      - name: OT Propagator
+      - name: OpenCensus Binary Propagator
+      - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
+      - name: Fields
+      - name: Setter argument
+        optional: true
+      - name: Getter argument
+        optional: true
+      - name: Getter argument returning Keys
+        optional: true
+  - name: Environment Variables
+    features:
+      - name: OTEL_SDK_DISABLED
+      - name: OTEL_RESOURCE_ATTRIBUTES
+      - name: OTEL_SERVICE_NAME
+      - name: OTEL_LOG_LEVEL
+      - name: OTEL_PROPAGATORS
+      - name: OTEL_BSP_*
+      - name: OTEL_BLRP_*
+      - name: OTEL_EXPORTER_OTLP_*
+      - name: OTEL_EXPORTER_ZIPKIN_*
+      - name: OTEL_TRACES_EXPORTER
+      - name: OTEL_METRICS_EXPORTER
+      - name: OTEL_LOGS_EXPORTER
+      - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
+      - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - name: OTEL_SPAN_EVENT_COUNT_LIMIT
+      - name: OTEL_SPAN_LINK_COUNT_LIMIT
+      - name: OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT
+      - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
+      - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
+      - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - name: OTEL_TRACES_SAMPLER
+      - name: OTEL_TRACES_SAMPLER_ARG
+      - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
+      - name: OTEL_ATTRIBUTE_COUNT_LIMIT
+      - name: OTEL_METRIC_EXPORT_INTERVAL
+      - name: OTEL_METRIC_EXPORT_TIMEOUT
+      - name: OTEL_METRICS_EXEMPLAR_FILTER
+      - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+      - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
+      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+    hide_optional_column: true
+  - name: Declarative configuration
+    features:
+      - name: '`Parse` a configuration file'
+      - name: The `Parse` operation accepts the configuration YAML file format
+      - name: The `Parse` operation performs environment variable substitution
+      - name: The `Parse` operation returns configuration model
+      - name: The `Parse` operation resolves extension component configuration to `properties`
+      - name: '`Create` SDK components'
+      - name: The `Create` operation accepts configuration model
+      - name: The `Create` operation returns `TracerProvider`
+      - name: The `Create` operation returns `MeterProvider`
+      - name: The `Create` operation returns `LoggerProvider`
+      - name: The `Create` operation returns `Propagators`
+      - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
+      - name: Register a `ComponentProvider`
+    hide_optional_column: true
+  - name: Exporters
+    features:
+      - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
+      - name: '[Exporter interface has `ForceFlush`](specification/trace/sdk.md#forceflush-2)'
+      - name: Standard output (logging)
+      - name: In-memory (mock exporter)
+      - heading: '**[OTLP](specification/protocol/otlp.md)**'
+        features:
+          - name: OTLP/gRPC Exporter
+            optional_one_of_group_is_required: true
+          - name: OTLP/HTTP binary Protobuf Exporter
+            optional_one_of_group_is_required: true
+          - name: OTLP/HTTP JSON Protobuf Exporter
+          - name: OTLP/HTTP gzip Content-Encoding support
+            optional: true
+          - name: Concurrent sending
+          - name: Honors retryable responses with backoff
+            optional: true
+          - name: Honors non-retryable responses
+            optional: true
+          - name: Honors throttling response
+            optional: true
+          - name: Multi-destination spec compliance
+            optional: true
+          - name: SchemaURL in ResourceSpans and ScopeSpans
+          - name: SchemaURL in ResourceMetrics and ScopeMetrics
+          - name: SchemaURL in ResourceLogs and ScopeLogs
+          - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
+              messages are handled and logged for OTLP/gRPC'
+            optional: true
+          - name:
+              '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
+              messages are handled and logged for OTLP/HTTP'
+            optional: true
+          - name: Metric Exporter configurable temporality preference
+          - name: Metric Exporter configurable default aggregation
+      - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
+        features:
+          - name: Zipkin V1 JSON
+            optional: true
+          - name: Zipkin V1 Thrift
+            optional: true
+          - name: Zipkin V2 JSON
+            optional_one_of_group_is_required: true
+          - name: Zipkin V2 Protobuf
+            optional_one_of_group_is_required: true
+          - name: Service name mapping
+          - name: SpanKind mapping
+          - name: InstrumentationLibrary mapping
+          - name: InstrumentationScope mapping
+          - name: Boolean attributes
+          - name: Array attributes
+          - name: Status mapping
+          - name: Error Status mapping
+          - name: Event attributes mapping to Annotations
+          - name: Integer microseconds in timestamps
+      - heading: '**Prometheus**'
+        features:
+          - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+          - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+          - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            optional: true
+          - name: '[Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            optional: true
+          - name: '[Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+            optional: true
+          - name: '[HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+          - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
+          - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+          - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+          - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
+            optional: true
+          - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
+          - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+          - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+          - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            optional: true
+          - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+          - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
+            optional: true
+          - name: '[Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+          - name: '[Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1)'
+            optional: true
+          - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+          - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
+          - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplars-1)'
+            optional: true
+          - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
+            optional: true
+  - name: OpenCensus Compatibility
+    features:
+      - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
+      - name: '[Metric Bridge](specification/compatibility/opencensus.md#metrics--stats)'
+    hide_optional_column: true
+    languages: # overridden just for initial PR to prove out 1-1 conversion
+      - Go
+      - Java
+      - JS
+      - Python
+      - C++
+      - .NET
+      - Erlang
+  - name: OpenTracing Compatibility
+    features:
+      - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
+      - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
+      - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
+      - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
+      - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
+      - name: Error mapping for attributes/events
+      - name: Migration to OpenTelemetry guide
+    hide_optional_column: true
+    languages: # overridden just for initial PR to prove out 1-1 conversion
+      - Go
+      - Java
+      - JS
+      - Python
+      - Ruby
+      - PHP
+      - Rust
+      - C++
+      - .NET
+      - Swift


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/3976#issuecomment-2375297172

The goal of this PR is to yamlify the spec compliance matrix without affecting the resulting markdown file (other than whitespace differences), so that folks can be sure the yaml files are correct extraction of the current state of the markdown file.