### PR TITLE
Define conversion of empty value to OTLP AnyValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ release.
   ([#4614](https://github.com/open-telemetry/opentelemetry-specification/pull/4614))
 - Define conversion of empty value to OTLP `AnyValue`.
   ([#4656](https://github.com/open-telemetry/opentelemetry-specification/pull/4656))
-  
+
 ### Supplementary Guidelines
 
 ### OTEPs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ release.
 - ⚠️ **IMPORTANT**: Extending the set of standard attribute value types is no longer a breaking change.
   ([#4614](https://github.com/open-telemetry/opentelemetry-specification/pull/4614))
 - Define conversion of empty value to OTLP `AnyValue`.
-
+  ([#4656](https://github.com/open-telemetry/opentelemetry-specification/pull/4656))
+  
 ### Supplementary Guidelines
 
 ### OTEPs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ release.
   ([#4560](https://github.com/open-telemetry/opentelemetry-specification/pull/4560))
 - ⚠️ **IMPORTANT**: Extending the set of standard attribute value types is no longer a breaking change.
   ([#4614](https://github.com/open-telemetry/opentelemetry-specification/pull/4614))
+- Define conversion of empty value to OTLP `AnyValue`.
 
 ### Supplementary Guidelines
 

--- a/specification/common/attribute-type-mapping.md
+++ b/specification/common/attribute-type-mapping.md
@@ -13,6 +13,7 @@ linkTitle: Mapping to AnyValue
 
 - [Converting to AnyValue](#converting-to-anyvalue)
   * [Primitive Values](#primitive-values)
+    + [Empty Value](#empty-value)
     + [Integer Values](#integer-values)
     + [Enumerations](#enumerations)
     + [Floating Point Values](#floating-point-values)
@@ -53,6 +54,12 @@ or data coming from other formats that needs to be converted to AnyValue SHOULD
 follow the rules described below.
 
 ### Primitive Values
+
+#### Empty Value
+
+Empty values MUST be converted to AnyValue with no
+[value](https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L28-L30)
+field being set.
 
 #### Integer Values
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4392

Define conversion of empty value to OTLP AnyValue.

This matches https://github.com/open-telemetry/opentelemetry-proto/blob/38b5b9b6e5257c6500a843f7fdacf89dd95833e8/opentelemetry/proto/common/v1/common.proto#L28-L30:

```proto
message AnyValue {
  // The value is one of the listed fields. It is valid for all values to be unspecified
  // in which case this AnyValue is considered to be "null".
```

The specification was double-checked by @jade-guiton-dd: https://github.com/open-telemetry/opentelemetry-specification/issues/4392#issuecomment-3274190309

