### PR TITLE
OTLP to Prometheus: Stabilize Instrumentation Scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ release.
 - Stabilize sections of Prometheus and OpenMetrics Compatibility.
   - Stabilize OpenTelemetry Gauge and Sum to Prometheus transformations.
     ([#5034](https://github.com/open-telemetry/opentelemetry-specification/pull/5034))
+  - Stabilize OpenTelemetry Instrumentation Scope to Prometheus labels transformation.
+    ([#5052](https://github.com/open-telemetry/opentelemetry-specification/pull/5052))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -460,9 +460,10 @@ the scope schema URL as the `otel_scope_schema_url` label,
 the scope attributes as labels with `otel_scope_` prefix and following the rules
 described in the [`Metric Attributes`](#metric-attributes) section below,
 on all metric points, based on the scope the original data point was nested in.
-Scope attributes with names 'name', 'version', or 'schema_url' MUST be dropped
-to avoid conflicts with the already existing `otel_scope_name`, `otel_scope_version`, and
-`otel_scope_schema_url` labels.
+Scope attributes that, after adding the `otel_scope_` prefix and applying the
+label-name conversion described in [`Metric Attributes`](#metric-attributes),
+would conflict with `otel_scope_name`, `otel_scope_version`, or
+`otel_scope_schema_url` MUST be dropped.
 
 ### Gauges
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -451,7 +451,7 @@ It also dictates type-specific conversion rules listed below.
 
 ### Instrumentation Scope
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 Prometheus exporters MUST by default add
 the scope name as the `otel_scope_name` label,


### PR DESCRIPTION
Fixes #4918 

## Changes

Stabilizes the conversion of Instrumentation Scope to Prometheus labels.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [X] Related issues #4918 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [X] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
