### PR TITLE
Prometheus exporter: Stabilize config option `scope_info_enabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ release.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
+  - Stabilize scope info configuration.
+    ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
 
 ### Logs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ release.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
+  - Stabilize scope info configuration.
+    ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
 - Change Prometheus Metric Exporter config property recommended names
   (`without_scope_info` -> `scope_info_enabled`, `without_target_info` -> `target_info_enabled`,
   `with_resource_constant_labels` -> `resource_constant_labels`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ release.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
   - Stabilize scope info configuration.
     ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
+  - Rename `without_scope_info` to `scope_info_enabled`, changing its default value from `false` to `true`.
+    ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
 - Change Prometheus Metric Exporter config property recommended names
   (`without_scope_info` -> `scope_info_enabled`, `without_target_info` -> `target_info_enabled`,
   `with_resource_constant_labels` -> `resource_constant_labels`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,7 @@ release.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
-  - Stabilize scope info configuration.
-    ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
-  - Rename `without_scope_info` to `scope_info_enabled`. To keep the existing behavior, its default value changed from `false` to `true`. 
+  - Stabilize `scope_info_enabled` configuration.
     ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
 - Change Prometheus Metric Exporter config property recommended names
   (`without_scope_info` -> `scope_info_enabled`, `without_target_info` -> `target_info_enabled`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ release.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
   - Stabilize scope info configuration.
     ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
-  - Rename `without_scope_info` to `scope_info_enabled`, changing its default value from `false` to `true`.
+  - Rename `without_scope_info` to `scope_info_enabled`. To keep the existing behavior, its default value changed from `false` to `true`. 
     ([#5056](https://github.com/open-telemetry/opentelemetry-specification/pull/5056))
 - Change Prometheus Metric Exporter config property recommended names
   (`without_scope_info` -> `scope_info_enabled`, `without_target_info` -> `target_info_enabled`,

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -149,7 +149,7 @@ If the Prometheus exporter supports such configuration it MUST be named to somet
 
 ### Scope Info
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter MAY support a configuration option to produce metrics without [scope labels](../../compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1).
 The option MAY be named `without_scope_info`, and MUST be `false` by default.

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -149,7 +149,7 @@ If the Prometheus exporter supports such configuration it MUST be named to somet
 
 ### Scope Info
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter MAY support configuration to specify whether metrics include
 [scope labels](../../compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1).


### PR DESCRIPTION
Fixes #4989

## Changes

Stabilizes the configuration option `without_scope_info`, documented in the Prometheus exporter spec. It is implemented by a few SDKs already https://github.com/open-telemetry/opentelemetry-specification/issues/4989#issuecomment-4214459250, an open PR for Python(https://github.com/open-telemetry/opentelemetry-python/pull/5123), and an issue for DotNet(https://github.com/open-telemetry/opentelemetry-dotnet/issues/7157). Both prometheus exporters in the collector have the option as well[[1](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusexporter#:~:text=without_scope_info%3A%20(default%20%3D%20false)%3A%20If%20true%2C%20metrics%20will%20be%20exported%20without%20scope%20name%2C%20version%2C%20schemaURL%2C%20and%20attributes%20encoded%20as%20labels.)][[2](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/prometheusremotewriteexporter#:~:text=disable_scope_info%20(default%20%3D%20false)%3A%20If%20true%2C%20the%20scope%20info%20labels%20(otel_scope_name%2C%20otel_scope_version%20and%20otel_scope_...%20attributes)%20will%20not%20be%20exported.)] (Although remote write exporter uses `disable_scope_info` instead of `without_scope_info`.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [X] Related issues #4989 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [X] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
