### PR TITLE
Expand metric instrument name allowed characters to support Windows performance counter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ release.
 ### Metrics
 
 - Expand the metric instrument name allowed character set to include `:`,
-  `\`, `(`, `)`, `%`, `*`, and space (with space restricted to non-leading,
-  non-trailing positions), and drop the requirement that the first character
-  be alphabetic. This enables Windows performance counter style names (e.g.
-  `\Processor(_Total)\% Processor Time`). ASCII, case-insensitivity, and the
-  255-character maximum are unchanged.
+  `\`, `(`, `)`, `%`, `*`, `#`, and space (with space restricted to
+  non-leading, non-trailing positions), and drop the requirement that the
+  first character be alphabetic. This enables Windows performance counter
+  style names (e.g. `\Processor(_Total)\% Processor Time`,
+  `\.NET CLR Memory(*)\# Bytes in all Heaps`). ASCII, case-insensitivity, and
+  the 255-character maximum are unchanged.
   ([#4371](https://github.com/open-telemetry/opentelemetry-specification/issues/4371),
   [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736))
 - Add in-development `Bind` API to synchronous instruments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,11 @@ release.
 
 ### Metrics
 
-- Relax the metric instrument name syntax to allow any valid, non-empty UTF-8
-  string. The previous restriction (ASCII-only, must start with an alphabetic
-  character, limited character set) is replaced; the maximum length of 255
-  characters and case-insensitivity are unchanged.
+- Expand the metric instrument name allowed character set to include `:` and
+  `\`, and drop the requirement that the first character be alphabetic. ASCII,
+  case-insensitivity, and the 255-character maximum are unchanged.
   ([#4371](https://github.com/open-telemetry/opentelemetry-specification/issues/4371),
-  [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736),
-  [#3422](https://github.com/open-telemetry/opentelemetry-specification/issues/3422))
+  [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736))
 - Add in-development `Bind` API to synchronous instruments.
   ([#5050](https://github.com/open-telemetry/opentelemetry-specification/pull/5050))
 - Stabilize sections of Prometheus Metrics Exporter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ release.
 
 ### Metrics
 
+- Relax the metric instrument name syntax to allow any valid, non-empty UTF-8
+  string. The previous restriction (ASCII-only, must start with an alphabetic
+  character, limited character set) is replaced; the maximum length of 255
+  characters and case-insensitivity are unchanged.
+  ([#4371](https://github.com/open-telemetry/opentelemetry-specification/issues/4371),
+  [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736),
+  [#3422](https://github.com/open-telemetry/opentelemetry-specification/issues/3422))
 - Add in-development `Bind` API to synchronous instruments.
   ([#5050](https://github.com/open-telemetry/opentelemetry-specification/pull/5050))
 - Stabilize sections of Prometheus Metrics Exporter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ release.
 ### Metrics
 
 - Expand the metric instrument name allowed character set to include `:`,
-  `\`, `(`, `)`, `%`, `*`, and space, and drop the requirement that the first
-  character be alphabetic. This enables Windows performance counter style
-  names (e.g. `\Processor(_Total)\% Processor Time`). ASCII,
-  case-insensitivity, and the 255-character maximum are unchanged.
+  `\`, `(`, `)`, `%`, `*`, and space (with space restricted to non-leading,
+  non-trailing positions), and drop the requirement that the first character
+  be alphabetic. This enables Windows performance counter style names (e.g.
+  `\Processor(_Total)\% Processor Time`). ASCII, case-insensitivity, and the
+  255-character maximum are unchanged.
   ([#4371](https://github.com/open-telemetry/opentelemetry-specification/issues/4371),
   [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736))
 - Add in-development `Bind` API to synchronous instruments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ release.
 
 ### Metrics
 
-- Expand the metric instrument name allowed character set to include `:` and
-  `\`, and drop the requirement that the first character be alphabetic. ASCII,
+- Expand the metric instrument name allowed character set to include `:`,
+  `\`, `(`, `)`, `%`, `*`, and space, and drop the requirement that the first
+  character be alphabetic. This enables Windows performance counter style
+  names (e.g. `\Processor(_Total)\% Processor Time`). ASCII,
   case-insensitivity, and the 255-character maximum are unchanged.
   ([#4371](https://github.com/open-telemetry/opentelemetry-specification/issues/4371),
   [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736))

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -427,12 +427,6 @@ name SHOULD be replaced with the `_` character by default, aiming for
 compatibility with Prometheus conventions. Multiple consecutive `_` characters
 SHOULD be replaced with a single `_` character.
 
-Note that even with [Prometheus's UTF-8 metric name support](https://prometheus.io/docs/guides/utf8/)
-enabled, Prometheus does not currently accept metric names that begin with a
-non-alphanumeric character; such leading characters are silently dropped on
-the Prometheus side. Producers emitting such names should account for this
-when targeting Prometheus.
-
 The Unit of an OTLP metric point MUST be converted from the UCUM unit to the
 equivalent unit word in Prometheus if it is included in the
 table in [Metric Metadata above](#metric-metadata).

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -427,6 +427,12 @@ name SHOULD be replaced with the `_` character by default, aiming for
 compatibility with Prometheus conventions. Multiple consecutive `_` characters
 SHOULD be replaced with a single `_` character.
 
+Note that even with [Prometheus's UTF-8 metric name support](https://prometheus.io/docs/guides/utf8/)
+enabled, Prometheus does not currently accept metric names that begin with a
+non-alphanumeric character; such leading characters are silently dropped on
+the Prometheus side. Producers emitting such names should account for this
+when targeting Prometheus.
+
 The Unit of an OTLP metric point MUST be converted from the UCUM unit to the
 equivalent unit word in Prometheus if it is included in the
 table in [Metric Metadata above](#metric-metadata).

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -201,23 +201,21 @@ identifying fields are equal.
 
 #### Instrument name syntax
 
-* They are non-empty strings.
-* They MUST NOT consist solely of ASCII whitespace characters (e.g., space, tab, newline).
-* They MUST support [BMP (Unicode Plane
-  0)](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane),
-  which is basically only the first three bytes of UTF-8 (or `utf8mb3`).
-  [OpenTelemetry API](../overview.md#api) authors MAY decide if they want to
-  support more Unicode [Planes](https://en.wikipedia.org/wiki/Plane_(Unicode)).
-* They are case-insensitive.
-* They can have a maximum length of 255 characters.
+The instrument name syntax is defined below using the [Augmented Backus-Naur
+Form](https://datatracker.ietf.org/doc/html/rfc5234):
 
-The API documentation MUST state that instrument names matching the regular
-expression `[A-Za-z][A-Za-z0-9_./-]{0,254}` are interoperable with the
-broadest set of backends. Names outside this pattern are valid, but some
-exporters (notably the
-[Prometheus](../compatibility/prometheus_and_openmetrics.md#metric-metadata-1)
-exporter) may need to transform them to conform to backend-specific
-conventions.
+```abnf
+instrument-name = 1*255 ("_" / "." / "-" / "/" / ":" / "\" / ALPHA / DIGIT)
+
+ALPHA = %x41-5A / %x61-7A; A-Z / a-z
+DIGIT = %x30-39 ; 0-9
+```
+
+* They are not null or empty strings.
+* They are case-insensitive, ASCII strings.
+* Characters must belong to the alphanumeric characters, '_', '.', '-', '/',
+  ':', and '\\'.
+* They can have a maximum length of 255 characters.
 
 #### Instrument unit
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -201,7 +201,13 @@ identifying fields are equal.
 
 #### Instrument name syntax
 
-* They are any valid, non-empty UTF-8 strings.
+* They are non-empty strings.
+* They MUST NOT consist solely of whitespace characters.
+* They MUST support [BMP (Unicode Plane
+  0)](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane),
+  which is basically only the first three bytes of UTF-8 (or `utf8mb3`).
+  [OpenTelemetry API](../overview.md#api) authors MAY decide if they want to
+  support more Unicode [Planes](https://en.wikipedia.org/wiki/Plane_(Unicode)).
 * They are case-insensitive.
 * They can have a maximum length of 255 characters.
 

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -207,7 +207,7 @@ Form](https://datatracker.ietf.org/doc/html/rfc5234):
 ```abnf
 instrument-name = NAME-CHAR [0*253(NAME-CHAR / " ") NAME-CHAR]
 
-NAME-CHAR = ALPHA / DIGIT / "_" / "." / "-" / "/" / ":" / "\" / "(" / ")" / "%" / "*"
+NAME-CHAR = ALPHA / DIGIT / "_" / "." / "-" / "/" / ":" / "\" / "(" / ")" / "%" / "*" / "#"
 ALPHA     = %x41-5A / %x61-7A; A-Z / a-z
 DIGIT     = %x30-39 ; 0-9
 ```
@@ -215,8 +215,8 @@ DIGIT     = %x30-39 ; 0-9
 * They are not null or empty strings.
 * They are case-insensitive, ASCII strings.
 * Characters must be ASCII alphanumeric or one of: `_`, `.`, `-`, `/`, `:`,
-  `\`, `(`, `)`, `%`, `*`, or space. The first and last characters MUST NOT
-  be a space.
+  `\`, `(`, `)`, `%`, `*`, `#`, or space. The first and last characters MUST
+  NOT be a space.
 * They can have a maximum length of 255 characters.
 
 #### Instrument unit

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -205,7 +205,7 @@ The instrument name syntax is defined below using the [Augmented Backus-Naur
 Form](https://datatracker.ietf.org/doc/html/rfc5234):
 
 ```abnf
-instrument-name = 1*255 ("_" / "." / "-" / "/" / ":" / "\" / ALPHA / DIGIT)
+instrument-name = 1*255 ("_" / "." / "-" / "/" / ":" / "\" / "(" / ")" / "%" / "*" / " " / ALPHA / DIGIT)
 
 ALPHA = %x41-5A / %x61-7A; A-Z / a-z
 DIGIT = %x30-39 ; 0-9
@@ -213,8 +213,8 @@ DIGIT = %x30-39 ; 0-9
 
 * They are not null or empty strings.
 * They are case-insensitive, ASCII strings.
-* Characters must belong to the alphanumeric characters, '_', '.', '-', '/',
-  ':', and '\\'.
+* Characters must be ASCII alphanumeric or one of: `_`, `.`, `-`, `/`, `:`,
+  `\`, `(`, `)`, `%`, `*`, or space.
 * They can have a maximum length of 255 characters.
 
 #### Instrument unit

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -202,7 +202,7 @@ identifying fields are equal.
 #### Instrument name syntax
 
 * They are non-empty strings.
-* They MUST NOT consist solely of whitespace characters.
+* They MUST NOT consist solely of ASCII whitespace characters (e.g., space, tab, newline).
 * They MUST support [BMP (Unicode Plane
   0)](https://en.wikipedia.org/wiki/Plane_(Unicode)#Basic_Multilingual_Plane),
   which is basically only the first three bytes of UTF-8 (or `utf8mb3`).

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -205,16 +205,18 @@ The instrument name syntax is defined below using the [Augmented Backus-Naur
 Form](https://datatracker.ietf.org/doc/html/rfc5234):
 
 ```abnf
-instrument-name = 1*255 ("_" / "." / "-" / "/" / ":" / "\" / "(" / ")" / "%" / "*" / " " / ALPHA / DIGIT)
+instrument-name = NAME-CHAR [0*253(NAME-CHAR / " ") NAME-CHAR]
 
-ALPHA = %x41-5A / %x61-7A; A-Z / a-z
-DIGIT = %x30-39 ; 0-9
+NAME-CHAR = ALPHA / DIGIT / "_" / "." / "-" / "/" / ":" / "\" / "(" / ")" / "%" / "*"
+ALPHA     = %x41-5A / %x61-7A; A-Z / a-z
+DIGIT     = %x30-39 ; 0-9
 ```
 
 * They are not null or empty strings.
 * They are case-insensitive, ASCII strings.
 * Characters must be ASCII alphanumeric or one of: `_`, `.`, `-`, `/`, `:`,
-  `\`, `(`, `)`, `%`, `*`, or space.
+  `\`, `(`, `)`, `%`, `*`, or space. The first and last characters MUST NOT
+  be a space.
 * They can have a maximum length of 255 characters.
 
 #### Instrument unit

--- a/specification/metrics/api.md
+++ b/specification/metrics/api.md
@@ -201,22 +201,17 @@ identifying fields are equal.
 
 #### Instrument name syntax
 
-The instrument name syntax is defined below using the [Augmented Backus-Naur
-Form](https://datatracker.ietf.org/doc/html/rfc5234):
-
-```abnf
-instrument-name = ALPHA 0*254 ("_" / "." / "-" / "/" / ALPHA / DIGIT)
-
-ALPHA = %x41-5A / %x61-7A; A-Z / a-z
-DIGIT = %x30-39 ; 0-9
-```
-
-* They are not null or empty strings.
-* They are case-insensitive, ASCII strings.
-* The first character must be an alphabetic character.
-* Subsequent characters must belong to the alphanumeric characters, '_', '.', '-',
-  and '/'.
+* They are any valid, non-empty UTF-8 strings.
+* They are case-insensitive.
 * They can have a maximum length of 255 characters.
+
+The API documentation MUST state that instrument names matching the regular
+expression `[A-Za-z][A-Za-z0-9_./-]{0,254}` are interoperable with the
+broadest set of backends. Names outside this pattern are valid, but some
+exporters (notably the
+[Prometheus](../compatibility/prometheus_and_openmetrics.md#metric-metadata-1)
+exporter) may need to transform them to conform to backend-specific
+conventions.
 
 #### Instrument unit
 


### PR DESCRIPTION
**Description**

Expands the metric instrument name allowed character set to include `:`, `\`, `(`, `)`, `%`, `*`, and space, and drops the requirement that the first character be alphabetic. This enables Windows performance counter style names (e.g. `\Processor(_Total)\% Processor Time`). Closes #4736 (`:`), #4371 (leading non-alphabetic characters), and (alongside the spec change) makes [open-telemetry/opentelemetry-rust#2527](https://github.com/open-telemetry/opentelemetry-rust/issues/2527)'s experimental feature flag obsolete. Backwards-compatible: all currently valid names remain valid.

Everything else stays as-is: ASCII-only, case-insensitive, maximum length 255 characters.

**Motivation**

Linked issues:

- [#4736](https://github.com/open-telemetry/opentelemetry-specification/issues/4736) — names containing `:`.
- [#4371](https://github.com/open-telemetry/opentelemetry-specification/issues/4371) — names starting with a non-alphabetic character.
- [open-telemetry/opentelemetry-rust#2527](https://github.com/open-telemetry/opentelemetry-rust/issues/2527) — Windows performance-counter names (e.g. `\Processor(_Total)\% Processor Time`). The current spec forces SDKs to either reject these names or ship workarounds; OTel Rust shipped an unofficial Cargo feature flag (`experimental_metrics_disable_name_validation`) to bypass validation entirely. With this PR, the spec accepts the full Windows perf-counter name shape so the workaround can be retired.

This PR addresses the specific characters that have been requested in open issues, rather than opening the door to arbitrary UTF-8. Per the SIG discussion on the earlier broader proposal (see comments in this PR), maintainers prefer expanding the allowlist over accepting any UTF-8.

**Verifying impact on the OpenTelemetry Collector / OTTL**

[open-telemetry/opentelemetry-collector-contrib#48345](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/48345) (merged) added unit tests confirming OTTL accepts arbitrary characters in `metric.name` — so this PR's allowlist expansion has no impact on OTTL.
