### PR TITLE
Fix link to DB semconv

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -764,7 +764,7 @@ are built and instrumented.
 [Semantic conventions](../overview.md#semantic-conventions) for
 specific technologies should document kind for each span they define.
 
-For instance, [Database Client Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/database-spans.md)
+For instance, [Database Client Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/database/database-spans/)
 recommend using `CLIENT` span kind to describes database calls.
 If the database client communicates to the server over HTTP, the HTTP
 instrumentation (when enabled) creates nested `CLIENT` spans to track individual


### PR DESCRIPTION
CI link check is failing since the page was moved in https://github.com/open-telemetry/semantic-conventions/pull/3108.

Using otel.io link instead since we make extra effort to keep them working when links change.