### PR TITLE
Clarify View name is not subject to instrument name syntax validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ release.
 
 ### Metrics
 
+- Clarify that View-provided metric stream `name` is not subject to instrument
+  name syntax validation.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
 - Add in-development `Bind` API to synchronous instruments.
   ([#5050](https://github.com/open-telemetry/opentelemetry-specification/pull/5050))
 - Stabilize sections of Prometheus Metrics Exporter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ release.
 
 - Clarify that View-provided metric stream `name` is not subject to instrument
   name syntax validation.
-  ([#XXXX](https://github.com/open-telemetry/opentelemetry-specification/pull/XXXX))
+  ([#5094](https://github.com/open-telemetry/opentelemetry-specification/pull/5094))
 - Add in-development `Bind` API to synchronous instruments.
   ([#5050](https://github.com/open-telemetry/opentelemetry-specification/pull/5050))
 - Stabilize sections of Prometheus Metrics Exporter.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -353,6 +353,10 @@ The SDK MUST accept the following stream configuration parameters:
   MUST NOT obligate a user to provide one. If the user does not provide a
   `name` value, name from the Instrument the View matches MUST be used by
   default.
+
+  The `name` provided via stream configuration is NOT REQUIRED to conform to
+  the [instrument name syntax](./api.md#instrument-name-syntax), and the SDK
+  MUST NOT validate it against that syntax.
 * `description`: The metric stream description that SHOULD be used.
   
   Users can provide a `description`, but it is up to their discretion.


### PR DESCRIPTION
The SDK spec is currently silent on whether the metric stream `name` provided via View stream configuration must conform to the [instrument name syntax](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/api.md#instrument-name-syntax). Implementations have diverged on this: .NET and Rust validate the View-provided name against the instrument name syntax (and reject/drop the stream on mismatch), while Go, Java, Python, and C++ pass it through without validation.

This PR makes the spec explicit that View-provided names are not subject to instrument name syntax validation.

Discussion context: https://github.com/open-telemetry/opentelemetry-specification/pull/5092#issuecomment-4452823075 and follow-ups.
