### PR TITLE
[prometheus] Reword SDK exporter client libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize temporality.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
-  - Reword client libraries.
+  - Clarify that OTel SDKs should not use unofficial Prometheus clients.
     ([#4980](https://github.com/open-telemetry/opentelemetry-specification/issues/4980))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize temporality.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
+  - Stabilize client libraries.
+    ([#4980](https://github.com/open-telemetry/opentelemetry-specification/issues/4980))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))
 - Change Prometheus Metric Exporter config property recommended names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize temporality.
     ([#5024](https://github.com/open-telemetry/opentelemetry-specification/issues/5024))
-  - Stabilize client libraries.
+  - Reword client libraries.
     ([#4980](https://github.com/open-telemetry/opentelemetry-specification/issues/4980))
   - Stabilize port configuration.
     ([#4985](https://github.com/open-telemetry/opentelemetry-specification/issues/4985))

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -52,7 +52,7 @@ OpenTelemetry metrics MUST be converted to Prometheus metrics according to the
 
 ### Client Libraries
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter SHOULD use
 [Prometheus client libraries](https://prometheus.io/docs/instrumenting/clientlibs/)

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -52,11 +52,12 @@ OpenTelemetry metrics MUST be converted to Prometheus metrics according to the
 
 ### Client Libraries
 
-**Status**: [Stable](../../document-status.md)
+**Status**: [Development](../../document-status.md)
 
-A Prometheus Exporter SHOULD use
-[Prometheus client libraries](https://prometheus.io/docs/instrumenting/clientlibs/)
-for serving Prometheus metrics. This allows the Prometheus client to negotiate
+A Prometheus Exporter SHOULD use an official [Prometheus client library](https://prometheus.io/docs/instrumenting/clientlibs/)
+when one exists for the implementation language for serving Prometheus metrics;
+it SHOULD NOT use an unofficial Prometheus client library.
+This allows the Prometheus client to negotiate
 the [format](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 of the response using the `Content-Type` header. If a Prometheus client library
 is used, the OpenTelemetry Prometheus Exporter SHOULD be modeled as a

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -55,8 +55,9 @@ OpenTelemetry metrics MUST be converted to Prometheus metrics according to the
 **Status**: [Development](../../document-status.md)
 
 A Prometheus Exporter SHOULD use an official [Prometheus client library](https://prometheus.io/docs/instrumenting/clientlibs/)
-when one exists for the implementation language for serving Prometheus metrics;
-it SHOULD NOT use an unofficial Prometheus client library.
+when one exists for the implementation language and it is practical to do so
+(e.g., dependency concerns) for serving Prometheus metrics; it SHOULD NOT use an
+unofficial Prometheus client library.
 This allows the Prometheus client to negotiate
 the [format](https://github.com/prometheus/docs/blob/main/docs/instrumenting/exposition_formats.md)
 of the response using the `Content-Type` header. If a Prometheus client library


### PR DESCRIPTION
Addresses #4980

## Changes

Updates Prometheus Metrics Exporter spec **Client Libraries** section so that its status can eventually from `Development` to `Stable`.

* [x] Related issues #4980
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
