### PR TITLE
feat: Explicitly define include/exclude attributes for views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ release.
   ([#4895](https://github.com/open-telemetry/opentelemetry-specification/pull/4895))
 - Add development `exclude_attribute_keys` parameter to Stream Configuration.
   ([#4951](https://github.com/open-telemetry/opentelemetry-specification/pull/4951))
-- Add development `Exclude_Attributes` parameter to Instrument Advisory.
+- Add development `include_attribute_keys` parameter to Stream Configuration.
   ([#4951](https://github.com/open-telemetry/opentelemetry-specification/pull/4951))
 
 ### Logs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ release.
 - Add development `maxExportBatchSize` parameter to Periodic exporting MetricReader.
   ([#4895](https://github.com/open-telemetry/opentelemetry-specification/pull/4895))
 - Add development `exclude_attribute_keys` parameter to Stream Configuration.
-  ([]())
+  ([#4951](https://github.com/open-telemetry/opentelemetry-specification/pull/4951))
 - Add development `Exclude_Attributes` parameter to Instrument Advisory.
-  ([]())
+  ([#4951](https://github.com/open-telemetry/opentelemetry-specification/pull/4951))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ release.
 
 - Add development `maxExportBatchSize` parameter to Periodic exporting MetricReader.
   ([#4895](https://github.com/open-telemetry/opentelemetry-specification/pull/4895))
+- Add development `exclude_attribute_keys` parameter to Stream Configuration.
+  ([]())
+- Add development `Exclude_Attributes` parameter to Instrument Advisory.
+  ([]())
 
 ### Logs
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -26,6 +26,7 @@ weight: 1
     + [Instrument advisory parameters](#instrument-advisory-parameters)
       - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
       - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
+      - [Instrument advisory parameter: `ExcludeAttributes`](#instrument-advisory-parameter-excludeattributes)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -276,13 +277,13 @@ Applies to all instrument types.
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
 
-##### Instrument advisory parameter: `Exclude_Attributes`
+##### Instrument advisory parameter: `ExcludeAttributes`
 
 **Status**: [Development](../document-status.md)
 
 Applies to all instrument types.
 
-`Exclude_Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
+`ExcludeAttributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to not be used for the resulting metrics.
 
 #### Synchronous and Asynchronous instruments

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -276,6 +276,15 @@ Applies to all instrument types.
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
 
+##### Instrument advisory parameter: `Exclude_Attributes`
+
+**Status**: [Development](../document-status.md)
+
+Applies to all instrument types.
+
+`Exclude_Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
+the recommended set of attribute keys to not be used for the resulting metrics.
+
 #### Synchronous and Asynchronous instruments
 
 Instruments are categorized on whether they are synchronous or

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -26,7 +26,6 @@ weight: 1
     + [Instrument advisory parameters](#instrument-advisory-parameters)
       - [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
       - [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-      - [Instrument advisory parameter: `ExcludeAttributes`](#instrument-advisory-parameter-excludeattributes)
     + [Synchronous and Asynchronous instruments](#synchronous-and-asynchronous-instruments)
       - [Synchronous Instrument API](#synchronous-instrument-api)
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
@@ -276,15 +275,6 @@ Applies to all instrument types.
 
 `Attributes` (a list of [attribute keys](../common/README.md#attribute)) is
 the recommended set of attribute keys to be used for the resulting metrics.
-
-##### Instrument advisory parameter: `ExcludeAttributes`
-
-**Status**: [Development](../document-status.md)
-
-Applies to all instrument types.
-
-`ExcludeAttributes` (a list of [attribute keys](../common/README.md#attribute)) is
-the recommended set of attribute keys to not be used for the resulting metrics.
 
 #### Synchronous and Asynchronous instruments
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -53,7 +53,6 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
-    + [Instrument advisory parameter: `ExcludeAttributes`](#instrument-advisory-parameter-excludeattributes)
   * [Instrument enabled](#instrument-enabled)
 - [Attribute limits](#attribute-limits)
 - [Exemplar](#exemplar)
@@ -360,23 +359,31 @@ The SDK MUST accept the following stream configuration parameters:
   accept a `description`, but MUST NOT obligate a user to provide one. If the
   user does not provide a `description` value, the description from the
   Instrument a View matches MUST be used by default.
-* `attribute_keys`: This is, at a minimum, an allow-list of attribute keys for
-  measurements captured in the metric stream. The allow-list contains attribute
+* `attribute_keys`: This is, at a minimum, a list of attribute keys for
+  measurements captured in the metric stream. The list contains attribute
   keys that identify the attributes that MUST be kept, and all other attributes
   MUST be ignored.
 
   Implementations MAY accept additional attribute filtering functionality for
   this parameter.
 
+  If a user specifies both `attribute_keys` and either `include_attribute_keys`
+  or `exclude_attribute_keys`, the SDK MAY fail fast in
+  accordance with initialization [error handling
+  principles](../error-handling.md#basic-error-handling-principles).
+
   Users can provide `attribute_keys`, but it is up to their discretion.
   Therefore, the stream configuration parameter needs to be structured to
   accept `attribute_keys`, but MUST NOT obligate a user to provide them.
+
   If the user does not provide any value, the SDK SHOULD use
   the [`Attributes`](./api.md#instrument-advisory-parameters) advisory
-  parameter configured on the instrument instead. If the `Attributes`
+  parameter configured on the instrument instead as well as any attributes
+  specified via `include_attribute_keys`. If the `Attributes`
   advisory parameter is absent, all attributes MUST be kept.
-
-* `exlude_attribute_keys`: This is, at a minimum, an exclude-list of attribute keys for 
+  In both cases
+  attributes specified via `exclude_attribute_keys` should not be kept.
+* `exclude_attribute_keys`: This is, an exclude-list of attribute keys for
   measurements captured in the metric stream.
   The exclude-list contains attribute keys that identify the
   attributes that MUST be excluded, all other attributes MUST be kept. If an
@@ -387,11 +394,18 @@ The SDK MUST accept the following stream configuration parameters:
   Users can provide `exclude_attribute_keys`, but it is up to their discretion.
   Therefore, the stream configuration parameter needs to be structured to
   accept `exclude_attribute_keys`, but MUST NOT obligate a user to provide them.
-  If the user does not provide any value, the SDK SHOULD use
-  the [`Exclude Attributes`](./api.md#instrument-advisory-parameters) advisory
-  parameter configured on the instrument instead. If the `Exclude Attributes`
-  advisory parameter is absent, all attributes MUST be kept.
+* `include_attribute_keys`: This is, an include-list of attribute keys for
+  measurements captured in the metric stream. The include-list contains
+  attribute keys that identify the attributes that MUST be kept in addition to
+  the [`Attributes`](./api.md#instrument-advisory-parameters) advisory parameter
+  configured on the instrument, all other attributes must be excluded. If an
+  attribute key is both included and excluded, the SDK MAY fail fast in
+  accordance with initialization [error handling
+  principles](../error-handling.md#basic-error-handling-principles).
 
+  Users can provide `include_attribute_keys`, but it is up to their discretion.
+  Therefore, the stream configuration parameter needs to be structured to
+  accept `include_attribute_keys`, but MUST NOT obligate a user to provide them.
 * `aggregation`: The name of an [aggregation](#aggregation) function to use in
   aggregating the metric stream data.
 
@@ -1033,21 +1047,6 @@ If the user has provided attribute keys via View(s), those keys take precedence.
 If no View is configured, or if a matching view does not specify attribute keys,
 the advisory parameter should be used. If neither is provided, all attributes
 must be retained.
-
-#### Instrument advisory parameter: `ExcludeAttributes`
-
-**Status**: [Development](../document-status.md)
-
-This advisory parameter applies to all aggregations.
-
-`ExcludeAttributes` (a list of [attribute keys](../common/README.md#attribute))
-specifies the recommended set of attribute keys not to be used for measurements to
-produce a metric stream.
-
-If the user has provided attribute keys via View(s), those keys take precedence.
-If no View is configured, or if a matching view does not specify exclude attribute keys,
-the advisory parameter should be used. If neither is provided, no attributes
-must be removed.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -53,6 +53,7 @@ weight: 3
   * [Instrument advisory parameters](#instrument-advisory-parameters)
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
+    + [Instrument advisory parameter: `ExcludeAttributes`](#instrument-advisory-parameter-excludeattributes)
   * [Instrument enabled](#instrument-enabled)
 - [Attribute limits](#attribute-limits)
 - [Exemplar](#exemplar)
@@ -1032,6 +1033,21 @@ If the user has provided attribute keys via View(s), those keys take precedence.
 If no View is configured, or if a matching view does not specify attribute keys,
 the advisory parameter should be used. If neither is provided, all attributes
 must be retained.
+
+#### Instrument advisory parameter: `ExcludeAttributes`
+
+**Status**: [Development](../document-status.md)
+
+This advisory parameter applies to all aggregations.
+
+`ExcludeAttributes` (a list of [attribute keys](../common/README.md#attribute))
+specifies the recommended set of attribute keys not to be used for measurements to
+produce a metric stream.
+
+If the user has provided attribute keys via View(s), those keys take precedence.
+If no View is configured, or if a matching view does not specify exclude attribute keys,
+the advisory parameter should be used. If neither is provided, no attributes
+must be removed.
 
 ### Instrument enabled
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -387,9 +387,7 @@ The SDK MUST accept the following stream configuration parameters:
   measurements captured in the metric stream.
   The exclude-list contains attribute keys that identify the
   attributes that MUST be excluded, all other attributes MUST be kept. If an
-  attribute key is both included and excluded, the SDK MAY fail fast in
-  accordance with initialization [error handling
-  principles](../error-handling.md#basic-error-handling-principles).
+  attribute key is both included and excluded, the attribute will be excluded.
 
   Users can provide `exclude_attribute_keys`, but it is up to their discretion.
   Therefore, the stream configuration parameter needs to be structured to
@@ -399,9 +397,7 @@ The SDK MUST accept the following stream configuration parameters:
   attribute keys that identify the attributes that MUST be kept in addition to
   the [`Attributes`](./api.md#instrument-advisory-parameters) advisory parameter
   configured on the instrument, all other attributes must be excluded. If an
-  attribute key is both included and excluded, the SDK MAY fail fast in
-  accordance with initialization [error handling
-  principles](../error-handling.md#basic-error-handling-principles).
+  attribute key is both included and excluded, the attribute will be excluded.
 
   Users can provide `include_attribute_keys`, but it is up to their discretion.
   Therefore, the stream configuration parameter needs to be structured to

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -375,12 +375,21 @@ The SDK MUST accept the following stream configuration parameters:
   parameter configured on the instrument instead. If the `Attributes`
   advisory parameter is absent, all attributes MUST be kept.
 
-  Additionally, implementations SHOULD support configuring an exclude-list of
-  attribute keys. The exclude-list contains attribute keys that identify the
+* `exlude_attribute_keys`: This is, at a minimum, an exclude-list of attribute keys for 
+  measurements captured in the metric stream.
+  The exclude-list contains attribute keys that identify the
   attributes that MUST be excluded, all other attributes MUST be kept. If an
   attribute key is both included and excluded, the SDK MAY fail fast in
   accordance with initialization [error handling
   principles](../error-handling.md#basic-error-handling-principles).
+
+  Users can provide `exclude_attribute_keys`, but it is up to their discretion.
+  Therefore, the stream configuration parameter needs to be structured to
+  accept `exclude_attribute_keys`, but MUST NOT obligate a user to provide them.
+  If the user does not provide any value, the SDK SHOULD use
+  the [`Exclude Attributes`](./api.md#instrument-advisory-parameters) advisory
+  parameter configured on the instrument instead. If the `Exclude Attributes`
+  advisory parameter is absent, all attributes MUST be kept.
 
 * `aggregation`: The name of an [aggregation](#aggregation) function to use in
   aggregating the metric stream data.


### PR DESCRIPTION
Fixes #

## Changes

Explicitly define method to exclude metric attributes which was already mentioned functionality in the attributes property description in the spec. This exclude functionality was already defined in the stable declarative config. The include is added to avoid changing the behaviour of the existing property.

Discussed on slack -> https://cloud-native.slack.com/archives/C01N7PP1THC/p1773667594006789

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
