### PR TITLE
[prometheus]: Stabilize OTLP -> Prometheus Summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ release.
     ([#5034](https://github.com/open-telemetry/opentelemetry-specification/pull/5034))
   - Stabilize OpenTelemetry Instrumentation Scope to Prometheus labels transformation.
     ([#5052](https://github.com/open-telemetry/opentelemetry-specification/pull/5052))
+  - Stabilize the conversion of OTLP Summaries into Prometheus Summaries.
+    ([#4923](https://github.com/open-telemetry/opentelemetry-specification/issues/4923))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -573,7 +573,13 @@ An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be conv
   be the stringified floating point value of quantiles (between 0.0 and 1.0),
   starting from lowest to highest, and all being non-negative.  The value of
   each point is the computed value of the quantile point.
-- Summaries with `StartTimeUnixNano` set should export the `{name}_created` metric as well.
+An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be converted to a Prometheus Summary as follows:
+
+- The count is converted to the Summary's count.
+- The sum is converted to the Summary's sum.
+- Quantiles are converted to the Summary's quantiles.
+- If it is a push protocol (e.g. PRW), `time_unix_nano` is converted to the Summary's timestamp. Explicit timestamps are strongly discouraged for pull protocols, such as the Prometheus text exposition format.
+- The `start_time_unix_nano` is converted to the Summary's start timestamp, if supported.
 
 Exemplars on OpenTelemetry Summaries SHOULD be dropped.
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -558,7 +558,7 @@ metrics with the delta aggregation temporality are dropped.
 
 ### Summaries
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be converted to a Prometheus metric family with the following metrics:
 


### PR DESCRIPTION
Fixes #4923

## Changes

Stabilizes the conversion of OTLP Summaries into Prometheus Summaries.

* [x] Related issues #4923
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
