### PR TITLE
Add compliance matrix row for documenting View/Exemplar attribute interaction

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -175,6 +175,7 @@ formats is required. Implementing more than one format is optional.
 | The metrics SDK supports `AlwaysOn` exemplar filter |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | The metrics SDK supports `AlwaysOff` exemplar filter |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration. |  | + | + | - | - | + | + |  |  |  | + |  | - |
+| Documentation notes that View-filtered attributes may still appear on Exemplars. |  | - | - | - | - | - | - | - | - | - | + | - | - |
 | Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken. |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | Exemplars contain the timestamp when the measurement was taken. |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - | + | + | + |  |  | - |  | - |

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -317,6 +317,8 @@ sections:
         status: '?'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '?'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -317,6 +317,8 @@ sections:
         status: '+'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '+'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '+'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -317,6 +317,8 @@ sections:
         status: '+'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '+'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -317,6 +317,8 @@ sections:
         status: '+'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '+'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -317,6 +317,8 @@ sections:
         status: '+'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '+'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -317,6 +317,8 @@ sections:
         status: '-'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '-'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -317,6 +317,8 @@ sections:
         status: '-'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '-'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -317,6 +317,8 @@ sections:
         status: '?'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '?'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -317,6 +317,8 @@ sections:
         status: '-'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '-'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -317,6 +317,8 @@ sections:
         status: '+'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '+'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -317,6 +317,8 @@ sections:
         status: '?'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '?'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -317,6 +317,8 @@ sections:
         status: '?'
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
         status: '?'
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
+        status: '-'
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -212,6 +212,7 @@ sections:
       - name: The metrics SDK supports `AlwaysOn` exemplar filter
       - name: The metrics SDK supports `AlwaysOff` exemplar filter
       - name: Exemplars retain any attributes available in the measurement that are not preserved by aggregation or view configuration.
+      - name: Documentation notes that View-filtered attributes may still appear on Exemplars.
       - name:
           Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was
           taken.


### PR DESCRIPTION
Adds a row to the spec compliance matrix tracking whether each SDK's user documentation notes that attributes filtered out by a `View` may still appear on Exemplars.

Follows the style of the existing `Documentation defines adding attributes at span creation as preferred` row - tracks user-facing documentation, not behavioral conformance.

Companion to #5073. .NET docs updated in open-telemetry/opentelemetry-dotnet#7270.