### PR TITLE
Add Prometheus interoperability to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,7 @@
 
 # Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md 
 *   @open-telemetry/technical-committee @open-telemetry/spec-sponsors
+
+# Prometheus-specific specifications
+/specification/compatibility/prometheus_and_openmetrics.md @open-telemetry/technical-committee @open-telemetry/spec-sponsors @open-telemetry/prometheus-interoperability
+/specification/metrics/sdk_exporters/prometheus.md @open-telemetry/technical-committee @open-telemetry/spec-sponsors @open-telemetry/prometheus-interoperability


### PR DESCRIPTION
## Changes

@johannaojeling just let me know that she opened a few PRs for the Prometheus spec, and they went unnoticed. If the TC is ok with it, I'm adding the @open-telemetry/prometheus-interoperability as codeowners of the two Prometheus spec files, to ensure we get notified when PRs against these files are open.

If this is too much, I don't have a problem closing the PR :)


* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
