### PR TITLE
Update YAML spec compliance matrix for Ruby

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -21,7 +21,7 @@ formats is required. Implementing more than one format is optional.
 | Get a Tracer |  | + | + | + | + | + | + | + | + | + | + | + |
 | Get a Tracer with schema_url |  | + | + |  | + |  |  | + |  | + |  |  |
 | Get a Tracer with scope attributes |  |  |  |  | + |  |  | + |  | + |  |  |
-| Associate Tracer with InstrumentationScope |  |  |  |  | + |  |  | + |  |  |  |  |
+| Associate Tracer with InstrumentationScope |  |  |  |  | + | + |  | + |  |  |  |  |
 | Safe for concurrent calls |  | + | + | + | + | + | + | + | + | + | + | + |
 | Shutdown (SDK only required) |  | + | + | + | + | + | + | + | + | + | + | + |
 | ForceFlush (SDK only required) |  | + | + | - | + | + | + | + | + | + | + | + |
@@ -102,26 +102,26 @@ formats is required. Implementing more than one format is optional.
 
 | Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + |  | + | + | + | + | - |  |
-| It is possible to create any number of `MeterProvider`s. | X | + | + | + | + |  | + | + | + | + | + |  |
-| `MeterProvider` provides a way to get a `Meter`. |  | + | + | + | + |  | + | + | + | + | - |  |
+| The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + | + | + | + | + | + | - |  |
+| It is possible to create any number of `MeterProvider`s. | X | + | + | + | + | + | + | + | + | + | + |  |
+| `MeterProvider` provides a way to get a `Meter`. |  | + | + | + | + | + | + | + | + | + | - |  |
 | `get_meter` accepts name, `version` and `schema_url`. |  | + | + | + | + |  | + | + | + | + | - |  |
 | `get_meter` accepts `attributes`. |  |  |  |  | + |  |  | + | + | + |  |  |
