### PR TITLE
use correct character for java spec

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -292,19 +292,19 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 
 | Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| `Parse` a configuration file |  | x |  |  |  |  | + |  |  |  |  |
-| The `Parse` operation accepts the configuration YAML file format |  | x |  |  |  |  | + |  |  |  |  |
-| The `Parse` operation performs environment variable substitution |  | x |  |  |  |  | + |  |  |  |  |
-| The `Parse` operation returns configuration model |  | x |  |  |  |  | + |  |  |  |  |
-| The `Parse` operation resolves extension component configuration to `properties` |  | x |  |  |  |  | + |  |  |  |  |
-| `Create` SDK components |  | x |  |  |  |  | + |  |  |  |  |
-| The `Create` operation accepts configuration model |  | x |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `TracerProvider` |  | x |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `MeterProvider` |  | x |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `LoggerProvider` |  | x |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `Propagators` |  | x |  |  |  |  | + |  |  |  |  |
-| The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components |  | x |  |  |  |  | + |  |  |  |  |
-| Register a `ComponentProvider` |  | x |  |  |  |  | + |  |  |  |  |
+| `Parse` a configuration file |  | + |  |  |  |  | + |  |  |  |  |
+| The `Parse` operation accepts the configuration YAML file format |  | + |  |  |  |  | + |  |  |  |  |
+| The `Parse` operation performs environment variable substitution |  | + |  |  |  |  | + |  |  |  |  |
+| The `Parse` operation returns configuration model |  | + |  |  |  |  | + |  |  |  |  |
+| The `Parse` operation resolves extension component configuration to `properties` |  | + |  |  |  |  | + |  |  |  |  |
+| `Create` SDK components |  | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation accepts configuration model |  | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `TracerProvider` |  | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `MeterProvider` |  | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `LoggerProvider` |  | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `Propagators` |  | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components |  | + |  |  |  |  | + |  |  |  |  |
+| Register a `ComponentProvider` |  | + |  |  |  |  | + |  |  |  |  |
 
 ## Exporters
 

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -502,31 +502,31 @@ sections:
   - name: Declarative configuration
     features:
       - name: '`Parse` a configuration file'
-        status: x
+        status: '+'
       - name: The `Parse` operation accepts the configuration YAML file format
-        status: x
+        status: '+'
       - name: The `Parse` operation performs environment variable substitution
-        status: x
+        status: '+'
       - name: The `Parse` operation returns configuration model
-        status: x
+        status: '+'
       - name: The `Parse` operation resolves extension component configuration to `properties`
-        status: x
+        status: '+'
       - name: '`Create` SDK components'
-        status: x
+        status: '+'
       - name: The `Create` operation accepts configuration model
-        status: x
+        status: '+'
       - name: The `Create` operation returns `TracerProvider`
-        status: x
+        status: '+'
       - name: The `Create` operation returns `MeterProvider`
-        status: x
+        status: '+'
       - name: The `Create` operation returns `LoggerProvider`
-        status: x
+        status: '+'
       - name: The `Create` operation returns `Propagators`
-        status: x
+        status: '+'
       - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components
-        status: x
+        status: '+'
       - name: Register a `ComponentProvider`
-        status: x
+        status: '+'
   - name: Exporters
     features:
       - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'


### PR DESCRIPTION
Nit PR: The Java Spec was using `X`, instead of the correct `+` for declarative configuration.

```
# Legend:
#   '+'     Implemented
#   '-'     Not implemented
#   '?'     Unknown
#   'N/A'   Not applicable to this language
```

I noticed the mistake while updating another spec, so creating this PR to fix it :) 