### PR TITLE
update go matrix to include support for propagators

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -303,7 +303,7 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | The `Create` operation returns `TracerProvider` | + | + |  |  |  |  | + |  | + |  |  |
 | The `Create` operation returns `MeterProvider` | + | + |  |  |  |  | + |  | + |  |  |
 | The `Create` operation returns `LoggerProvider` | + | + |  |  |  |  | + |  | + |  |  |
-| The `Create` operation returns `Propagators` |  | + |  |  |  |  | + |  | + |  |  |
+| The `Create` operation returns `Propagators` | + | + |  |  |  |  | + |  | + |  |  |
 | The `Create` operation calls `CreateComponent` of corresponding `PluginComponentProvider` when encountering plugin components |  | + |  |  |  |  | + |  | + |  |  |
 | Register a `PluginComponentProvider` |  | + |  |  |  |  | + |  | + |  |  |
 

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -522,7 +522,7 @@ sections:
       - name: The `Create` operation returns `LoggerProvider`
         status: '+'
       - name: The `Create` operation returns `Propagators`
-        status: '?'
+        status: '+'
       - name: The `Create` operation calls `CreateComponent` of corresponding `PluginComponentProvider` when encountering plugin components
         status: '?'
       - name: Register a `PluginComponentProvider`


### PR DESCRIPTION
## Changes

Support for propagators in the Go implementation of Declarative config was completed in https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8281

* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
