### PR TITLE
[WIP] Extend the set of standard attribute value types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ release.
 
 - ⚠️ **IMPORTANT**: Extending the set of standard attribute value types is no longer a breaking change.
   ([#4614](https://github.com/open-telemetry/opentelemetry-specification/pull/4614))
-- Add empty value attribute.
-  ([#4595](https://github.com/open-telemetry/opentelemetry-specification/pull/4595))
 
 ### Supplementary Guidelines
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ release.
 
 ### Common
 
+- Add empty value to attribute.
+  ([#4595](https://github.com/open-telemetry/opentelemetry-specification/pull/4595))
+
 ### Supplementary Guidelines
 
 ### OTEPs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ release.
 
 ### Common
 
-- Add empty value to attribute.
+- Add empty value attribute.
   ([#4595](https://github.com/open-telemetry/opentelemetry-specification/pull/4595))
 
 ### Supplementary Guidelines

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -38,7 +38,7 @@ An `Attribute` is a key-value pair, which MUST have the following properties:
   - A primitive type: string, boolean, double precision floating point (IEEE 754-1985) or signed 64 bit integer.
   - An array of primitive type values. The array MUST be homogeneous,
     i.e., it MUST NOT contain values of different types.
-  - **Status**: [Stable](../document-status.md) - An empty value (e.g. `null`).
+  - **Status**: [Development](../document-status.md) - An empty value (e.g. `null`).
 
 For protocols that do not natively support non-string values, non-string values SHOULD be represented as JSON-encoded strings.  For example, the expression `int64(100)` will be encoded as `100`, `float64(1.5)` will be encoded as `1.5`, and an empty array of any type will be encoded as `[]`.
 

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -81,6 +81,21 @@ reflects that LogRecord attributes are expected to model data produced from
 external log APIs, which do not necessarily have the same value type
 restrictions as the standard attribute definition.
 
+Note: Extending the set of standard attribute value types is a breaking change.
+This was decided after extensive debate, with arguments as follows:
+
+* Limiting the types of attribute values to a set which has proved sufficient
+  during several years of OpenTelemetry's development is a useful guardrail for
+  design. In taking additional value types off the table, we narrow the solution
+  space and have more productive design conversations.
+* Upon proposing to extend support for complex value types, we received significant
+  pushback. Limiting attribute value types to primitives and arrays of primitives
+  simplifies data consumers' efforts to create search indexes and perform statistical
+  analysis.
+* To address concerns over restricting standard attributes to primitive types, it was
+  called out that complex types can be encoded as existing primitive types, such as
+  representing datetime as a string or 64 bit integer.
+
 ### Attribute Limits
 
 Execution of erroneous code can result in unintended attributes. If there are no

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -81,21 +81,6 @@ reflects that LogRecord attributes are expected to model data produced from
 external log APIs, which do not necessarily have the same value type
 restrictions as the standard attribute definition.
 
-Note: Extending the set of standard attribute value types is a breaking change.
-This was decided after extensive debate, with arguments as follows:
-
-* Limiting the types of attribute values to a set which has proved sufficient
-  during several years of OpenTelemetry's development is a useful guardrail for
-  design. In taking additional value types off the table, we narrow the solution
-  space and have more productive design conversations.
-* Upon proposing to extend support for complex value types, we received significant
-  pushback. Limiting attribute value types to primitives and arrays of primitives
-  simplifies data consumers' efforts to create search indexes and perform statistical
-  analysis.
-* To address concerns over restricting standard attributes to primitive types, it was
-  called out that complex types can be encoded as existing primitive types, such as
-  representing datetime as a string or 64 bit integer.
-
 ### Attribute Limits
 
 Execution of erroneous code can result in unintended attributes. If there are no

--- a/specification/common/README.md
+++ b/specification/common/README.md
@@ -8,7 +8,7 @@ path_base_for_github_subdir:
 
 # Common specification concepts
 
-**Status**: [Stable](../document-status.md)
+**Status**: [Stable](../document-status.md), except where otherwise specified
 
 <details>
 <summary>Table of Contents</summary>
@@ -38,15 +38,13 @@ An `Attribute` is a key-value pair, which MUST have the following properties:
   - A primitive type: string, boolean, double precision floating point (IEEE 754-1985) or signed 64 bit integer.
   - An array of primitive type values. The array MUST be homogeneous,
     i.e., it MUST NOT contain values of different types.
+  - **Status**: [Stable](../document-status.md) - An empty value (e.g. `null`).
 
 For protocols that do not natively support non-string values, non-string values SHOULD be represented as JSON-encoded strings.  For example, the expression `int64(100)` will be encoded as `100`, `float64(1.5)` will be encoded as `1.5`, and an empty array of any type will be encoded as `[]`.
 
-Attribute values expressing a numerical value of zero, an empty string, or an
-empty array are considered meaningful and MUST be stored and passed on to
-processors / exporters.
-
-Attribute values of `null` are not valid and attempting to set a `null` value is
-undefined behavior.
+Attribute values expressing an empty value, a numerical value of zero,
+an empty string, or an empty array are considered meaningful and MUST be stored
+and passed on to processors / exporters.
 
 `null` values SHOULD NOT be allowed in arrays. However, if it is impossible to
 make sure that no `null` values are accepted

--- a/specification/common/attribute-type-mapping.md
+++ b/specification/common/attribute-type-mapping.md
@@ -54,6 +54,12 @@ follow the rules described below.
 
 ### Primitive Values
 
+#### Empty Value
+
+Empty values SHOULD be converted to AnyValue with no
+[value](https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L28-L30)
+field being set.
+
 #### Integer Values
 
 Integer values which are within the range of 64 bit signed numbers

--- a/specification/common/attribute-type-mapping.md
+++ b/specification/common/attribute-type-mapping.md
@@ -13,6 +13,7 @@ linkTitle: Mapping to AnyValue
 
 - [Converting to AnyValue](#converting-to-anyvalue)
   * [Primitive Values](#primitive-values)
+    + [Empty Value](#empty-value)
     + [Integer Values](#integer-values)
     + [Enumerations](#enumerations)
     + [Floating Point Values](#floating-point-values)

--- a/specification/common/attribute-type-mapping.md
+++ b/specification/common/attribute-type-mapping.md
@@ -57,7 +57,7 @@ follow the rules described below.
 
 #### Empty Value
 
-Empty values SHOULD be converted to AnyValue with no
+Empty values MUST be converted to AnyValue with no
 [value](https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L28-L30)
 field being set.
 


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-specification/issues/4602

Follows https://github.com/open-telemetry/opentelemetry-specification/pull/4614

https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/4485-extending-attributes-to-support-complex-values.md#how contains guidelines describing how languages should add support for new attribute value types.
