### PR TITLE
Stabilize Prometheus Counter->OTLP Sum

### DIFF
--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -107,7 +107,7 @@ under the `prometheus.type` key (e.g. `prometheus.type="unknown"`).
 
 ### Counters
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 A [Prometheus Counter](https://prometheus.io/docs/instrumenting/exposition_formats/#basic-info) MUST be converted to an OTLP Sum with `is_monotonic` equal to `true`.
 


### PR DESCRIPTION
Depends on #4860 being merged first.

## Changes

In this PR, I'm declaring the transformation of Prometheus Counters into OTLP Monotonic Sums stable.

I'm still not declaring Gauges stable, as requested in #4744, because I suspect we want to discuss when a Prometheus Gauge becomes an OTLP Gauge or an OTLP UpDownCounter.

* [X] Related issues #4744 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
