### PR TITLE
Have Lychee ignore 429 errors (too many requests).

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,6 +1,6 @@
 include_fragments = true
 
-accept = ["200..=299", "403"]
+accept = ["200..=299", "403", "429"]
 
 remap = [
   # workaround for https://github.com/lycheeverse/lychee/issues/1729


### PR DESCRIPTION
Lately we are getting a 429 error on _most_ of our PRs, so this is a temporary fix. Probably testing with Lychee's caching facilities will help?

cc @trask @chalin 
