### PR TITLE
Organize Prometheus stabilization changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,28 +53,30 @@ release.
 
 - Deprecate OpenTracing compatibility requirements in the specification.
   ([#4849](https://github.com/open-telemetry/opentelemetry-specification/issues/4849))
-- Stabilize Prometheus Classic Histogram to OTLP Explicit Histogram transformation.
-  ([#4874](https://github.com/open-telemetry/opentelemetry-specification/pull/4874))
-- Stabilize Prometheus Timestamp and Start timestamp transformation.
-  ([#4953](https://github.com/open-telemetry/opentelemetry-specification/pull/4953))
-- Clarify Prometheus Native Histogram to OTLP Exponential Histogram conversion,
-  add conversion rules for Native Histograms with Custom Buckets (NHCB) to OTLP
-  Histogram.
-  ([#4898](https://github.com/open-telemetry/opentelemetry-specification/pull/4898))
-- Stabilize Prometheus Dropped Types transformation.
-  ([#4952](https://github.com/open-telemetry/opentelemetry-specification/pull/4952))
-- Stabilize OpenTelemetry Attributes to Prometheus labels transformation.
-  ([#4963](https://github.com/open-telemetry/opentelemetry-specification/pull/4963))
-- Stabilize Prometheus Exemplar to OpenTelemetry Exemplar transformation.
-  ([#4962](https://github.com/open-telemetry/opentelemetry-specification/pull/4962))
-- Stabilize Prometheus Metadata transformation.
-  ([#4954](https://github.com/open-telemetry/opentelemetry-specification/pull/4954))
-- Stabilize OpenTelemetry Metric Metadata to Prometheus metric metadata.
-  ([#4966](https://github.com/open-telemetry/opentelemetry-specification/pull/4966))
-- Stabilize Prometheus SDK Exporter host configuration.
-  ([#4984](https://github.com/open-telemetry/opentelemetry-specification/issues/4984))
-- Stabilize OpenTelemetry Exemplar to Prometheus Exemplar transformation.
-  ([#4964](https://github.com/open-telemetry/opentelemetry-specification/pull/4964))
+- Stabilize sections of Prometheus and OpenMetrics Compatibility.
+  - Stabilize Prometheus Classic Histogram to OTLP Explicit Histogram transformation.
+    ([#4874](https://github.com/open-telemetry/opentelemetry-specification/pull/4874))
+  - Stabilize Prometheus Timestamp and Start timestamp transformation.
+    ([#4953](https://github.com/open-telemetry/opentelemetry-specification/pull/4953))
+  - Clarify Prometheus Native Histogram to OTLP Exponential Histogram conversion,
+    add conversion rules for Native Histograms with Custom Buckets (NHCB) to OTLP
+    Histogram.
+    ([#4898](https://github.com/open-telemetry/opentelemetry-specification/pull/4898))
+  - Stabilize Prometheus Dropped Types transformation.
+    ([#4952](https://github.com/open-telemetry/opentelemetry-specification/pull/4952))
+  - Stabilize OpenTelemetry Attributes to Prometheus labels transformation.
+    ([#4963](https://github.com/open-telemetry/opentelemetry-specification/pull/4963))
+  - Stabilize Prometheus Exemplar to OpenTelemetry Exemplar transformation.
+    ([#4962](https://github.com/open-telemetry/opentelemetry-specification/pull/4962))
+  - Stabilize Prometheus Metadata transformation.
+    ([#4954](https://github.com/open-telemetry/opentelemetry-specification/pull/4954))
+  - Stabilize OpenTelemetry Metric Metadata to Prometheus metric metadata.
+    ([#4966](https://github.com/open-telemetry/opentelemetry-specification/pull/4966))
+  - Stabilize OpenTelemetry Exemplar to Prometheus Exemplar transformation.
+    ([#4964](https://github.com/open-telemetry/opentelemetry-specification/pull/4964))
+- Stabilize sections of Prometheus Metrics Exporter.
+  - Stabilize host configuration.
+    ([#4984](https://github.com/open-telemetry/opentelemetry-specification/issues/4984))
 
 ### SDK Configuration
 


### PR DESCRIPTION
Fixes a remark made in https://github.com/open-telemetry/opentelemetry-specification/pull/5026#discussion_r3096505761.

## Changes

Groups the Prometheus stabilization changelog entries into top level bullet points.

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
