### PR TITLE
[editorial] Cleanup in error-handling.md

### DIFF
--- a/specification/error-handling.md
+++ b/specification/error-handling.md
@@ -93,10 +93,9 @@ func main() {
     // Other setup ...
     opentelemetrysdk.SetHandler(IgnoreExporterErrorsHandler{})
 }
-
 ```
 
-##### Java
+#### Java
 
 OpenTelemetry Java uses [java.util.logging](https://docs.oracle.com/javase/7/docs/api/java/util/logging/package-summary.html)
 to output and handle all logs, including errors. Custom handlers and filters can be registered both in code and using the Java logging configuration file.  


### PR DESCRIPTION
- Updates heading level for Java example so that it is at the same level as Go, as opposed to this (which it is currently):
  <img width="230" height="118" alt="image" src="https://github.com/user-attachments/assets/1c5e8764-14d5-43cf-b2c3-31b5085e098f" />
- Trims code-block trailing space
- Related issue: https://github.com/open-telemetry/opentelemetry.io/issues/8271

/cc @vitorvasc