### PR TITLE
[chore] Minor improvement to PR Template about changelog skip

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,5 @@ For non-trivial changes, follow the [change proposal process](https://github.com
 * [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
 * [ ] Links to the prototypes (when adding or changing features)
 * [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
+  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
 * [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary


### PR DESCRIPTION
Non-approvers cannot add label, but they can fix the title easily. Sending PR and seeing "red" CI checks feels less welcoming, so this is a small fix so contributors can self-fix.