### PR TITLE
Add OptIn metric advisory parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Add the DefaultDisabled advisory parameter.
+  ([#4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809))
+
 ### Logs
 
 ### Baggage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ release.
 
 ### Metrics
 
-- Add the DefaultDisabled advisory parameter.
+- Add the OptIn advisory parameter.
   ([#4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809))
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ release.
 - Clarify `maxExportBatchSize` behavior, timeouts, and error handling for
   Periodic exporting MetricReader.
   ([#5265](https://github.com/open-telemetry/opentelemetry-specification/pull/5265))
+- Add the DefaultDisabled advisory parameter.
+  ([#4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ release.
 - Clarify `maxExportBatchSize` behavior, timeouts, and error handling for
   Periodic exporting MetricReader.
   ([#5265](https://github.com/open-telemetry/opentelemetry-specification/pull/5265))
-- Add the DefaultDisabled advisory parameter.
+- Add the OptIn advisory parameter.
   ([#4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809))
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ release.
 - Clarify `maxExportBatchSize` behavior, timeouts, and error handling for
   Periodic exporting MetricReader.
   ([#5265](https://github.com/open-telemetry/opentelemetry-specification/pull/5265))
-- Add the OptIn advisory parameter.
+- Add the OptIn advisory parameter and enabled View stream parameter.
   ([#4809](https://github.com/open-telemetry/opentelemetry-specification/pull/4809))
 
 ### Logs

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -130,6 +130,7 @@ formats is required. Implementing more than one format is optional.
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  |
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  |
+| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -130,7 +130,7 @@ formats is required. Implementing more than one format is optional.
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  |
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  |
-| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
+| Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -100,7 +100,6 @@ formats is required. Implementing more than one format is optional.
 
 ## Metrics
 
-<<<<<<< HEAD
 | Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- | ------ |
 | The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + | + | + | + | + | + | - |  | - |
@@ -192,94 +191,6 @@ formats is required. Implementing more than one format is optional.
 | Metric SDK supports configuring cardinality limit per metric (using Views) |  | - | + | + | - |  | - |  | - | - | + |  | - |
 | Metric SDK supports per-timeseries cumulative start timestamps |  |  | + |  |  |  |  |  |  |  |  |  | - |
 | The metric SDK's periodic Reader implementation supports the `maxExportBatchSize` parameter |  | - | + | - | - | - | - | - | - | - | - | - | - |
-=======
-| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
-| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
-| The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + | + | + | + | + | + | - |  |
-| It is possible to create any number of `MeterProvider`s. | X | + | + | + | + | + | + | + | + | + | + |  |
-| `MeterProvider` provides a way to get a `Meter`. |  | + | + | + | + | + | + | + | + | + | - |  |
-| `get_meter` accepts name, `version` and `schema_url`. |  | + | + | + | + |  | + | + | + | + | - |  |
-| `get_meter` accepts `attributes`. |  | + |  | - | + |  |  | + | + | + |  |  |
-| When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + | + | + |  | + | + | - |  |
-| The fallback `Meter` `name` property keeps its original invalid value. | X | + | - | + | + | + | + |  | + | - | - |  |
-| Associate `Meter` with `InstrumentationScope`. |  | + | + | + | + | + | + |  | + | + |  |  |
-| `Counter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
-| `AsynchronousCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
-| `Histogram` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
-| `AsynchronousGauge` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
-| `Gauge` instrument is supported. |  | + | - | + | + | + | - | + | + | - | - |  |
-| `UpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
-| `AsynchronousUpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
-| Instruments have `name` |  | + | + | + | + | + | + | + | + | + | + |  |
-| Instruments have kind. |  | + | + | + | + | + | + | + | + | + | + |  |
-| Instruments have an optional unit of measure. |  | + | + | + | + | + | + | + | + | + | + |  |
-| Instruments have an optional description. |  | + | + | + | + | + | + | + | + | + | + |  |
-| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  | + | + | + | + | + | + |  |  |  |  |  |
-| Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name. |  |  | + |  |  | - | + |  |  |  |  |  |
-| It is possible to register two instruments with same `name` under different `Meter`s. |  | + | + | + | + |  | + |  | + | + | + |  |
-| Instrument names conform to the specified syntax. |  | + | + | + | + | + | + |  |  | + |  |  |
-| Instrument units conform to the specified syntax. |  | - | + |  | + | + | + |  | + | + | + |  |
-| Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  |
-| Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  |
-| Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  |
-| Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
-| All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
-| All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
-| All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
-| `MeterProvider` allows a `Resource` to be specified. |  | + | + | + | + | + |  | + | + | + | + |  |
-| A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary` instance stored in the `Meter`. |  | + | - |  | + |  | + |  | + | + | - |  |
-| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`. |  | + | + | + | + |  | + | + | + | + |  |  |
-| Configuration is managed solely by the `MeterProvider`. |  | + | + | + | + |  | + | + | + | + | + |  |
-| The `MeterProvider` provides methods to update the configuration | X | - | - | - | + |  | - |  |  | - | + |  |
-| The updated configuration applies to all already returned `Meter`s. | if above | - | - | - | - |  | - |  |  | - | + |  |
-| There is a way to register `View`s with a `MeterProvider`. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The `View` instrument selection criteria is as specified. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The `View` instrument selection criteria supports wildcards. | X | + | + | + | + | + | - |  | + | + | + |  |
-| The `View` instrument selection criteria supports the match-all wildcard. |  | + | + | + | + | + | + |  | + | + | + |  |
-| The name of the `View` can be specified. |  | - | + | + | + | + | + | + |  | + | + |  |
-| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | - |  |
-| The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + |  | + |  |  | - |  |  |  |  |  |
-| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  |
-| The SDK allows more than one `View` to be specified per instrument. | X | + | + | + | + | + | + |  | + | + | + |  |
-| The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  |
-| The `Default` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  |
-| The `Default` aggregation uses the specified aggregation by instrument. |  | + | + | + | + | + | + |  | + | + | + |  |
-| The `Sum` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The `LastValue` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The `ExplicitBucketHistogram` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The `ExponentialBucketHistogram` aggregation is available. |  | + |  | + | + | + |  |  |  |  | + |  |
-| The metrics Reader implementation supports registering metric Exporters |  | + | + | + | + | + | + | + | + | + | + |  |
-| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  | + | + | + | + | + | + |  |  | - | - |  |
-| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  | + | + | + | + | + | + |  | + | + |  |  |
-| The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements). |  | + | + | + | + | + | + |  | + | + | + |  |
-| The metrics Exporter `export` function can not be called concurrently from the same Exporter instance. |  | + | + | + | - | + | + |  |  | + | + |  |
-| The metrics Exporter `export` function does not block indefinitely. |  | + | + | + | - | + | + |  |  | + | + |  |
-| The metrics Exporter `export` function receives a batch of metrics. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The metrics Exporter `export` function returns `Success` or `Failure`. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The metrics Exporter provides a `ForceFlush` function. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out. |  | + | + | + | + | + | + | + |  | + | + |  |
-| The metrics Exporter provides a `shutdown` function. |  | + | + | + | + | + | + | + | + | + | + |  |
-| The metrics Exporter `shutdown` function do not block indefinitely. |  | + | + | + | - |  | + |  |  | + | + |  |
-| The metrics SDK samples `Exemplar`s from measurements. |  | + | + | - | - |  | + |  |  |  | + |  |
-| Exemplar sampling can be disabled. |  | + | - | - | - |  | + |  |  |  | + |  |
-| The metrics SDK supports SDK-wide exemplar filter configuration |  | + | + | - | - |  | + |  |  |  | + |  |
-| The metrics SDK supports `TraceBased` exemplar filter |  | + | + | - | - |  | + |  |  |  | + |  |
-| The metrics SDK supports `AlwaysOn` exemplar filter |  | + | + | - | - |  | + |  |  |  | + |  |
-| The metrics SDK supports `AlwaysOff` exemplar filter |  | + | + | - | - |  | + |  |  |  | + |  |
-| Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration. |  | + | + | - | - |  | + |  |  |  | + |  |
-| Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken. |  | + | + | - | - |  | + |  |  |  | + |  |
-| Exemplars contain the timestamp when the measurement was taken. |  | + | + | - | - |  | + |  |  |  | + |  |
-| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - |  | + | + |  |  | - |  |
-| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  | + | - | - | - |  | + | + |  |  | - |  |
-| The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`. |  | + | + | - | - |  | + | + |  |  | - |  |
-| The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation. |  | + | + | - | - |  | + |  |  |  | - |  |
-| A metric Producer accepts an optional metric Filter |  | - |  |  |  |  | - |  |  |  |  |  |
-| The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers |  | - |  |  |  |  | - |  |  |  |  |  |
-| The metric SDK's metric Producer implementations uses the metric Filter |  | - |  |  |  |  | - |  |  |  |  |  |
-| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits) |  | + | + | + | - |  | - |  | - | + | + |  |
-| Metric SDK supports configuring cardinality limit at MeterReader level |  | - | + | + | - |  | - |  | - | - | - |  |
-| Metric SDK supports configuring cardinality limit per metric (using Views) |  | - | + | + | - |  | - |  | - | - | + |  |
 
 ## Logs
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -132,7 +132,6 @@ formats is required. Implementing more than one format is optional.
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  | - |  | - |
 | Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | + | - | - | - |
 | Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
-| Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
@@ -281,7 +280,6 @@ formats is required. Implementing more than one format is optional.
 | Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits) |  | + | + | + | - |  | - |  | - | + | + |  |
 | Metric SDK supports configuring cardinality limit at MeterReader level |  | - | + | + | - |  | - |  | - | - | - |  |
 | Metric SDK supports configuring cardinality limit per metric (using Views) |  | - | + | + | - |  | - |  | - | - | + |  |
->>>>>>> ea7d7ec9 (add DefaultDisabled advisory parameter)
 
 ## Logs
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -131,8 +131,8 @@ formats is required. Implementing more than one format is optional.
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  | + |  | - |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  | - |  | - |
 | Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | + | - | - | - |
-| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
-| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
+| Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
+| Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
@@ -223,7 +223,7 @@ formats is required. Implementing more than one format is optional.
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  |
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  |
-| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
+| Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -129,8 +129,8 @@ formats is required. Implementing more than one format is optional.
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  | - |
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  | + |  | - |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  | - |  | - |
-| Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | + | - | - | - |
 | Instrument supports the advisory OptIn parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
+| Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | + | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -100,6 +100,7 @@ formats is required. Implementing more than one format is optional.
 
 ## Metrics
 
+<<<<<<< HEAD
 | Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- | ------ |
 | The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + | + | + | + | + | + | - |  | - |
@@ -130,6 +131,8 @@ formats is required. Implementing more than one format is optional.
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  | + |  | - |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  | - |  | - |
 | Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | + | - | - | - |
+| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
+| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
@@ -190,6 +193,95 @@ formats is required. Implementing more than one format is optional.
 | Metric SDK supports configuring cardinality limit per metric (using Views) |  | - | + | + | - |  | - |  | - | - | + |  | - |
 | Metric SDK supports per-timeseries cumulative start timestamps |  |  | + |  |  |  |  |  |  |  |  |  | - |
 | The metric SDK's periodic Reader implementation supports the `maxExportBatchSize` parameter |  | - | + | - | - | - | - | - | - | - | - | - | - |
+=======
+| Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift |
+| ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- |
+| The API provides a way to set and get a global default `MeterProvider`. | X | + | + | + | + | + | + | + | + | + | - |  |
+| It is possible to create any number of `MeterProvider`s. | X | + | + | + | + | + | + | + | + | + | + |  |
+| `MeterProvider` provides a way to get a `Meter`. |  | + | + | + | + | + | + | + | + | + | - |  |
+| `get_meter` accepts name, `version` and `schema_url`. |  | + | + | + | + |  | + | + | + | + | - |  |
+| `get_meter` accepts `attributes`. |  | + |  | - | + |  |  | + | + | + |  |  |
+| When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + | + | + |  | + | + | - |  |
+| The fallback `Meter` `name` property keeps its original invalid value. | X | + | - | + | + | + | + |  | + | - | - |  |
+| Associate `Meter` with `InstrumentationScope`. |  | + | + | + | + | + | + |  | + | + |  |  |
+| `Counter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `AsynchronousCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `Histogram` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `AsynchronousGauge` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `Gauge` instrument is supported. |  | + | - | + | + | + | - | + | + | - | - |  |
+| `UpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| `AsynchronousUpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have `name` |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have kind. |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have an optional unit of measure. |  | + | + | + | + | + | + | + | + | + | + |  |
+| Instruments have an optional description. |  | + | + | + | + | + | + | + | + | + | + |  |
+| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  | + | + | + | + | + | + |  |  |  |  |  |
+| Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name. |  |  | + |  |  | - | + |  |  |  |  |  |
+| It is possible to register two instruments with same `name` under different `Meter`s. |  | + | + | + | + |  | + |  | + | + | + |  |
+| Instrument names conform to the specified syntax. |  | + | + | + | + | + | + |  |  | + |  |  |
+| Instrument units conform to the specified syntax. |  | - | + |  | + | + | + |  | + | + | + |  |
+| Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  |
+| Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  |
+| Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  |
+| Instrument supports the advisory DefaultDisabled parameter. |  | - | - | - | - | - | - | - | - | - | - | - |
+| All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
+| All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
+| All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  |
+| `MeterProvider` allows a `Resource` to be specified. |  | + | + | + | + | + |  | + | + | + | + |  |
+| A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary` instance stored in the `Meter`. |  | + | - |  | + |  | + |  | + | + | - |  |
+| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`. |  | + | + | + | + |  | + | + | + | + |  |  |
+| Configuration is managed solely by the `MeterProvider`. |  | + | + | + | + |  | + | + | + | + | + |  |
+| The `MeterProvider` provides methods to update the configuration | X | - | - | - | + |  | - |  |  | - | + |  |
+| The updated configuration applies to all already returned `Meter`s. | if above | - | - | - | - |  | - |  |  | - | + |  |
+| There is a way to register `View`s with a `MeterProvider`. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `View` instrument selection criteria is as specified. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `View` instrument selection criteria supports wildcards. | X | + | + | + | + | + | - |  | + | + | + |  |
+| The `View` instrument selection criteria supports the match-all wildcard. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The name of the `View` can be specified. |  | - | + | + | + | + | + | + |  | + | + |  |
+| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | - |  |
+| The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + |  | + |  |  | - |  |  |  |  |  |
+| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  |
+| The SDK allows more than one `View` to be specified per instrument. | X | + | + | + | + | + | + |  | + | + | + |  |
+| The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The `Default` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The `Default` aggregation uses the specified aggregation by instrument. |  | + | + | + | + | + | + |  | + | + | + |  |
+| The `Sum` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `LastValue` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `ExplicitBucketHistogram` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The `ExponentialBucketHistogram` aggregation is available. |  | + |  | + | + | + |  |  |  |  | + |  |
+| The metrics Reader implementation supports registering metric Exporters |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  | + | + | + | + | + | + |  |  | - | - |  |
+| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  | + | + | + | + | + | + |  | + | + |  |  |
+| The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements). |  | + | + | + | + | + | + |  | + | + | + |  |
+| The metrics Exporter `export` function can not be called concurrently from the same Exporter instance. |  | + | + | + | - | + | + |  |  | + | + |  |
+| The metrics Exporter `export` function does not block indefinitely. |  | + | + | + | - | + | + |  |  | + | + |  |
+| The metrics Exporter `export` function receives a batch of metrics. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter `export` function returns `Success` or `Failure`. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter provides a `ForceFlush` function. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter `ForceFlush` can inform the caller whether it succeeded, failed or timed out. |  | + | + | + | + | + | + | + |  | + | + |  |
+| The metrics Exporter provides a `shutdown` function. |  | + | + | + | + | + | + | + | + | + | + |  |
+| The metrics Exporter `shutdown` function do not block indefinitely. |  | + | + | + | - |  | + |  |  | + | + |  |
+| The metrics SDK samples `Exemplar`s from measurements. |  | + | + | - | - |  | + |  |  |  | + |  |
+| Exemplar sampling can be disabled. |  | + | - | - | - |  | + |  |  |  | + |  |
+| The metrics SDK supports SDK-wide exemplar filter configuration |  | + | + | - | - |  | + |  |  |  | + |  |
+| The metrics SDK supports `TraceBased` exemplar filter |  | + | + | - | - |  | + |  |  |  | + |  |
+| The metrics SDK supports `AlwaysOn` exemplar filter |  | + | + | - | - |  | + |  |  |  | + |  |
+| The metrics SDK supports `AlwaysOff` exemplar filter |  | + | + | - | - |  | + |  |  |  | + |  |
+| Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration. |  | + | + | - | - |  | + |  |  |  | + |  |
+| Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken. |  | + | + | - | - |  | + |  |  |  | + |  |
+| Exemplars contain the timestamp when the measurement was taken. |  | + | + | - | - |  | + |  |  |  | + |  |
+| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - |  | + | + |  |  | - |  |
+| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  | + | - | - | - |  | + | + |  |  | - |  |
+| The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`. |  | + | + | - | - |  | + | + |  |  | - |  |
+| The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation. |  | + | + | - | - |  | + |  |  |  | - |  |
+| A metric Producer accepts an optional metric Filter |  | - |  |  |  |  | - |  |  |  |  |  |
+| The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers |  | - |  |  |  |  | - |  |  |  |  |  |
+| The metric SDK's metric Producer implementations uses the metric Filter |  | - |  |  |  |  | - |  |  |  |  |  |
+| Metric SDK implements [cardinality limit](./specification/metrics/sdk.md#cardinality-limits) |  | + | + | + | - |  | - |  | - | + | + |  |
+| Metric SDK supports configuring cardinality limit at MeterReader level |  | - | + | + | - |  | - |  | - | - | - |  |
+| Metric SDK supports configuring cardinality limit per metric (using Views) |  | - | + | + | - |  | - |  | - | - | + |  |
+>>>>>>> ea7d7ec9 (add DefaultDisabled advisory parameter)
 
 ## Logs
 

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '+'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -221,10 +221,10 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '+'
       - name: Instrument supports the advisory OptIn parameter.
         status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '+'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '+'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -223,6 +223,8 @@ sections:
         status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -221,9 +221,9 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -223,7 +223,7 @@ sections:
         status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -223,7 +223,7 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -221,9 +221,9 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -223,7 +223,7 @@ sections:
         status: '+'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -223,7 +223,7 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -223,6 +223,8 @@ sections:
         status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -221,9 +221,9 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -223,7 +223,7 @@ sections:
         status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -223,7 +223,7 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -221,9 +221,9 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -223,7 +223,7 @@ sections:
         status: '+'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -221,9 +221,9 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -221,9 +221,9 @@ sections:
         status: '-'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -223,6 +223,8 @@ sections:
         status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -223,7 +223,7 @@ sections:
         status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -221,9 +221,9 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -221,9 +221,9 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -221,9 +221,9 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '+'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -221,10 +221,10 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '+'
       - name: Instrument supports the advisory OptIn parameter.
         status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '+'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '+'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -221,9 +221,9 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
-      - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
       - name: Instrument supports the advisory OptIn parameter.
+        status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -223,7 +223,7 @@ sections:
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -155,7 +155,7 @@ sections:
       - name: Instrument descriptions conform to the specified syntax.
       - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
       - name: Instrument supports the advisory Attributes parameter.
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -155,6 +155,7 @@ sections:
       - name: Instrument descriptions conform to the specified syntax.
       - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
       - name: Instrument supports the advisory Attributes parameter.
+      - name: Instrument supports the advisory DefaultDisabled parameter.
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -158,7 +158,6 @@ sections:
       - name: Synchronous instruments support Bind to pre-associate attributes.
         optional: true
       - name: Instrument supports the advisory OptIn parameter.
-      - name: Instrument supports the advisory OptIn parameter.
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -155,9 +155,9 @@ sections:
       - name: Instrument descriptions conform to the specified syntax.
       - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
       - name: Instrument supports the advisory Attributes parameter.
+      - name: Instrument supports the advisory OptIn parameter.
       - name: Synchronous instruments support Bind to pre-associate attributes.
         optional: true
-      - name: Instrument supports the advisory OptIn parameter.
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -157,8 +157,8 @@ sections:
       - name: Instrument supports the advisory Attributes parameter.
       - name: Synchronous instruments support Bind to pre-associate attributes.
         optional: true
-      - name: Instrument supports the advisory DefaultDisabled parameter.
-      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory OptIn parameter.
+      - name: Instrument supports the advisory OptIn parameter.
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -157,6 +157,8 @@ sections:
       - name: Instrument supports the advisory Attributes parameter.
       - name: Synchronous instruments support Bind to pre-associate attributes.
         optional: true
+      - name: Instrument supports the advisory DefaultDisabled parameter.
+      - name: Instrument supports the advisory DefaultDisabled parameter.
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -26,7 +26,7 @@ weight: 1
     + [Instrument advisory parameters](#instrument-advisory-parameters)
       - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
       - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-      - [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
+      - [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-optin)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -277,13 +277,13 @@ Applies to all instrument types.
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
 
-##### Instrument advisory parameter: `DefaultDisabled`
+##### Instrument advisory parameter: `OptIn`
 
 **Status**: [Development](../document-status.md)
 
 Applies to all instrument types.
 
-`DefaultDisabled` (bool) if true, indicates that the instrument should not
+`OptIn` (bool) if true, indicates that the instrument should not
 produce metric data and that functions on the instrument should be no-ops
 unless the user has explicitly enabled the metric.
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -26,6 +26,7 @@ weight: 1
     + [Instrument advisory parameters](#instrument-advisory-parameters)
       - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
       - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
+      - [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -275,6 +276,16 @@ Applies to all instrument types.
 
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
+
+##### Instrument advisory parameter: `DefaultDisabled`
+
+**Status**: [Development](../document-status.md)
+
+Applies to all instrument types.
+
+`DefaultDisabled` indicates that the instrument should not produce metric data
+and functions on the instrument should be no-ops unless the user has explicitly
+enabled the metric.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -283,9 +283,9 @@ the recommended set of attribute keys to be used for the resulting metrics.
 
 Applies to all instrument types.
 
-`DefaultDisabled` indicates that the instrument should not produce metric data
-and functions on the instrument should be no-ops unless the user has explicitly
-enabled the metric.
+`DefaultDisabled` (bool) if true, indicates that the instrument should not
+produce metric data and that functions on the instrument should be no-ops
+unless the user has explicitly enabled the metric.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -283,8 +283,8 @@ the recommended set of attribute keys to be used for the resulting metrics.
 
 Applies to all instrument types.
 
-`OptIn` (bool) if true, indicates that the instrument should not
-produce metric data and that functions on the instrument should be no-ops
+`OptIn` (bool) if true, indicates that the instrument MUST NOT
+produce metric data and that functions on the instrument SHOULD be no-ops
 unless the user has explicitly enabled the metric.
 
 #### Synchronous and Asynchronous instruments

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -285,8 +285,7 @@ the recommended set of attribute keys to be used for the resulting metrics.
 Applies to all instrument types.
 
 `OptIn` (bool) if true, indicates that the instrument MUST NOT
-produce metric data and that functions on the instrument SHOULD be no-ops
-unless the user has explicitly enabled the metric.
+produce metric data unless the user has explicitly enabled the metric.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -284,8 +284,8 @@ the recommended set of attribute keys to be used for the resulting metrics.
 
 Applies to all instrument types.
 
-`OptIn` (bool) if true, indicates that the instrument should not
-produce metric data and that functions on the instrument should be no-ops
+`OptIn` (bool) if true, indicates that the instrument MUST NOT
+produce metric data and that functions on the instrument SHOULD be no-ops
 unless the user has explicitly enabled the metric.
 
 #### Synchronous and Asynchronous instruments

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -284,8 +284,9 @@ the recommended set of attribute keys to be used for the resulting metrics.
 
 Applies to all instrument types.
 
-`OptIn` (bool) if true, indicates that the instrument MUST NOT
-produce metric data unless the user has explicitly enabled the metric.
+`OptIn` (bool) indicates that the instrument is disabled unless the user
+explicitly enables it. If true, OpenTelemetry SDKs produce no metric data for
+the instrument by default.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -284,9 +284,9 @@ the recommended set of attribute keys to be used for the resulting metrics.
 
 Applies to all instrument types.
 
-`DefaultDisabled` indicates that the instrument should not produce metric data
-and functions on the instrument should be no-ops unless the user has explicitly
-enabled the metric.
+`DefaultDisabled` (bool) if true, indicates that the instrument should not
+produce metric data and that functions on the instrument should be no-ops
+unless the user has explicitly enabled the metric.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -26,6 +26,7 @@ weight: 1
     + [Instrument advisory parameters](#instrument-advisory-parameters)
       - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
       - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
+      - [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -276,6 +277,16 @@ Applies to all instrument types.
 
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
+
+##### Instrument advisory parameter: `DefaultDisabled`
+
+**Status**: [Development](../document-status.md)
+
+Applies to all instrument types.
+
+`DefaultDisabled` indicates that the instrument should not produce metric data
+and functions on the instrument should be no-ops unless the user has explicitly
+enabled the metric.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -26,7 +26,7 @@ weight: 1
     + [Instrument advisory parameters](#instrument-advisory-parameters)
       - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
       - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-      - [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
+      - [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-optin)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -278,13 +278,13 @@ Applies to all instrument types.
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
 
-##### Instrument advisory parameter: `DefaultDisabled`
+##### Instrument advisory parameter: `OptIn`
 
 **Status**: [Development](../document-status.md)
 
 Applies to all instrument types.
 
-`DefaultDisabled` (bool) if true, indicates that the instrument should not
+`OptIn` (bool) if true, indicates that the instrument should not
 produce metric data and that functions on the instrument should be no-ops
 unless the user has explicitly enabled the metric.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -414,6 +414,11 @@ The SDK MUST accept the following stream configuration parameters:
   `aggregation_cardinality_limit` value, the `MeterProvider` MUST apply the
   [default aggregation cardinality limit](#metricreader) the `MetricReader` is
   configured with.
+* **Status**: [Development](../document-status.md) - `enabled` (optional): A
+  boolean denoting whether the instrument should be enabled. When `enabled` is
+  `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
+  provided. If unset, the default is `true` unless the `OptIn` 
+  parameter is `true`.
 
 #### Measurement processing
 
@@ -449,8 +454,8 @@ made with an Instrument:
     specify the same aspect of the [Stream configuration](#stream-configuration),
     the setting defined by the View MUST take precedence over the advisory parameters.
 
-Users can configure match-all Views using [Drop aggregation](#drop-aggregation)
-to disable instruments by default.
+Users can configure match-all Views with `enabled=false` or with the
+[Drop aggregation](#drop-aggregation), to disable instruments by default.
 
 #### View examples
 
@@ -1010,11 +1015,12 @@ must be retained.
 This advisory parameter applies to all aggregations.
 
 When an instrument has `OptIn=true`, the SDK MUST use the
-[Drop Aggregation](#drop-aggregation) by default. If the user has provided an
-Aggregation via View(s), that aggregation takes precedence. If the user
-provides the [Default Aggregation](#default-aggregation) using a View, this
-"enables" the instrument with the same behavior as-if the instrument was not
-`OptIn`--including respecting other advisory parameters.
+[Drop Aggregation](#drop-aggregation). If the user sets `enabled=true` on a
+View's [Stream configuration](#stream-configuration), this "enables" the
+instrument with the same behavior as-if the instrument was not `OptIn` --
+including respecting other advisory parameters. Setting fields other than
+`enabled` on the View, including setting the `aggregation`, does not enable
+the instrument.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1009,7 +1009,7 @@ must be retained.
 
 This advisory parameter applies to all aggregations.
 
-When an instrument is `OptIn`, the SDK MUST use the
+When an instrument has `OptIn=true`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation) by default. If the user has provided an
 Aggregation via View(s), that aggregation takes precedence. If the user
 provides the [Default Aggregation](#default-aggregation) using a View, this

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -421,7 +421,8 @@ The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:
 
 * Determine the `MeterProvider` which "owns" the Instrument.
-* If the `MeterProvider` has no `View` registered:
+* If the `MeterProvider` has no `View` registered, or if the Instrument does
+  not match any View's instrument selection criteria:
   * **Status**: [Development](../document-status.md) - If the instrument's
     [OptIn advisory parameter](#instrument-advisory-parameter-OptIn)
     is set to true, use the [Drop Aggregation](#drop-aggregation).
@@ -430,28 +431,26 @@ made with an Instrument:
     [MetricReader](#metricreader) instance's `aggregation` property.
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
     MUST be honored.
-* If the `MeterProvider` has one or more `View`(s) registered:
-  * If the Instrument could match the instrument selection criteria, for each
-    View:
-    * Try to apply the View's stream configuration independently of any other
-      Views registered for the same matching Instrument (i.e. Views are not
-      merged). This may result in [conflicting metric identities](./data-model.md#opentelemetry-protocol-data-model-producer-recommendations)
-      even if stream configurations specify non-overlapping properties (e.g.
-      one View setting `aggregation` and another View setting `attribute_keys`,
-      both leaving the stream `name` as the default configured by the
-      Instrument). If applying the View results in conflicting metric identities
-      the implementation SHOULD apply the View and emit a warning. If it is not
-      possible to apply the View without producing semantic errors (e.g. the
-      View sets an asynchronous instrument to use the [Explicit bucket
-      histogram aggregation](#explicit-bucket-histogram-aggregation)) the
-      implementation SHOULD emit a warning and proceed as if the View did not
-      If both a View and [Instrument advisory parameters](#instrument-advisory-parameters)
-      specify the same aspect of the [Stream configuration](#stream-configuration),
-      the setting defined by the View MUST take precedence over the advisory parameters.
-  * If the Instrument could not match with any of the registered `View`(s), the
-    SDK SHOULD enable the instrument using the default aggregation and temporality.
-    Users can configure match-all Views using [Drop aggregation](#drop-aggregation)
-    to disable instruments by default.
+* If the `MeterProvider` has one or more matching `View`(s) registered, for
+  each `View` that matches the instrument selection criteria:
+  * Try to apply the View's stream configuration independently of any other
+    Views registered for the same matching Instrument (i.e. Views are not
+    merged). This may result in [conflicting metric identities](./data-model.md#opentelemetry-protocol-data-model-producer-recommendations)
+    even if stream configurations specify non-overlapping properties (e.g.
+    one View setting `aggregation` and another View setting `attribute_keys`,
+    both leaving the stream `name` as the default configured by the
+    Instrument). If applying the View results in conflicting metric identities
+    the implementation SHOULD apply the View and emit a warning. If it is not
+    possible to apply the View without producing semantic errors (e.g. the
+    View sets an asynchronous instrument to use the [Explicit bucket
+    histogram aggregation](#explicit-bucket-histogram-aggregation)) the
+    implementation SHOULD emit a warning and proceed as if the View did not
+    If both a View and [Instrument advisory parameters](#instrument-advisory-parameters)
+    specify the same aspect of the [Stream configuration](#stream-configuration),
+    the setting defined by the View MUST take precedence over the advisory parameters.
+
+Users can configure match-all Views using [Drop aggregation](#drop-aggregation)
+to disable instruments by default.
 
 #### View examples
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -417,7 +417,7 @@ The SDK MUST accept the following stream configuration parameters:
 * **Status**: [Development](../document-status.md) - `enabled` (optional): A
   boolean denoting whether the instrument should be enabled. When `enabled` is
   `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
-  provided. If unset, the default is `true` unless the `OptIn` 
+  provided. If unset, the default is `true` unless the `OptIn`
   parameter is `true`.
 
 #### Measurement processing

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -52,7 +52,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-    + [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-OptIn)
+    + [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-optin)
   * [Instrument enabled](#instrument-enabled)
 - [Attribute limits](#attribute-limits)
 - [Exemplar](#exemplar)
@@ -424,7 +424,7 @@ made with an Instrument:
 * If the `MeterProvider` has no `View` registered, or if the Instrument does
   not match any View's instrument selection criteria:
   * **Status**: [Development](../document-status.md) - If the instrument's
-    [OptIn advisory parameter](#instrument-advisory-parameter-OptIn)
+    [OptIn advisory parameter](#instrument-advisory-parameter-optin)
     is set to true, use the [Drop Aggregation](#drop-aggregation).
   * If OptIn is false, take the Instrument and apply the default
     Aggregation on the basis of instrument kind according to the

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -52,7 +52,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-    + [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
+    + [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-OptIn)
   * [Instrument enabled](#instrument-enabled)
 - [Attribute limits](#attribute-limits)
 - [Exemplar](#exemplar)
@@ -423,9 +423,9 @@ made with an Instrument:
 * Determine the `MeterProvider` which "owns" the Instrument.
 * If the `MeterProvider` has no `View` registered:
   * **Status**: [Development](../document-status.md) - If the instrument's
-    [DefaultDisabled advisory parameter](#instrument-advisory-parameter-defaultdisabled)
-    is set, use the [Drop Aggregation](#drop-aggregation).
-  * If DefaultDisabled is not set, take the Instrument and apply the default
+    [OptIn advisory parameter](#instrument-advisory-parameter-OptIn)
+    is set to true, use the [Drop Aggregation](#drop-aggregation).
+  * If OptIn is false, take the Instrument and apply the default
     Aggregation on the basis of instrument kind according to the
     [MetricReader](#metricreader) instance's `aggregation` property.
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
@@ -1004,13 +1004,13 @@ If no View is configured, or if a matching view does not specify attribute keys,
 the advisory parameter should be used. If neither is provided, all attributes
 must be retained.
 
-#### Instrument advisory parameter: `DefaultDisabled`
+#### Instrument advisory parameter: `OptIn`
 
 **Status**: [Development](../document-status.md)
 
 This advisory parameter applies to all aggregations.
 
-When an instrument is `DefaultDisabled`, the SDK MUST use the
+When an instrument is `OptIn`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation) by default. If the user has provided an
 Aggregation via View(s), that aggregation takes precedence.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -52,6 +52,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
+    + [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
   * [Instrument enabled](#instrument-enabled)
 - [Attribute limits](#attribute-limits)
 - [Exemplar](#exemplar)
@@ -420,9 +421,13 @@ The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:
 
 * Determine the `MeterProvider` which "owns" the Instrument.
-* If the `MeterProvider` has no `View` registered, take the Instrument
-    and apply the default Aggregation on the basis of instrument kind according
-    to the [MetricReader](#metricreader) instance's `aggregation` property.
+* If the `MeterProvider` has no `View` registered:
+  * **Status**: [Development](../document-status.md) - If the instrument's
+    [DefaultDisabled advisory parameter](#instrument-advisory-parameter-defaultdisabled)
+    is set, use the [Drop Aggregation](#drop-aggregation).
+  * If DefaultDisabled is not set, take the Instrument and apply the default
+    Aggregation on the basis of instrument kind according to the
+    [MetricReader](#metricreader) instance's `aggregation` property.
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
     MUST be honored.
 * If the `MeterProvider` has one or more `View`(s) registered:
@@ -998,6 +1003,16 @@ If the user has provided attribute keys via View(s), those keys take precedence.
 If no View is configured, or if a matching view does not specify attribute keys,
 the advisory parameter should be used. If neither is provided, all attributes
 must be retained.
+
+#### Instrument advisory parameter: `DefaultDisabled`
+
+**Status**: [Development](../document-status.md)
+
+This advisory parameter applies to all aggregations.
+
+When an instrument is `DefaultDisabled`, the SDK MUST use the
+[Drop Aggregation](#drop-aggregation) by default. If the user has provided an
+Aggregation via View(s), that aggregation takes precedence.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -417,8 +417,10 @@ The SDK MUST accept the following stream configuration parameters:
 * **Status**: [Development](../document-status.md) - `enabled` (optional): A
   boolean denoting whether the instrument should be enabled. When `enabled` is
   `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
-  provided. If unset, the default is `true` unless the `OptIn`
-  parameter is `true`.
+  provided. When `enabled` is `true` for an instrument with `OptIn` set to
+  `true`, the SDK treats the instrument as-if `OptIn` was set to false. The
+  SDK must allow `enabled` to be unset (neither true nor false). If unset,
+  `enabled` has no effect.
 
 #### Measurement processing
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1017,7 +1017,7 @@ This advisory parameter applies to all aggregations.
 When an instrument has `OptIn=true`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation). If the user sets `enabled=true` on a
 View's [Stream configuration](#stream-configuration), this "enables" the
-instrument with the same behavior as-if the instrument was not `OptIn` --
+instrument with the same behavior as-if the instrument was `OptIn=false` --
 including respecting other advisory parameters. Setting fields other than
 `enabled` on the View, including setting the `aggregation`, does not enable
 the instrument.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1011,7 +1011,10 @@ This advisory parameter applies to all aggregations.
 
 When an instrument is `OptIn`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation) by default. If the user has provided an
-Aggregation via View(s), that aggregation takes precedence.
+Aggregation via View(s), that aggregation takes precedence. If the user
+provides the [Default Aggregation](#default-aggregation) using a View, this
+"enables" the instrument with the same behavior as-if the instrument was not
+`OptIn`--including respecting other advisory parameters.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1115,7 +1115,7 @@ This advisory parameter applies to all aggregations.
 When an instrument has `OptIn=true`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation). If the user sets `enabled=true` on a
 View's [Stream configuration](#stream-configuration), this "enables" the
-instrument with the same behavior as-if the instrument was not `OptIn` --
+instrument with the same behavior as-if the instrument was `OptIn=false` --
 including respecting other advisory parameters. Setting fields other than
 `enabled` on the View, including setting the `aggregation`, does not enable
 the instrument.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -54,7 +54,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-    + [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
+    + [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-OptIn)
   * [Instrument enabled](#instrument-enabled)
   * [Instrument bind](#instrument-bind)
 - [Attribute limits](#attribute-limits)
@@ -470,9 +470,9 @@ made with an Instrument:
 * Determine the `MeterProvider` which "owns" the Instrument.
 * If the `MeterProvider` has no `View` registered:
   * **Status**: [Development](../document-status.md) - If the instrument's
-    [DefaultDisabled advisory parameter](#instrument-advisory-parameter-defaultdisabled)
-    is set, use the [Drop Aggregation](#drop-aggregation).
-  * If DefaultDisabled is not set, take the Instrument and apply the default
+    [OptIn advisory parameter](#instrument-advisory-parameter-OptIn)
+    is set to true, use the [Drop Aggregation](#drop-aggregation).
+  * If OptIn is false, take the Instrument and apply the default
     Aggregation on the basis of instrument kind according to the
     [MetricReader](#metricreader) instance's `aggregation` property.
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
@@ -1101,13 +1101,13 @@ If no View is configured, or if a matching view does not specify attribute keys,
 the advisory parameter should be used. If neither is provided, all attributes
 must be retained.
 
-#### Instrument advisory parameter: `DefaultDisabled`
+#### Instrument advisory parameter: `OptIn`
 
 **Status**: [Development](../document-status.md)
 
 This advisory parameter applies to all aggregations.
 
-When an instrument is `DefaultDisabled`, the SDK MUST use the
+When an instrument is `OptIn`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation) by default. If the user has provided an
 Aggregation via View(s), that aggregation takes precedence.
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -503,7 +503,9 @@ made with an Instrument:
     * If both the View and [Instrument advisory
       parameters](#instrument-advisory-parameters) specify the same aspect of
       the [Stream configuration](#stream-configuration), the setting defined by
-      the View MUST take precedence over the advisory parameters.
+      the View MUST take precedence over the advisory parameters, except for the
+      [OptIn](#instrument-advisory-parameter-optin) advisory parameter which
+      requires `enabled` to be set to `true` to be overridden.
   * (**Development**) If `view_matching_mode` is `composable`, and the Instrument could match the instrument selection criteria of one or more Views:
     * Group the matching Views by their configured stream `name`.
       * A group contains Views that configure the same stream `name` and all
@@ -528,7 +530,9 @@ made with an Instrument:
       * If both the matching Views and [Instrument advisory
         parameters](#instrument-advisory-parameters) specify the same aspect of
         the [Stream configuration](#stream-configuration), the setting defined
-        by the Views MUST take precedence over the advisory parameters.
+        by the Views MUST take precedence over the advisory parameters, except
+        for the [OptIn](#instrument-advisory-parameter-optin) advisory parameter
+        which requires `enabled` to be set to `true` to be overridden.
 
 Users can configure match-all Views with `enabled=false` or with the
 [Drop aggregation](#drop-aggregation), to disable instruments by default.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -460,22 +460,22 @@ The SDK MUST accept the following stream configuration parameters:
   [default aggregation cardinality limit](#metricreader) the `MetricReader` is
   configured with.
 * **Status**: [Development](../document-status.md) - `enabled`: A boolean
-  denoting whether the instrument produces metric data.
+  denoting whether the resulting stream produces metric data.
 
   Users can provide an `enabled` value, but it is up to their discretion.
   Therefore, the stream configuration parameter needs to be structured to
   accept an `enabled` value, but MUST NOT obligate a user to provide one.
   The parameter MUST distinguish an unset value from `false`.
 
-  * If `enabled` is `true`, the `MeterProvider` MUST aggregate the instrument
-    as if its [`OptIn`](#instrument-advisory-parameter-optin) advisory
+  * If `enabled` is `true`, the `MeterProvider` MUST aggregate the stream as if
+    the instrument's [`OptIn`](#instrument-advisory-parameter-optin) advisory
     parameter were `false`.
   * If `enabled` is `false`, the `MeterProvider` MUST use the
     [Drop Aggregation](#drop-aggregation), regardless of the `aggregation`
     provided.
   * If `enabled` is unset, the
     [`OptIn`](#instrument-advisory-parameter-optin) advisory parameter
-    determines whether the instrument is enabled.
+    determines whether the stream is enabled.
 
 #### Measurement processing
 
@@ -526,7 +526,7 @@ made with an Instrument:
     * For each resulting stream, apply the Views in its group in registration order.
       For all aspects of the [Stream configuration](#stream-configuration) other
       than `attribute_keys` (`name`, `description`, `aggregation`,
-      `exemplar_reservoir`, `aggregation_cardinality_limit`), the last matching
+      `exemplar_reservoir`, `aggregation_cardinality_limit`, `enabled`), the last matching
       View that specifies that aspect wins. Complex configurations like
       `aggregation` (including internal properties such as bucket boundaries or
       max buckets) are treated as a single atomic unit and are not merged across

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -459,6 +459,11 @@ The SDK MUST accept the following stream configuration parameters:
   `aggregation_cardinality_limit` value, the `MeterProvider` MUST apply the
   [default aggregation cardinality limit](#metricreader) the `MetricReader` is
   configured with.
+* **Status**: [Development](../document-status.md) - `enabled` (optional): A
+  boolean denoting whether the instrument should be enabled. When `enabled` is
+  `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
+  provided. If unset, the default is `true` unless the `OptIn` 
+  parameter is `true`.
 
 #### Measurement processing
 
@@ -523,8 +528,8 @@ made with an Instrument:
         the [Stream configuration](#stream-configuration), the setting defined
         by the Views MUST take precedence over the advisory parameters.
 
-Users can configure match-all Views using [Drop aggregation](#drop-aggregation)
-to disable instruments by default.
+Users can configure match-all Views with `enabled=false` or with the
+[Drop aggregation](#drop-aggregation), to disable instruments by default.
 
 #### View examples
 
@@ -1108,11 +1113,12 @@ must be retained.
 This advisory parameter applies to all aggregations.
 
 When an instrument has `OptIn=true`, the SDK MUST use the
-[Drop Aggregation](#drop-aggregation) by default. If the user has provided an
-Aggregation via View(s), that aggregation takes precedence. If the user
-provides the [Default Aggregation](#default-aggregation) using a View, this
-"enables" the instrument with the same behavior as-if the instrument was not
-`OptIn`--including respecting other advisory parameters.
+[Drop Aggregation](#drop-aggregation). If the user sets `enabled=true` on a
+View's [Stream configuration](#stream-configuration), this "enables" the
+instrument with the same behavior as-if the instrument was not `OptIn` --
+including respecting other advisory parameters. Setting fields other than
+`enabled` on the View, including setting the `aggregation`, does not enable
+the instrument.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -54,6 +54,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
+    + [Instrument advisory parameter: `DefaultDisabled`](#instrument-advisory-parameter-defaultdisabled)
   * [Instrument enabled](#instrument-enabled)
   * [Instrument bind](#instrument-bind)
 - [Attribute limits](#attribute-limits)
@@ -467,9 +468,13 @@ The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:
 
 * Determine the `MeterProvider` which "owns" the Instrument.
-* If the `MeterProvider` has no `View` registered, take the Instrument
-    and apply the default Aggregation on the basis of instrument kind according
-    to the [MetricReader](#metricreader) instance's `aggregation` property.
+* If the `MeterProvider` has no `View` registered:
+  * **Status**: [Development](../document-status.md) - If the instrument's
+    [DefaultDisabled advisory parameter](#instrument-advisory-parameter-defaultdisabled)
+    is set, use the [Drop Aggregation](#drop-aggregation).
+  * If DefaultDisabled is not set, take the Instrument and apply the default
+    Aggregation on the basis of instrument kind according to the
+    [MetricReader](#metricreader) instance's `aggregation` property.
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
     MUST be honored.
 * If the `MeterProvider` has one or more `View`(s) registered:
@@ -1095,6 +1100,16 @@ If the user has provided attribute keys via View(s), those keys take precedence.
 If no View is configured, or if a matching view does not specify attribute keys,
 the advisory parameter should be used. If neither is provided, all attributes
 must be retained.
+
+#### Instrument advisory parameter: `DefaultDisabled`
+
+**Status**: [Development](../document-status.md)
+
+This advisory parameter applies to all aggregations.
+
+When an instrument is `DefaultDisabled`, the SDK MUST use the
+[Drop Aggregation](#drop-aggregation) by default. If the user has provided an
+Aggregation via View(s), that aggregation takes precedence.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1121,7 +1121,7 @@ This advisory parameter applies to all aggregations.
 When an instrument has `OptIn=true`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation). If the user sets `enabled=true` on a
 View's [Stream configuration](#stream-configuration), this "enables" the
-instrument with the same behavior as-if the instrument was `OptIn=false` --
+instrument with the same behavior as-if the instrument was `OptIn=false`,
 including respecting other advisory parameters. Setting fields other than
 `enabled` on the View, including setting the `aggregation`, does not enable
 the instrument.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -488,10 +488,10 @@ made with an Instrument:
 * If the `MeterProvider` has no `View` registered, or if the Instrument does
   not match any View's instrument selection criteria:
   * **Status**: [Development](../document-status.md) - If the instrument's
-    [OptIn advisory parameter](#instrument-advisory-parameter-optin)
-    is set to true, use the [Drop Aggregation](#drop-aggregation).
-  * If OptIn is false, take the Instrument and apply the default
-    Aggregation on the basis of instrument kind according to the
+    [`OptIn` advisory parameter](#instrument-advisory-parameter-optin)
+    is set to `true`, use the [Drop Aggregation](#drop-aggregation).
+  * If `OptIn` is unset or set to `false`, take the Instrument and apply the
+    default Aggregation on the basis of instrument kind according to the
     [MetricReader](#metricreader) instance's `aggregation` property.
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
     MUST be honored.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -462,7 +462,7 @@ The SDK MUST accept the following stream configuration parameters:
 * **Status**: [Development](../document-status.md) - `enabled` (optional): A
   boolean denoting whether the instrument should be enabled. When `enabled` is
   `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
-  provided. If unset, the default is `true` unless the `OptIn` 
+  provided. If unset, the default is `true` unless the `OptIn`
   parameter is `true`.
 
 #### Measurement processing

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -462,8 +462,10 @@ The SDK MUST accept the following stream configuration parameters:
 * **Status**: [Development](../document-status.md) - `enabled` (optional): A
   boolean denoting whether the instrument should be enabled. When `enabled` is
   `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
-  provided. If unset, the default is `true` unless the `OptIn`
-  parameter is `true`.
+  provided. When `enabled` is `true` for an instrument with `OptIn` set to
+  `true`, the SDK treats the instrument as-if `OptIn` was set to false. The
+  SDK must allow `enabled` to be unset (neither true nor false). If unset,
+  `enabled` has no effect.
 
 #### Measurement processing
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -459,13 +459,23 @@ The SDK MUST accept the following stream configuration parameters:
   `aggregation_cardinality_limit` value, the `MeterProvider` MUST apply the
   [default aggregation cardinality limit](#metricreader) the `MetricReader` is
   configured with.
-* **Status**: [Development](../document-status.md) - `enabled` (optional): A
-  boolean denoting whether the instrument should be enabled. When `enabled` is
-  `false`, the View uses the `DropAggregation`, regardless of the `aggregation`
-  provided. When `enabled` is `true` for an instrument with `OptIn` set to
-  `true`, the SDK treats the instrument as-if `OptIn` was set to false. The
-  SDK must allow `enabled` to be unset (neither true nor false). If unset,
-  `enabled` has no effect.
+* **Status**: [Development](../document-status.md) - `enabled`: A boolean
+  denoting whether the instrument produces metric data.
+
+  Users can provide an `enabled` value, but it is up to their discretion.
+  Therefore, the stream configuration parameter needs to be structured to
+  accept an `enabled` value, but MUST NOT obligate a user to provide one.
+  The parameter MUST distinguish an unset value from `false`.
+
+  * If `enabled` is `true`, the `MeterProvider` MUST aggregate the instrument
+    as if its [`OptIn`](#instrument-advisory-parameter-optin) advisory
+    parameter were `false`.
+  * If `enabled` is `false`, the `MeterProvider` MUST use the
+    [Drop Aggregation](#drop-aggregation), regardless of the `aggregation`
+    provided.
+  * If `enabled` is unset, the
+    [`OptIn`](#instrument-advisory-parameter-optin) advisory parameter
+    determines whether the instrument is enabled.
 
 #### Measurement processing
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1133,7 +1133,7 @@ when either:
 
 - **Status**: [Development](../document-status.md) - The [MeterConfig](#meterconfig)
   of the `Meter` used to create the instrument has parameter `enabled=false`.
-- All [resolved views](#measurement-processing) for the instrument are
+- All [resolved streams](#measurement-processing) for the instrument are
   configured with the [Drop Aggregation](#drop-aggregation).
 
 Otherwise, it SHOULD return `true`.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -468,7 +468,8 @@ The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:
 
 * Determine the `MeterProvider` which "owns" the Instrument.
-* If the `MeterProvider` has no `View` registered:
+* If the `MeterProvider` has no `View` registered, or if the Instrument does
+  not match any View's instrument selection criteria:
   * **Status**: [Development](../document-status.md) - If the instrument's
     [OptIn advisory parameter](#instrument-advisory-parameter-OptIn)
     is set to true, use the [Drop Aggregation](#drop-aggregation).
@@ -521,10 +522,9 @@ made with an Instrument:
         parameters](#instrument-advisory-parameters) specify the same aspect of
         the [Stream configuration](#stream-configuration), the setting defined
         by the Views MUST take precedence over the advisory parameters.
-  * If the Instrument could not match with any of the registered `View`(s), the
-    SDK SHOULD enable the instrument using the default aggregation and temporality.
-    Users can configure match-all Views using [Drop aggregation](#drop-aggregation)
-    to disable instruments by default.
+
+Users can configure match-all Views using [Drop aggregation](#drop-aggregation)
+to disable instruments by default.
 
 #### View examples
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1139,15 +1139,16 @@ when either:
 
 - **Status**: [Development](../document-status.md) - The [MeterConfig](#meterconfig)
   of the `Meter` used to create the instrument has parameter `enabled=false`.
-- All [resolved streams](#measurement-processing) for the instrument are
+- All [resulting streams](#measurement-processing) for the instrument are
   configured with the [Drop Aggregation](#drop-aggregation).
 
 Otherwise, it SHOULD return `true`.
 It MAY return `false` to support additional optimizations and features.
 
-Note: If a user makes no configuration changes, `Enabled` returns `true` since by
-default `MeterConfig.enabled=true` and instruments use the default
-aggregation when no matching views match the instrument.
+Note: If a user makes no configuration changes, `Enabled` returns `true` for
+instruments with `OptIn=false` (or unset), since by default
+`MeterConfig.enabled=true` and instruments use the default aggregation when no
+matching views match the instrument.
 
 ### Instrument bind
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -513,9 +513,7 @@ made with an Instrument:
     * If both the View and [Instrument advisory
       parameters](#instrument-advisory-parameters) specify the same aspect of
       the [Stream configuration](#stream-configuration), the setting defined by
-      the View MUST take precedence over the advisory parameters, except for the
-      [OptIn](#instrument-advisory-parameter-optin) advisory parameter which
-      requires `enabled` to be set to `true` to be overridden.
+      the View MUST take precedence over the advisory parameters.
   * (**Development**) If `view_matching_mode` is `composable`, and the Instrument could match the instrument selection criteria of one or more Views:
     * Group the matching Views by their configured stream `name`.
       * A group contains Views that configure the same stream `name` and all
@@ -540,9 +538,7 @@ made with an Instrument:
       * If both the matching Views and [Instrument advisory
         parameters](#instrument-advisory-parameters) specify the same aspect of
         the [Stream configuration](#stream-configuration), the setting defined
-        by the Views MUST take precedence over the advisory parameters, except
-        for the [OptIn](#instrument-advisory-parameter-optin) advisory parameter
-        which requires `enabled` to be set to `true` to be overridden.
+        by the Views MUST take precedence over the advisory parameters.
 
 Users can configure match-all Views with `enabled=false` or with the
 [Drop aggregation](#drop-aggregation), to disable instruments by default.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1109,7 +1109,10 @@ This advisory parameter applies to all aggregations.
 
 When an instrument is `OptIn`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation) by default. If the user has provided an
-Aggregation via View(s), that aggregation takes precedence.
+Aggregation via View(s), that aggregation takes precedence. If the user
+provides the [Default Aggregation](#default-aggregation) using a View, this
+"enables" the instrument with the same behavior as-if the instrument was not
+`OptIn`--including respecting other advisory parameters.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -54,7 +54,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-    + [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-OptIn)
+    + [Instrument advisory parameter: `OptIn`](#instrument-advisory-parameter-optin)
   * [Instrument enabled](#instrument-enabled)
   * [Instrument bind](#instrument-bind)
 - [Attribute limits](#attribute-limits)
@@ -471,7 +471,7 @@ made with an Instrument:
 * If the `MeterProvider` has no `View` registered, or if the Instrument does
   not match any View's instrument selection criteria:
   * **Status**: [Development](../document-status.md) - If the instrument's
-    [OptIn advisory parameter](#instrument-advisory-parameter-OptIn)
+    [OptIn advisory parameter](#instrument-advisory-parameter-optin)
     is set to true, use the [Drop Aggregation](#drop-aggregation).
   * If OptIn is false, take the Instrument and apply the default
     Aggregation on the basis of instrument kind according to the

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1107,7 +1107,7 @@ must be retained.
 
 This advisory parameter applies to all aggregations.
 
-When an instrument is `OptIn`, the SDK MUST use the
+When an instrument has `OptIn=true`, the SDK MUST use the
 [Drop Aggregation](#drop-aggregation) by default. If the user has provided an
 Aggregation via View(s), that aggregation takes precedence. If the user
 provides the [Default Aggregation](#default-aggregation) using a View, this


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4391

## Changes

Add a new advisory parameter, OptIn, which causes the SDK to use the DropAggregation by default.  The instrument's Enabled method returns `false` by default.

Users can enable metrics by using Views.  They can set a new `enabled` parameter to true in the stream configuration to do this.  They can enable _all_ metrics by setting enabled=true with a wildcard (*) view.

### Example in Declarative Config

If accepted, this would likely be an enabled: <bool> field within stream configuraiton.

A user could enable a single instrument with a view:
```
meter_provider:
  views:
    - selector:
        instrument_name: my.optin.instrument
      stream:
        enabled: true
```

A user could disable a single instrument with a view:
```
meter_provider:
  views:
    - selector:
        instrument_name: my.unwanted.instrument
      stream:
        enabled: false
```

A user could enable all OptIn instruments:

```
meter_provider:
  views:
    - selector:
        instrument_name: *
      stream:
        enabled: true
```

## Motivation

I would like to be able to metric semantic conventions with the [opt-in](https://opentelemetry.io/docs/specs/semconv/general/metric-requirement-level/#opt-in) requirement level. In particular, I am interested in this to be able to define some for Go runtime semantic conventions.  See https://github.com/open-telemetry/opentelemetry-go-contrib/issues/6321#issuecomment-2616091391.

## Prototypes

* Go: https://github.com/open-telemetry/opentelemetry-go/pull/7721

## Alternative Considered: DefaultAggregation enables metrics

Instead of a new `enabled` parameter in View, we could just tell users to use `aggregation=DefaultAggregation` to enable OptIn metrics.

The issue is that DefaultAggregation is often used in Views to make a small change (enable exponential histograms, change default histogram boundaries, etc), but **otherwise leave the aggregation unmodified**. If we use DefaultAggregation as a signal to enable OptIn metrics, it prevents DefaultAggregation from being used as a signal to "keep the normal aggregation behavior".

## Alternative Considered: Metric Levels

TL;DR: Metric Levels should be built on-top-of views, and can co-exist with this OptIn parameter.

In a similar vein to https://github.com/open-telemetry/opentelemetry-specification/issues/3205, we could define levels for metrics. As an instrumentation author, instead of defining a metric as "default disabled", I would define a metric as "debug level".  Users would be able to enable all debug metrics as a group, similar to how debug logging is turned on today.

A complete metric levels feature should control more than just which instruments are enabled or disabled. The overall goal should be managing **cardinality** and **data size**, which has many other dimensions. I've opened https://github.com/open-telemetry/opentelemetry-specification/issues/4828 with details about how levels could be layered on-top-of views, as an alternative to adding them to the API.

## Alternative Considered: MeterConfig.EnableOptIn

Instead of (or in addition to) allowing views to enable OptIn instruments, allow enabling all metrics on a Meter using a new configuration option on `MeterConfig`: `EnableOptIn` (or similar). This would cause all OptIn instruments on the meter to be enabled and produce metric data.

* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [x] opentelemetry-configuration PR: https://github.com/open-telemetry/opentelemetry-configuration/pull/724
