### PR TITLE
Release 1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ release.
 
 ### Context
 
+### Traces
+
+### Metrics
+
+### Logs
+
+### Baggage
+
+### Profiles
+
+### Resource
+
+### Entities
+
+### Common
+
+### OpenTelemetry Protocol
+
+### Compatibility
+
+### SDK Configuration
+
+### Supplementary Guidelines
+
+### OTEPs
+
+## v1.56.0
+
+### Context
+
 - Align environment variable context propagation name restrictions with POSIX.1-2024
   and define normalization behavior.
   ([#4914](https://github.com/open-telemetry/opentelemetry-specification/issues/4914))
@@ -50,7 +80,7 @@ release.
 ### Compatibility
 
 - Deprecate OpenTracing compatibility requirements in the specification.
-  ([#4849](https://github.com/open-telemetry/opentelemetry-specification/issues/4849))
+  ([#4938](https://github.com/open-telemetry/opentelemetry-specification/issues/4938))
 - Stabilize Prometheus Classic Histogram to OTLP Explicit Histogram transformation.
   ([#4874](https://github.com/open-telemetry/opentelemetry-specification/pull/4874))
 - Stabilize Prometheus Timestamp and Start timestamp transformation.
@@ -74,7 +104,7 @@ release.
 
 - Declarative configuration: add in-development guidance for exposing the
   effective `Resource` returned by `Create`.
-  ([#4948](https://github.com/open-telemetry/opentelemetry-specification/issues/4948))
+  ([#4949](https://github.com/open-telemetry/opentelemetry-specification/issues/4949))
 - Require spec changes to consider declarative config schema
   ([#4916](https://github.com/open-telemetry/opentelemetry-specification/pull/4916))
 - Add strict YAML parsing guidance to configuration supplementary guidelines.
@@ -86,8 +116,10 @@ release.
 
 - Process Context: Sharing Resource Attributes with External Readers.
   ([#4719](https://github.com/open-telemetry/opentelemetry-specification/pull/4719))
+- Support multiple Resources within an SDK.
+  ([#4665](https://github.com/open-telemetry/opentelemetry-specification/pull/4665))
 
-## v1.55.0 (TODO: update date before merging)
+## v1.55.0
 
 ### Traces
 
@@ -199,9 +231,6 @@ release.
 
 - Stabilize complex `AnyValue` attribute value types and related attribute limits.
   ([#4794](https://github.com/open-telemetry/opentelemetry-specification/issues/4794))
-
-- Support multiple Resources within an SDK.
-  ([#4665](https://github.com/open-telemetry/opentelemetry-specification/pull/4665))
 
 ## v1.52.0 (2025-12-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,19 +35,19 @@ release.
 
 ### OTEPs
 
-## v1.56.0
+## v1.56.0 (2025-04-20)
 
 ### Context
 
 - Align environment variable context propagation name restrictions with POSIX.1-2024
   and define normalization behavior.
-  ([#4914](https://github.com/open-telemetry/opentelemetry-specification/issues/4914))
+  ([#4944](https://github.com/open-telemetry/opentelemetry-specification/pull/4944))
 - Decouple the responsibilities of the environment variable propagation carrier.
-  ([#4961](https://github.com/open-telemetry/opentelemetry-specification/issues/4961))
+  ([#4961](https://github.com/open-telemetry/opentelemetry-specification/pull/4961))
 - Remove misleading implementation approach the environment variable propagation.
-  ([#5003](https://github.com/open-telemetry/opentelemetry-specification/issues/5003))
+  ([#5003](https://github.com/open-telemetry/opentelemetry-specification/pull/5003))
 - Change Environment Variables as Context Propagation Carriers document status to Beta.
-  ([#5020](https://github.com/open-telemetry/opentelemetry-specification/issues/5020))
+  ([#5020](https://github.com/open-telemetry/opentelemetry-specification/pull/5020))
 
 ### Traces
 
@@ -105,7 +105,7 @@ release.
 
 - Declarative configuration: add in-development guidance for exposing the
   effective `Resource` returned by `Create`.
-  ([#4949](https://github.com/open-telemetry/opentelemetry-specification/issues/4949))
+  ([#4949](https://github.com/open-telemetry/opentelemetry-specification/pull/4949))
 - Require spec changes to consider declarative config schema
   ([#4916](https://github.com/open-telemetry/opentelemetry-specification/pull/4916))
 - Add strict YAML parsing guidance to configuration supplementary guidelines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,23 +59,11 @@ release.
 - Add development `maxExportBatchSize` parameter to Periodic exporting MetricReader.
   ([#4895](https://github.com/open-telemetry/opentelemetry-specification/pull/4895))
 
-### Logs
-
-### Baggage
-
-### Profiles
-
 ### Resource
 
 - Clarify that a Resource describes the observed entity, not the component
   that technically emits telemetry.
   ([#4905](https://github.com/open-telemetry/opentelemetry-specification/pull/4905))
-
-### Entities
-
-### Common
-
-### OpenTelemetry Protocol
 
 ### Compatibility
 
@@ -109,8 +97,6 @@ release.
   ([#4916](https://github.com/open-telemetry/opentelemetry-specification/pull/4916))
 - Add strict YAML parsing guidance to configuration supplementary guidelines.
   ([#4878](https://github.com/open-telemetry/opentelemetry-specification/pull/4878))
-
-### Supplementary Guidelines
 
 ### OTEPs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@ release.
 - Support multiple Resources within an SDK.
   ([#4665](https://github.com/open-telemetry/opentelemetry-specification/pull/4665))
 
-## v1.55.0
+## v1.55.0 (2025-03-05)
 
 ### Traces
 


### PR DESCRIPTION
### Context

- Align environment variable context propagation name restrictions with POSIX.1-2024
  and define normalization behavior.
  ([#4944](https://github.com/open-telemetry/opentelemetry-specification/pull/4944))
- Decouple the responsibilities of the environment variable propagation carrier.
  ([#4961](https://github.com/open-telemetry/opentelemetry-specification/pull/4961))
- Remove misleading implementation approach the environment variable propagation.
  ([#5003](https://github.com/open-telemetry/opentelemetry-specification/pull/5003))
- Change Environment Variables as Context Propagation Carriers document status to Beta.
  ([#5020](https://github.com/open-telemetry/opentelemetry-specification/pull/5020))

### Traces

- Stabilize Tracer `enabled` operation
  ([#4941](https://github.com/open-telemetry/opentelemetry-specification/pull/4941))
- Stabilize `AlwaysRecord` sampler.
  ([#4934](https://github.com/open-telemetry/opentelemetry-specification/pull/4934))

### Metrics

- Add development `maxExportBatchSize` parameter to Periodic exporting MetricReader.
  ([#4895](https://github.com/open-telemetry/opentelemetry-specification/pull/4895))

### Logs

- Add event to span event bridge.
  ([#5006](https://github.com/open-telemetry/opentelemetry-specification/pull/5006))

### Resource

- Clarify that a Resource describes the observed entity, not the component
  that technically emits telemetry.
  ([#4905](https://github.com/open-telemetry/opentelemetry-specification/pull/4905))

### Compatibility

- Deprecate OpenTracing compatibility requirements in the specification.
  ([#4938](https://github.com/open-telemetry/opentelemetry-specification/pull/4938))
- Stabilize sections of Prometheus and OpenMetrics Compatibility.
  - Stabilize Prometheus Classic Histogram to OTLP Explicit Histogram transformation.
    ([#4874](https://github.com/open-telemetry/opentelemetry-specification/pull/4874))
  - Stabilize Prometheus Timestamp and Start timestamp transformation.
    ([#4953](https://github.com/open-telemetry/opentelemetry-specification/pull/4953))
  - Clarify Prometheus Native Histogram to OTLP Exponential Histogram conversion,
    add conversion rules for Native Histograms with Custom Buckets (NHCB) to OTLP
    Histogram.
    ([#4898](https://github.com/open-telemetry/opentelemetry-specification/pull/4898))
  - Stabilize Prometheus Dropped Types transformation.
    ([#4952](https://github.com/open-telemetry/opentelemetry-specification/pull/4952))
  - Stabilize OpenTelemetry Attributes to Prometheus labels transformation.
    ([#4963](https://github.com/open-telemetry/opentelemetry-specification/pull/4963))
  - Stabilize Prometheus Exemplar to OpenTelemetry Exemplar transformation.
    ([#4962](https://github.com/open-telemetry/opentelemetry-specification/pull/4962))
  - Stabilize Prometheus Metadata transformation.
    ([#4954](https://github.com/open-telemetry/opentelemetry-specification/pull/4954))
  - Stabilize OpenTelemetry Metric Metadata to Prometheus metric metadata.
    ([#4966](https://github.com/open-telemetry/opentelemetry-specification/pull/4966))
  - Stabilize OpenTelemetry Exemplar to Prometheus Exemplar transformation.
    ([#4964](https://github.com/open-telemetry/opentelemetry-specification/pull/4964))
- Stabilize sections of Prometheus Metrics Exporter.
  - Stabilize host configuration.
    ([#5025](https://github.com/open-telemetry/opentelemetry-specification/pull/5025))

### SDK Configuration

- Declarative configuration: add in-development guidance for exposing the
  effective `Resource` returned by `Create`.
  ([#4949](https://github.com/open-telemetry/opentelemetry-specification/pull/4949))
- Require spec changes to consider declarative config schema
  ([#4916](https://github.com/open-telemetry/opentelemetry-specification/pull/4916))
- Add strict YAML parsing guidance to configuration supplementary guidelines.
  ([#4878](https://github.com/open-telemetry/opentelemetry-specification/pull/4878))

### OTEPs

- Process Context: Sharing Resource Attributes with External Readers.
  ([#4719](https://github.com/open-telemetry/opentelemetry-specification/pull/4719))
- Support multiple Resources within an SDK.
  ([#4665](https://github.com/open-telemetry/opentelemetry-specification/pull/4665))