### PR TITLE
update spec compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -294,7 +294,7 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
 | `Parse` a configuration file | + | + | + |  |  |  | + |  |  |  |  |
 | The `Parse` operation accepts the configuration YAML file format | + | + | + |  |  |  | + |  |  |  |  |
-| The `Parse` operation performs environment variable substitution |  | + |  |  |  |  | + |  |  |  |  |
+| The `Parse` operation performs environment variable substitution | + | + |  |  |  |  | + |  |  |  |  |
 | The `Parse` operation returns configuration model | + | + | + |  |  |  | + |  |  |  |  |
 | The `Parse` operation resolves extension component configuration to `properties` |  | + |  |  |  |  | + |  |  |  |  |
 | `Create` SDK components | + | + |  |  |  |  | + |  |  |  |  |

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -506,7 +506,7 @@ sections:
       - name: The `Parse` operation accepts the configuration YAML file format
         status: '+'
       - name: The `Parse` operation performs environment variable substitution
-        status: '?'
+        status: '+'
       - name: The `Parse` operation returns configuration model
         status: '+'
       - name: The `Parse` operation resolves extension component configuration to `properties`


### PR DESCRIPTION
## Changes

Declarative configuration in Go now supports parsing environment variables with the merge of https://github.com/open-telemetry/opentelemetry-go-contrib/pull/6215. Updating the spec compliance matrix to reflect this.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
