### PR TITLE
Prometheus exporter: Stabilize Default Aggregation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize client libs section.
     ([#5106](https://github.com/open-telemetry/opentelemetry-specification/pull/5106))
+  - Stabilize Prometheus Metrics Exporter default aggregation configuration.
+    ([#5113](https://github.com/open-telemetry/opentelemetry-specification/pull/5113))
 
 ### Logs
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -120,7 +120,7 @@ default.
 
 ### Default Aggregation
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter SHOULD support a configuration option to set
 the [MetricReader](../sdk.md#metricreader) default `aggregation` as a function


### PR DESCRIPTION
Fixes #4986 

## Changes

Stabilizes the section `Default Aggregation` in the Prometheus exporter spec.

Among existing implementors, it seems that only Go[[1](https://github.com/open-telemetry/opentelemetry-go/blob/e5bdc311108b8283b3d2c97636de96657dde2d4a/exporters/prometheus/config.go#L74-L82)] and Java[[2](https://github.com/open-telemetry/opentelemetry-java/blob/32440c1f83c6b1b90dee78dcdcfcecfbab42af44/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java#L152-L163)] implement it correctly, I haven't found any other implementations. Collector's Prometheus exporter and Remote Write exporters aren't applicable since they don't go through the MetricReader interfaces. 

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #4986
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [X] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
