### PR TITLE
Systemd journal mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ release.
 
 ### Logs
 
+- Add systemd-journald example mapping to the logs data model appendix.
+  ([#4995](https://github.com/open-telemetry/opentelemetry-specification/pull/4995))
+
 ### Baggage
 
 ### Profiles

--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -504,22 +504,18 @@ When mapping from the unified model to HEC, we apply this additional mapping:
 
 | Field | Type | Description | Maps to Unified Model Field |
 | ----- | ---- | ----------- | --------------------------- |
-| `_SOURCE_REALTIME_TIMESTAMP` or `__REALTIME_TIMESTAMP` | uint64 | Use `_SOURCE_REALTIME_TIMESTAMP` (the earliest trusted timestamp of the message) if present; otherwise fall back to `__REALTIME_TIMESTAMP` (the wallclock time at which the entry was received by the journal). Both are CLOCK_REALTIME in microseconds since the UNIX epoch. `_SOURCE_REALTIME_TIMESTAMP` is optional and only present when the source timestamp differs from journal reception time; `__REALTIME_TIMESTAMP` is always present. | Timestamp |
+| `__REALTIME_TIMESTAMP` | uint64 | The wallclock time at which the entry was received by the journal, as CLOCK_REALTIME in microseconds since the UNIX epoch. Always present. | Timestamp |
 | `PRIORITY` | number | Syslog-compatible priority value (0=Emergency … 7=Debug). | Severity |
 | `_HOSTNAME` | string | The name of the originating host. | `Resource["host.name"]` |
-| `_MACHINE_ID` | string | The machine ID of the originating host as configured in machine-id(5). | `Resource["host.id"]` |
-| `_SYSTEMD_UNIT` | string | The systemd unit name of the service that generated the log entry (e.g. `nginx.service`). | `Resource["service.name"]` |
-| `SYSLOG_FACILITY` | number | Syslog compatibility field: the syslog facility (formatted as decimal string). See [RFC5424 FACILITY](#rfc5424-syslog). | `Attributes["syslog.facility"]` |
-| `SYSLOG_IDENTIFIER` | string | Syslog compatibility field: the identifier string (i.e. "tag"). Equivalent to the RFC5424 APP-NAME. Used as service name when `_SYSTEMD_UNIT` is not present. | `Resource["service.name"]` |
-| `SYSLOG_PID` | number | Syslog compatibility field: the client PID from the original syslog datagram. See [RFC5424 PROCID](#rfc5424-syslog). | `Attributes["syslog.procid"]` |
+| `SYSLOG_FACILITY` | number | Syslog compatibility field: the syslog facility (formatted as decimal string). See [RFC5424 FACILITY](#rfc5424-syslog). | `Attributes["syslog.facility.code"]` |
+| `SYSLOG_IDENTIFIER` | string | Syslog compatibility field: the identifier string (i.e. "tag"). Equivalent to the RFC5424 APP-NAME. | `Attributes["syslog.msg.id"]` |
+| `SYSLOG_PID` | number | Syslog compatibility field: the client PID from the original syslog datagram. See [RFC5424 PROCID](#rfc5424-syslog). | `Attributes["syslog.pid"]` |
 | `MESSAGE` | string | The human-readable log message. | Body |
 | `TID` | number | The numeric thread ID the log message originates from. | `Attributes["thread.id"]` |
 | `_PID` | number | The process identifier (PID) of the process that generated the log entry. | `Resource["process.pid"]` |
-| `_UID` | number | The user identifier (UID) of the process that generated the log entry. | `Resource["process.user.id"]` |
 | `_COMM` | string | The name of the executable (as found in /proc/\<pid\>/comm). | `Resource["process.executable.name"]` |
 | `_EXE` | string | The path to the executable. | `Resource["process.executable.path"]` |
 | `_CMDLINE` | string | The command line of the process. | `Resource["process.command_line"]` |
-| `_SYSTEMD_CGROUP` | string | The control group path in the systemd hierarchy of the process. | `Resource["process.linux.cgroup"]` |
 | `CODE_FILE` | string | The source code file generating this message. | `Attributes["code.file.path"]` |
 | `CODE_LINE` | number | The source code line generating this message. | `Attributes["code.line.number"]` |
 | `CODE_FUNC` | string | The source code function generating this message. | `Attributes["code.function.name"]` |

--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -17,6 +17,7 @@ the respective exporter documentation if exact details are required.
   * [Apache HTTP Server access log](#apache-http-server-access-log)
   * [CloudTrail Log Event](#cloudtrail-log-event)
   * [Google Cloud Logging](#google-cloud-logging)
+  * [systemd-journald](#systemd-journald)
   * [Elastic Common Schema](#elastic-common-schema)
 - [Appendix B: `SeverityNumber` example mappings](#appendix-b-severitynumber-example-mappings)
 - [References](#references)
@@ -498,6 +499,31 @@ When mapping from the unified model to HEC, we apply this additional mapping:
 | http_request | HttpRequest | The HTTP request associated with the log entry, if any. | `Attributes["gcp.http_request"]` |
 | trace_sampled | boolean | The sampling decision of the trace associated with the log entry. | TraceFlags.SAMPLED |
 | All other fields | | | `Attributes["gcp.*"]` |
+
+### systemd-journald
+
+| Field | Type | Description | Maps to Unified Model Field |
+| ----- | ---- | ----------- | --------------------------- |
+| `_SOURCE_REALTIME_TIMESTAMP` or `__REALTIME_TIMESTAMP` | uint64 | Use `_SOURCE_REALTIME_TIMESTAMP` (the earliest trusted timestamp of the message) if present; otherwise fall back to `__REALTIME_TIMESTAMP` (the wallclock time at which the entry was received by the journal). Both are CLOCK_REALTIME in microseconds since the UNIX epoch. `_SOURCE_REALTIME_TIMESTAMP` is optional and only present when the source timestamp differs from journal reception time; `__REALTIME_TIMESTAMP` is always present. | Timestamp |
+| `PRIORITY` | number | Syslog-compatible priority value (0=Emergency … 7=Debug). | Severity |
+| `_HOSTNAME` | string | The name of the originating host. | `Resource["host.name"]` |
+| `_MACHINE_ID` | string | The machine ID of the originating host as configured in machine-id(5). | `Resource["host.id"]` |
+| `_SYSTEMD_UNIT` | string | The systemd unit name of the service that generated the log entry (e.g. `nginx.service`). | `Resource["service.name"]` |
+| `SYSLOG_FACILITY` | number | Syslog compatibility field: the syslog facility (formatted as decimal string). See [RFC5424 FACILITY](#rfc5424-syslog). | `Attributes["syslog.facility"]` |
+| `SYSLOG_IDENTIFIER` | string | Syslog compatibility field: the identifier string (i.e. "tag"). Equivalent to the RFC5424 APP-NAME. Used as service name when `_SYSTEMD_UNIT` is not present. | `Resource["service.name"]` |
+| `SYSLOG_PID` | number | Syslog compatibility field: the client PID from the original syslog datagram. See [RFC5424 PROCID](#rfc5424-syslog). | `Attributes["syslog.procid"]` |
+| `MESSAGE` | string | The human-readable log message. | Body |
+| `TID` | number | The numeric thread ID the log message originates from. | `Attributes["thread.id"]` |
+| `_PID` | number | The process identifier (PID) of the process that generated the log entry. | `Resource["process.pid"]` |
+| `_UID` | number | The user identifier (UID) of the process that generated the log entry. | `Resource["process.user.id"]` |
+| `_COMM` | string | The name of the executable (as found in /proc/\<pid\>/comm). | `Resource["process.executable.name"]` |
+| `_EXE` | string | The path to the executable. | `Resource["process.executable.path"]` |
+| `_CMDLINE` | string | The command line of the process. | `Resource["process.command_line"]` |
+| `_SYSTEMD_CGROUP` | string | The control group path in the systemd hierarchy of the process. | `Resource["process.linux.cgroup"]` |
+| `CODE_FILE` | string | The source code file generating this message. | `Attributes["code.file.path"]` |
+| `CODE_LINE` | number | The source code line generating this message. | `Attributes["code.line.number"]` |
+| `CODE_FUNC` | string | The source code function generating this message. | `Attributes["code.function.name"]` |
+| All other fields | any | All other journal fields. | `Attributes["journald.*"]` |
 
 ### Elastic Common Schema
 

--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -17,6 +17,7 @@ the respective exporter documentation if exact details are required.
   * [Apache HTTP Server access log](#apache-http-server-access-log)
   * [CloudTrail Log Event](#cloudtrail-log-event)
   * [Google Cloud Logging](#google-cloud-logging)
+  * [systemd-journald](#systemd-journald)
   * [Elastic Common Schema](#elastic-common-schema)
   * [ETW (Event Tracing for Windows)](#etw-event-tracing-for-windows)
 - [Appendix B: `SeverityNumber` example mappings](#appendix-b-severitynumber-example-mappings)
@@ -499,6 +500,28 @@ When mapping from the unified model to HEC, we apply this additional mapping:
 | http_request | HttpRequest | The HTTP request associated with the log entry, if any. | `Attributes["gcp.http_request"]` |
 | trace_sampled | boolean | The sampling decision of the trace associated with the log entry. | TraceFlags.SAMPLED |
 | All other fields | | | `Attributes["gcp.*"]` |
+
+### systemd-journald
+
+| Field | Type | Description | Maps to Unified Model Field |
+| ----- | ---- | ----------- | --------------------------- |
+| `__REALTIME_TIMESTAMP` | uint64 | The wallclock time at which the entry was received by the journal, as CLOCK_REALTIME in microseconds since the UNIX epoch. Always present. | Timestamp |
+| `PRIORITY` | number | Syslog-compatible priority value (0=Emergency … 7=Debug). | Severity |
+| `_HOSTNAME` | string | The name of the originating host. | `Resource["host.name"]` |
+| `SYSLOG_FACILITY` | number | Syslog compatibility field: the syslog facility (formatted as decimal string). See [RFC5424 FACILITY](#rfc5424-syslog). | `Attributes["syslog.facility.code"]` |
+| `SYSLOG_IDENTIFIER` | string | Syslog compatibility field: the identifier string (i.e. "tag"). Equivalent to the RFC5424 APP-NAME. | `Resource["service.name"]` |
+| `SYSLOG_PID` | number | Syslog compatibility field: the client PID from the original syslog datagram. See [RFC5424 PROCID](#rfc5424-syslog). | `Attributes["syslog.pid"]` |
+| `MESSAGE` | string | The human-readable log message. | Body |
+| `_PID` | number | The process identifier (PID) of the process that generated the log entry. | `Resource["process.pid"]` |
+| `_COMM` | string | The name of the executable (as found in /proc/\<pid\>/comm). | `Resource["process.executable.name"]` |
+| `_EXE` | string | The path to the executable. | `Resource["process.executable.path"]` |
+| `_CMDLINE` | string | The command line of the process. | `Resource["process.command_line"]` |
+| `CODE_FILE` | string | The source code file generating this message. | `Attributes["code.file.path"]` |
+| `CODE_LINE` | number | The source code line generating this message. | `Attributes["code.line.number"]` |
+| `CODE_FUNC` | string | The source code function generating this message. | `Attributes["code.function.name"]` |
+| All other fields | any | All other journal fields. | `Attributes["journald.*"]` |
+
+See [systemd.journal-fields](https://www.freedesktop.org/software/systemd/man/latest/systemd.journal-fields.html) for detailed description of the journald fields.
 
 ### Elastic Common Schema
 

--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -55,7 +55,7 @@ this data model.
     <td>FACILITY</td>
     <td>enum</td>
     <td>Describes where the event originated. A predefined list of UNIX processes. Part of event source identity. Example: <code>mail system</code></td>
-    <td>`Attributes["syslog.facility"]`</td>
+    <td>`Attributes["syslog.facility.code"]`</td>
   </tr>
   <tr>
     <td>VERSION</td>
@@ -73,7 +73,7 @@ this data model.
     <td>APP-NAME</td>
     <td>string</td>
     <td>User-defined app name. Part of event source identity.</td>
-    <td>`Resource["service.name"]`</td>
+    <td>`Attributes["syslog.identifier"]`</td>
   </tr>
   <tr>
     <td>PROCID</td>
@@ -85,7 +85,7 @@ this data model.
     <td>MSGID</td>
     <td>string</td>
     <td>Defines the type of the event. Part of event source identity. Example: `"TCPIN"`</td>
-    <td>`Attributes["syslog.msgid"]`</td>
+    <td>`Attributes["syslog.msg.id"]`</td>
   </tr>
   <tr>
     <td>STRUCTURED-DATA</td>
@@ -509,8 +509,9 @@ When mapping from the unified model to HEC, we apply this additional mapping:
 | `PRIORITY` | number | Syslog-compatible priority value (0=Emergency … 7=Debug). | Severity |
 | `_HOSTNAME` | string | The name of the originating host. | `Resource["host.name"]` |
 | `SYSLOG_FACILITY` | number | Syslog compatibility field: the syslog facility (formatted as decimal string). See [RFC5424 FACILITY](#rfc5424-syslog). | `Attributes["syslog.facility.code"]` |
-| `SYSLOG_IDENTIFIER` | string | Syslog compatibility field: the identifier string (i.e. "tag"). Equivalent to the RFC5424 APP-NAME. | `Resource["service.name"]` |
-| `SYSLOG_PID` | number | Syslog compatibility field: the client PID from the original syslog datagram. See [RFC5424 PROCID](#rfc5424-syslog). | `Attributes["syslog.pid"]` |
+| `SYSLOG_IDENTIFIER` | string | Syslog compatibility field: the client-supplied identifier string (i.e. "tag"). | `Attributes["syslog.identifier"]` |
+| `SYSLOG_PID` | number | Syslog compatibility field: the client-supplied PID. Unlike the trusted `_PID` field, journald does not validate this value. | `Attributes["syslog.pid"]` |
+| `SYSLOG_TIMESTAMP` | string | Syslog compatibility field: the timestamp from the original syslog datagram. | `Attributes["syslog.timestamp"]` |
 | `MESSAGE` | string | The human-readable log message. | Body |
 | `_PID` | number | The process identifier (PID) of the process that generated the log entry. | `Resource["process.pid"]` |
 | `_COMM` | string | The name of the executable (as found in /proc/\<pid\>/comm). | `Resource["process.executable.name"]` |
@@ -520,6 +521,10 @@ When mapping from the unified model to HEC, we apply this additional mapping:
 | `CODE_LINE` | number | The source code line generating this message. | `Attributes["code.line.number"]` |
 | `CODE_FUNC` | string | The source code function generating this message. | `Attributes["code.function.name"]` |
 | All other fields | any | All other journal fields. | `Attributes["journald.*"]` |
+
+`SYSLOG_PID` maps to `syslog.pid` rather than the RFC5424 `syslog.procid`
+because journald defines it as a numeric client PID, while RFC5424 `PROCID` is
+an implementation-defined string that is not necessarily a process ID.
 
 See [systemd.journal-fields](https://www.freedesktop.org/software/systemd/man/latest/systemd.journal-fields.html) for detailed description of the journald fields.
 


### PR DESCRIPTION
## Changes

Add example how to map Journald fields to OpenTelemetry to the Log Data Model Appendix.

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes (when adding or changing features): https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46500
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
