### PR TITLE
[chore] fix link checks for swift

### DIFF
--- a/oteps/0258-env-context-baggage-carriers.md
+++ b/oteps/0258-env-context-baggage-carriers.md
@@ -195,7 +195,7 @@ information below, it is recommended to leverage upper-cased environment
 variables for the carrier that align with context propagator specifications.
 
 [python-env]: https://github.com/Div95/opentelemetry-python/tree/feature/env_propagator/propagator/opentelemetry-propagator-env
-[swift-env]: https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+[swift-env]: https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
 
 ### UNIX Limitations
 

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -204,4 +204,4 @@ are the same in that they:
 2. **Inject context**: Return a dictionary/map of environment variables that
    application owners can pass to their process spawning libraries
 
-[swift]: https://github.com/open-telemetry/opentelemetry-swift/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
+[swift]: https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift


### PR DESCRIPTION
Fixes #4652

Minor change. The opentelemetry swift repo code was migrated recently to `opentelemetry-swift-core` causing urls to fail link checks