### PR TITLE
Add composable views matching mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ release.
 - Amend the description of Composite/Composable samplers.
   ([#5161](https://github.com/open-telemetry/opentelemetry-specification/pull/5161))
 
+- Add `view_matching_mode` parameter to `MeterProvider` to support composable View matching.
+  ([#5173](https://github.com/open-telemetry/opentelemetry-specification/pull/5173))
+
 ### Logs
 
 - Add ETW (Event Tracing for Windows) example mapping to the logs data

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -149,6 +149,7 @@ formats is required. Implementing more than one format is optional.
 | The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + | + | + |  |  | - |  |  |  | + |  | - |
 | The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  | - |
 | The SDK allows more than one `View` to be specified per instrument. | X | + | + | + | + | + | + |  | + | + | + |  | - |
+| The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching. | X | - | - | - | - | - | - | - | - | - | - | - | - |
 | The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Default` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Default` aggregation uses the specified aggregation by instrument. |  | + | + | + | + | + | + |  | + | + | + |  | - |

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -265,6 +265,8 @@ sections:
         status: '?'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -265,6 +265,8 @@ sections:
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -265,6 +265,8 @@ sections:
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -265,6 +265,8 @@ sections:
         status: '+'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -265,6 +265,8 @@ sections:
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -265,6 +265,8 @@ sections:
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -265,6 +265,8 @@ sections:
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '-'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '-'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -265,6 +265,8 @@ sections:
         status: '?'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '?'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '?'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -265,6 +265,8 @@ sections:
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -265,6 +265,8 @@ sections:
         status: '?'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -265,6 +265,8 @@ sections:
         status: '?'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '+'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -265,6 +265,8 @@ sections:
         status: '?'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '?'
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        status: '-'
       - name: The `Drop` aggregation is available.
         status: '?'
       - name: The `Default` aggregation is available.

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -186,6 +186,8 @@ sections:
         optional: true
       - name: The SDK allows more than one `View` to be specified per instrument.
         optional: true
+      - name: The `MeterProvider` supports configuring `view_matching_mode` to enable composable View matching.
+        optional: true
       - name: The `Drop` aggregation is available.
       - name: The `Default` aggregation is available.
       - name: The `Default` aggregation uses the specified aggregation by instrument.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -171,7 +171,6 @@ MUST support the following values:
   See [Measurement processing](#measurement-processing) for details.
 
 If `view_matching_mode` is not specified, the SDK MUST use `independent`.
-Any other value MUST be treated as unsupported.
 
 Any other value MUST be treated as unsupported.
 If an unsupported value is provided, the SDK MUST either fail fast during

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -143,7 +143,8 @@ a `Meter` whose behavior conforms to that `MeterConfig`.
 
 Configuration (
 i.e. [MetricExporters](#metricexporter), [MetricReaders](#metricreader), [Views](#view),
-and (**Development**) [MeterConfigurator](#meterconfigurator)) MUST be
+and (**Development**) [MeterConfigurator](#meterconfigurator) and
+`view_matching_mode`) MUST be
 owned by the `MeterProvider`. The configuration MAY be applied at the time
 of `MeterProvider` creation if appropriate.
 
@@ -154,6 +155,17 @@ matter whether a `Meter` was obtained from the `MeterProvider` before or after
 the configuration change). Note: Implementation-wise, this could mean that
 `Meter` instances have a reference to their `MeterProvider` and access
 configuration only via this reference.
+
+#### View matching mode
+
+**Status**: [Development](../document-status.md)
+
+A `MeterProvider` MAY accept a `view_matching_mode` parameter which controls how multiple matching [Views](#view) are applied to an [Instrument](./api.md#instrument).
+
+Acceptable values are:
+
+* `independent`: (Default) Each matching View creates a separate metric stream independently of any other Views registered for the same matching Instrument.
+* `composable`: Matching Views are combined (merged) to modify metric streams. See [Measurement processing](#measurement-processing) for details.
 
 #### MeterConfigurator
 
@@ -447,7 +459,7 @@ made with an Instrument:
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
     MUST be honored.
 * If the `MeterProvider` has one or more `View`(s) registered:
-  * If the Instrument could match the instrument selection criteria, for each
+  * If `view_matching_mode` is `independent` (or unspecified), and the Instrument could match the instrument selection criteria, for each
     View:
     * Try to apply the View's stream configuration independently of any other
       Views registered for the same matching Instrument (i.e. Views are not
@@ -456,14 +468,16 @@ made with an Instrument:
       one View setting `aggregation` and another View setting `attribute_keys`,
       both leaving the stream `name` as the default configured by the
       Instrument). If applying the View results in conflicting metric identities
-      the implementation SHOULD apply the View and emit a warning. If it is not
-      possible to apply the View without producing semantic errors (e.g. the
-      View sets an asynchronous instrument to use the [Explicit bucket
-      histogram aggregation](#explicit-bucket-histogram-aggregation)) the
-      implementation SHOULD emit a warning and proceed as if the View did not
-      If both a View and [Instrument advisory parameters](#instrument-advisory-parameters)
-      specify the same aspect of the [Stream configuration](#stream-configuration),
-      the setting defined by the View MUST take precedence over the advisory parameters.
+      the implementation SHOULD apply the View and emit a warning.
+  * (**Development**) If `view_matching_mode` is `composable`, and the Instrument could match the instrument selection criteria of one or more Views:
+    * Group the matching Views by their configured stream `name`.
+      * If a matching View does not configure a stream `name`, leaving `name` as null or unspecified, it applies to all streams created for that matching Instrument.
+      * Each distinct configured stream `name` creates a separate stream. If no matching View configures a stream `name`, a single stream is created using the Instrument's default name.
+    * For each resulting stream, apply the matching Views in order. For all aspects of the [Stream configuration](#stream-configuration) other than `attribute_keys` (`name`, `description`, `aggregation`, `exemplar_reservoir`, `aggregation_cardinality_limit`), the first matching View in the list that specifies that aspect wins using first-wins precedence. Note that complex configurations like `aggregation` (including any internal properties such as bucket boundaries or max buckets) are treated as a single atomic unit and are not merged across Views.
+    * For `attribute_keys`, matching Views are merged by combining their attribute filters using logical AND: an attribute key is preserved if it is included in all specified allow-lists (if any) and not excluded by any specified exclude-lists.
+  * For each resulting stream configured by matching View(s):
+    * If applying the resolved stream configuration results in semantic errors (e.g. setting an asynchronous instrument to use the [Explicit bucket histogram aggregation](#explicit-bucket-histogram-aggregation)), the implementation SHOULD emit a warning and ignore the invalid setting. When `view_matching_mode` is `independent`, the implementation falls back to the Instrument default. When `view_matching_mode` is `composable`, the implementation falls back to the next valid setting from subsequent matching Views (or the Instrument default if no subsequent Views specify a valid setting).
+    * If both matching View(s) and [Instrument advisory parameters](#instrument-advisory-parameters) specify the same aspect of the [Stream configuration](#stream-configuration), the setting defined by the View(s) MUST take precedence over the advisory parameters.
   * If the Instrument could not match with any of the registered `View`(s), the
     SDK SHOULD enable the instrument using the default aggregation and temporality.
     Users can configure match-all Views using [Drop aggregation](#drop-aggregation)

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -469,15 +469,40 @@ made with an Instrument:
       both leaving the stream `name` as the default configured by the
       Instrument). If applying the View results in conflicting metric identities
       the implementation SHOULD apply the View and emit a warning.
+    * If applying the View would produce semantic errors (for example,
+      configuring an asynchronous instrument to use the [Explicit bucket
+      histogram aggregation](#explicit-bucket-histogram-aggregation)), the
+      implementation SHOULD emit a warning and proceed as if that View did not
+      exist.
+    * If both the View and [Instrument advisory
+      parameters](#instrument-advisory-parameters) specify the same aspect of
+      the [Stream configuration](#stream-configuration), the setting defined by
+      the View MUST take precedence over the advisory parameters.
   * (**Development**) If `view_matching_mode` is `composable`, and the Instrument could match the instrument selection criteria of one or more Views:
     * Group the matching Views by their configured stream `name`.
-      * If a matching View does not configure a stream `name`, leaving `name` as null or unspecified, it applies to all streams created for that matching Instrument.
-      * Each distinct configured stream `name` creates a separate stream. If no matching View configures a stream `name`, a single stream is created using the Instrument's default name.
-    * For each resulting stream, apply the matching Views in order. For all aspects of the [Stream configuration](#stream-configuration) other than `attribute_keys` (`name`, `description`, `aggregation`, `exemplar_reservoir`, `aggregation_cardinality_limit`), the first matching View in the list that specifies that aspect wins using first-wins precedence. Note that complex configurations like `aggregation` (including any internal properties such as bucket boundaries or max buckets) are treated as a single atomic unit and are not merged across Views.
+      * A group contains Views that configure the same stream `name` and all
+        matching Views that leave `name` null or unspecified.
+      * Each distinct configured stream `name` creates a separate stream. If no
+        matching View configures a stream `name`, create a single group and
+        stream using the Instrument's default name.
+    * For each resulting stream, apply the matching Views in registration order.
+      For all aspects of the [Stream configuration](#stream-configuration) other
+      than `attribute_keys` (`name`, `description`, `aggregation`,
+      `exemplar_reservoir`, `aggregation_cardinality_limit`), the first matching
+      View that specifies that aspect wins. Complex configurations like
+      `aggregation` (including internal properties such as bucket boundaries or
+      max buckets) are treated as a single atomic unit and are not merged across
+      Views.
     * For `attribute_keys`, matching Views are merged by combining their attribute filters using logical AND: an attribute key is preserved if it is included in all specified allow-lists (if any) and not excluded by any specified exclude-lists.
-  * For each resulting stream configured by matching View(s):
-    * If applying the resolved stream configuration results in semantic errors (e.g. setting an asynchronous instrument to use the [Explicit bucket histogram aggregation](#explicit-bucket-histogram-aggregation)), the implementation SHOULD emit a warning and ignore the invalid setting. When `view_matching_mode` is `independent`, the implementation falls back to the Instrument default. When `view_matching_mode` is `composable`, the implementation falls back to the next valid setting from subsequent matching Views (or the Instrument default if no subsequent Views specify a valid setting).
-    * If both matching View(s) and [Instrument advisory parameters](#instrument-advisory-parameters) specify the same aspect of the [Stream configuration](#stream-configuration), the setting defined by the View(s) MUST take precedence over the advisory parameters.
+    * For each resulting stream:
+      * If a setting selected for the stream would produce semantic errors, the
+        implementation SHOULD emit a warning and use the next valid setting for
+        that aspect from a subsequent View in the same group, or the Instrument
+        default if no subsequent View specifies a valid setting.
+      * If both the matching Views and [Instrument advisory
+        parameters](#instrument-advisory-parameters) specify the same aspect of
+        the [Stream configuration](#stream-configuration), the setting defined
+        by the Views MUST take precedence over the advisory parameters.
   * If the Instrument could not match with any of the registered `View`(s), the
     SDK SHOULD enable the instrument using the default aggregation and temporality.
     Users can configure match-all Views using [Drop aggregation](#drop-aggregation)

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -173,6 +173,7 @@ MUST support the following values:
 If `view_matching_mode` is not specified, the SDK MUST use `independent`.
 Any other value MUST be treated as unsupported.
 
+Any other value MUST be treated as unsupported.
 If an unsupported value is provided, the SDK MUST either fail fast during
 initialization in accordance with the [error handling
 principles](../error-handling.md#basic-error-handling-principles), or emit a

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -144,7 +144,7 @@ a `Meter` whose behavior conforms to that `MeterConfig`.
 Configuration (
 i.e. [MetricExporters](#metricexporter), [MetricReaders](#metricreader), [Views](#view),
 and (**Development**) [MeterConfigurator](#meterconfigurator) and
-`view_matching_mode`) MUST be
+(**Development**) [view_matching_mode](#view-matching-mode)) MUST be
 owned by the `MeterProvider`. The configuration MAY be applied at the time
 of `MeterProvider` creation if appropriate.
 
@@ -171,6 +171,7 @@ MUST support the following values:
   See [Measurement processing](#measurement-processing) for details.
 
 If `view_matching_mode` is not specified, the SDK MUST use `independent`.
+Any other value MUST be treated as unsupported.
 
 If an unsupported value is provided, the SDK MUST either fail fast during
 initialization in accordance with the [error handling
@@ -459,6 +460,8 @@ The SDK MUST accept the following stream configuration parameters:
 
 #### Measurement processing
 
+**Status**: [Mixed](../document-status.md)
+
 The SDK SHOULD use the following logic to determine how to process Measurements
 made with an Instrument:
 
@@ -469,8 +472,7 @@ made with an Instrument:
     [Instrument advisory parameters](#instrument-advisory-parameters), if any,
     MUST be honored.
 * If the `MeterProvider` has one or more `View`(s) registered:
-  * If `view_matching_mode` is `independent` (or unspecified), and the Instrument could match the instrument selection criteria, for each
-    View:
+  * If `view_matching_mode` is `independent` (or unspecified), and the Instrument matches the instrument selection criteria of one or more Views, for each matching View:
     * Try to apply the View's stream configuration independently of any other
       Views registered for the same matching Instrument (i.e. Views are not
       merged). This may result in [conflicting metric identities](./data-model.md#opentelemetry-protocol-data-model-producer-recommendations)
@@ -495,7 +497,7 @@ made with an Instrument:
       * Each distinct configured stream `name` creates a separate stream. If no
         matching View configures a stream `name`, create a single group and
         stream using the Instrument's default name.
-    * For each resulting stream, apply the matching Views in registration order.
+    * For each resulting stream, apply the Views in its group in registration order.
       For all aspects of the [Stream configuration](#stream-configuration) other
       than `attribute_keys` (`name`, `description`, `aggregation`,
       `exemplar_reservoir`, `aggregation_cardinality_limit`), the first matching
@@ -503,7 +505,7 @@ made with an Instrument:
       `aggregation` (including internal properties such as bucket boundaries or
       max buckets) are treated as a single atomic unit and are not merged across
       Views.
-    * For `attribute_keys`, matching Views are merged by combining their attribute filters using logical AND: an attribute key is preserved if it is included in all specified allow-lists (if any) and not excluded by any specified exclude-lists.
+    * For `attribute_keys`, merge the Views in the group by combining their attribute filters using logical AND: an attribute key is preserved if it is included in all specified allow-lists (if any) and not excluded by any specified exclude-lists.
     * For each resulting stream:
       * If a setting selected for the stream would produce semantic errors, the
         implementation SHOULD emit a warning and use the next valid setting for

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -160,12 +160,22 @@ configuration only via this reference.
 
 **Status**: [Development](../document-status.md)
 
-A `MeterProvider` MAY accept a `view_matching_mode` parameter which controls how multiple matching [Views](#view) are applied to an [Instrument](./api.md#instrument).
+A `MeterProvider` MAY accept a `view_matching_mode` parameter which controls
+how multiple matching [Views](#view) are applied to an
+[Instrument](./api.md#instrument). A `MeterProvider` that accepts this parameter
+MUST support the following values:
 
-Acceptable values are:
+* `independent`: Each matching View creates a separate metric stream
+  independently of any other Views registered for the same matching Instrument.
+* `composable`: Matching Views are combined (merged) to modify metric streams.
+  See [Measurement processing](#measurement-processing) for details.
 
-* `independent`: (Default) Each matching View creates a separate metric stream independently of any other Views registered for the same matching Instrument.
-* `composable`: Matching Views are combined (merged) to modify metric streams. See [Measurement processing](#measurement-processing) for details.
+If `view_matching_mode` is not specified, the SDK MUST use `independent`.
+
+If an unsupported value is provided, the SDK MUST either fail fast during
+initialization in accordance with the [error handling
+principles](../error-handling.md#basic-error-handling-principles), or emit a
+warning, ignore the value, and use `independent`.
 
 #### MeterConfigurator
 

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -500,7 +500,7 @@ made with an Instrument:
     * For each resulting stream, apply the Views in its group in registration order.
       For all aspects of the [Stream configuration](#stream-configuration) other
       than `attribute_keys` (`name`, `description`, `aggregation`,
-      `exemplar_reservoir`, `aggregation_cardinality_limit`), the first matching
+      `exemplar_reservoir`, `aggregation_cardinality_limit`), the last matching
       View that specifies that aspect wins. Complex configurations like
       `aggregation` (including internal properties such as bucket boundaries or
       max buckets) are treated as a single atomic unit and are not merged across
@@ -509,8 +509,8 @@ made with an Instrument:
     * For each resulting stream:
       * If a setting selected for the stream would produce semantic errors, the
         implementation SHOULD emit a warning and use the next valid setting for
-        that aspect from a subsequent View in the same group, or the Instrument
-        default if no subsequent View specifies a valid setting.
+        that aspect from a preceding View in the same group, or the Instrument
+        default if no preceding View specifies a valid setting.
       * If both the matching Views and [Instrument advisory
         parameters](#instrument-advisory-parameters) specify the same aspect of
         the [Stream configuration](#stream-configuration), the setting defined


### PR DESCRIPTION
Fixes #5013

Following-up after this came up in the spec SIG meeting on 6/23.

### Summary
Introduces an opt-in `view_matching_mode` configuration parameter on `MeterProvider` to support merging multiple Views that match the same Instrument.

### API

*  Adds `view_matching_mode` to `MeterProvider` with two modes:
   * `independent`: (Default) Maintains existing behavior where matching Views create separate streams independently.
   * `composable`: Merges matching Views into a single stream unless they configure different stream `name`s.

### Composable merge rules

  * For `name`, `description`, `aggregation`, `exemplar_reservoir`, and `aggregation_cardinality_limit`, **last-wins precedence** applies based on View registration order.
  * `attribute_keys`' `included` and `excluded` sets are merged.
    * `include` keeps only keys present in **all include-lists** (set intersection).
    * `exclude` drops keys listed in **any of the exclude-lists** (set union).

### Declarative Config example

```yaml
meter_provider:
  view_matching_mode: composable
  views:
    # 1. Specific override: Rename histogram and use sum aggregation
    - selector:
        meter_name: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
        instrument_name: http.client.request.duration
      stream:
        name: http.client.latency
        aggregation:
          sum: {}
    # 2. Scope policy: Drop status code from all metrics in otelhttp scope
    - selector:
        meter_name: go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
      stream:
        attribute_keys:
          exclude:
            - http.response.status_code
```

### Alternatives Considered
* Considered a boolean (`composable_views_enabled: true`) or alternative naming (`composable_views`), but opted for an explicit enum (`view_matching_mode`) to support future extensibility.
* Considered **first-wins** ordering because first-wins is used more often in the specification, but aligned on **last-wins** to match reviewer intuition for how it should work.
* Considered atomic whole-field last-wins for `attribute_keys`, but opted for set composition so global governance policies (e.g., dropping sensitive PII) layer safely with specific View overrides.
* Other alternatives are listed in #5013

### Checklist

* [x] Related issues #
* [x] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes (when adding or changing features): https://github.com/open-telemetry/opentelemetry-go/pull/8510
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary:
* [x] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed: https://github.com/open-telemetry/opentelemetry-configuration/pull/666

@open-telemetry/specs-metrics-approvers 