### PR TITLE
Deprecate OpenCensus compatibility requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ release.
 
 ### Compatibility
 
+- Deprecate OpenCensus compatibility requirements in the specification.
+  ([#5109](https://github.com/open-telemetry/opentelemetry-specification/issues/5109))
 - Stabilize sections of Prometheus Metrics Exporter.
   - Clarify resource attributes configuration.
     ([#5084](https://github.com/open-telemetry/opentelemetry-specification/pull/5084))

--- a/specification/compatibility/opencensus.md
+++ b/specification/compatibility/opencensus.md
@@ -4,7 +4,17 @@ linkTitle: OpenCensus
 
 # OpenCensus Compatibility
 
-**Status**: [Stable](../document-status.md), Unless otherwise specified.
+**Status**: [Deprecated](../document-status.md)
+
+> [!NOTE]
+> OpenCensus compatibility requirements are deprecated.
+> Existing OpenCensus shims MAY continue to be supported for backwards
+> compatibility, but implementing new OpenCensus compatibility is not required
+> by this specification.
+>
+> OpenCensus compatibility requirements are deprecated as of June 2026.
+> OpenCensus compatibility requirements in this specification will be removed
+> no earlier than June 2027.
 
 The OpenTelemetry project aims to provide backwards compatibility with the
 [OpenCensus](https://opencensus.io) project in order to ease migration of


### PR DESCRIPTION
Deprecate OpenCensus compatibility requirements, following the same pattern as the OpenTracing deprecation in #4938.

OpenCensus was [sunset in July 2023](https://opentelemetry.io/blog/2023/sunsetting-opencensus/#what-to-expect-after-july-31-2023). Adoption numbers are microscopic (JS: 31/week npm; Python: ~225/week PyPI; no .NET or Rust shim shipped). @jack-berg [confirmed](https://github.com/open-telemetry/opentelemetry-specification/issues/5109#issuecomment-4623964177) he is happy to sponsor.

Changes:
- `specification/compatibility/opencensus.md`: status → Deprecated; added NOTE block with June 2027 removal timeline
- `CHANGELOG.md`: Unreleased → Compatibility entry

Fixes #5109
