### PR TITLE
Prometheus: Stabilize OpenTelemetry to Prometheus Metric Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ release.
   ([#4962](https://github.com/open-telemetry/opentelemetry-specification/pull/4962))
 - Stabilize Prometheus Metadata transformation.
   ([#4954](https://github.com/open-telemetry/opentelemetry-specification/pull/4954))
+- Stabilize OpenTelemetry Metric Metadata to Prometheus metric metadata.
+  ([#4966](https://github.com/open-telemetry/opentelemetry-specification/pull/4966))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -419,17 +419,46 @@ registration, indicative of the same problem](https://opentelemetry.io/docs/spec
 
 The Name of an OTLP metric MUST be added as the
 [Prometheus Metric Name](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information).
-Prometheus naming conventions encourage metric names to match the regular expression:
-`[a-zA-Z_:]([a-zA-Z0-9_:])*`. Discouraged characters in the metric name SHOULD
-be replaced with the `_` character by default, aiming for compatibility with
-Prometheus conventions. Multiple consecutive `_` characters SHOULD be replaced
-with a single `_` character.
+Prometheus naming conventions encourage metric names to match the regular
+expression: `[a-zA-Z_:]([a-zA-Z0-9_:])*`. Discouraged characters in the metric
+name SHOULD be replaced with the `_` character by default, aiming for
+compatibility with Prometheus conventions. Multiple consecutive `_` characters
+SHOULD be replaced with a single `_` character.
 
-The Unit of an OTLP metric point SHOULD be converted to the equivalent unit in Prometheus when possible. This includes:
+The Unit of an OTLP metric point MUST be converted from the UCUM unit to the
+equivalent unit word in Prometheus if it is included in the table below:
 
-* Converting from abbreviations to full words (e.g. "ms" to "milliseconds").
-* Dropping the portions of the Unit within brackets (e.g. {packet}). Brackets MUST NOT be included in the resulting unit. A "count of foo" is considered unitless in Prometheus.
-* Converting "foo/bar" to "foo_per_bar".
+| UCUM Abbreviation | Prometheus Unit |
+| :--- | :--- |
+| `d` | `days` |
+| `h` | `hours` |
+| `min` | `minutes` |
+| `s` | `seconds` |
+| `ms` | `milliseconds` |
+| `us` | `microseconds` |
+| `ns` | `nanoseconds` |
+| `By` | `bytes` |
+| `KiBy` | `kibibytes` |
+| `MiBy` | `mebibytes` |
+| `GiBy` | `gibibytes` |
+| `TiBy` | `tibibytes` |
+| `KBy` | `kilobytes` |
+| `MBy` | `megabytes` |
+| `GBy` | `gigabytes` |
+| `TBy` | `terabytes` |
+| `m` | `meters` |
+| `V` | `volts` |
+| `A` | `amperes` |
+| `J` | `joules` |
+| `W` | `watts` |
+| `g` | `grams` |
+| `Cel` | `celsius` |
+| `Hz` | `hertz` |
+| `%` | `percent` |
+
+Portions of the Unit within brackets (e.g. {packet}) MUST be dropped.
+
+Units defined as rates over time e.g. "m/s" MUST be converted to "meters_per_second".
 
 The resulting unit SHOULD be added to the metric as
 [UNIT metadata](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metricfamily).

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -419,11 +419,11 @@ registration, indicative of the same problem](https://opentelemetry.io/docs/spec
 
 The Name of an OTLP metric MUST be added as the
 [Prometheus Metric Name](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information).
-Prometheus naming conventions encourage metric names to match the regular
-expression: `[a-zA-Z_:]([a-zA-Z0-9_:])*`. Discouraged characters in the metric
-name SHOULD be replaced with the `_` character by default, aiming for
-compatibility with Prometheus conventions. Multipleconsecutive `_` characters
-SHOULD be replaced with a single `_` character.
+Prometheus naming conventions encourage metric names to match the regular expression:
+`[a-zA-Z_:]([a-zA-Z0-9_:])*`. Discouraged characters in the metric name SHOULD
+be replaced with the `_` character by default, aiming for compatibility with
+Prometheus conventions. Multiple consecutive `_` characters SHOULD be replaced
+with a single `_` character.
 
 The Unit of an OTLP metric point SHOULD be converted to the equivalent unit in Prometheus when possible. This includes:
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -414,7 +414,8 @@ conflicting TYPE comments, but SHOULD NOT drop metric points as a result of
 conflicting UNIT or HELP comments. Instead, all but one of the conflicting UNIT
 and HELP comments (but not metric points) SHOULD be dropped. If dropping a
 comment or metric points, the exporter SHOULD warn the user through error
-logging.
+logging. Note that SDKs are required to [warn the user over duplicate instrument
+registration, indicative of the same problem](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#duplicate-instrument-registration).
 
 The Name of an OTLP metric MUST be added as the
 [Prometheus Metric Name](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information).

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -426,39 +426,13 @@ compatibility with Prometheus conventions. Multiple consecutive `_` characters
 SHOULD be replaced with a single `_` character.
 
 The Unit of an OTLP metric point MUST be converted from the UCUM unit to the
-equivalent unit word in Prometheus if it is included in the table below:
-
-| UCUM Abbreviation | Prometheus Unit |
-| :--- | :--- |
-| `d` | `days` |
-| `h` | `hours` |
-| `min` | `minutes` |
-| `s` | `seconds` |
-| `ms` | `milliseconds` |
-| `us` | `microseconds` |
-| `ns` | `nanoseconds` |
-| `By` | `bytes` |
-| `KiBy` | `kibibytes` |
-| `MiBy` | `mebibytes` |
-| `GiBy` | `gibibytes` |
-| `TiBy` | `tebibytes` |
-| `kBy` | `kilobytes` |
-| `MBy` | `megabytes` |
-| `GBy` | `gigabytes` |
-| `TBy` | `terabytes` |
-| `m` | `meters` |
-| `V` | `volts` |
-| `A` | `amperes` |
-| `J` | `joules` |
-| `W` | `watts` |
-| `g` | `grams` |
-| `Cel` | `celsius` |
-| `Hz` | `hertz` |
-| `%` | `percent` |
+equivalent unit word in Prometheus if it is included in the
+table in [Metric Metadata above](#metric-metadata).
 
 Portions of the Unit within brackets (e.g. {packet}) MUST be dropped.
 
-Units defined as rates over time e.g. "m/s" MUST be converted to "meters_per_second".
+Units defined as rates over time (e.g. "m/s") MUST be converted to words (e.g.
+"meters_per_second").
 
 The resulting unit SHOULD be added to the metric as
 [UNIT metadata](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#metricfamily).

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -405,27 +405,29 @@ in keys).
 
 ### Metric Metadata
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
-Prometheus Pull exporters MUST NOT allow duplicate UNIT, HELP, or TYPE
-comments for the same metric name to be returned in a single scrape of the
-Prometheus endpoint. Exporters MUST drop entire metrics to prevent conflicting
-TYPE comments, but SHOULD NOT drop metric points as a result of conflicting
-UNIT or HELP comments. Instead, all but one of the conflicting UNIT and HELP
-comments (but not metric points) SHOULD be dropped. If dropping a comment or
-metric points, the exporter SHOULD warn the user through error logging.
+Prometheus Pull exporters for OpenTelemetry metric data MUST NOT allow duplicate
+UNIT, HELP, or TYPE comments for the same metric name to be returned in a single
+scrape of the Prometheus endpoint. Exporters MUST drop entire metrics to prevent
+conflicting TYPE comments, but SHOULD NOT drop metric points as a result of
+conflicting UNIT or HELP comments. Instead, all but one of the conflicting UNIT
+and HELP comments (but not metric points) SHOULD be dropped. If dropping a
+comment or metric points, the exporter SHOULD warn the user through error
+logging.
 
 The Name of an OTLP metric MUST be added as the
 [Prometheus Metric Name](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information).
-Prometheus naming conventions encourage metric names to match the regular expression: `[a-zA-Z_:]([a-zA-Z0-9_:])*`. Discouraged characters
-in the metric name SHOULD be replaced with the `_` character by default, aiming for compatibility with Prometheus conventions. Multiple
-consecutive `_` characters SHOULD be replaced with a single `_` character.
+Prometheus naming conventions encourage metric names to match the regular
+expression: `[a-zA-Z_:]([a-zA-Z0-9_:])*`. Discouraged characters in the metric
+name SHOULD be replaced with the `_` character by default, aiming for
+compatibility with Prometheus conventions. Multipleconsecutive `_` characters
+SHOULD be replaced with a single `_` character.
 
 The Unit of an OTLP metric point SHOULD be converted to the equivalent unit in Prometheus when possible. This includes:
 
 * Converting from abbreviations to full words (e.g. "ms" to "milliseconds").
 * Dropping the portions of the Unit within brackets (e.g. {packet}). Brackets MUST NOT be included in the resulting unit. A "count of foo" is considered unitless in Prometheus.
-* Special case: Converting "1" to "ratio".
 * Converting "foo/bar" to "foo_per_bar".
 
 The resulting unit SHOULD be added to the metric as

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -441,8 +441,8 @@ equivalent unit word in Prometheus if it is included in the table below:
 | `KiBy` | `kibibytes` |
 | `MiBy` | `mebibytes` |
 | `GiBy` | `gibibytes` |
-| `TiBy` | `tibibytes` |
-| `KBy` | `kilobytes` |
+| `TiBy` | `tebibytes` |
+| `kBy` | `kilobytes` |
 | `MBy` | `megabytes` |
 | `GBy` | `gigabytes` |
 | `TBy` | `terabytes` |


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/4917

## Changes

Removed converting a unit of `1` to `ratio`.  `1` just means a count of something. This is already the behavior in the Go implementation, collector, and prometheus server: https://github.com/prometheus/otlptranslator/blob/ab718f015b85ef4213f23a52ccbeec2bd826ce78/unit_namer.go#L38