### PR TITLE
Prepare release 1.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,7 @@ release.
 
 ### Metrics
 
-- Stabilize part of `Enabled` SDK for synchronous instruments.
-  ([#4787](https://github.com/open-telemetry/opentelemetry-specification/pull/4787))
-
 ### Logs
-
-- Add optional Ergonomic API.
-  ([#4741](https://github.com/open-telemetry/opentelemetry-specification/pull/4741))
 
 ### Baggage
 
@@ -32,6 +26,24 @@ release.
 ### OpenTelemetry Protocol
 
 ### Compatibility
+
+### SDK Configuration
+
+### Supplementary Guidelines
+
+### OTEPs
+
+## v1.53.0 (2026-01-09)
+
+### Metrics
+
+- Stabilize part of `Enabled` SDK for synchronous instruments.
+  ([#4787](https://github.com/open-telemetry/opentelemetry-specification/pull/4787))
+
+### Logs
+
+- Add optional Ergonomic API.
+  ([#4741](https://github.com/open-telemetry/opentelemetry-specification/pull/4741))
 
 ### SDK Configuration
 
@@ -51,10 +63,6 @@ release.
 
 - Stabilize complex `AnyValue` attribute value types and related attribute limits.
   ([#4794](https://github.com/open-telemetry/opentelemetry-specification/issues/4794))
-
-### Supplementary Guidelines
-
-### OTEPs
 
 ## v1.52.0 (2025-12-12)
 


### PR DESCRIPTION

### Metrics

- Stabilize part of `Enabled` SDK for synchronous instruments.
  ([#4787](https://github.com/open-telemetry/opentelemetry-specification/pull/4787))

### Logs

- Add optional Ergonomic API.
  ([#4741](https://github.com/open-telemetry/opentelemetry-specification/pull/4741))

### SDK Configuration

- Declarative configuration: clarify default behavior and validation
  requirements of `create` and `parse`.
  ([#4780](https://github.com/open-telemetry/opentelemetry-specification/pull/4780))
- Declarative configuration: add optional programmatic customization to
  `create`, and add related supplemental guidelines.
  ([#4777](https://github.com/open-telemetry/opentelemetry-specification/pull/4777))
- Declarative configuration: add links between SDK extension plugins and
  corresponding declarative config types.
  ([#4802](https://github.com/open-telemetry/opentelemetry-specification/pull/4802))
- Declarative configuration: clarify Registry ComponentProvider `type` parameter
  ([#4799](https://github.com/open-telemetry/opentelemetry-specification/pull/4799))

### Common

- Stabilize complex `AnyValue` attribute value types and related attribute limits.
  ([#4794](https://github.com/open-telemetry/opentelemetry-specification/issues/4794))