### PR TITLE
Mark SpanProcessor.OnEnding as N/A for .NET

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -56,7 +56,7 @@ formats is required. Implementing more than one format is optional.
 | events collection size limit |  | + | + | + | + | + | + | + | + | - | - | + | + |
 | attribute collection size limit |  | + | + | + | + | + | + | + | + | - | - | + | + |
 | links collection size limit |  | + | + | + | + | + | + | + | + | - | - | + | + |
-| [SpanProcessor.OnEnding](specification/trace/sdk.md#onending) | X | - | + | - | - | - | - | - | - | - | - | - | + |
+| [SpanProcessor.OnEnding](specification/trace/sdk.md#onending) | X | - | + | - | - | - | - | - | - | - | N/A | - | + |
 | [Span attributes](specification/trace/api.md#set-attributes) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | SetAttribute |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Set order preserved | X | + | - | + | + | + | + | + | + | + | + | + | - |

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -90,7 +90,7 @@ sections:
           - name: links collection size limit
             status: '-'
           - name: '[SpanProcessor.OnEnding](specification/trace/sdk.md#onending)'
-            status: '-'
+            status: 'N/A'
       - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
         features:
           - name: SetAttribute


### PR DESCRIPTION
.NET uses `System.Diagnostics.Activity` to represent spans, which is already writable in `OnEnd`. `OnEnding` is not applicable. See https://github.com/open-telemetry/opentelemetry-dotnet/pull/6617.