### PR TITLE
[docs] Fix OpenTracing migration links in documentation

### DIFF
--- a/specification/compatibility/opentracing.md
+++ b/specification/compatibility/opentracing.md
@@ -78,8 +78,8 @@ may have higher version requirements than their OpenTracing counterparts.
 For details, see the [Language version support][] section of [Migrating from
 OpenTracing][].
 
-[Language version support]: https://opentelemetry.io/docs/migration/opentracing/#language-version-support
-[Migrating from OpenTracing]: https://opentelemetry.io/docs/migration/opentracing/
+[Language version support]: https://opentelemetry.io/docs/compatibility/migration/opentracing/#language-version-support
+[Migrating from OpenTracing]: https://opentelemetry.io/docs/compatibility/migration/opentracing/
 
 ## Create an OpenTracing Tracer Shim
 


### PR DESCRIPTION
Update links to the compatibility migration section for OpenTracing.

## Changes

The Comms SIG is conducting a small rearchitecture of the Migration section of opentelemetry.io. Our link checker is failing on these two links, so this PR updates the URLs to the correct paths.

**EDIT**: The broken links are expected. They'll be fixed when the [Comms PR](https://github.com/open-telemetry/opentelemetry.io/pull/9439) is merged.
