### PR TITLE
Rename prometheus exporter config property names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ release.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
+- Change Prometheus Metric Exporter config property recommended names
+  (`without_scope_info` -> `scope_info_enabled`, `without_target_info` -> `target_info_enabled`,
+  `with_resource_constant_labels` -> `resource_constant_labels`)
+  ([#5071](https://github.com/open-telemetry/opentelemetry-specification/issues/5071))
 
 ### Logs
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -133,7 +133,7 @@ A Prometheus Exporter MAY offer configuration to add resource attributes as metr
 By default, it MUST NOT add any resource attributes as metric attributes.
 The configuration SHOULD allow the user to select which resource attributes to copy (e.g.
 include / exclude or regular expression based). Copied Resource attributes MUST NOT be
-excluded from the `target` info metric. The option MAY be named `with_resource_constant_labels`.
+excluded from the `target` info metric. The option MAY be named `resource_constant_labels`.
 
 ### Translation Strategy
 
@@ -151,15 +151,17 @@ If the Prometheus exporter supports such configuration it MUST be named to somet
 
 **Status**: [Development](../../document-status.md)
 
-A Prometheus Exporter MAY support a configuration option to produce metrics without [scope labels](../../compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1).
-The option MAY be named `without_scope_info`, and MUST be `false` by default.
+A Prometheus Exporter MAY support configuration to specify whether metrics include
+[scope labels](../../compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1).
+The option MAY be named `scope_info_enabled`, and MUST be `true` by default.
 
 ### Target Info
 
 **Status**: [Development](../../document-status.md)
 
-A Prometheus Exporter MAY support a configuration option to produce metrics without a [target info](../../compatibility/prometheus_and_openmetrics.md#resource-attributes-1)
-metric. The option MAY be named `without_target_info`, and MUST be `false` by default.
+A Prometheus Exporter MAY support a configuration to specify whether to produce a
+[target info](../../compatibility/prometheus_and_openmetrics.md#resource-attributes-1) metric.
+The option MAY be named `target_info_enabled`, and MUST be `true` by default.
 
 ## Content Negotiation
 


### PR DESCRIPTION
Here, I change:

* without_scope_info -> scope_info_enabled (default true)
* without_target_info -> target_info_enabled (default true)
* with_resource_constant_labels -> resource_constant_labels (default none are added)

The `with` prefix of a few (but not all) prometheus exporter options seems to be a carry over from go functional options pattern. We don't see it in the spec'd property names of any other built in components. It doesn't doesn't contribute to the property's meaning in any way. Omitting it doesn't block a language from using it in their implementation, since that choice falls within maintainer discretion.

I think the use of "without" without_scope_info / without_target_info with a default value of false was probably inspired by the "All Boolean environment variables SHOULD be named and defined such that false is the expected safe default behavior." language that we decided is not applicable to other configuration interfaces: https://github.com/open-telemetry/opentelemetry-specification/pull/4723

So since there's no env vars for without_scope_info / without_target_info, we don't need to be constrained by that.

Originated from: https://github.com/open-telemetry/opentelemetry-specification/pull/5056#issuecomment-4389593975

Corresponding change in declarative config schema: github.com/open-telemetry/opentelemetry-configuration/pull/612

