### PR TITLE
Add normative language for logging API/SDK concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ release.
 
 - Add optional `Exception` parameter to Emit LogRecord.
   ([#4824](https://github.com/open-telemetry/opentelemetry-specification/pull/4824))
+- - Add normative language to the Logging API/SDK spec concurrency requirements.
+  ([#4885](https://github.com/open-telemetry/opentelemetry-specification/pull/4885))
 
 ### Baggage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ release.
 
 - Add optional `Exception` parameter to Emit LogRecord.
   ([#4824](https://github.com/open-telemetry/opentelemetry-specification/pull/4824))
-- - Add normative language to the Logging API/SDK spec concurrency requirements.
+- Add normative language to the Logging API/SDK spec concurrency requirements.
   ([#4885](https://github.com/open-telemetry/opentelemetry-specification/pull/4885))
 
 ### Baggage

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -169,9 +169,11 @@ provide it.
 For languages which support concurrent execution the Logs APIs provide
 specific guarantees and safeties.
 
-**LoggerProvider** - all methods are safe to be called concurrently.
+**LoggerProvider** - all methods MUST be documented that implementations need to
+be safe for concurrent use by default.
 
-**Logger** - all methods are safe to be called concurrently.
+**Logger** - all methods MUST be documented that implementations need to
+be safe for concurrent use by default.
 
 ## Ergonomic API
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -41,7 +41,7 @@ weight: 3
     + [Export](#export)
     + [ForceFlush](#forceflush-2)
     + [Shutdown](#shutdown-1)
-
+- [Concurrency requirements](#concurrency-requirements)
 <!-- tocstop -->
 
 </details>
@@ -643,3 +643,18 @@ and the destination is unavailable). [OpenTelemetry SDK](../overview.md#sdk)
 authors MAY decide if they want to make the shutdown timeout configurable.
 
 - [OTEP0150 Logging Library SDK Prototype Specification](../../oteps/logs/0150-logging-library-sdk.md)
+
+## Concurrency requirements
+
+**Status**: [Stable](../document-status.md)
+
+For languages which support concurrent execution the Logging SDKs provide
+specific guarantees and safeties.
+
+**LoggerProvider** - Logger creation, `ForceFlush` and `Shutdown` MUST be safe
+to be called concurrently.
+
+**Logger** - all methods MUST be safe to be called concurrently.
+
+**LogRecordExporter** - `ForceFlush` and `Shutdown` MUST be safe to be called
+concurrently.

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -42,6 +42,7 @@ weight: 3
     + [ForceFlush](#forceflush-2)
     + [Shutdown](#shutdown-1)
 - [Concurrency requirements](#concurrency-requirements)
+
 <!-- tocstop -->
 
 </details>


### PR DESCRIPTION
Similar to #4868.

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #4867
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
