### PR TITLE
Add syslog numeric priority values to SeverityNumber example mappings

### DIFF
--- a/specification/logs/data-model-appendix.md
+++ b/specification/logs/data-model-appendix.md
@@ -803,19 +803,19 @@ for an exhaustive list.
 
 ## Appendix B: `SeverityNumber` example mappings
 
-|Syslog       |WinEvtLog  |Log4j |Zap   |java.util.logging|.NET (Microsoft.Extensions.Logging)|SeverityNumber|
-|-------------|-----------|------|------|-----------------|-----------------------------------|--------------|
-|             |           |TRACE |      | FINEST          |LogLevel.Trace                     |TRACE         |
-|Debug        |Verbose    |DEBUG |Debug | FINER           |LogLevel.Debug                     |DEBUG         |
-|             |           |      |      | FINE            |                                   |DEBUG2        |
-|             |           |      |      | CONFIG          |                                   |DEBUG3        |
-|Informational|Information|INFO  |Info  | INFO            |LogLevel.Information               |INFO          |
-|Notice       |           |      |      |                 |                                   |INFO2         |
-|Warning      |Warning    |WARN  |Warn  | WARNING         |LogLevel.Warning                   |WARN          |
-|Error        |Error      |ERROR |Error | SEVERE          |LogLevel.Error                     |ERROR         |
-|Critical     |Critical   |      |Dpanic|                 |                                   |ERROR2        |
-|Alert        |           |      |Panic |                 |                                   |ERROR3        |
-|Emergency    |           |FATAL |Fatal |                 |LogLevel.Critical                  |FATAL         |
+|Syslog              |WinEvtLog  |Log4j |Zap   |java.util.logging|.NET (Microsoft.Extensions.Logging)|SeverityNumber|
+|---------------------|-----------|------|------|-----------------|-----------------------------------|--------------|
+|                     |           |TRACE |      | FINEST          |LogLevel.Trace                     |TRACE (1)     |
+|Debug (7)            |Verbose    |DEBUG |Debug | FINER           |LogLevel.Debug                     |DEBUG (5)     |
+|                     |           |      |      | FINE            |                                   |DEBUG2 (6)    |
+|                     |           |      |      | CONFIG          |                                   |DEBUG3 (7)    |
+|Informational (6)    |Information|INFO  |Info  | INFO            |LogLevel.Information               |INFO (9)      |
+|Notice (5)           |           |      |      |                 |                                   |INFO2 (10)    |
+|Warning (4)          |Warning    |WARN  |Warn  | WARNING         |LogLevel.Warning                   |WARN (13)     |
+|Error (3)            |Error      |ERROR |Error | SEVERE          |LogLevel.Error                     |ERROR (17)    |
+|Critical (2)         |Critical   |      |Dpanic|                 |                                   |ERROR2 (18)   |
+|Alert (1)            |           |      |Panic |                 |                                   |ERROR3 (19)   |
+|Emergency (0)        |           |FATAL |Fatal |                 |LogLevel.Critical                  |FATAL (21)    |
 
 ## References
 


### PR DESCRIPTION
## Changes

Make the Severity mapping table clearer by:

- Adding the numeric syslog priority values (RFC 5424) to the Syslog column
- Adding the numeric values to SeverityNumber columns according to the data-model

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
