### PR TITLE
[prometheus] Reword SDK exporter resource attributes config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ release.
 
 ### Compatibility
 
+- Stabilize sections of Prometheus Metrics Exporter.
+  - Clarify resource attributes configuration.
+    ([#5084](https://github.com/open-telemetry/opentelemetry-specification/pull/5084))
+
 ### SDK Configuration
 
 ### Supplementary Guidelines

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -133,8 +133,7 @@ the [default aggregation](../sdk.md#default-aggregation) by default.
 
 A Prometheus Exporter MAY offer configuration to add resource attributes as metric labels.
 By default, it MUST NOT add any resource attributes as metric labels.
-The configuration SHOULD allow the user to select a list of resource attributes to include,
-or a list of resource attributes to exclude. Copied Resource attributes MUST NOT be
+The configuration SHOULD allow the user to select resource attributes to include or exclude. Copied Resource attributes MUST NOT be
 excluded from the `target_info` metric. The option SHOULD be named `resource_constant_labels`.
 
 ### Translation Strategy

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -23,7 +23,7 @@ linkTitle: Prometheus
   * [Host](#host)
   * [Port](#port)
   * [Default Aggregation](#default-aggregation)
-  * [Resource Attributes as Metric Attributes](#resource-attributes-as-metric-attributes)
+  * [Resource Attributes as Metric Labels](#resource-attributes-as-metric-labels)
   * [Translation Strategy](#translation-strategy)
   * [Scope Info](#scope-info)
   * [Target Info](#target-info)
@@ -127,15 +127,15 @@ the [MetricReader](../sdk.md#metricreader) default `aggregation` as a function
 of instrument kind. This option MAY be named `default_aggregation`, and MUST use
 the [default aggregation](../sdk.md#default-aggregation) by default.
 
-### Resource Attributes as Metric Attributes
+### Resource Attributes as Metric Labels
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
-A Prometheus Exporter MAY offer configuration to add resource attributes as metric attributes.
-By default, it MUST NOT add any resource attributes as metric attributes.
-The configuration SHOULD allow the user to select which resource attributes to copy (e.g.
-include / exclude or regular expression based). Copied Resource attributes MUST NOT be
-excluded from the `target` info metric. The option MAY be named `resource_constant_labels`.
+A Prometheus Exporter MAY offer configuration to add resource attributes as metric labels.
+By default, it MUST NOT add any resource attributes as metric labels.
+The configuration SHOULD allow the user to select a list of resource attributes to include,
+or a list of resource attributes to exclude. Copied Resource attributes MUST NOT be
+excluded from the `target_info` metric. The option SHOULD be named `resource_constant_labels`.
 
 ### Translation Strategy
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -129,7 +129,7 @@ the [default aggregation](../sdk.md#default-aggregation) by default.
 
 ### Resource Attributes as Metric Labels
 
-**Status**: [Stable](../../document-status.md)
+**Status**: [Development](../../document-status.md)
 
 A Prometheus Exporter MAY offer configuration to add resource attributes as metric labels.
 By default, it MUST NOT add any resource attributes as metric labels.


### PR DESCRIPTION
Addresses #4987

## Changes

Updates Prometheus Metrics Exporter spec **Resource Attributes** configuration section so that its status can eventually move from `Development` to `Stable`. Addresses feedback in https://github.com/open-telemetry/opentelemetry-specification/issues/4987#issuecomment-4407854244.

* [x] Related issues #4987
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
