### PR TITLE
Update Probability Sampler description to remove "ratio-based" reference

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -512,14 +512,7 @@ OpenTelemetry follows W3C Trace Context Level 2, which specifies 56 bits of rand
 The `ProbabilitySampler` sampler MUST ignore the parent `SampledFlag`.
 For respecting the parent `SampledFlag`, see the `ParentBased` sampler specified below.
 
-Note that the "ratio-based" part of this Sampler's name implies that
-it makes a probability decision directly from the TraceID, even though
-it was not originally specified in an exact way.  In the present
-specification, the Sampler decision is more nuanced: only a portion of
-the identifier is used, after checking whether the OpenTelemetry
-TraceState field contains an explicit randomness value.
-
-Note that this is a non-composable form of probaiblity
+Note that this is a non-composable form of probability
 sampler. `ProbabilitySampler` directly implements the SDKs Sampler
 API, whereas [`ComposableProbability`](#composableprobability) is the
 composable form for use with [`CompositeSampler`](#compositesampler).


### PR DESCRIPTION
## Changes

When reading through #4627, I noticed that the Probability Sampler description still had a reference to ratio-based. I think that entire section may be cut since the clarifications were specifically related to the old name.

Also, found a small typo.

This seems like a trivial change, so I did not create a new issue nor add a CHANGELOG.md entry. Please let me know if you would rather I make one.

* [ ] Related issues: PR #4627
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) N/A
* [ ] Links to the prototypes (when adding or changing features) N/A
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes N/A
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary N/A