### PR TITLE
chore: Remove redundant 'View name' entry from compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -144,7 +144,6 @@ formats is required. Implementing more than one format is optional.
 | The `View` instrument selection criteria is as specified. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | The `View` instrument selection criteria supports wildcards. | X | + | + | + | + | + | - |  | + | + | + |  | - |
 | The `View` instrument selection criteria supports the match-all wildcard. |  | + | + | + | + | + | + |  | + | + | + |  | - |
-| The name of the `View` can be specified. |  | - | + | + | + | + | + | + |  | + | + |  | - |
 | The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | - |  | - |
 | The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + |  | + |  |  | - |  |  |  |  |  | - |
 | The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  | - |

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '-'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -255,8 +255,6 @@ sections:
         status: '-'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '-'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -255,8 +255,6 @@ sections:
         status: '-'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '-'
-      - name: The name of the `View` can be specified.
-        status: '-'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '-'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -255,8 +255,6 @@ sections:
         status: '?'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '?'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '?'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -255,8 +255,6 @@ sections:
         status: '+'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
-      - name: The name of the `View` can be specified.
-        status: '?'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -255,8 +255,6 @@ sections:
         status: '?'
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '?'
-      - name: The name of the `View` can be specified.
-        status: '?'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '?'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -178,7 +178,6 @@ sections:
       - name: The `View` instrument selection criteria supports wildcards.
         optional: true
       - name: The `View` instrument selection criteria supports the match-all wildcard.
-      - name: The name of the `View` can be specified.
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
       - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.


### PR DESCRIPTION
The compliance matrix entry "The name of the `View` can be specified" is misleading and redundant:

1. The spec defines `name` as a [stream configuration](./specification/metrics/sdk.md#stream-configuration) parameter that renames the output metric stream — **there is no concept of naming a View itself.**
2. This capability is already covered by the existing entry: "The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream."
3. The redundancy caused contradictory compliance statuses in some languages (e.g. Go marked `-` for the removed entry but `+` for the broader one).

**Changes:**
- Remove "The name of the `View` can be specified" from `spec-compliance-matrix/template.yaml` and all 12 language YAML files
- Regenerate `spec-compliance-matrix.md`