### PR TITLE
Add in-development SpanProcessor operations tracking Span changes.

### DIFF
--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -980,7 +980,7 @@ are invoked in the order they have been registered.
 
 **Status**: [Development](../document-status.md)
 
-`OnAddLink` is called after a link has been added to a span. This method
+`OnAddLink` MUST be called after a link has been added to a span. This method
 MUST NOT be called in case the cardinality limits prevented the link from being
 added. This method is called synchronously on the thread that added the link,
 therefore it should not block or throw exceptions.

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -976,6 +976,58 @@ are invoked in the order they have been registered.
 
 **Returns:** `Void`
 
+#### OnNameUpdate
+
+**Status**: [Development](../document-status.md)
+
+`OnNameUpdate` is called after the span name has been updated. This method is
+called synchronously on the thread that updated the span name, therefore it
+should not block or throw exceptions.
+
+**Parameters:**
+
+* `span` - a [readable span object](#additional-span-interfaces) with the
+  updated name.
+
+**Returns:** `Void`
+
+#### OnSetAttribute
+
+**Status**: [Development](../document-status.md)
+
+`OnSetAttribute` is called after an attribute has been set on a span.
+This includes an existing attribute being updated. This method MUST NOT be
+called in case the cardinality limits prevented the attribute from being set.
+This method is called synchronously on the thread that set the attribute,
+therefore it should not block or throw exceptions.
+
+**Parameters:**
+
+* `span` - a [readable span object](#additional-span-interfaces) on which
+  the attribute was just set.
+* `attributeKey` - the key of the attribute.
+* `attributeValue` - the value of the attribute.
+
+**Returns:** `Void`
+
+#### OnAddLink
+
+**Status**: [Development](../document-status.md)
+
+`OnAddLink` is called after a link has been added to a span. This method
+MUST NOT be called in case the cardinality limits prevented the link from being
+added. This method is called synchronously on the thread that added the link,
+therefore it should not block or throw exceptions.
+
+**Parameters:**
+
+* `span` - a [readable span object](#additional-span-interfaces) on which
+  the link was just added.
+* `spanContext` - the span context of the linked span.
+* `attributes` - the attributes describing the link.
+
+**Returns:** `Void`
+
 #### OnEnding
 
 **Status**: [Development](../document-status.md)

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -976,6 +976,24 @@ are invoked in the order they have been registered.
 
 **Returns:** `Void`
 
+#### OnAddLink
+
+**Status**: [Development](../document-status.md)
+
+`OnAddLink` is called after a link has been added to a span. This method
+MUST NOT be called in case the cardinality limits prevented the link from being
+added. This method is called synchronously on the thread that added the link,
+therefore it should not block or throw exceptions.
+
+**Parameters:**
+
+* `span` - a [readable span object](#additional-span-interfaces) on which
+  the link was just added.
+* `spanContext` - the span context of the linked span.
+* `attributes` - the attributes describing the link.
+
+**Returns:** `Void`
+
 #### OnNameUpdate
 
 **Status**: [Development](../document-status.md)
@@ -1007,24 +1025,6 @@ therefore it should not block or throw exceptions.
   the attribute was just set.
 * `attributeKey` - the key of the attribute.
 * `attributeValue` - the value of the attribute.
-
-**Returns:** `Void`
-
-#### OnAddLink
-
-**Status**: [Development](../document-status.md)
-
-`OnAddLink` is called after a link has been added to a span. This method
-MUST NOT be called in case the cardinality limits prevented the link from being
-added. This method is called synchronously on the thread that added the link,
-therefore it should not block or throw exceptions.
-
-**Parameters:**
-
-* `span` - a [readable span object](#additional-span-interfaces) on which
-  the link was just added.
-* `spanContext` - the span context of the linked span.
-* `attributes` - the attributes describing the link.
 
 **Returns:** `Void`
 

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -982,7 +982,7 @@ are invoked in the order they have been registered.
 
 `OnAddLink` MUST be called after a link has been added to a span. This method
 MUST NOT be called in case the cardinality limits prevented the link from being
-added. This method is called synchronously on the thread that added the link,
+added. This method MUST be called synchronously on the thread that added the link,
 therefore it should not block or throw exceptions.
 
 **Parameters:**

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -983,7 +983,7 @@ are invoked in the order they have been registered.
 `OnAddLink` MUST be called after a link has been added to a span. This method
 MUST NOT be called in case the cardinality limits prevented the link from being
 added. This method MUST be called synchronously on the thread that added the link,
-therefore it should not block or throw exceptions.
+therefore the implementation should not block or throw exceptions.
 
 **Parameters:**
 


### PR DESCRIPTION
Fixes #5002 

The new operations are:

1) OnAddLink() - called after a link as been added.
2) OnSetAttribute() - called after an attribute has been set or updated.
3) OnUpdateName() - called after the span name has been changed.

These methods will not be called if limits prevent them from taking effect.

Java prototype: https://github.com/open-telemetry/opentelemetry-java/compare/main...carlosalberto:span-procesor-changed1?expand=1 

**Note**: In the related issue, there was some discussion regarding how the new operations would appear, and this PR takes the per-operation-method approach (rather than a-method-for-all-operations). Happy to explore the alternative approach as needed.