### PR TITLE
Adjust language related to maintainer and approver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,5 +170,5 @@ If a PR is stuck, the owner should:
 If still stuck after two weeks, bring it to the [OpenTelemetry Specification SIG
 meeting](https://github.com/open-telemetry/community/blob/main/README.md#specification-sigs).
 
-[spec-maintainers]: https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto
+[spec-maintainers]: README.md#maintainers
 [code-owners]: ./.github/CODEOWNERS

--- a/README.md
+++ b/README.md
@@ -62,13 +62,29 @@ By contributing to OpenTelemetry Specification repository, you agree that your c
 
 ## Maintainers
 
+The maintainers of the specification are a superset of the Technical Committee.
+
 - [OpenTelemetry Technical Committee](https://github.com/open-telemetry/community/blob/main/community-members.md#technical-committee)
 
 For more information about the maintainer role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#maintainer).
 
 ## Approvers
 
-- [OpenTelemetry Specification Sponsors](https://github.com/open-telemetry/community/blob/main/community-members.md#specifications-and-proto)
+[Specification sponsors](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#specification-sponsor) represent the approver role for the specification, along with additional responsibilities and privileges.
+
+- [Alex Boten](https://github.com/codeboten), Honeycomb
+- [Christian Neumüller](https://github.com/Oberon00), Dynatrace
+- [Cijo Thomas](https://github.com/cijothomas), Microsoft
+- [Daniel Dyla](https://github.com/dyladan), Dynatrace
+- [Josh Suereth](https://github.com/jsuereth), Google
+- [Juraci Paixão Kröhling](https://github.com/jpkrohling), OllyGarden
+- [Leighton Chen](https://github.com/lzchen), Microsoft
+- [Marc Alff](https://github.com/marcalff), Oracle
+- [Robert Pająk](https://github.com/pellared), Splunk
+- [Severin Neumann](https://github.com/svrnm), Independent
+- [Ted Young](https://github.com/tedsuo), Grafana Labs
+- [Tristan Sloughter](https://github.com/tsloughter), MyDecisiveAI
+- [Tyler Yahn](https://github.com/MrAlias), Splunk
 
 For more information about the approver role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#approver).
 
@@ -77,3 +93,10 @@ For more information about the approver role, see the [community repository](htt
 - [OpenTelemetry Governance Committee](https://github.com/open-telemetry/community/blob/main/community-members.md#governance-committee)
 
 For more information about the triager role, see the [community repository](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#triager).
+
+## Emeritus
+
+- [Christian Beedgen](https://github.com/kumoroku), Approver
+- [Daniel Jaglowski](https://github.com/djaglowski), Approver
+- [David Poncelow](https://github.com/zenmoto), Approver
+- [Nikita Salnikov-Tarnovski](https://github.com/iNikem), Approver

--- a/issue-management.md
+++ b/issue-management.md
@@ -9,7 +9,7 @@
     they work with the Reviewer to get feedback implemented and complete the work. They
     are responsible for making sure issue status labels are up to date.
 - Reviewer:
-  - Person whose Approval is needed to merge the PR.
+  - Person whose Approval is needed to merge the PR. See [approvers](README.md#approvers).
 - Sponsor:
   - The [specification sponsors](https://github.com/open-telemetry/community/blob/main/guides/contributor/membership.md#specification-sponsor), identified as the assignee of the issue, is responsible for the completion of the issue.
 - Triager:
@@ -32,14 +32,14 @@ These labels are applied to issues when it is unclear yet if they are something 
 
 * `triage:deciding:community-feedback` - This issue is open to community discussion. If the community can provide sufficient reasoning, it may be accepted by the project.
 * `triage:deciding:needs-info` - This issue does not provide enough information for the project to accept it. It is left open to provide the author with time to add more details.
-* `triage:deciding:tc-inbox` - This issue needs attention from the TC in order to move forward. It may need TC input for triage, or to unblock a discussion that is deadlocked.
+* `triage:deciding:tc-inbox` - This issue needs attention from the maintainers in order to move forward. It may need maintainer input for triage, or to unblock a discussion that is deadlocked. (NOTE: historically, the TC were the maintainers of the specification. Now maintainers are a superset of TC and others. For simplicity, we keep the `*:tc-inbox`).
 
 ### `triage:accepted:*`
 
 These labels are applied to issues that describe a problem that is in scope and that we would like to tackle.
 Just because an issue is accepted does not mean that a solution suggested by the issue will be the solution applied.
 
-* `triage:accepted:ready` - This issue is ready to be implemented. It is either small enough in scope or uncontroversial enough to be implemented without a TC sponsor.
+* `triage:accepted:ready` - This issue is ready to be implemented. It is either small enough in scope or uncontroversial enough to be implemented without a specification sponsor.
 * `triage:accepted:ready-with-sponsor` - This issue is ready to be implemented and has a specification sponsor assigned.
 * `triage:accepted:needs-sponsor` - This issue is ready to be implemented, but does not yet have a specification sponsor. A pull request without a specification sponsor may not be reviewed in a timely manner.
 


### PR DESCRIPTION
Related to https://github.com/open-telemetry/community/issues/3509.

- Update readme:
  - Indicate that maintainers are a superset of the technical commitee.
  - Indicate that spec sponsors act as approvers for this repo, amongst other things.
  - List approver and emeritus section, [companion PR to remove listing from community](https://github.com/open-telemetry/community/pull/3513).
- Update issue management to refer to maintainers rather than TC where appropriate.