### PR TITLE
update JS declarative config spec compliance

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -292,10 +292,10 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 
 | Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| `Parse` a configuration file |  | x |  |  |  |  |  |  |  |  |  |
-| The `Parse` operation accepts the configuration YAML file format |  | x |  |  |  |  |  |  |  |  |  |
+| `Parse` a configuration file |  | x | + |  |  |  |  |  |  |  |  |
+| The `Parse` operation accepts the configuration YAML file format |  | x | + |  |  |  |  |  |  |  |  |
 | The `Parse` operation performs environment variable substitution |  | x |  |  |  |  |  |  |  |  |  |
-| The `Parse` operation returns configuration model |  | x |  |  |  |  |  |  |  |  |  |
+| The `Parse` operation returns configuration model |  | x | + |  |  |  |  |  |  |  |  |
 | The `Parse` operation resolves extension component configuration to `properties` |  | x |  |  |  |  |  |  |  |  |  |
 | `Create` SDK components |  | x |  |  |  |  |  |  |  |  |  |
 | The `Create` operation accepts configuration model |  | x |  |  |  |  |  |  |  |  |  |

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -502,13 +502,13 @@ sections:
   - name: Declarative configuration
     features:
       - name: '`Parse` a configuration file'
-        status: '?'
+        status: '+'
       - name: The `Parse` operation accepts the configuration YAML file format
-        status: '?'
+        status: '+'
       - name: The `Parse` operation performs environment variable substitution
         status: '?'
       - name: The `Parse` operation returns configuration model
-        status: '?'
+        status: '+'
       - name: The `Parse` operation resolves extension component configuration to `properties`
         status: '?'
       - name: '`Create` SDK components'


### PR DESCRIPTION
Update the JavaScript spec compliance to the latest values for Declarative Config

Implementation: https://github.com/open-telemetry/opentelemetry-js/pulls?q=is%3Apr+%22feat%28opentelemetry-configuration%29%22+is%3Aclosed