### PR TITLE
env var carrier must be part of OTel Core repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ release.
 
 ### Context
 
-- Clarify that environment variable carrier implementations SHOULD be maintained
+- Clarify that environment variable carrier implementations MUST be maintained
   and distributed as part of Core OpenTelemetry repositories.
   ([#5042](https://github.com/open-telemetry/opentelemetry-specification/pull/5042))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ release.
 
 - Clarify that environment variable carrier implementations SHOULD be maintained
   and distributed as part of Core OpenTelemetry repositories.
+  ([#5042](https://github.com/open-telemetry/opentelemetry-specification/pull/5042))
 
 ### Traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ release.
 
 ### Context
 
+- Clarify that environment variable carrier implementations SHOULD be maintained
+  and distributed as part of Core OpenTelemetry repositories.
+
 ### Traces
 
 ### Metrics

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -56,7 +56,7 @@ When using environment variables as carriers:
   - applying any truncation or other format-specific behaviors
 
 Environment variable carrier implementation SHOULD be maintained and distributed
-as part of the Core OpenTelemetry repository.
+as part of the Core OpenTelemetry repositories.
 
 ### Key Name Normalization
 

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -55,6 +55,9 @@ When using environment variables as carriers:
   - validating and parsing values
   - applying any truncation or other format-specific behaviors
 
+Environment variable carrier implementation SHOULD be maintained and distributed
+as part of the Core OpenTelemetry repository.
+
 ### Key Name Normalization
 
 Environment variable names used for context propagation:

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -55,7 +55,7 @@ When using environment variables as carriers:
   - validating and parsing values
   - applying any truncation or other format-specific behaviors
 
-Environment variable carrier implementation SHOULD be maintained and distributed
+Environment variable carrier implementation MUST be maintained and distributed
 as part of the Core OpenTelemetry repositories.
 
 ### Key Name Normalization


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-specification/issues/5040

Clarify that the environment variable carrier implementation must be maintained and distributed as part of the Core OpenTelemetry repositories. I have used wording that I found in other parts of the spec. See https://github.com/open-telemetry/opentelemetry-specification/pull/5042#discussion_r3118522476

This is important because instrumentations that want to propagate context through environment variables should be able to reuse a common carrier implementation instead of re-creating their own. Making it a core component gives users and instrumentation authors something stable and reliable to depend on, improves consistency across languages, and reduces the risk of fragmented or incompatible implementations.
