### PR TITLE
[prometheus] Stabilize SDK exporter temporality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ release.
   - Stabilize OpenTelemetry Exemplar to Prometheus Exemplar transformation.
     ([#4964](https://github.com/open-telemetry/opentelemetry-specification/pull/4964))
 - Stabilize sections of Prometheus Metrics Exporter.
+  - Stabilize temporality.
+    ([#4983](https://github.com/open-telemetry/opentelemetry-specification/issues/4983))
   - Stabilize host configuration.
     ([#4984](https://github.com/open-telemetry/opentelemetry-specification/issues/4984))
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -92,7 +92,7 @@ Prometheus exporter.
 
 ### Temporality
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter MUST set
 the [MetricReader](../sdk.md#metricreader) `temporality` as a function of


### PR DESCRIPTION
Fixes #4983

## Changes

Moves Prometheus Metrics Exporter spec **Temporality** status from `Development` to `Stable`. Implemented by [3+ SDKs](https://github.com/open-telemetry/opentelemetry-specification/issues/4983#issuecomment-4134865000).

* [x] Related issues #4983
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
