### PR TITLE
Change Environment Variables as Context Propagation Carriers to Beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ release.
   ([#4961](https://github.com/open-telemetry/opentelemetry-specification/issues/4961))
 - Remove misleading implementation approach the environment variable propagation.
   ([#5003](https://github.com/open-telemetry/opentelemetry-specification/issues/5003))
-- Change environment variable context propagation carriers  document status to Beta.
+- Change environment variable context propagation carriers document status to Beta.
   ([#5020](https://github.com/open-telemetry/opentelemetry-specification/issues/5020))
 
 ### Traces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ release.
   ([#4961](https://github.com/open-telemetry/opentelemetry-specification/issues/4961))
 - Remove misleading implementation approach the environment variable propagation.
   ([#5003](https://github.com/open-telemetry/opentelemetry-specification/issues/5003))
+- Change environment variable context propagation carriers  document status to Beta.
 
 ### Traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ release.
   ([#4961](https://github.com/open-telemetry/opentelemetry-specification/issues/4961))
 - Remove misleading implementation approach the environment variable propagation.
   ([#5003](https://github.com/open-telemetry/opentelemetry-specification/issues/5003))
-- Change environment variable context propagation carriers document status to Beta.
+- Change Environment Variables as Context Propagation Carriers document status to Beta.
   ([#5020](https://github.com/open-telemetry/opentelemetry-specification/issues/5020))
 
 ### Traces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ release.
 - Remove misleading implementation approach the environment variable propagation.
   ([#5003](https://github.com/open-telemetry/opentelemetry-specification/issues/5003))
 - Change environment variable context propagation carriers  document status to Beta.
+  ([#5020](https://github.com/open-telemetry/opentelemetry-specification/issues/5020))
 
 ### Traces
 

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -250,6 +250,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Setter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + | - |
 | Getter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + | - |
 | Getter argument returning Keys | X | N/A | + | + | + | + | + | + | N/A | + | - | + | - |
+| [Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md) |  | + | + |  |  |  |  |  |  |  |  |  |  |
 
 ## Environment Variables
 

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '-'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -443,6 +443,8 @@ sections:
         status: 'N/A'
       - name: Getter argument returning Keys
         status: 'N/A'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '+'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '+'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -443,6 +443,8 @@ sections:
         status: '-'
       - name: Getter argument returning Keys
         status: '-'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -443,6 +443,8 @@ sections:
         status: 'N/A'
       - name: Getter argument returning Keys
         status: 'N/A'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -443,6 +443,8 @@ sections:
         status: '+'
       - name: Getter argument returning Keys
         status: '+'
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
+        status: '?'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -291,6 +291,7 @@ sections:
         optional: true
       - name: Getter argument returning Keys
         optional: true
+      - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -1,6 +1,6 @@
 # Environment Variables as Context Propagation Carriers
 
-**Status**: [Alpha](../document-status.md)
+**Status**: [Beta](../document-status.md)
 
 <details>
 <summary>Table of Contents</summary>


### PR DESCRIPTION
Towards stabilization of "environment variables as context propagation carriers".

According to my review, the Java and Go implementations are already spec compliant. The rest need some little improvements related to normalization.
