### PR TITLE
chore: Nit improvement to changelog check ci

### DIFF
--- a/.github/workflows/verify-changelog.yaml
+++ b/.github/workflows/verify-changelog.yaml
@@ -7,7 +7,7 @@ name: Verify CHANGELOG
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
     branches:
       - main
 
@@ -20,11 +20,12 @@ jobs:
     # Skip if:
     # - PR has "Skip Changelog" label
     # - PR has "dependencies" label
-    # - PR title contains "[chore]"
+    # - PR title contains "[chore]" or starts with "chore:"
     if: >
       ! contains(github.event.pull_request.labels.*.name, 'Skip Changelog') &&
       ! contains(github.event.pull_request.labels.*.name, 'dependencies') &&
-      ! contains(github.event.pull_request.title, '[chore]')
+      ! contains(github.event.pull_request.title, '[chore]') &&
+      ! startsWith(github.event.pull_request.title, 'chore:')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Changes

Changelog checking CI is triggered when Title is edited.
Also ignores changelog check when title starts with `chore:`, which is common in [conventional commits.](https://www.conventionalcommits.org/en/v1.0.0/), so folks might put that due to familiarity with such style, though OTel collector and spec uses `[chore]`
