### PR TITLE
Clarify environment carrier key normalization behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ release.
 
 - Clarify that environment variable propagation carriers normalize requested
   keys, carrier keys, and returned keys.
+  ([#5102](https://github.com/open-telemetry/opentelemetry-specification/pull/5102))
 
 ### Traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ release.
 
 ### Context
 
-- Clarify that environment variable propagation carriers normalize both
-  requested keys and carrier keys when extracting context.
+- Clarify that environment variable propagation carriers normalize requested
+  keys, carrier keys, and returned keys.
 
 ### Traces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ release.
 
 ### Context
 
+- Clarify that environment variable propagation carriers normalize both
+  requested keys and carrier keys when extracting context.
+
 ### Traces
 
 ### Metrics

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -66,6 +66,16 @@ Environment variable names used for context propagation:
     (`_`) with an underscore (`_`),
   - prefixing the name with an underscore (`_`) if it would otherwise start with
     an ASCII digit.
+- MUST be normalized consistently by both get and set operations:
+  - when injecting context, the carrier MUST write values using the normalized
+    form of the key provided by the propagator,
+  - when extracting context, the carrier MUST normalize the key requested by the
+    propagator and the key names present in the carrier before matching them.
+
+For example, if a propagator requests the key `x-b3-traceid`, the environment
+variable carrier MUST match it to the carrier key `X_B3_TRACEID`. It MUST also
+match it to a carrier key such as `x-b3-traceid`, because both key names
+normalize to `X_B3_TRACEID`.
 
 > [!NOTE]
 > This normalization is consistent with the environment variable naming rules

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -66,11 +66,13 @@ Environment variable names used for context propagation:
     (`_`) with an underscore (`_`),
   - prefixing the name with an underscore (`_`) if it would otherwise start with
     an ASCII digit.
-- MUST be normalized consistently by both get and set operations:
+- MUST be normalized consistently by get, set, and keys operations:
   - when injecting context, the carrier MUST write values using the normalized
     form of the key provided by the propagator,
   - when extracting context, the carrier MUST normalize the key requested by the
-    propagator and the key names present in the carrier before matching them.
+    propagator and the key names present in the carrier before matching them,
+  - when listing keys, the carrier `Keys` function MUST return normalized key
+    names.
 
 For example, if a propagator requests the key `x-b3-traceid`, the environment
 variable carrier MUST match it to the carrier key `X_B3_TRACEID`. It MUST also

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -66,11 +66,12 @@ Environment variable names used for context propagation:
     (`_`) with an underscore (`_`),
   - prefixing the name with an underscore (`_`) if it would otherwise start with
     an ASCII digit.
-- MUST be normalized consistently by get, set, and keys operations:
-  - when injecting context, the carrier MUST write values using the normalized
-    form of the key provided by the propagator,
-  - when extracting context, the carrier MUST normalize the key requested by the
-    propagator and the key names present in the carrier before matching them,
+- MUST be normalized consistently by `Get`, `Set`, and `Keys` operations:
+  - when injecting context, the carrier `Set` operation MUST write values using
+    the normalized form of the key provided by the propagator,
+  - when extracting context, the carrier `Get` operation MUST normalize the key
+    requested by the propagator and the key names present in the carrier before
+    matching them,
   - when listing keys, the carrier `Keys` function MUST return normalized key
     names.
 

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -71,7 +71,9 @@ Environment variable names used for context propagation:
     the normalized form of the key provided by the propagator,
   - when extracting context, the carrier `Get` operation MUST normalize the key
     requested by the propagator and the key names present in the carrier before
-    matching them,
+    matching them. If multiple carrier key names normalize to the same key name,
+    the carrier is ambiguous and in that case, the value returned by `Get` is
+    unspecified,
   - when listing keys, the carrier `Keys` function MUST return normalized key
     names.
 


### PR DESCRIPTION
Towards https://github.com/open-telemetry/opentelemetry-specification/issues/5040

## Changes

Clarifies the environment variable propagation carrier key normalization requirements:

- `Set` writes values using normalized key names.
- `Get` normalizes both the requested propagator key and carrier keys before matching.
- `Keys` returns normalized key names.

## Motivation

The existing text defined how key names are normalized, but it did not explicitly say where that normalization applies. This PR clarifies that normalization is part of the carrier behavior for writing, reading, and listing keys.

This follows the robustness principle: carriers write the normalized representation, while getters can still accept a non-normalized environment variable key if it normalizes to the requested propagation key. For example, a non-normalized `traceparent` environment variable can still be used by the propagation getter when matching `TRACEPARENT`.

This retrospects https://github.com/open-telemetry/opentelemetry-specification/pull/4944#discussion_r2950829108 now that implementations are in place.

## Implementation references

- Go: https://github.com/open-telemetry/opentelemetry-go-contrib/pull/8761
- .NET: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7174
- Java: https://github.com/open-telemetry/opentelemetry-java/pull/8233
- Python: https://github.com/open-telemetry/opentelemetry-python/pull/5119
- Swift: https://github.com/open-telemetry/opentelemetry-swift-core/pull/47

Related Java discussion: https://github.com/open-telemetry/opentelemetry-java/pull/8233#discussion_r3029570897

