### PR TITLE
Prometheus exporter: Stabilize section 'Content Negotiation'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ release.
 
 ### Compatibility
 
+- Stabilize content negotiation section.
+  ([#5136](https://github.com/open-telemetry/opentelemetry-specification/pull/5136))
+
 ### SDK Configuration
 
 ### Supplementary Guidelines
@@ -77,8 +80,6 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize Target section.
     ([#5221](https://github.com/open-telemetry/opentelemetry-specification/pull/5221))
-  - Stabilize content negotiation section.
-    ([#5136](https://github.com/open-telemetry/opentelemetry-specification/pull/5136))
 
 ### SDK Configuration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ release.
 - Stabilize sections of Prometheus Metrics Exporter.
   - Stabilize Target section.
     ([#5221](https://github.com/open-telemetry/opentelemetry-specification/pull/5221))
+  - Stabilize content negotiation section.
+    ([#5136](https://github.com/open-telemetry/opentelemetry-specification/pull/5136))
 
 ### SDK Configuration
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -166,7 +166,7 @@ The option MAY be named `target_info_enabled`, and MUST be `true` by default.
 
 ## Content Negotiation
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 A Prometheus Exporter MUST support content negotiation to allow clients to request
 metrics in different formats based on the `Accept` header in HTTP requests. Content

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -172,6 +172,10 @@ A Prometheus Exporter MUST support content negotiation to allow clients to reque
 metrics in different formats based on the `Accept` header in HTTP requests. Content
 negotiation MUST follow [Prometheus Content Negotiation guidelines](https://prometheus.io/docs/instrumenting/content_negotiation/).
 
+If no `Accept` header is provided and no fallback protocol is configured, the
+exporter MUST use Prometheus text format 0.0.4 (`text/plain; version=0.0.4`) and
+apply `underscores` escaping.
+
 ### Interaction with Translation Strategy
 
 **Status**: [Development](../../document-status.md)

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -178,7 +178,7 @@ apply `underscores` escaping.
 
 ### Interaction with Translation Strategy
 
-**Status**: [Development](../../document-status.md)
+**Status**: [Stable](../../document-status.md)
 
 Regardless of the configured `translation_strategy`, the final output format and
 character escaping MUST comply with the content negotiation's restrictions based


### PR DESCRIPTION
Fixes #4991

## Changes

Stabilize the section `Content Negotiation` in the Prometheus exporter spec.

While reviewing the SDK implementation, I found these:

**Fully compliant**

* Go SDK - Let's Prometheus Go SDK handle content negotiation; it is fully compliant.
* Java SDK - Owns Content negotiation, but let's Prometheus Java SDK handle the transformation of a Registry into the output. Is fully compliant.
* Collector's Prometheus exporter - Let's Prometheus Go SDK handle content negotiation; It is fully compliant.

**Almost compliant**

* Python SDK - Let's Prometheus Python SDK handle content negotiation, but Prometheus Python SDK doesn't honor `q` weights and doesn't support protobuf.
* DotNet - It parses `Accept` headers, supports `text/plain` and `application/openmetrics`, respects `q` weights, and falls back to Prometheus text 0.0.4. It doesn't support. `allow-utf-8` is treated the same way as `underscores`, they are always escaped.

**Non compliant**
* JS SDK - No content negotiation.
* C++ SDK - No content negotiation.
* Rust SDK - No content negotiation.
* Swift SDK - No content negotiation.

---

* [ ] Related issues #4991 
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
