### PR TITLE
fix: correct examples to use getLoggerProvider method name

### DIFF
--- a/specification/configuration/sdk.md
+++ b/specification/configuration/sdk.md
@@ -376,7 +376,7 @@ try {
 // Access SDK components and install instrumentation
 TracerProvider tracerProvider = openTelemetry.getTracerProvider();
 MeterProvider meterProvider = openTelemetry.getMeterProvider();
-LoggerProvider loggerProvider = openTelemetry.getLogsBridge();
+LoggerProvider loggerProvider = openTelemetry.getLoggerProvider();
 ContextPropagators propagators = openTelemetry.getPropagators();
 ConfigProvider configProvider = openTelemetry.getConfigProvider();
 ```
@@ -404,7 +404,7 @@ try {
 // Access SDK components and install instrumentation
 TracerProvider tracerProvider = openTelemetry.getTracerProvider();
 MeterProvider meterProvider = openTelemetry.getMeterProvider();
-LoggerProvider loggerProvider = openTelemetry.getLogsBridge();
+LoggerProvider loggerProvider = openTelemetry.getLoggerProvider();
 ContextPropagators propagators = openTelemetry.getPropagators();
 ConfigProvider configProvider = openTelemetry.getConfigProvider();
 ```
@@ -432,7 +432,7 @@ OpenTelemetry openTelemetry = AutoConfiguredOpenTelemetrySdk.initialize().getOpe
 // Access SDK components and install instrumentation
 TracerProvider tracerProvider = openTelemetry.getTracerProvider();
 MeterProvider meterProvider = openTelemetry.getMeterProvider();
-LoggerProvider loggerProvider = openTelemetry.getLogsBridge();
+LoggerProvider loggerProvider = openTelemetry.getLoggerProvider();
 ContextPropagators propagators = openTelemetry.getPropagators();
 ConfigProvider configProvider = openTelemetry.getConfigProvider();
 ```


### PR DESCRIPTION
Fixes #

## Changes

This updates the example code to call getLoggerProvider rather than getLogBridges as the create operation https://opentelemetry.io/docs/specs/otel/configuration/sdk/#create actually returns LoggerProvider.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
