### PR TITLE
[prometheus] Stabilize SDK exporter port config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize host configuration.
     ([#4984](https://github.com/open-telemetry/opentelemetry-specification/issues/4984))
+  - Stabilize port configuration.
+    ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
 
 ### SDK Configuration
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -110,7 +110,7 @@ by default.
 
 ### Port
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter SHOULD support a configuration option to set the port
 that metrics are served on. The option MAY be named `port`, and MUST be `9464` by


### PR DESCRIPTION
Fixes #4985

## Changes

Moves Prometheus Metrics Exporter spec **Port configuration** status from `Development` to `Stable`. Implemented by [3+ SDKs](https://github.com/open-telemetry/opentelemetry-specification/issues/4985#issuecomment-4142690420).

* [x] Related issues #4985
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
