### PR TITLE
Set specs-approvers as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,10 @@
 #  https://help.github.com/en/articles/about-code-owners
 #
 
-# Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md 
-*   @open-telemetry/technical-committee @open-telemetry/spec-sponsors
+# Global owners, will be the owners for everything in the repo. Membership is tracked via https://github.com/open-telemetry/community/blob/main/community-members.md
+*   @open-telemetry/specs-approvers
 
 # Prometheus-specific specifications
-/specification/compatibility/prometheus_and_openmetrics.md @open-telemetry/technical-committee @open-telemetry/spec-sponsors @open-telemetry/prometheus-interoperability
-/specification/metrics/sdk_exporters/prometheus.md @open-telemetry/technical-committee @open-telemetry/spec-sponsors @open-telemetry/prometheus-interoperability
+# Note: prometheus-interoperability is listed for notification purposes only. Their approvals do not count towards the review requirements for these files.
+/specification/compatibility/prometheus_and_openmetrics.md @open-telemetry/specs-approvers @open-telemetry/prometheus-interoperability
+/specification/metrics/sdk_exporters/prometheus.md @open-telemetry/specs-approvers @open-telemetry/prometheus-interoperability


### PR DESCRIPTION
Related to https://github.com/open-telemetry/community/issues/3509.

Works in tandem with https://github.com/open-telemetry/admin/pull/706. With a single `specs-approvers` now assigned as codeowners, all specs-approvers (superset of spec-sponsors, spec-maintainers, and other teams) are the CODEOWNERS.