### PR TITLE
[editorial] Add an alias for tracestate-probability-sampling-experimental

### DIFF
--- a/specification/trace/tracestate-probability-sampling.md
+++ b/specification/trace/tracestate-probability-sampling.md
@@ -1,5 +1,6 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: Probability Sampling
+aliases: [tracestate-probability-sampling-experimental]
 --->
 
 # TraceState: Probability Sampling


### PR DESCRIPTION
- Fixes #4687
- Adds an alias for `tracestate-probability-sampling-experimental` so that any links to that page into OTel.io, will redirect to https://opentelemetry.io/docs/specs/otel/trace/tracestate-probability-sampling/

/cc @jmacd @jsuereth 