### PR TITLE
update spec compliance matrix for declarative config in go

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -292,16 +292,16 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 
 | Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| `Parse` a configuration file |  | + | + |  |  |  | + |  |  |  |  |
-| The `Parse` operation accepts the configuration YAML file format |  | + | + |  |  |  | + |  |  |  |  |
+| `Parse` a configuration file | + | + | + |  |  |  | + |  |  |  |  |
+| The `Parse` operation accepts the configuration YAML file format | + | + | + |  |  |  | + |  |  |  |  |
 | The `Parse` operation performs environment variable substitution |  | + |  |  |  |  | + |  |  |  |  |
-| The `Parse` operation returns configuration model |  | + | + |  |  |  | + |  |  |  |  |
+| The `Parse` operation returns configuration model | + | + | + |  |  |  | + |  |  |  |  |
 | The `Parse` operation resolves extension component configuration to `properties` |  | + |  |  |  |  | + |  |  |  |  |
-| `Create` SDK components |  | + |  |  |  |  | + |  |  |  |  |
-| The `Create` operation accepts configuration model |  | + |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `TracerProvider` |  | + |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `MeterProvider` |  | + |  |  |  |  | + |  |  |  |  |
-| The `Create` operation returns `LoggerProvider` |  | + |  |  |  |  | + |  |  |  |  |
+| `Create` SDK components | + | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation accepts configuration model | + | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `TracerProvider` | + | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `MeterProvider` | + | + |  |  |  |  | + |  |  |  |  |
+| The `Create` operation returns `LoggerProvider` | + | + |  |  |  |  | + |  |  |  |  |
 | The `Create` operation returns `Propagators` |  | + |  |  |  |  | + |  |  |  |  |
 | The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components |  | + |  |  |  |  | + |  |  |  |  |
 | Register a `ComponentProvider` |  | + |  |  |  |  | + |  |  |  |  |

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -502,25 +502,25 @@ sections:
   - name: Declarative configuration
     features:
       - name: '`Parse` a configuration file'
-        status: '?'
+        status: '+'
       - name: The `Parse` operation accepts the configuration YAML file format
-        status: '?'
+        status: '+'
       - name: The `Parse` operation performs environment variable substitution
         status: '?'
       - name: The `Parse` operation returns configuration model
-        status: '?'
+        status: '+'
       - name: The `Parse` operation resolves extension component configuration to `properties`
         status: '?'
       - name: '`Create` SDK components'
-        status: '?'
+        status: '+'
       - name: The `Create` operation accepts configuration model
-        status: '?'
+        status: '+'
       - name: The `Create` operation returns `TracerProvider`
-        status: '?'
+        status: '+'
       - name: The `Create` operation returns `MeterProvider`
-        status: '?'
+        status: '+'
       - name: The `Create` operation returns `LoggerProvider`
-        status: '?'
+        status: '+'
       - name: The `Create` operation returns `Propagators`
         status: '?'
       - name: The `Create` operation calls `CreatePlugin` of corresponding `ComponentProvider` when encountering extension components


### PR DESCRIPTION
## Changes

Updates the spec compliance matrix for declarative config implementation in Go.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
