### PR TITLE
fix: update OTLP links to location the doc points to

### DIFF
--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -307,7 +307,7 @@ The implementation MAY accept a comma-separated list to enable setting multiple 
 
 Known values for `OTEL_TRACES_EXPORTER` are:
 
-- `"otlp"`: [OTLP](../protocol/otlp.md)
+- `"otlp"`: [OTLP](https://opentelemetry.io/docs/specs/otlp/)
 - `"zipkin"`: [Zipkin](https://zipkin.io/zipkin-api/) (Defaults to [protobuf](https://github.com/openzipkin/zipkin-api/blob/master/zipkin.proto) format)
 - `"console"`: [Standard Output](../trace/sdk_exporters/stdout.md)
 - `"logging"`: [Standard Output](../trace/sdk_exporters/stdout.md). It is a deprecated value left for backwards compatibility. It SHOULD
@@ -316,7 +316,7 @@ NOT be supported by new implementations.
 
 Known values for `OTEL_METRICS_EXPORTER` are:
 
-- `"otlp"`: [OTLP](../protocol/otlp.md)
+- `"otlp"`: [OTLP](https://opentelemetry.io/docs/specs/otlp/)
 - `"prometheus"`: [Prometheus](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 - `"console"`: [Standard Output](../metrics/sdk_exporters/stdout.md)
 - `"logging"`: [Standard Output](../metrics/sdk_exporters/stdout.md). It is a deprecated value left for backwards compatibility. It SHOULD
@@ -325,7 +325,7 @@ NOT be supported by new implementations.
 
 Known values for `OTEL_LOGS_EXPORTER` are:
 
-- `"otlp"`: [OTLP](../protocol/otlp.md)
+- `"otlp"`: [OTLP](https://opentelemetry.io/docs/specs/otlp/)
 - `"console"`: [Standard Output](../logs/sdk_exporters/stdout.md)
 - `"logging"`: [Standard Output](../logs/sdk_exporters/stdout.md). It is a deprecated value left for backwards compatibility. It SHOULD
 NOT be supported by new implementations.

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -576,7 +576,7 @@ Concurrent requests and retry logic is the responsibility of the exporter. The
 default SDK's `LogRecordProcessors` SHOULD NOT implement retry logic, as the
 required logic is likely to depend heavily on the specific protocol and backend
 the logs are being sent to. For example,
-the [OpenTelemetry Protocol (OTLP) specification](../protocol/otlp.md) defines
+the [OpenTelemetry Protocol (OTLP) specification](https://opentelemetry.io/docs/specs/otlp/) defines
 logic for both sending concurrent requests and retrying requests.
 
 **Parameters:**

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -1072,7 +1072,7 @@ Concurrent requests and retry logic is the responsibility of the exporter. The
 default SDK's Span Processors SHOULD NOT implement retry logic, as the required
 logic is likely to depend heavily on the specific protocol and backend the spans
 are being sent to. For example, the [OpenTelemetry Protocol (OTLP)
-specification](../protocol/otlp.md)
+specification](https://opentelemetry.io/docs/specs/otlp/)
 defines logic for both sending concurrent requests and retrying requests.
 
 **Parameters:**


### PR DESCRIPTION
## Changes

Various places were still linking to `../protocol/otlp.md` which then points people to https://opentelemetry.io/docs/specs/otlp/. This update removes the need for readers to click twice.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
