### PR TITLE
remove propagation wrapper wording

### DIFF
--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -45,9 +45,10 @@ Propagators](api-propagators.md) specification.
 
 When using environment variables as carriers:
 
-- The **environment variable carrier** (or propagator wrapper) MUST be
-  format-agnostic and MUST treat values as opaque strings and MUST NOT apply propagation-format-specific logic such as validating, parsing values, or
-  enforcing other format-specific constraints.
+- The **environment variable carrier** MUST be format-agnostic and MUST treat
+  values as opaque strings and MUST NOT apply propagation-format-specific logic
+  such as validating, parsing values, or enforcing other format-specific
+  constraints.
 - The **propagators** that implement specific propagation formats (for example,
   W3C Trace Context or W3C Baggage) remain solely responsible for:
   - choosing the key names they use with the carrier


### PR DESCRIPTION
This removes "(or propagator wrapper)".

Leftover after https://github.com/open-telemetry/opentelemetry-specification/pull/5003 (we agreed that a wrapper/decorator implementation is invalid).