### PR TITLE
Prometheus exporter: Stabilize Resource Constant Labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ release.
 - Update the OpenTelemetry Exponential Histogram to Prometheus Native Histogram
   with standard (exponential) schema transformation.
   ([#4922](https://github.com/open-telemetry/opentelemetry-specification/issues/4922))
+- Stabilize `resource_constant_labels` configuration.
+  ([#5130](https://github.com/open-telemetry/opentelemetry-specification/pull/5130))
 
 ### SDK Configuration
 
@@ -87,8 +89,6 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize Target section.
     ([#5221](https://github.com/open-telemetry/opentelemetry-specification/pull/5221))
-  - Stabilize `resource_constant_labels` configuration.
-    ([#5130](https://github.com/open-telemetry/opentelemetry-specification/pull/5130))
 
 ### SDK Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize Target section.
     ([#5221](https://github.com/open-telemetry/opentelemetry-specification/pull/5221))
+  - Stabilize `resource_constant_labels` configuration.
+    ([#5130](https://github.com/open-telemetry/opentelemetry-specification/pull/5130))
 
 ### SDK Configuration
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -129,7 +129,7 @@ the [default aggregation](../sdk.md#default-aggregation) by default.
 
 ### Resource Attributes as Metric Labels
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter MAY offer configuration to add resource attributes as metric labels.
 By default, it MUST NOT add any resource attributes as metric labels.

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -133,8 +133,10 @@ the [default aggregation](../sdk.md#default-aggregation) by default.
 
 A Prometheus Exporter MAY offer configuration to add resource attributes as metric labels.
 By default, it MUST NOT add any resource attributes as metric labels.
-The configuration SHOULD allow the user to select resource attributes to include or exclude. Copied Resource attributes MUST NOT be
-excluded from the `target_info` metric. The option MAY be named `resource_constant_labels`.
+The configuration SHOULD allow the user to select resource attributes to
+[include or exclude](https://opentelemetry.io/docs/specs/otel-config/types/#type-experimentalprometheusmetricexporter).
+Copied Resource attributes MUST NOT be excluded from the `target_info` metric.
+The option MAY be named `resource_constant_labels`.
 
 ### Translation Strategy
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -134,7 +134,7 @@ the [default aggregation](../sdk.md#default-aggregation) by default.
 A Prometheus Exporter MAY offer configuration to add resource attributes as metric labels.
 By default, it MUST NOT add any resource attributes as metric labels.
 The configuration SHOULD allow the user to select resource attributes to include or exclude. Copied Resource attributes MUST NOT be
-excluded from the `target_info` metric. The option SHOULD be named `resource_constant_labels`.
+excluded from the `target_info` metric. The option MAY be named `resource_constant_labels`.
 
 ### Translation Strategy
 


### PR DESCRIPTION
Fixes #4987

## Changes

Stabilize the configuration option for transforming OTLP Resource Attributes into Prometheus Labels.


The configuration option is currently available in the following SDKs:
* Go SDK - [API](https://github.com/open-telemetry/opentelemetry-go/blob/c221f3e8563e3811b08d10a55ca1884284b0ae22/exporters/prometheus/config.go#L189-L198)
* Java SDK - [API](https://github.com/open-telemetry/opentelemetry-java/blob/79608eb3828a9ad120af6ac526bca0e9a1dde34d/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/PrometheusHttpServerBuilder.java#L105-L120) and [Declarative config](https://github.com/open-telemetry/opentelemetry-java/blob/79608eb3828a9ad120af6ac526bca0e9a1dde34d/exporters/prometheus/src/main/java/io/opentelemetry/exporter/prometheus/internal/PrometheusComponentProvider.java#L58-L70). Although names used for API and declarative config don't match the suggested name in the spec.
* Javascript SDK - [API](https://github.com/open-telemetry/opentelemetry-js/blob/8e4d4ed2fc424a8b2ba9a0272c507cb6f29738a7/experimental/packages/opentelemetry-exporter-prometheus/src/export/types.ts#L59-L65)
* Rust SDK - [API](https://github.com/open-telemetry/opentelemetry-rust/blob/25717768b2b94822b5e54b7950555bbbd632cbf2/opentelemetry-prometheus/src/config.rs#L104-L115), although the name is slightly different from the one suggested in the spec.

Weird ones:
* OTel Collector Prometheus exporter - has [`resource_to_telemetry_conversion`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/54095460bc51105714c8cfd5c82819db36ca43af/exporter/prometheusexporter/config.go#L38-L39), which has an "all or nothing" behavior; it doesn't allow the user to pick which ones to transform.
* OTel Collector Prometheus remotewrite exporter - Similar to the one above, has a [`resource_to_telemetry_conversion`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/54095460bc51105714c8cfd5c82819db36ca43af/exporter/prometheusremotewriteexporter/config.go#L45-L50) with "all or nothing" behavior.

All other implementations do not provide this option yet

--- 

* [X] Related issues #4987
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
