### PR TITLE
Recommend log_bridge.name and log_bridge.version Instrumentation Scope attributes for Log Bridges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ release.
   Instrumentation Scope attributes to identify themselves, distinct from the
   producer of the log call (which is reported as the instrumentation scope
   name).
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
+  ([#5089](https://github.com/open-telemetry/opentelemetry-specification/pull/5089))
 
 ### Baggage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ release.
 
 ### Logs
 
+- Recommend that Log Bridges set `log_bridge.name` and `log_bridge.version`
+  Instrumentation Scope attributes to identify themselves, distinct from the
+  producer of the log call (which is reported as the instrumentation scope
+  name).
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
+
 ### Baggage
 
 ### Profiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ release.
 
 ### Logs
 
-- Recommend that Log Bridges set `log_bridge.name` and `log_bridge.version`
+- Recommend that Log Bridges set `log.bridge.name` and `log.bridge.version`
   Instrumentation Scope attributes to identify themselves, distinct from the
   producer of the log call (which is reported as the instrumentation scope
   name).

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -91,6 +91,14 @@ parameters:
 * `attributes` (optional): Specifies the instrumentation scope attributes to
   associate with emitted telemetry. This API MUST be structured to accept a
   variable number of attributes, including none.
+  Log Bridges (components that bridge a logging library to OpenTelemetry)
+  SHOULD set the `log_bridge.name` and `log_bridge.version` attributes
+  (defined in the [Semantic Conventions for Log Bridges][semconv-log-bridge])
+  on the `Logger`(s) they create, to identify the bridge itself,
+  distinct from the producer of the log call which is reported as the
+  instrumentation scope `name`.
+
+[semconv-log-bridge]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/log-bridge.md
 
 The term *identical* applied to `Logger`s describes instances where all
 parameters are equal. The term *distinct* applied to `Logger`s describes

--- a/specification/logs/api.md
+++ b/specification/logs/api.md
@@ -91,14 +91,6 @@ parameters:
 * `attributes` (optional): Specifies the instrumentation scope attributes to
   associate with emitted telemetry. This API MUST be structured to accept a
   variable number of attributes, including none.
-  Log Bridges (components that bridge a logging library to OpenTelemetry)
-  SHOULD set the `log_bridge.name` and `log_bridge.version` attributes
-  (defined in the [Semantic Conventions for Log Bridges][semconv-log-bridge])
-  on the `Logger`(s) they create, to identify the bridge itself,
-  distinct from the producer of the log call which is reported as the
-  instrumentation scope `name`.
-
-[semconv-log-bridge]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/log-bridge.md
 
 The term *identical* applied to `Logger`s describes instances where all
 parameters are equal. The term *distinct* applied to `Logger`s describes

--- a/specification/logs/supplementary-guidelines.md
+++ b/specification/logs/supplementary-guidelines.md
@@ -83,7 +83,7 @@ obtained with the same identity of the [Logger](./api.md#get-a-logger),
 which, according to the specification, is an error.
 
 Appenders SHOULD however identify themselves by setting the
-`log_bridge.name` and `log_bridge.version` Instrumentation Scope attributes
+`log.bridge.name` and `log.bridge.version` Instrumentation Scope attributes
 (defined in the [Semantic Conventions for Log Bridges][semconv-log-bridge])
 on the `Logger`(s) they create. These attributes describe the appender
 itself, not the producer of the log call, so different appenders setting

--- a/specification/logs/supplementary-guidelines.md
+++ b/specification/logs/supplementary-guidelines.md
@@ -90,7 +90,7 @@ itself, not the producer of the log call, so different appenders setting
 different values is the intended behavior — it correctly produces distinct
 Loggers per appender.
 
-[semconv-log-bridge]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/log-bridge.md
+[semconv-log-bridge]: https://github.com/open-telemetry/semantic-conventions/pull/3716
 
 ### Context
 

--- a/specification/logs/supplementary-guidelines.md
+++ b/specification/logs/supplementary-guidelines.md
@@ -75,11 +75,22 @@ This is for example applicable to:
 - Logger name in [Log4J](https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/latest/org.apache.logging.log4j/org/apache/logging/log4j/Logger.html)
 - Channel name in [Monolog](https://github.com/Seldaek/monolog/blob/3.4.0/doc/01-usage.md#leveraging-channels)
 
-Appenders should avoid setting any attributes of the Instrumentation Scope.
-Doing so may result in different appenders setting different attributes on the
-same Instrumentation Scope, obtained with the same identity of the
-[Logger](./api.md#get-a-logger), which, according to the specification,
-is an error.
+Appenders should avoid setting Instrumentation Scope attributes that
+describe the producer of the log call (e.g. attributes derived from the
+underlying logging library's logger), as doing so may result in different
+appenders setting different attributes on the same Instrumentation Scope,
+obtained with the same identity of the [Logger](./api.md#get-a-logger),
+which, according to the specification, is an error.
+
+Appenders SHOULD however identify themselves by setting the
+`log_bridge.name` and `log_bridge.version` Instrumentation Scope attributes
+(defined in the [Semantic Conventions for Log Bridges][semconv-log-bridge])
+on the `Logger`(s) they create. These attributes describe the appender
+itself, not the producer of the log call, so different appenders setting
+different values is the intended behavior — it correctly produces distinct
+Loggers per appender.
+
+[semconv-log-bridge]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/registry/attributes/log-bridge.md
 
 ### Context
 


### PR DESCRIPTION
Draft. Adds bridge-author guidance for the in-progress semantic convention proposed in open-telemetry/semantic-conventions#3716 (issue: open-telemetry/semantic-conventions#1550). Recommends Log Bridges identify themselves via `log_bridge.name` / `log_bridge.version` Instrumentation Scope attributes, distinct from the producer of the log call (reported as the scope name). Held in draft until the convention lands.

### Revising the existing "avoid setting any scope attributes" advice

The existing guidance tells appenders to set no scope attributes at all, to prevent **scope identity ambiguity** — the same logger name producing multiple Loggers that differ only in attributes (e.g. an appender attaching per-request data, or two appenders attaching inconsistent metadata for the same name). That was the right blanket rule when there was no convention for *what* an appender could legitimately put on the scope.

`log_bridge.*` doesn't trip this concern because:

1. **Values are constant per bridge** — `log_bridge.name`/`.version` never vary per record, per request, or per anything dynamic. No cardinality blowup, no identity drift over time.
2. **When two bridges produce the same scope name with different `log_bridge.*` values, the difference is correct.** They really did come from different bridges, and the attributes are doing identity work, not muddying it. That's the disambiguation the original warning was protecting, not violating.

This PR narrows the existing ban to its actual intent — *don't put producer-derived or per-event data on the scope* — while permitting the one well-defined scope-attribute set that's now standardized.