### PR TITLE
[prometheus] Stabilize SDK exporter host config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ release.
   ([#4954](https://github.com/open-telemetry/opentelemetry-specification/pull/4954))
 - Stabilize OpenTelemetry Metric Metadata to Prometheus metric metadata.
   ([#4966](https://github.com/open-telemetry/opentelemetry-specification/pull/4966))
+- Stabilize Prometheus SDK Exporter host configuration.
+  ([#4984](https://github.com/open-telemetry/opentelemetry-specification/issues/4984))
 
 ### SDK Configuration
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -102,7 +102,7 @@ instrument kind to be `cumulative` for all instrument kinds.
 
 ### Host
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter SHOULD support a configuration option to set the host
 that metrics are served on. The option MAY be named `host`, and MUST be `localhost`


### PR DESCRIPTION
Fixes #4984

## Changes

Moves Prometheus Metrics Exporter spec **Host configuration** status from `Development` to `Stable`. Implemented by [3+ SDKs](https://github.com/open-telemetry/opentelemetry-specification/issues/4984#issuecomment-4142678815).

* [x] Related issues #4984
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
