### PR TITLE
chore: Update Rust compliance matrix for Bound instrument support

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -130,7 +130,7 @@ formats is required. Implementing more than one format is optional.
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  | - |
 | Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  | - |
 | Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  | - |
-| Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | - | - | - | - | - |
+| Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of any instrument are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -224,7 +224,7 @@ sections:
       - name: Instrument supports the advisory Attributes parameter.
         status: '?'
       - name: Synchronous instruments support Bind to pre-associate attributes.
-        status: '-'
+        status: '+'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
         status: '?'
       - name: All methods of `Meter` are safe to be called concurrently.


### PR DESCRIPTION
OTel Rust supports Bound instruments; update spec compliance matrix.