### PR TITLE
Fix changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ release.
 - Declarative configuration: clarify default behavior and validation
   requirements of `create` and `parse`.
   ([#4780](https://github.com/open-telemetry/opentelemetry-specification/pull/4780))
+- Declarative configuration: add optional programmatic customization to
+  `create`, and add related supplemental guidelines.
+  ([#4777](https://github.com/open-telemetry/opentelemetry-specification/pull/4777))
 
 ### Common
 
@@ -69,9 +72,6 @@ release.
 
 - Clarifies that guidance related to boolean environment variables is not applicable
   to other configuration interfaces. ([#4723](https://github.com/open-telemetry/opentelemetry-specification/pull/4723))
-- Declarative configuration: add optional programmatic customization to
-  `create`, and add related supplemental guidelines.
-  ([#4777](https://github.com/open-telemetry/opentelemetry-specification/pull/4777))
 
 ## v1.51.0 (2025-11-17)
 


### PR DESCRIPTION
Merged https://github.com/open-telemetry/opentelemetry-specification/pull/4780 before adding a changleog entry

#4777  changelog entry was in 1.52.0 section instead of unreleased. 