### PR TITLE
[chore] Add eventname as supported on ruby

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -204,7 +204,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | LoggerProvider.ForceFlush |  | + | + | + | + | + |  | + | + | + | - |  | + |
 | Logger.Emit(LogRecord) |  | + | + | + | + | + |  | + | + | + | - |  | + |
 | Logger.Emit(LogRecord) with Exception parameter | X |  |  |  |  |  |  |  |  |  |  |  | + |
-| LogRecord.Set EventName |  | + |  |  |  |  |  |  | + | + |  |  | + |
+| LogRecord.Set EventName |  | + |  |  |  | + |  |  | + | + |  |  | + |
 | Logger.Enabled | X | + |  |  |  |  |  | + | + | + |  |  | + |
 | Ergonomic API | X |  |  |  |  |  |  |  |  |  |  |  |  |
 | SimpleLogRecordProcessor |  | + | + | + | + | + |  | + | + | + |  |  | + |

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -368,7 +368,7 @@ sections:
       - name: Logger.Emit(LogRecord) with Exception parameter
         status: '?'
       - name: LogRecord.Set EventName
-        status: '?'
+        status: '+'
       - name: Logger.Enabled
         status: '?'
       - name: SimpleLogRecordProcessor


### PR DESCRIPTION
## Changes

This updates the status of add_links for ruby to be classed as implemented. See implementation in https://github.com/open-telemetry/opentelemetry-ruby/pull/2077

Note this will move from draft once functionality is released.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
