### PR TITLE
[chore] Fix broken markdownlint anchor link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,7 +130,7 @@ make markdown-toc # regenerate tables of contents
 To fix markdownlint violations, use the
 [Visual Studio Code markdownlint extension](https://github.com/DavidAnson/vscode-markdownlint)
 `fixAll` command, or follow the
-[markdownlint instructions](https://github.com/DavidAnson/markdownlint#optionsresultversion).
+[markdownlint instructions](https://github.com/igorshubovych/markdownlint-cli#fixing-issues).
 
 ### Compliance Matrix
 


### PR DESCRIPTION
The link `https://github.com/DavidAnson/markdownlint#optionsresultversion` in `CONTRIBUTING.md` is broken — the `options.resultVersion` section was removed from the upstream README in markdownlint v0.41.0 (2026-06-08), so the anchor no longer resolves. This is the only failure in the `markdown-link-check` CI job.

Replacing it with `https://github.com/igorshubovych/markdownlint-cli#fixing-issues`, which is a better target for two reasons:

1. It points at the `--fix` flag documentation, which is what "fix markdownlint violations" actually means for a CLI user. The original anchor pointed at result-format versioning, unrelated to fixing.
2. `markdownlint-cli` is the tool OTel actually invokes via `make markdownlint` (declared in `package.json` and called from the `Makefile`). `DavidAnson/markdownlint` is the underlying Node library; contributors don't interact with it directly.