### PR TITLE
chore: Remove LogRecordProcessor.enabled for Ruby

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -204,7 +204,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | SimpleLogRecordProcessor |  | + | + | + | + | + |  | + |  | + |  |  |
 | BatchLogRecordProcessor |  | + | + | + | + | + |  | + |  | + |  |  |
 | Can plug custom LogRecordProcessor |  | + | + | + | + | + |  | + |  | + |  |  |
-| LogRecordProcessor.Enabled | X | + |  |  |  | + |  |  | + |  |  |  |
+| LogRecordProcessor.Enabled | X | + |  |  |  |  |  |  | + |  |  |  |
 | OTLP/gRPC exporter |  | + | + | + | + |  |  | + |  | + | + |  |
 | OTLP/HTTP exporter |  | + | + | + | + | + |  | + |  | + | + |  |
 | OTLP File exporter |  | - | - |  | - |  |  |  |  | + | - |  |

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -368,7 +368,7 @@ sections:
       - name: Can plug custom LogRecordProcessor
         status: '+'
       - name: LogRecordProcessor.Enabled
-        status: '+'
+        status: '?'
       - name: OTLP/gRPC exporter
         status: '?'
       - name: OTLP/HTTP exporter


### PR DESCRIPTION
This was a typo. The language does not currently support this feature.

cc @pellared 

* [X] Related issues #4717 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [X] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
