### PR TITLE
Bound instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ release.
 
 ### Metrics
 
+- Add in-development `Bind` API to synchronous instruments.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize temporality.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ release.
 ### Metrics
 
 - Add in-development `Bind` API to synchronous instruments.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
+  ([#5050](https://github.com/open-telemetry/opentelemetry-specification/pull/5050))
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize temporality.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -130,6 +130,7 @@ formats is required. Implementing more than one format is optional.
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  | - |
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  | - |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  | - |
+| Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | - | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -223,6 +223,8 @@ sections:
         status: '+'
       - name: Instrument supports the advisory Attributes parameter.
         status: '+'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '+'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -223,6 +223,8 @@ sections:
         status: '-'
       - name: Instrument supports the advisory Attributes parameter.
         status: '-'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '-'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -223,6 +223,8 @@ sections:
         status: '?'
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -157,6 +157,8 @@ sections:
       - name: Instrument descriptions conform to the specified syntax.
       - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
       - name: Instrument supports the advisory Attributes parameter.
+      - name: Synchronous instruments support Bind to pre-associate attributes.
+        optional: true
       - name: All methods of `MeterProvider` are safe to be called concurrently.
       - name: All methods of `Meter` are safe to be called concurrently.
       - name: All methods of any instrument are safe to be called concurrently.

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -480,6 +480,9 @@ or something else).
 All [synchronous instruments](#synchronous-instrument-api) SHOULD provide functions to:
 
 * [Report if instrument is `Enabled`](#enabled)
+
+All [synchronous instruments](#synchronous-instrument-api) MAY provide:
+
 * [Bind to a set of attributes](#bind)
 
 #### Enabled

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -31,10 +31,12 @@ weight: 1
       - [Asynchronous Instrument API](#asynchronous-instrument-api)
   * [General operations](#general-operations)
     + [Enabled](#enabled)
+    + [Bind](#bind)
   * [Counter](#counter)
     + [Counter creation](#counter-creation)
     + [Counter operations](#counter-operations)
       - [Add](#add)
+      - [Bound Add](#bound-add)
   * [Asynchronous Counter](#asynchronous-counter)
     + [Asynchronous Counter creation](#asynchronous-counter-creation)
     + [Asynchronous Counter operations](#asynchronous-counter-operations)
@@ -42,10 +44,12 @@ weight: 1
     + [Histogram creation](#histogram-creation)
     + [Histogram operations](#histogram-operations)
       - [Record](#record)
+      - [Bound Record](#bound-record)
   * [Gauge](#gauge)
     + [Gauge creation](#gauge-creation)
     + [Gauge operations](#gauge-operations)
       - [Record](#record-1)
+      - [Bound Record](#bound-record-1)
   * [Asynchronous Gauge](#asynchronous-gauge)
     + [Asynchronous Gauge creation](#asynchronous-gauge-creation)
     + [Asynchronous Gauge operations](#asynchronous-gauge-operations)
@@ -53,6 +57,7 @@ weight: 1
     + [UpDownCounter creation](#updowncounter-creation)
     + [UpDownCounter operations](#updowncounter-operations)
       - [Add](#add-1)
+      - [Bound Add](#bound-add-1)
   * [Asynchronous UpDownCounter](#asynchronous-updowncounter)
     + [Asynchronous UpDownCounter creation](#asynchronous-updowncounter-creation)
     + [Asynchronous UpDownCounter operations](#asynchronous-updowncounter-operations)
@@ -475,6 +480,7 @@ or something else).
 All [synchronous instruments](#synchronous-instrument-api) SHOULD provide functions to:
 
 * [Report if instrument is `Enabled`](#enabled)
+* [Bind to a set of attributes](#bind)
 
 #### Enabled
 
@@ -493,6 +499,56 @@ value of `false` means the instrument is disabled for the provided arguments.
 The returned value is not always static, it can change over time. The API
 SHOULD be documented that instrumentation authors needs to call this API each
 time they record a measurement to ensure they have the most up-to-date response.
+
+#### Bind
+
+**Status**: [Development](../document-status.md)
+
+The `Bind` API associates a fixed set of [Attributes](../common/README.md#attribute) with every
+measurement recorded on the returned bound instrument. Because attributes are resolved at bind
+time rather than at each recording, implementations can avoid per-recording attribute processing
+and lookup overhead.
+
+This API MUST accept the following parameter:
+
+* [Attributes](../common/README.md#attribute) to associate with every measurement recorded on
+  the returned bound instrument.
+
+  Users can provide attributes to associate with the bound instrument, but it is up
+  to their discretion. Therefore, this API MUST be structured to accept a variable
+  number of attributes, including none.
+
+This API MUST return a language-idiomatic type representing the instrument bound to those
+attributes.
+
+The returned bound instrument MUST support the instrument's core recording operation without
+accepting [Attributes](../common/README.md#attribute) as a parameter. The instrument kind
+determines the recording operation on the bound instrument:
+
+* [Counter](#counter): [Bound Add](#bound-add)
+* [Histogram](#histogram): [Bound Record](#bound-record)
+* [Gauge](#gauge): [Bound Record](#bound-record-1)
+* [UpDownCounter](#updowncounter): [Bound Add](#bound-add-1)
+
+Measurements recorded on the bound instrument can be associated with the
+[Context](../context/README.md).
+
+Here are some examples that [OpenTelemetry API](../overview.md#api) authors might consider:
+
+```java
+// Java
+
+LongCounter rolls = meter.counterBuilder("dice.rolls")
+    .setDescription("The number of times each side of the die was rolled")
+    .setUnit("{roll}")
+    .build();
+
+var face1 = rolls.bind(Attributes.of(AttributeKey.longKey("roll.value"), 1L));
+var face6 = rolls.bind(Attributes.of(AttributeKey.longKey("roll.value"), 6L));
+
+face1.add(1);
+face6.add(1);
+```
 
 ### Counter
 
@@ -595,6 +651,14 @@ counterExceptions.Add(1, ("exception_type", "FileLoadException"), ("handled_by_u
 counterPowerUsed.Add(13.5, new PowerConsumption { customer = "Tom" });
 counterPowerUsed.Add(200, new PowerConsumption { customer = "Jerry" }, ("is_green_energy", true));
 ```
+
+##### Bound Add
+
+**Status**: [Development](../document-status.md)
+
+The bound counterpart to [Add](#add), obtained via [Bind](#bind). All semantics are
+identical to [Add](#add) except [Attributes](../common/README.md#attribute) are not
+accepted as a parameter.
 
 ### Asynchronous Counter
 
@@ -825,6 +889,14 @@ httpServerDuration.Record(50, ("http.request.method", "POST"), ("url.scheme", "h
 httpServerDuration.Record(100, new HttpRequestAttributes { method = "GET", scheme = "http" });
 ```
 
+##### Bound Record
+
+**Status**: [Development](../document-status.md)
+
+The bound counterpart to [Record](#record), obtained via [Bind](#bind). All semantics are
+identical to [Record](#record) except [Attributes](../common/README.md#attribute) are not
+accepted as a parameter.
+
 ### Gauge
 
 `Gauge` is a [synchronous Instrument](#synchronous-instrument-api) which can be
@@ -913,6 +985,14 @@ Attributes roomB = Attributes.builder().put("room.id", "Rack B");
 backgroundNoiseLevel.record(4.3, roomA);
 backgroundNoiseLevel.record(2.5, roomB);
 ```
+
+##### Bound Record
+
+**Status**: [Development](../document-status.md)
+
+The bound counterpart to [Record](#record-1), obtained via [Bind](#bind). All semantics are
+identical to [Record](#record-1) except [Attributes](../common/README.md#attribute) are not
+accepted as a parameter.
 
 ### Asynchronous Gauge
 
@@ -1154,6 +1234,14 @@ customers_in_store.add(-1, account_type="residential")
 customersInStore.Add(1, ("account.type", "commercial"));
 customersInStore.Add(-1, new Account { Type = "residential" });
 ```
+
+##### Bound Add
+
+**Status**: [Development](../document-status.md)
+
+The bound counterpart to [Add](#add-1), obtained via [Bind](#bind). All semantics are
+identical to [Add](#add-1) except [Attributes](../common/README.md#attribute) are not
+accepted as a parameter.
 
 ### Asynchronous UpDownCounter
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -483,7 +483,7 @@ All [synchronous instruments](#synchronous-instrument-api) SHOULD provide functi
 
 All [synchronous instruments](#synchronous-instrument-api) MAY provide:
 
-* [Bind to a set of attributes](#bind)
+* (**Development**) [Bind to a set of attributes](#bind)
 
 #### Enabled
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -36,7 +36,6 @@ weight: 1
     + [Counter creation](#counter-creation)
     + [Counter operations](#counter-operations)
       - [Add](#add)
-      - [Bound Add](#bound-add)
   * [Asynchronous Counter](#asynchronous-counter)
     + [Asynchronous Counter creation](#asynchronous-counter-creation)
     + [Asynchronous Counter operations](#asynchronous-counter-operations)
@@ -44,12 +43,10 @@ weight: 1
     + [Histogram creation](#histogram-creation)
     + [Histogram operations](#histogram-operations)
       - [Record](#record)
-      - [Bound Record](#bound-record)
   * [Gauge](#gauge)
     + [Gauge creation](#gauge-creation)
     + [Gauge operations](#gauge-operations)
       - [Record](#record-1)
-      - [Bound Record](#bound-record-1)
   * [Asynchronous Gauge](#asynchronous-gauge)
     + [Asynchronous Gauge creation](#asynchronous-gauge-creation)
     + [Asynchronous Gauge operations](#asynchronous-gauge-operations)
@@ -57,7 +54,6 @@ weight: 1
     + [UpDownCounter creation](#updowncounter-creation)
     + [UpDownCounter operations](#updowncounter-operations)
       - [Add](#add-1)
-      - [Bound Add](#bound-add-1)
   * [Asynchronous UpDownCounter](#asynchronous-updowncounter)
     + [Asynchronous UpDownCounter creation](#asynchronous-updowncounter-creation)
     + [Asynchronous UpDownCounter operations](#asynchronous-updowncounter-operations)
@@ -524,14 +520,19 @@ This API MUST accept the following parameter:
 This API MUST return a language-idiomatic type representing the instrument bound to those
 attributes.
 
-The returned bound instrument MUST support the instrument's core recording operation without
-accepting [Attributes](../common/README.md#attribute) as a parameter. The instrument kind
-determines the recording operation on the bound instrument:
+The returned bound instrument MUST support the instrument's core recording operation.
+The instrument kind determines the recording operation on the bound instrument:
 
-* [Counter](#counter): [Bound Add](#bound-add)
-* [Histogram](#histogram): [Bound Record](#bound-record)
-* [Gauge](#gauge): [Bound Record](#bound-record-1)
-* [UpDownCounter](#updowncounter): [Bound Add](#bound-add-1)
+* [Counter](#counter): [Add](#add)
+* [Histogram](#histogram): [Record](#record)
+* [Gauge](#gauge): [Record](#record-1)
+* [UpDownCounter](#updowncounter): [Add](#add-1)
+
+This MAY be achieved by introducing a dedicated bound instrument type, or by reusing
+the existing instrument interface. If the existing instrument interface is reused, the
+`Bind` API MUST be documented to communicate to users that invoking attribute-bearing
+recording operations on the returned bound instrument negates the performance benefits
+of binding.
 
 Measurements recorded on the bound instrument can be associated with the
 [Context](../context/README.md).
@@ -654,14 +655,6 @@ counterExceptions.Add(1, ("exception_type", "FileLoadException"), ("handled_by_u
 counterPowerUsed.Add(13.5, new PowerConsumption { customer = "Tom" });
 counterPowerUsed.Add(200, new PowerConsumption { customer = "Jerry" }, ("is_green_energy", true));
 ```
-
-##### Bound Add
-
-**Status**: [Development](../document-status.md)
-
-The bound counterpart to [Add](#add), obtained via [Bind](#bind). All semantics are
-identical to [Add](#add) except [Attributes](../common/README.md#attribute) are not
-accepted as a parameter.
 
 ### Asynchronous Counter
 
@@ -892,14 +885,6 @@ httpServerDuration.Record(50, ("http.request.method", "POST"), ("url.scheme", "h
 httpServerDuration.Record(100, new HttpRequestAttributes { method = "GET", scheme = "http" });
 ```
 
-##### Bound Record
-
-**Status**: [Development](../document-status.md)
-
-The bound counterpart to [Record](#record), obtained via [Bind](#bind). All semantics are
-identical to [Record](#record) except [Attributes](../common/README.md#attribute) are not
-accepted as a parameter.
-
 ### Gauge
 
 `Gauge` is a [synchronous Instrument](#synchronous-instrument-api) which can be
@@ -988,14 +973,6 @@ Attributes roomB = Attributes.builder().put("room.id", "Rack B");
 backgroundNoiseLevel.record(4.3, roomA);
 backgroundNoiseLevel.record(2.5, roomB);
 ```
-
-##### Bound Record
-
-**Status**: [Development](../document-status.md)
-
-The bound counterpart to [Record](#record-1), obtained via [Bind](#bind). All semantics are
-identical to [Record](#record-1) except [Attributes](../common/README.md#attribute) are not
-accepted as a parameter.
 
 ### Asynchronous Gauge
 
@@ -1237,14 +1214,6 @@ customers_in_store.add(-1, account_type="residential")
 customersInStore.Add(1, ("account.type", "commercial"));
 customersInStore.Add(-1, new Account { Type = "residential" });
 ```
-
-##### Bound Add
-
-**Status**: [Development](../document-status.md)
-
-The bound counterpart to [Add](#add-1), obtained via [Bind](#bind). All semantics are
-identical to [Add](#add-1) except [Attributes](../common/README.md#attribute) are not
-accepted as a parameter.
 
 ### Asynchronous UpDownCounter
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1046,8 +1046,6 @@ aggregation when no matching views match the instrument.
 
 **Status**: [Development](../document-status.md)
 
-The SDK MAY implement the [Bind](./api.md#bind) API for synchronous instruments.
-
 A bound instrument MUST behave identically to calling the equivalent unbound recording
 operation with the pre-bound [Attributes](../common/README.md#attribute) on each
 measurement.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -54,6 +54,7 @@ weight: 3
     + [Instrument advisory parameter: `ExplicitBucketBoundaries`](#instrument-advisory-parameter-explicitbucketboundaries)
     + [Instrument advisory parameter: `Attributes`](#instrument-advisory-parameter-attributes)
   * [Instrument enabled](#instrument-enabled)
+  * [Instrument bind](#instrument-bind)
 - [Attribute limits](#attribute-limits)
 - [Exemplar](#exemplar)
   * [ExemplarFilter](#exemplarfilter)
@@ -1040,6 +1041,20 @@ It MAY return `false` to support additional optimizations and features.
 Note: If a user makes no configuration changes, `Enabled` returns `true` since by
 default `MeterConfig.enabled=true` and instruments use the default
 aggregation when no matching views match the instrument.
+
+### Instrument bind
+
+**Status**: [Development](../document-status.md)
+
+The SDK MAY implement the [Bind](./api.md#bind) API for synchronous instruments.
+
+A bound instrument MUST behave identically to calling the equivalent unbound recording
+operation with the pre-bound [Attributes](../common/README.md#attribute) on each
+measurement.
+
+The SDK SHOULD optimize by pre-resolving the underlying aggregator state at bind time,
+such that subsequent recordings bypass per-recording attribute processing and map
+lookup.
 
 ## Attribute limits
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1054,7 +1054,7 @@ measurement.
 evaluation MUST be performed at bind time. The resolved aggregator is fixed for the
 lifetime of the bound instrument and does not change across collection cycles.
 
-The SDK MUST ensure subsequent recordings on a bound instrument bypass per-recording
+The SDK MUST ensure attribute-free recordings on a bound instrument bypass per-recording
 map lookup.
 
 ## Attribute limits

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1050,9 +1050,12 @@ A bound instrument MUST behave identically to calling the equivalent unbound rec
 operation with the pre-bound [Attributes](../common/README.md#attribute) on each
 measurement.
 
-The SDK SHOULD optimize by pre-resolving the underlying aggregator state at bind time,
-such that subsequent recordings bypass per-recording attribute processing and map
-lookup.
+[Attribute processing](#measurement-processing) and [cardinality limit](#cardinality-limits)
+evaluation MUST be performed at bind time. The resolved aggregator is fixed for the
+lifetime of the bound instrument and does not change across collection cycles.
+
+The SDK MUST ensure subsequent recordings on a bound instrument bypass per-recording
+map lookup.
 
 ## Attribute limits
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1051,8 +1051,17 @@ operation with the pre-bound [Attributes](../common/README.md#attribute) on each
 measurement.
 
 [Attribute processing](#measurement-processing) and [cardinality limit](#cardinality-limits)
-evaluation MUST be performed at bind time. The resolved aggregator is fixed for the
-lifetime of the bound instrument and does not change across collection cycles.
+evaluation MUST be performed at bind time. Each call to `Bind` MUST be independently
+evaluated against the cardinality state at that moment. As a consequence, separate calls
+to `Bind` with identical attributes may resolve to different aggregators (e.g. one to a
+concrete series, another to the [overflow series](#overflow-attribute)) based on the
+cardinality state at the time of each call. The resolved aggregator MUST be fixed and
+not change across collection cycles.
+
+Measurements recorded on a bound instrument MUST be candidates for [Exemplar](#exemplar)
+sampling. The [Context](../context/README.md) associated with each recording, whether
+implicit or explicit, MUST be used for exemplar [TraceBased](#tracebased) filtering and
+passed to the [ExemplarReservoir](#exemplarreservoir) offer method.
 
 The SDK MUST ensure attribute-free recordings on a bound instrument bypass per-recording
 map lookup.


### PR DESCRIPTION
Resolves #4126.

See issue for full details, but some of the key bits:

- Adds new optional "bind" capability to synchronous instruments
- Marked as "in development"
- SDK implementation requirements phrase it as "A bound instrument MUST behave identically to calling the equivalent unbound recording operation with the pre-bound Attributes on each measurement". That is, the same behavior with respect to cardinality limits, exemplars, and anything else relevant. Since attributes are pre-bound, this excludes attributes processing from views, which is done at bind time.

There have been a few prototypes built:

- Java: https://github.com/open-telemetry/opentelemetry-java/pull/8314                                                                                                                                                 
- Rust: https://github.com/open-telemetry/opentelemetry-rust/pull/3421
- Go: https://github.com/open-telemetry/opentelemetry-go/pull/8278

I'm particularly interested to here from @dashpole and @cijothomas if this aligns with their prototypes and ideas.

Other interest has been expressed in .NET and Erlang, but no prototypes that I'm aware of.