### PR TITLE
OTEP: correlating OBI traces to profiles

### DIFF
--- a/oteps/profiles/4855-profiles-obi-correlation.md
+++ b/oteps/profiles/4855-profiles-obi-correlation.md
@@ -20,19 +20,17 @@ Currently, OBI traces and profiles operate independently, making it difficult to
 
 ### Communication Channel
 
-The communication channel between OBI and the profiler is implemented via an eBPF map pinned at `$PINPATH/otel_traces_ctx_v1`.
+The communication channel between OBI and the profiler is implemented via an eBPF map pinned at `$PINPATH/otel/traces_ctx_v1`.
 
 $PINPATH will default to bpffs (`/sys/fs/bpf`) but there must be options to specify an alternative location. If set, the user-configured
 
 location in OBI must match the one set in the profiler.
 
-On startup, both OBI and the profiler, will create the map and pin it if it doesn't exist. OBI will expose an helper function for the profiler
-
-to do so.
+On startup, both OBI and the profiler, will create the map and pin it if it doesn't exist.
 
 ### Data Model
 
-As described in the [Profiles Data Model](./0239-profiles-data-model.md), the shared eBPF map uses a minimal structure to store correlation data.
+As described in the [Profiles Data Model](./0239-profiles-data-model.md), the shared eBPF map uses a minimal structure to store correlation data. OBI will be responsible of removing entries in order to avoid keeping stale contexts.
 
 #### eBPF Map Specification
 
@@ -43,7 +41,7 @@ struct {
     __type(value, struct trace_context);
     __uint(max_entries, 1 << 14);
     __uint(pinning, LIBBPF_PIN_BY_NAME);
-} otel_traces_ctx_v1 SEC(".maps");
+} traces_ctx_v1 SEC(".maps");
 ```
 
 - **Key:** `(u64)pid_tgid`


### PR DESCRIPTION
## Changes

This OTEP introduces a standard communication channel and a specification for correlating profiles to [opentelemetry-ebpf-instrumentation (OBI)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation) traces.

There is a PoC implementation at https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation/pull/1184 and https://github.com/coralogix/opentelemetry-ebpf-profiler/pull/1

* [ ] Related issues #
* [x] Related [OTEP(s)](https://github.com/open-telemetry/oteps) [#212](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0212-profiling-vision.md)
* [x] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary

Opening as Draft for submission to the relevant SIGs first