### PR TITLE
[chore] Update implementation status of add link in ruby

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -69,7 +69,7 @@ formats is required. Implementing more than one format is optional.
 | Unicode support for keys and string values |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | [Span linking](specification/trace/api.md#specifying-links) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | Links can be recorded on span creation |  | + | + | + | + | + | + | + | + | + | + |  | + |
-| Links can be recorded after span creation |  | + |  | + | + |  |  | + | + | + | + |  | + |
+| Links can be recorded after span creation |  | + |  | + | + | + |  | + | + | + | + |  | + |
 | Links order is preserved |  | + | + | + | + | + | + | + | + | + | + |  | + |
 | [Span events](specification/trace/api.md#add-events) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | AddEvent |  | + | + | + | + | + | + | + | + | + | + | + | + |

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -116,7 +116,7 @@ sections:
           - name: Links can be recorded on span creation
             status: '+'
           - name: Links can be recorded after span creation
-            status: '?'
+            status: '+'
           - name: Links order is preserved
             status: '+'
       - heading: '[Span events](specification/trace/api.md#add-events)'


### PR DESCRIPTION
## Changes

This updates the status of add_links for ruby to be classed as implemented. This is based on the implementation in https://github.com/open-telemetry/opentelemetry-ruby/blob/656936c4c82fde11b173e5f55c8e55d19c3854e2/sdk/lib/opentelemetry/sdk/trace/span.rb#L121-150

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
