### PR TITLE
Refine guidance on providing attributes at span creation time

### DIFF
--- a/specification/trace/api.md
+++ b/specification/trace/api.md
@@ -400,9 +400,20 @@ The API MUST accept the following parameters:
   description](sdk.md#sampling). An empty collection will be assumed if
   not specified.
 
-  The API documentation MUST state that adding attributes at span creation is preferred
-  to calling `SetAttribute` later, as samplers can only consider information
-  already present during span creation.
+  Attributes provided at span creation time are the only attributes available
+  to [`Sampler`s](sdk.md#sampler) when making sampling decisions.
+  The API documentation MUST state that:
+
+  - Providing readily-available, low-cost attributes at span creation time
+    enables head-based samplers that rely on attributes (e.g., custom or
+    rule-based samplers) to make informed sampling decisions.
+  - Collecting attribute values can be expensive (e.g., URL parsing, string
+    formatting). When the configured `Sampler` does not consider attributes —
+    as is the case for all built-in samplers — the cost of eagerly computing
+    them for spans that are ultimately dropped is wasted. Instrumentations
+    MAY defer expensive attribute computation until after span creation,
+    guarded by [`IsRecording`](#isrecording), to avoid unnecessary overhead
+    when spans are not being recorded.
 
 - `Link`s - an ordered sequence of Links, see [API definition](#link).
 - `Start timestamp`, default to current time. This argument SHOULD only be set
@@ -515,7 +526,9 @@ attributes"](https://github.com/open-telemetry/semantic-conventions/blob/main/do
 
 Note that [Samplers](sdk.md#sampler) can only consider information already
 present during span creation. Any changes done later, including new or changed
-attributes, cannot change their decisions.
+attributes, cannot change their decisions. See
+[Span Creation](#span-creation) for guidance on when to provide attributes at
+creation time versus setting them later.
 
 #### Add Events
 


### PR DESCRIPTION
## Changes

The current spec gives a blanket preference for providing attributes at span creation for samplers. However, no built-in sampler actually examines attributes — AlwaysOn, AlwaysOff, TraceIdRatioBased, ParentBased, and ProbabilitySampler all ignore them. Eagerly collecting attributes (URL parsing, string ops, Vec/array allocation) for spans that get dropped is wasted work.

This PR replaces the blanket preference with balanced guidance: provide cheap/readily-available attributes at creation (to support custom head-based samplers), but defer expensive attribute computation until after creation, guarded by IsRecording().

.NET instrumentations already follow this guidance - they don't provide attributes at startup time unless they are readily available. I am now adding Rust instrumentations where the costs of providing attributes before sampling is quite high. Hence trying to see if we can balance the wording in the spec.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
