### PR TITLE
prometheus: stabilize metadata transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ release.
   ([#4952](https://github.com/open-telemetry/opentelemetry-specification/pull/4952))
 - Stabilize OpenTelemetry Attributes to Prometheus labels transformation.
   ([#4963](https://github.com/open-telemetry/opentelemetry-specification/pull/4963))
+- Stabilize Prometheus Metadata transformation.
+  ([#4954](https://github.com/open-telemetry/opentelemetry-specification/pull/4954))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -88,12 +88,37 @@ The [Prometheus Metric Name](https://prometheus.io/docs/instrumenting/exposition
 MUST be added as the Name of the OTLP metric. The name SHOULD NOT be altered.
 
 [Prometheus UNIT metadata](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metricfamily),
-if present, MUST be converted to the unit of the OTLP metric. The unit SHOULD
-be translated from Prometheus conventions to OpenTelemetry conventions by:
+if present, MUST be converted to the unit of the OTLP metric. The unit MUST
+be translated from words to the UCUM abbreviation if it is in the following set
+of commonly-used units:
 
-* Converting from full words to abbreviations (e.g. "milliseconds" to "ms").
-* Special case: Converting "ratio" to "1".
-* Converting "foo_per_bar" to "foo/bar".
+| Prometheus Unit | UCUM Abbreviation |
+| :--- | :--- |
+| `days` | `d` |
+| `hours` | `h` |
+| `minutes` | `min` |
+| `seconds` | `s` |
+| `milliseconds` | `ms` |
+| `microseconds` | `us` |
+| `nanoseconds` | `ns` |
+| `bytes` | `By` |
+| `kibibytes` | `KiBy` |
+| `mebibytes` | `MiBy` |
+| `gibibytes` | `GiBy` |
+| `tibibytes` | `TiBy` |
+| `kilobytes` | `KBy` |
+| `megabytes` | `MBy` |
+| `gigabytes` | `GBy` |
+| `terabytes` | `TBy` |
+| `meters` | `m` |
+| `volts` | `V` |
+| `amperes` | `A` |
+| `joules` | `J` |
+| `watts` | `W` |
+| `grams` | `g` |
+| `celsius` | `Cel` |
+| `hertz` | `Hz` |
+| `percent` | `%` |
 
 [Prometheus HELP metadata](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information),
 if present, MUST be added as the description of the OTLP metric.

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -82,10 +82,10 @@ at the time of writing:
 
 ### Metric Metadata
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 The [Prometheus Metric Name](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information)
-MUST be added as the Name of the OTLP metric. By default, the name SHOULD NOT be altered, but translation SHOULD provide configuration which, when enabled, removes type (e.g. `_total`) and unit (e.g. `_seconds`) suffixes.
+MUST be added as the Name of the OTLP metric. The name SHOULD NOT be altered.
 
 [Prometheus UNIT metadata](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metricfamily),
 if present, MUST be converted to the unit of the OTLP metric. The unit SHOULD

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -105,8 +105,8 @@ of commonly-used units:
 | `kibibytes` | `KiBy` |
 | `mebibytes` | `MiBy` |
 | `gibibytes` | `GiBy` |
-| `tibibytes` | `TiBy` |
-| `kilobytes` | `KBy` |
+| `tebibytes` | `TiBy` |
+| `kilobytes` | `kBy` |
 | `megabytes` | `MBy` |
 | `gigabytes` | `GBy` |
 | `terabytes` | `TBy` |


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4743

## Changes

Remove configuration from the transformation spec, and stabilize the section. The collector's prometheus receiver will likely remove its configuration to trim_metric_suffixes, hence why it says that the name SHOULD NOT be altered.

@open-telemetry/prometheus-interoperability 