### PR TITLE
Add Entity Type Uniqueness and Attribute Ownership restrictions

### DIFF
--- a/specification/entities/data-model.md
+++ b/specification/entities/data-model.md
@@ -153,6 +153,14 @@ of entity type uniqueness and the prefix naming convention. For descriptive
 attributes, ownership is determined by the placement rules described in the
 following section.
 
+> **Implementation Note**: The above constraints (entity type uniqueness,
+> attribute ownership, and identifying attribute naming conventions) define
+> validity requirements for Resources. Implementations (SDKs, Collectors) SHOULD
+> validate these constraints when constructing or processing Resources.
+> Implementations SHOULD reject or log errors for invalid Resources and MAY use
+> fallback strategies such as dropping conflicting entities or attributes to
+> maintain data integrity.
+
 ### Placement of Shared Descriptive Attributes
 
 Attribute flattening allows multiple entities to reference the same attribute key,


### PR DESCRIPTION
While working on adding API for managing the Resource Entity references in collector pipelines, I found that it's very complicated to maintain data integrity if we don't explicitly impose the following restrictions on the data model:

1. Entity Type Uniqueness: Enforces that all entities within a resource must have unique types, ensuring unambiguous identification and preventing ID attribute key collisions when combined with the prefix naming convention.

2. Attribute Ownership: Ensures each resource attribute key is owned by at  most one entity, preventing description attribute key collisions and data inconsistencies from multiple entities competing for control of the same attribute. 

* [x] Related issues: https://github.com/open-telemetry/opentelemetry-collector/issues/14042
* [x] Related [OTEP(s)](https://github.com/open-telemetry/oteps): https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/entities/0264-resource-and-entities.md
* [x] Links to the prototypes (when adding or changing features): https://github.com/open-telemetry/opentelemetry-collector/pull/14039
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
