### PR TITLE
fix: clarify description of LoggerConfig.trace_based

### DIFF
--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -210,6 +210,9 @@ It consists of the following parameters:
 
   If not explicitly set, the `trace_based` parameter MUST default to `false`.
 
+  If `trace_based` is `false`, log records MUST NOT be affected because of this
+  parameter.
+
   If `trace_based` is `true`, log records associated with unsampled traces MUST
   be dropped by the `Logger`. A log record is considered associated with an unsampled trace
   if it has a valid `SpanId` and its `TraceFlags` indicate that the trace is unsampled.


### PR DESCRIPTION
Minor clarification. The reader of the current description may think that if `trace_based = true` then log records not associated with a trace should not be recorded (which is not true).

The proposed change is more precise and follows other parts of the specification that use normative language such as

https://github.com/open-telemetry/opentelemetry-specification/blob/e4ad687a9e89abf9d59ee394ee10977d041b71ba/specification/logs/sdk.md?plain=1#L213-L217

https://github.com/open-telemetry/opentelemetry-specification/blob/e4ad687a9e89abf9d59ee394ee10977d041b71ba/specification/logs/sdk.md?plain=1#L249-L252

https://github.com/open-telemetry/opentelemetry-specification/blob/e4ad687a9e89abf9d59ee394ee10977d041b71ba/specification/logs/sdk.md?plain=1#L264-L266

Moreover, define the behavior when `trace_based = false` using normative language. 