### PR TITLE
Update Swift env carrier compliance

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -251,7 +251,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Setter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + | - |
 | Getter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + | - |
 | Getter argument returning Keys | X | N/A | + | + | + | + | + | + | N/A | + | - | + | - |
-| [Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md) |  | + | + |  |  |  |  |  |  |  | + |  |  |
+| [Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md) |  | + | + |  |  |  |  |  |  |  | + | + |  |
 
 ## Environment Variables
 

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -446,7 +446,7 @@ sections:
       - name: Getter argument returning Keys
         status: '+'
       - name: '[Environment Variables as Context Propagation Carriers](specification/context/env-carriers.md)'
-        status: '?'
+        status: '+'
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -131,9 +131,11 @@ Examples:
 - [OpenTelemetry Go implementation][gi]
 - [OpenTelemetry Java implementation][ji]
 - [OpenTelemetry Python implementation][pi]
+- [OpenTelemetry Swift implementation][si]
 
 [di]: https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/Context/Propagation/EnvironmentVariableCarrier.cs
 [ci]: https://github.com/open-telemetry/opentelemetry-cpp/blob/main/api/include/opentelemetry/context/propagation/environment_carrier.h
 [gi]: https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/propagators/envcar
 [ji]: https://github.com/open-telemetry/opentelemetry-java/tree/main/api/incubator/src/main/java/io/opentelemetry/api/incubator/propagation
 [pi]: https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-api/src/opentelemetry/propagators/_envcarrier.py
+[si]: https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift


### PR DESCRIPTION
Per https://github.com/open-telemetry/opentelemetry-swift-core/pull/47

Towards https://github.com/open-telemetry/opentelemetry-specification/issues/5040

This updates the compliance matrix to mark Swift as implementing Environment Variables as Context Propagation Carriers and adds the Swift implementation to the examples list.