-| When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + |  | + |  | + | + | - |  |
-| The fallback `Meter` `name` property keeps its original invalid value. | X | - | - | + | + |  | + |  | + | - | - |  |
-| Associate `Meter` with `InstrumentationScope`. |  |  | + | + | + |  | + |  | + | + |  |  |
-| `Counter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
-| `AsynchronousCounter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
-| `Histogram` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
-| `AsynchronousGauge` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
-| `Gauge` instrument is supported. |  | - | - | - | + |  | - | - | + | - | - |  |
-| `UpDownCounter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
-| `AsynchronousUpDownCounter` instrument is supported. |  | + | + | + | + |  | + | + | + | + | + |  |
-| Instruments have `name` |  | + | + | + | + |  | + | + | + | + | + |  |
-| Instruments have kind. |  | + | + | + | + |  | + | + | + | + | + |  |
-| Instruments have an optional unit of measure. |  | + | + | + | + |  | + | + | + | + | + |  |
-| Instruments have an optional description. |  | + | + | + | + |  | + | + | + | + | + |  |
-| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  |  | + | + | + |  | + |  |  |  |  |  |
+| When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + | + | + |  | + | + | - |  |
+| The fallback `Meter` `name` property keeps its original invalid value. | X | - | - | + | + | + | + |  | + | - | - |  |
+| Associate `Meter` with `InstrumentationScope`. |  |  | + | + | + | + | + |  | + | + |  |  |
+| `Counter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `AsynchronousCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `Histogram` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `AsynchronousGauge` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `Gauge` instrument is supported. |  | - | - | - | + | + | - | - | + | - | - |  |
+| `UpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `AsynchronousUpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have `name` |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have kind. |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have an optional unit of measure. |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have an optional description. |  | + | + | + | + | + | + | + | + | + | + |  |
+| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  |  | + | + | + | + | + |  |  |  |  |  |
 | Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name. |  |  | + |  |  |  | + |  |  |  |  |  |
 | It is possible to register two instruments with same `name` under different `Meter`s. |  | + | + | + | + |  | + |  | + | + | + |  |
 | Instrument names conform to the specified syntax. |  | + | + | + | + |  | + |  |  | + |  |  |
@@ -139,33 +139,33 @@ formats is required. Implementing more than one format is optional.
 | Configuration is managed solely by the `MeterProvider`. |  | + | + | + | + |  | + | + | + | + | + |  |
 | The `MeterProvider` provides methods to update the configuration | X | - | - | - | + |  | - |  |  | - | + |  |
 | The updated configuration applies to all already returned `Meter`s. | if above | - | - | - | - |  | - |  |  | - | + |  |
-| There is a way to register `View`s with a `MeterProvider`. |  | - | + | + | + |  | + | + | + | + | + |  |
-| The `View` instrument selection criteria is as specified. |  |  | + | + | + |  | + | + | + | + | + |  |
-| The `View` instrument selection criteria supports wildcards. | X |  | + | + | + |  | - |  | + | + | + |  |
-| The `View` instrument selection criteria supports the match-all wildcard. |  |  | + | + | + |  | + |  | + | + | + |  |
-| The name of the `View` can be specified. |  |  | + | + | + |  | + | + |  | + | + |  |
+| There is a way to register `View`s with a `MeterProvider`. |  | - | + | + | + | + | + | + | + | + | + |  |
+| The `View` instrument selection criteria is as specified. |  |  | + | + | + | + | + | + | + | + | + |  |
+| The `View` instrument selection criteria supports wildcards. | X |  | + | + | + | + | - |  | + | + | + |  |
+| The `View` instrument selection criteria supports the match-all wildcard. |  |  | + | + | + | + | + |  | + | + | + |  |
+| The name of the `View` can be specified. |  |  | + | + | + | + | + | + |  | + | + |  |
 | The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  |  | + | + | + |  | + | + | + | + | - |  |
 | The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + |  |  |  |  |  |  |  |  |  |  |
 | The `View` allows configuring the exemplar reservoir of resulting metric stream. | X |  | - |  | - |  | - |  |  |  | - |  |
 | The SDK allows more than one `View` to be specified per instrument. | X |  | + | + | + |  | + |  | + | + | + |  |
-| The `Drop` aggregation is available. |  | + | + | + | + |  | + |  | + | + | + |  |
-| The `Default` aggregation is available. |  | + | + | + | + |  | + |  | + | + | + |  |
-| The `Default` aggregation uses the specified aggregation by instrument. |  | + | + | + | + |  | + |  | + | + | + |  |
-| The `Sum` aggregation is available. |  | + | + | + | + |  | + | + | + | + | + |  |
-| The `LastValue` aggregation is available. |  | + | + | + | + |  | + | + | + | + | + |  |
-| The `ExplicitBucketHistogram` aggregation is available. |  | - | + | + | + |  | + | + | + | + | + |  |
-| The `ExponentialBucketHistogram` aggregation is available. |  |  |  |  | + |  |  |  |  |  | + |  |
-| The metrics Reader implementation supports registering metric Exporters |  |  | + | + | + |  | + | + | + | + | + |  |
-| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  |  | + |  | + |  | + |  |  | - | - |  |
-| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  |  | + | + | + |  | + |  | + | + |  |  |
-| The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements). |  | + | + | + | + |  | + |  | + | + | + |  |
-| The metrics Exporter `export` function can not be called concurrently from the same Exporter instance. |  | + | + | + | - |  | + |  |  | + | + |  |
-| The metrics Exporter `export` function does not block indefinitely. |  | + | + | + | - |  | + |  |  | + | + |  |
-| The metrics Exporter `export` function receives a batch of metrics. |  | + | + | + | + |  | + | + | + | + | + |  |
-| The metrics Exporter `export` function returns `Success` or `Failure`. |  | + | + | + | + |  | + | + | + | + | + |  |
-| The metrics Exporter provides a `ForceFlush` function. |  | - | + | + | + |  | + | + | + | + | + |  |
-| The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out. |  |  | + | + | + |  | + | + |  | + | + |  |
-| The metrics Exporter provides a `shutdown` function. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The `Default` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The `Default` aggregation uses the specified aggregation by instrument. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The `Sum` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `LastValue` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `ExplicitBucketHistogram` aggregation is available. |  | - | + | + | + | + | + | + | + | + | + |  |
+| The `ExponentialBucketHistogram` aggregation is available. |  |  |  |  | + | + |  |  |  |  | + |  |
+| The metrics Reader implementation supports registering metric Exporters |  |  | + | + | + | + | + | + | + | + | + |  |
+| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  |  | + |  | + | + | + |  |  | - | - |  |
+| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  |  | + | + | + | + | + |  | + | + |  |  |
+| The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements). |  | + | + | + | + | + | + |  | + | + | + |  |
+| The metrics Exporter `export` function can not be called concurrently from the same Exporter instance. |  | + | + | + | - | + | + |  |  | + | + |  |
+| The metrics Exporter `export` function does not block indefinitely. |  | + | + | + | - | + | + |  |  | + | + |  |
+| The metrics Exporter `export` function receives a batch of metrics. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter `export` function returns `Success` or `Failure`. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter provides a `ForceFlush` function. |  | - | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out. |  |  | + | + | + | + | + | + |  | + | + |  |
+| The metrics Exporter provides a `shutdown` function. |  | + | + | + | + | + | + | + | + | + | + |  |
 | The metrics Exporter `shutdown` function do not block indefinitely. |  | + | + | + | - |  | + |  |  | + | + |  |
 | The metrics SDK samples `Exemplar`s from measurements. |  |  | + |  | - |  | + |  |  |  | + |  |
 | Exemplar sampling can be disabled. |  |  | - |  | - |  | + |  |  |  | + |  |
@@ -194,23 +194,23 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 
 | Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| LoggerProvider.Get Logger |  |  | + |  | + |  |  | + |  | + | - |  |
+| LoggerProvider.Get Logger |  |  | + |  | + | + |  | + |  | + | - |  |
 | LoggerProvider.Get Logger accepts attributes |  |  |  |  | + |  |  | + |  | + |  |  |
-| LoggerProvider.Shutdown |  |  | + |  | + |  |  | + |  | + | - |  |
-| LoggerProvider.ForceFlush |  |  | + |  | + |  |  | + |  | + | - |  |
-| Logger.Emit(LogRecord) |  |  | + |  | + |  |  | + |  | + | - |  |
+| LoggerProvider.Shutdown |  |  | + |  | + | + |  | + |  | + | - |  |
+| LoggerProvider.ForceFlush |  |  | + |  | + | + |  | + |  | + | - |  |
+| Logger.Emit(LogRecord) |  |  | + |  | + | + |  | + |  | + | - |  |
 | Reuse Standard Attributes | X | + |  |  |  |  |  |  |  |  |  |  |
 | LogRecord.Set EventName |  | + |  |  |  |  |  |  | + | + |  |  |
 | Logger.Enabled | X | + |  |  |  |  |  |  | + | + |  |  |
-| SimpleLogRecordProcessor |  |  | + |  | + |  |  | + |  | + |  |  |
-| BatchLogRecordProcessor |  |  | + |  | + |  |  | + |  | + |  |  |
-| Can plug custom LogRecordProcessor |  |  | + |  | + |  |  | + |  | + |  |  |
-| LogRecordProcessor.Enabled | X | + |  |  |  |  |  |  | + |  |  |  |
+| SimpleLogRecordProcessor |  |  | + |  | + | + |  | + |  | + |  |  |
+| BatchLogRecordProcessor |  |  | + |  | + | + |  | + |  | + |  |  |
+| Can plug custom LogRecordProcessor |  |  | + |  | + | + |  | + |  | + |  |  |
+| LogRecordProcessor.Enabled | X | + |  |  |  | + |  |  | + |  |  |  |
 | OTLP/gRPC exporter |  |  | + |  | + |  |  | + |  | + | + |  |
-| OTLP/HTTP exporter |  |  | + |  | + |  |  | + |  | + | + |  |
+| OTLP/HTTP exporter |  |  | + |  | + | + |  | + |  | + | + |  |
 | OTLP File exporter |  |  | - |  | - |  |  |  |  | + | - |  |
-| Can plug custom LogRecordExporter |  |  | + |  | + |  |  | + |  | + |  |  |
-| Trace Context Injection |  |  | + |  | + |  |  | + |  | + | + |  |
+| Can plug custom LogRecordExporter |  |  | + |  | + | + |  | + |  | + |  |  |
+| Trace Context Injection |  |  | + |  | + | + |  | + |  | + | + |  |
 
 ## Resource
 
@@ -253,35 +253,35 @@ Note: Support for environment variables is optional.
 
 | Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| OTEL_SDK_DISABLED | - | + | - | + | - | - | + | - | - | - | - |
+| OTEL_SDK_DISABLED | - | + | - | + | + | - | + | - | - | - | - |
 | OTEL_RESOURCE_ATTRIBUTES | + | + | + | + | + | + | + | + | + | + | - |
 | OTEL_SERVICE_NAME | + | + | + | + | + | + | + |  | + | + |  |
 | OTEL_LOG_LEVEL | - | - | + | [-][py1059] | + | - | + |  | - | - | - |
 | OTEL_PROPAGATORS | - | + |  | + | + | + | + | - | - | - | - |
 | OTEL_BSP_* | + | + | + | + | + | + | + | + | - | + | - |
-| OTEL_BLRP_* |  | + |  |  |  |  |  | + | - | + |  |
+| OTEL_BLRP_* |  | + |  |  | + |  |  | + | - | + |  |
 | OTEL_EXPORTER_OTLP_* | + | + |  | + | + | + | + | + | + | + | - |
 | OTEL_EXPORTER_ZIPKIN_* | - | + |  | + | + | - | + | - | - | + | - |
 | OTEL_TRACES_EXPORTER | - | + | + | + | + | + | + | - | - | - |  |
-| OTEL_METRICS_EXPORTER | - | + |  | + | - | - | + | - | - | - | - |
-| OTEL_LOGS_EXPORTER | - | + |  | + |  |  | + |  | - | - |  |
+| OTEL_METRICS_EXPORTER | - | + |  | + | + | - | + | - | - | - | - |
+| OTEL_LOGS_EXPORTER | - | + |  | + | + |  | + |  | - | - |  |
 | OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  |
 | OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | + | + | + | + | + | + |  | - | + |  |
 | OTEL_SPAN_EVENT_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  |
 | OTEL_SPAN_LINK_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  |
 | OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT | + | - |  | + | + | + | + |  | - | + |  |
 | OTEL_LINK_ATTRIBUTE_COUNT_LIMIT | + | - |  | + | + | + | + |  | - | + |  |
-| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT |  |  |  |  |  |  | + |  | - |  |  |
-| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT |  |  |  |  |  |  | + |  | - |  |  |
+| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT |  |  |  |  | + |  | + |  | - |  |  |
+| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT |  |  |  |  | + |  | + |  | - |  |  |
 | OTEL_TRACES_SAMPLER | + | + | + | + | + | + | + | - | - | - |  |
 | OTEL_TRACES_SAMPLER_ARG | + | + | + | + | + | + | + | - | - | - |  |
 | OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | + | + | + | + | - | + |  | - | + |  |
 | OTEL_ATTRIBUTE_COUNT_LIMIT | + | + | + | + | + | - | + |  | - | + |  |
-| OTEL_METRIC_EXPORT_INTERVAL | - | + |  | + |  |  | + |  | - | + |  |
-| OTEL_METRIC_EXPORT_TIMEOUT | - | - |  | + |  |  | + |  | - | + |  |
-| OTEL_METRICS_EXEMPLAR_FILTER | - | + |  |  |  |  | + |  | - | + |  |
-| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | + | + | + | + |  |  | + |  | - | + |  |
-| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |  | + |  | + |  |  |  |  | - |  |  |
+| OTEL_METRIC_EXPORT_INTERVAL | - | + |  | + | + |  | + |  | - | + |  |
+| OTEL_METRIC_EXPORT_TIMEOUT | - | - |  | + | + |  | + |  | - | + |  |
+| OTEL_METRICS_EXEMPLAR_FILTER | - | + |  |  | + |  | + |  | - | + |  |
+| OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | + | + | + | + | + |  | + |  | - | + |  |
+| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION |  | + |  | + | + |  |  |  | - |  |  |
 | OTEL_EXPERIMENTAL_CONFIG_FILE |  |  |  |  |  |  |  |  | - |  |  |
 
 ## Declarative configuration

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -20,7 +20,7 @@ sections:
           - name: Get a Tracer with scope attributes
             status: '?'
           - name: Associate Tracer with InstrumentationScope
-            status: '?'
+            status: '+'
           - name: Safe for concurrent calls
             status: '+'
           - name: Shutdown (SDK only required)
@@ -166,47 +166,47 @@ sections:
   - name: Metrics
     features:
       - name: The API provides a way to set and get a global default `MeterProvider`.
-        status: '?'
+        status: '+'
       - name: It is possible to create any number of `MeterProvider`s.
-        status: '?'
+        status: '+'
       - name: '`MeterProvider` provides a way to get a `Meter`.'
-        status: '?'
+        status: '+'
       - name: '`get_meter` accepts name, `version` and `schema_url`.'
         status: '?'
       - name: '`get_meter` accepts `attributes`.'
         status: '?'
       - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
-        status: '?'
+        status: '+'
       - name: The fallback `Meter` `name` property keeps its original invalid value.
-        status: '?'
+        status: '+'
       - name: Associate `Meter` with `InstrumentationScope`.
-        status: '?'
+        status: '+'
       - name: '`Counter` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: '`AsynchronousCounter` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: '`Histogram` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: '`AsynchronousGauge` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: '`Gauge` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: '`UpDownCounter` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: '`AsynchronousUpDownCounter` instrument is supported.'
-        status: '?'
+        status: '+'
       - name: Instruments have `name`
-        status: '?'
+        status: '+'
       - name: Instruments have kind.
-        status: '?'
+        status: '+'
       - name: Instruments have an optional unit of measure.
-        status: '?'
+        status: '+'
       - name: Instruments have an optional description.
-        status: '?'
+        status: '+'
       - name:
           A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
           the same `Meter` using the same `name`.
-        status: '?'
+        status: '+'
       - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
         status: '?'
       - name: It is possible to register two instruments with same `name` under different `Meter`s.
@@ -246,15 +246,15 @@ sections:
       - name: The updated configuration applies to all already returned `Meter`s.
         status: '?'
       - name: There is a way to register `View`s with a `MeterProvider`.
-        status: '?'
+        status: '+'
       - name: The `View` instrument selection criteria is as specified.
-        status: '?'
+        status: '+'
       - name: The `View` instrument selection criteria supports wildcards.
-        status: '?'
+        status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
-        status: '?'
+        status: '+'
       - name: The name of the `View` can be specified.
-        status: '?'
+        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '?'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
@@ -262,43 +262,43 @@ sections:
       - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
         status: '?'
       - name: The SDK allows more than one `View` to be specified per instrument.
-        status: '?'
+        status: '+'
       - name: The `Drop` aggregation is available.
-        status: '?'
+        status: '+'
       - name: The `Default` aggregation is available.
-        status: '?'
+        status: '+'
       - name: The `Default` aggregation uses the specified aggregation by instrument.
-        status: '?'
+        status: '+'
       - name: The `Sum` aggregation is available.
-        status: '?'
+        status: '+'
       - name: The `LastValue` aggregation is available.
-        status: '?'
+        status: '+'
       - name: The `ExplicitBucketHistogram` aggregation is available.
-        status: '?'
+        status: '+'
       - name: The `ExponentialBucketHistogram` aggregation is available.
-        status: '?'
+        status: '+'
       - name: The metrics Reader implementation supports registering metric Exporters
-        status: '?'
+        status: '+'
       - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
-        status: '?'
+        status: '+'
       - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
-        status: '?'
+        status: '+'
       - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter `export` function does not block indefinitely.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter `export` function receives a batch of metrics.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter `export` function returns `Success` or `Failure`.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter provides a `ForceFlush` function.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter provides a `shutdown` function.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter `shutdown` function do not block indefinitely.
         status: '?'
       - name: The metrics SDK samples `Exemplar`s from measurements.
@@ -348,15 +348,15 @@ sections:
   - name: Logs
     features:
       - name: LoggerProvider.Get Logger
-        status: '?'
+        status: '+'
       - name: LoggerProvider.Get Logger accepts attributes
         status: '?'
       - name: LoggerProvider.Shutdown
-        status: '?'
+        status: '+'
       - name: LoggerProvider.ForceFlush
-        status: '?'
+        status: '+'
       - name: Logger.Emit(LogRecord)
-        status: '?'
+        status: '+'
       - name: Reuse Standard Attributes
         status: '?'
       - name: LogRecord.Set EventName
@@ -364,23 +364,23 @@ sections:
       - name: Logger.Enabled
         status: '?'
       - name: SimpleLogRecordProcessor
-        status: '?'
+        status: '+'
       - name: BatchLogRecordProcessor
-        status: '?'
+        status: '+'
       - name: Can plug custom LogRecordProcessor
-        status: '?'
+        status: '+'
       - name: LogRecordProcessor.Enabled
-        status: '?'
+        status: '+'
       - name: OTLP/gRPC exporter
         status: '?'
       - name: OTLP/HTTP exporter
-        status: '?'
+        status: '+'
       - name: OTLP File exporter
         status: '?'
       - name: Can plug custom LogRecordExporter
-        status: '?'
+        status: '+'
       - name: Trace Context Injection
-        status: '?'
+        status: '+'
   - name: Resource
     features:
       - name: Create from Attributes
@@ -440,7 +440,7 @@ sections:
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED
-        status: '-'
+        status: '+'
       - name: OTEL_RESOURCE_ATTRIBUTES
         status: '+'
       - name: OTEL_SERVICE_NAME
@@ -452,7 +452,7 @@ sections:
       - name: OTEL_BSP_*
         status: '+'
       - name: OTEL_BLRP_*
-        status: '?'
+        status: '+'
       - name: OTEL_EXPORTER_OTLP_*
         status: '+'
       - name: OTEL_EXPORTER_ZIPKIN_*
@@ -460,9 +460,9 @@ sections:
       - name: OTEL_TRACES_EXPORTER
         status: '+'
       - name: OTEL_METRICS_EXPORTER
-        status: '-'
+        status: '+'
       - name: OTEL_LOGS_EXPORTER
-        status: '?'
+        status: '+'
       - name: OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT
         status: '+'
       - name: OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT
@@ -476,9 +476,9 @@ sections:
       - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
         status: '+'
       - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
-        status: '?'
+        status: '+'
       - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
-        status: '?'
+        status: '+'
       - name: OTEL_TRACES_SAMPLER
         status: '+'
       - name: OTEL_TRACES_SAMPLER_ARG
@@ -488,15 +488,15 @@ sections:
       - name: OTEL_ATTRIBUTE_COUNT_LIMIT
         status: '+'
       - name: OTEL_METRIC_EXPORT_INTERVAL
-        status: '?'
+        status: '+'
       - name: OTEL_METRIC_EXPORT_TIMEOUT
-        status: '?'
+        status: '+'
       - name: OTEL_METRICS_EXEMPLAR_FILTER
-        status: '?'
+        status: '+'
       - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
-        status: '?'
+        status: '+'
       - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
-        status: '?'
+        status: '+'
       - name: OTEL_EXPERIMENTAL_CONFIG_FILE
         status: '?'
   - name: Declarative configuration


### PR DESCRIPTION
## Changes

This PR is a redo of #4628 to account for the changes made in #4631. 

To quote the description of #4628: 
> The Ruby Metrics and Logs implementations added a lot of features since this matrix was last updated. However, we're still in "Development" status, so I'm not sure if this is the appropriate time to update the matrix. Please let me know if we should wait.

This also includes some changes to the traces and environment variables sections. There are a few small differences between the boxes checked in #4628 to reflect recent changes.

cc @open-telemetry/ruby-maintainers 