### PR TITLE
OTLP->Prometheus: Stabilize Summary transformation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ release.
 
 ### Compatibility
 
+- Stabilize sections of Prometheus and OpenMetrics Compatibility.
+  - Stabilize the conversion of OTLP Summaries into Prometheus Summaries.
+    ([#5107](https://github.com/open-telemetry/opentelemetry-specification/issues/5107))
+
 ### SDK Configuration
 
 ### Supplementary Guidelines

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -558,22 +558,26 @@ metrics with the delta aggregation temporality are dropped.
 
 ### Summaries
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
-An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be converted to a Prometheus metric family with the following metrics:
+An [OpenTelemetry Summary](../metrics/data-model.md#summary-legacy) MUST be
+converted to a Prometheus Summary as follows:
 
-- A single `{name}_count` metric denoting the count field of the summary.
-  All attributes of the summary point are converted to Prometheus labels.
-- `{name}_sum` metric denoting the sum field of the summary, reported
-  only if the sum is positive and monotonic. All attributes of the summary
-  point are converted to Prometheus labels.
-- A series of `{name}` metric points that contain all attributes of the
-  summary point recorded as labels.  Additionally, a label, denoted as
-  `quantile` is added denoting a reported quantile point, and having its value
-  be the stringified floating point value of quantiles (between 0.0 and 1.0),
-  starting from lowest to highest, and all being non-negative.  The value of
-  each point is the computed value of the quantile point.
-- Summaries with `StartTimeUnixNano` set should export the `{name}_created` metric as well.
+- Attributes are converted as described in the
+  [`Metric Attributes`](#metric-attributes) section.
+- The count is converted to the Summary's count.
+- The sum is converted to the Summary's sum, reported only if the sum is
+  positive and monotonic.
+- Quantiles are converted to the Summary's quantiles. The `quantile` label
+  value MUST be the stringified floating point value of each quantile (between
+  0.0 and 1.0), starting from lowest to highest, and all being non-negative.
+  The value of each quantile is the computed value of the quantile point.
+- When using a push protocol, such as Prometheus Remote Write,
+  `time_unix_nano` is converted to the Summary's timestamp. Explicit timestamps
+  are strongly discouraged for pull protocols, such as the Prometheus text
+  exposition format.
+- The `start_time_unix_nano` is converted to the Summary's start timestamp, if
+  supported.
 
 Exemplars on OpenTelemetry Summaries SHOULD be dropped.
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -566,16 +566,15 @@ converted to a Prometheus Summary as follows:
 - Attributes are converted as described in the
   [`Metric Attributes`](#metric-attributes) section.
 - The count is converted to the Summary's count.
-- The sum is converted to the Summary's sum, reported only if the sum is
-  positive and monotonic.
+- The sum is converted to the Summary's sum.
 - Quantiles are converted to the Summary's quantiles. The `quantile` label
   value MUST be the stringified floating point value of each quantile (between
   0.0 and 1.0), starting from lowest to highest, and all being non-negative.
   The value of each quantile is the computed value of the quantile point.
 - When using a push protocol, such as Prometheus Remote Write,
   `time_unix_nano` is converted to the Summary's timestamp. Explicit timestamps
-  are strongly discouraged for pull protocols, such as the Prometheus text
-  exposition format.
+  SHOULD NOT be used for pull protocols, such as the Prometheus text exposition
+  format, where Prometheus assigns the scrape timestamp.
 - The `start_time_unix_nano` is converted to the Summary's start timestamp, if
   supported.
 


### PR DESCRIPTION
Fixes #4923

## Changes

Stabilizes the transformation of OTLP Summaries to Prometheus summaries.

This PR superseeds #5090, since @johannaojeling is out on PTO for a couple of weeks

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [X] Related issues #4923 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [X] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
