### PR TITLE
Update .NET compliance matrix entries

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -145,9 +145,9 @@ formats is required. Implementing more than one format is optional.
 | The `View` instrument selection criteria is as specified. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | The `View` instrument selection criteria supports wildcards. | X | + | + | + | + | + | - |  | + | + | + |  | - |
 | The `View` instrument selection criteria supports the match-all wildcard. |  | + | + | + | + | + | + |  | + | + | + |  | - |
-| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | + |  | - |
+| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | - |  | - |
 | The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + | + | + |  |  | - |  |  |  |  |  | - |
-| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | + |  | - |
+| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  | - |
 | The SDK allows more than one `View` to be specified per instrument. | X | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Default` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
@@ -178,8 +178,8 @@ formats is required. Implementing more than one format is optional.
 | Documentation notes that View-filtered attributes may still appear on Exemplars. |  | - | - | - | - | - | - | - | - | - | + | - | - |
 | Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken. |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | Exemplars contain the timestamp when the measurement was taken. |  | + | + | - | - | + | + |  |  |  | + |  | - |
-| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - | + | + | + |  |  | + |  | - |
-| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  | + | - | - | - | + | + | + |  |  | + |  | - |
+| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - | + | + | + |  |  | - |  | - |
+| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  | + | - | - | - | + | + | + |  |  | - |  | - |
 | The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`. |  | + | + | - | - | + | + | + |  |  | + |  | - |
 | The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation. |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | A metric Producer accepts an optional metric Filter |  | - | - |  |  |  | - |  |  |  |  |  | - |
@@ -198,13 +198,13 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 
 | Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- | ------ |
-| LoggerProvider.Get Logger |  | + | + | + | + | + |  | + | + | + | + |  | + |
+| LoggerProvider.Get Logger |  | + | + | + | + | + |  | + | + | + | - |  | + |
 | LoggerProvider.Get Logger accepts attributes |  | + | - |  | + |  |  | + | + | + | - |  | + |
 | LoggerProvider.Shutdown |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | LoggerProvider.ForceFlush |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | Logger.Emit(LogRecord) |  | + | + | + | + | + |  | + | + | + | - |  | + |
 | Logger.Emit(LogRecord) with Exception parameter | X |  | + |  |  |  |  |  |  |  | - |  | + |
-| LogRecord.Set EventName |  | + | + |  |  | + |  |  | + | + | + |  | + |
+| LogRecord.Set EventName |  | + | + |  |  | + |  |  | + | + |  |  | + |
 | Logger.Enabled | X | + | + |  |  |  |  | + | + | + | - |  | + |
 | Ergonomic API | X |  |  |  |  |  |  |  |  |  | + |  |  |
 | SimpleLogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
@@ -326,9 +326,9 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | OTLP/HTTP JSON Protobuf Exporter |  | + | - | + | [-][py1003] |  | - | + |  | + | - | - | - |
 | OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | + | - | + |
 | Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - |  |
-| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | + | - |  |
-| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | + | - |  |
-| Honors throttling response | X | + | - | - | + | + | - |  |  | - | + | - |  |
+| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - |  |
+| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - |  |
+| Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - |  |
 | Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - |  |
 | SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | - |  |  |
 | SchemaURL in ResourceMetrics and ScopeMetrics |  | + | + |  | + |  | - | + |  |  | - |  |  |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -19,9 +19,9 @@ formats is required. Implementing more than one format is optional.
 | [TracerProvider](specification/trace/api.md#tracerprovider-operations) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | Create TracerProvider |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Get a Tracer |  | + | + | + | + | + | + | + | + | + | + | + | + |
-| Get a Tracer with schema_url |  | + | + | + | + |  |  | + | + | + |  |  | + |
-| Get a Tracer with scope attributes |  | + | - |  | + |  |  | + | + | + |  |  | + |
-| Associate Tracer with InstrumentationScope |  | + | + | + | + | + |  | + | + | + |  |  | + |
+| Get a Tracer with schema_url |  | + | + | + | + |  |  | + | + | + | + |  | + |
+| Get a Tracer with scope attributes |  | + | - |  | + |  |  | + | + | + | + |  | + |
+| Associate Tracer with InstrumentationScope |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | Safe for concurrent calls |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Shutdown (SDK only required) |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | ForceFlush (SDK only required) |  | + | + | + | + | + | + | + | + | + | + | + | + |
@@ -87,7 +87,7 @@ formats is required. Implementing more than one format is optional.
 | [SpanLimits](specification/trace/sdk.md#span-limits) | X | + | + | + | + | + | + | + | + | - |  | + | + |
 | [Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1) |  | + | + | + | + | + | + | + | + | + | + |  | + |
 | [Attribute Limits](specification/common/README.md#attribute-limits) | X | + | + | + | + | + | + | + |  |  |  |  | - |
-| Fetch InstrumentationScope from ReadableSpan |  | + | + | + | + |  |  | + |  |  |  |  | + |
+| Fetch InstrumentationScope from ReadableSpan |  | + | + | + | + |  |  | + |  |  | + |  | + |
 | [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X | - |  |  |  |  |  |  |  |  |  |  | - |
 | [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X | - | + |  |  |  |  |  |  |  |  |  | - |
 | [Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord) |  | - | + |  |  |  |  |  |  |  |  |  | - |
@@ -110,26 +110,26 @@ formats is required. Implementing more than one format is optional.
 | `get_meter` accepts `attributes`. |  | + | - | - | + |  |  | + | + | + |  |  | - |
 | When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + | + | + |  | + | + | - |  | - |
 | The fallback `Meter` `name` property keeps its original invalid value. | X | + | - | + | + | + | + |  | + | - | - |  | - |
-| Associate `Meter` with `InstrumentationScope`. |  | + | + | + | + | + | + |  | + | + |  |  | - |
+| Associate `Meter` with `InstrumentationScope`. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | `Counter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | `AsynchronousCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | `Histogram` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | `AsynchronousGauge` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  | - |
-| `Gauge` instrument is supported. |  | + | + | + | + | + | - | + | + | + | - |  | - |
+| `Gauge` instrument is supported. |  | + | + | + | + | + | - | + | + | + | + |  | - |
 | `UpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | `AsynchronousUpDownCounter` instrument is supported. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | Instruments have `name` |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | Instruments have kind. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | Instruments have an optional unit of measure. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | Instruments have an optional description. |  | + | + | + | + | + | + | + | + | + | + |  | - |
-| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  | + | + | + | + | + | + |  |  | + |  |  | - |
-| Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name. |  |  | + |  |  | - | + |  |  | + |  |  | - |
+| A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under the same `Meter` using the same `name`. |  | + | + | + | + | + | + |  |  | + | + |  | - |
+| Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name. |  |  | + |  |  | - | + |  |  | + | + |  | - |
 | It is possible to register two instruments with same `name` under different `Meter`s. |  | + | + | + | + |  | + |  | + | + | + |  | - |
-| Instrument names conform to the specified syntax. |  | + | + | + | + | + | + |  |  | + |  |  | - |
+| Instrument names conform to the specified syntax. |  | + | + | + | + | + | + |  |  | + | + |  | - |
 | Instrument units conform to the specified syntax. |  | - | + |  | + | + | + |  | + | + | + |  | - |
 | Instrument descriptions conform to the specified syntax. |  | - | + |  | - | + | + |  |  | - | + |  | - |
-| Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  |  |  | - |
-| Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  |  |  | - |
+| Instrument supports the advisory ExplicitBucketBoundaries parameter. |  | + | + |  |  |  | + |  |  |  | + |  | - |
+| Instrument supports the advisory Attributes parameter. |  | - | + |  |  |  | + |  |  |  | - |  | - |
 | Synchronous instruments support Bind to pre-associate attributes. | X | - | - | - | - | - | - | - | + | - | - | - | - |
 | All methods of `MeterProvider` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
 | All methods of `Meter` are safe to be called concurrently. |  | + | + | + | - |  | + |  |  | + | + |  | - |
@@ -137,7 +137,7 @@ formats is required. Implementing more than one format is optional.
 | `MeterProvider` allows a `Resource` to be specified. |  | + | + | + | + | + |  | + | + | + | + |  | - |
 | A specified `Resource` can be associated with all the produced metrics from any `Meter` from the `MeterProvider`. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationLibrary` instance stored in the `Meter`. |  | + | - |  | + |  | + |  | + | + | - |  | - |
-| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`. |  | + | + | + | + |  | + | + | + | + |  |  | - |
+| The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope` instance stored in the `Meter`. |  | + | + | + | + |  | + | + | + | + | + |  | - |
 | Configuration is managed solely by the `MeterProvider`. |  | + | + | + | + |  | + | + | + | + | + |  | - |
 | The `MeterProvider` provides methods to update the configuration | X | - | + | - | + |  | - |  |  | - | + |  | - |
 | The updated configuration applies to all already returned `Meter`s. | if above | - | + | - | - |  | - |  |  | - | + |  | - |
@@ -145,9 +145,9 @@ formats is required. Implementing more than one format is optional.
 | The `View` instrument selection criteria is as specified. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | The `View` instrument selection criteria supports wildcards. | X | + | + | + | + | + | - |  | + | + | + |  | - |
 | The `View` instrument selection criteria supports the match-all wildcard. |  | + | + | + | + | + | + |  | + | + | + |  | - |
-| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | - |  | - |
+| The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | + |  | - |
 | The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + | + | + |  |  | - |  |  |  |  |  | - |
-| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  | - |
+| The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | + |  | - |
 | The SDK allows more than one `View` to be specified per instrument. | X | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Default` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
@@ -157,8 +157,8 @@ formats is required. Implementing more than one format is optional.
 | The `ExplicitBucketHistogram` aggregation is available. |  | + | + | + | + | + | + | + | + | + | + |  | - |
 | The `ExponentialBucketHistogram` aggregation is available. |  | + | + | + | + | + |  |  |  | + | + |  | - |
 | The metrics Reader implementation supports registering metric Exporters |  | + | + | + | + | + | + | + | + | + | + |  | - |
-| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  | + | + | + | + | + | + |  |  | - | - |  | - |
-| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  | + | + | + | + | + | + |  | + | + |  |  | - |
+| The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind. |  | + | + | + | + | + | + |  |  | - | + |  | - |
+| The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements). |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The metrics Exporter `export` function can not be called concurrently from the same Exporter instance. |  | + | + | + | - | + | + |  |  | + | + |  | - |
 | The metrics Exporter `export` function does not block indefinitely. |  | + | + | + | - | + | + |  |  | + | + |  | - |
@@ -178,10 +178,10 @@ formats is required. Implementing more than one format is optional.
 | Documentation notes that View-filtered attributes may still appear on Exemplars. |  | - | - | - | - | - | - | - | - | - | + | - | - |
 | Exemplars contain the associated trace id and span id of the active span in the Context when the measurement was taken. |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | Exemplars contain the timestamp when the measurement was taken. |  | + | + | - | - | + | + |  |  |  | + |  | - |
-| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - | + | + | + |  |  | - |  | - |
-| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  | + | - | - | - | + | + | + |  |  | - |  | - |
-| The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`. |  | + | + | - | - | + | + | + |  |  | - |  | - |
-| The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation. |  | + | + | - | - | + | + |  |  |  | - |  | - |
+| The metrics SDK provides an `ExemplarReservoir` interface or extension point. |  | + | - | - | - | + | + | + |  |  | + |  | - |
+| An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp. |  | + | - | - | - | + | + | + |  |  | + |  | - |
+| The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except `ExplicitBucketHistogram`. |  | + | + | - | - | + | + | + |  |  | + |  | - |
+| The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram` aggregation. |  | + | + | - | - | + | + |  |  |  | + |  | - |
 | A metric Producer accepts an optional metric Filter |  | - | - |  |  |  | - |  |  |  |  |  | - |
 | The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers |  | - | - |  |  |  | - |  |  |  |  |  | - |
 | The metric SDK's metric Producer implementations uses the metric Filter |  | - | - |  |  |  | - |  |  |  |  |  | - |
@@ -198,23 +198,23 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 
 | Feature | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | ------- | -------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- | ------ |
-| LoggerProvider.Get Logger |  | + | + | + | + | + |  | + | + | + | - |  | + |
-| LoggerProvider.Get Logger accepts attributes |  | + | - |  | + |  |  | + | + | + |  |  | + |
-| LoggerProvider.Shutdown |  | + | + | + | + | + |  | + | + | + | - |  | + |
-| LoggerProvider.ForceFlush |  | + | + | + | + | + |  | + | + | + | - |  | + |
+| LoggerProvider.Get Logger |  | + | + | + | + | + |  | + | + | + | + |  | + |
+| LoggerProvider.Get Logger accepts attributes |  | + | - |  | + |  |  | + | + | + | - |  | + |
+| LoggerProvider.Shutdown |  | + | + | + | + | + |  | + | + | + | + |  | + |
+| LoggerProvider.ForceFlush |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | Logger.Emit(LogRecord) |  | + | + | + | + | + |  | + | + | + | - |  | + |
-| Logger.Emit(LogRecord) with Exception parameter | X |  | + |  |  |  |  |  |  |  |  |  | + |
-| LogRecord.Set EventName |  | + | + |  |  | + |  |  | + | + |  |  | + |
-| Logger.Enabled | X | + | + |  |  |  |  | + | + | + |  |  | + |
-| Ergonomic API | X |  |  |  |  |  |  |  |  |  |  |  |  |
-| SimpleLogRecordProcessor |  | + | + | + | + | + |  | + | + | + |  |  | + |
-| BatchLogRecordProcessor |  | + | + | + | + | + |  | + | + | + |  |  | + |
-| Can plug custom LogRecordProcessor |  | + | + | + | + | + |  | + | + | + |  |  | + |
-| LogRecordProcessor.Enabled | X | + | - |  |  |  |  |  | + |  |  |  | + |
+| Logger.Emit(LogRecord) with Exception parameter | X |  | + |  |  |  |  |  |  |  | - |  | + |
+| LogRecord.Set EventName |  | + | + |  |  | + |  |  | + | + | + |  | + |
+| Logger.Enabled | X | + | + |  |  |  |  | + | + | + | - |  | + |
+| Ergonomic API | X |  |  |  |  |  |  |  |  |  | + |  |  |
+| SimpleLogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
+| BatchLogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
+| Can plug custom LogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
+| LogRecordProcessor.Enabled | X | + | - |  |  |  |  |  | + |  | - |  | + |
 | OTLP/gRPC exporter |  | + | + | + | + |  |  | + | + | + | + |  | - |
 | OTLP/HTTP exporter |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | OTLP File exporter |  | - | + |  | - |  |  |  | - | + | - |  | - |
-| Can plug custom LogRecordExporter |  | + | + | + | + | + |  | + | + | + |  |  | + |
+| Can plug custom LogRecordExporter |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | Trace Context Injection |  | + | + |  | + | + |  | + | + | + | + |  | + |
 
 ## Resource
@@ -243,10 +243,10 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Global Propagator |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | TraceContext Propagator |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | B3 Propagator |  | + | + | + | + | + | + | + | + | + | + | + | - |
-| Jaeger Propagator | X | + | + | + | + | + | + | + | + | + | - | + | - |
+| Jaeger Propagator | X | + | + | + | + | + | + | + | + | + | + | + | - |
 | OT Propagator | X | + | + | + | + |  |  |  |  |  | - |  | - |
 | OpenCensus Binary Propagator |  | + | - |  |  |  |  |  |  |  |  |  | - |
-| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |  | + | + |  | + | + |  | + |  | + |  |  | - |
+| [TextMapPropagator](specification/context/api-propagators.md#textmap-propagator) |  | + | + |  | + | + |  | + |  | + | + |  | - |
 | Fields |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | Setter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + | - |
 | Getter argument | X | N/A | + | + | + | + | + | + | N/A | + | + | + | - |
@@ -259,7 +259,7 @@ Note: Support for environment variables is optional.
 
 | Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- | ------ |
-| OTEL_SDK_DISABLED | - | + | - | + | + | - | + | - | + | - | - | - |
+| OTEL_SDK_DISABLED | - | + | - | + | + | - | + | - | + | + | - | - |
 | OTEL_RESOURCE_ATTRIBUTES | + | + | + | + | + | + | + | + | + | + | - | - |
 | OTEL_SERVICE_NAME | + | + | + | + | + | + | + | + | + | + |  | - |
 | OTEL_LOG_LEVEL | - | - | + | [-][py1059] | + | - | + |  | - | - | - | - |
@@ -277,17 +277,17 @@ Note: Support for environment variables is optional.
 | OTEL_SPAN_LINK_COUNT_LIMIT | + | + | + | + | + | + | + | + | - | + |  | - |
 | OTEL_EVENT_ATTRIBUTE_COUNT_LIMIT | + | - |  | + | + | + | + |  | - | + |  | - |
 | OTEL_LINK_ATTRIBUTE_COUNT_LIMIT | + | - |  | + | + | + | + |  | - | + |  | - |
-| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT | + | - |  |  | + |  | + | - | - |  |  | - |
-| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | - |  |  | + |  | + | - | - |  |  | - |
-| OTEL_TRACES_SAMPLER | + | + | + | + | + | + | + | + | - | - |  | - |
-| OTEL_TRACES_SAMPLER_ARG | + | + | + | + | + | + | + | + | - | - |  | - |
+| OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT | + | - |  |  | + |  | + | - | - | + |  | - |
+| OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | - |  |  | + |  | + | - | - | + |  | - |
+| OTEL_TRACES_SAMPLER | + | + | + | + | + | + | + | + | - | + |  | - |
+| OTEL_TRACES_SAMPLER_ARG | + | + | + | + | + | + | + | + | - | + |  | - |
 | OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT | + | + | + | + | + | - | + |  | - | + |  | - |
 | OTEL_ATTRIBUTE_COUNT_LIMIT | + | + | + | + | + | - | + |  | - | + |  | - |
 | OTEL_METRIC_EXPORT_INTERVAL | + | + |  | + | + |  | + |  | + | + |  | - |
 | OTEL_METRIC_EXPORT_TIMEOUT | + | - |  | + | + |  | + |  | + | + |  | - |
 | OTEL_METRICS_EXEMPLAR_FILTER | + | + |  |  | + |  | + |  | - | + |  | - |
 | OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | + | + | + | + | + |  | + |  | - | + |  | - |
-| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION | + | + |  | + | + |  |  |  | - |  |  | - |
+| OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION | + | + |  | + | + |  |  |  | - | + |  | - |
 | OTEL_CONFIG_FILE | + | + |  |  |  |  | + |  | + |  |  |  |
 
 ## Declarative configuration
@@ -324,11 +324,11 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | OTLP/gRPC Exporter | * | + | + | + | + |  | + | + | + | + | + | + | - |
 | OTLP/HTTP binary Protobuf Exporter | * | + | + | + | + | + | + | + | + | + | + | - | + |
 | OTLP/HTTP JSON Protobuf Exporter |  | + | - | + | [-][py1003] |  | - | + |  | + | - | - | - |
-| OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | - | - | + |
+| OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | + | - | + |
 | Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - |  |
-| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - |  |
-| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - |  |
-| Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - |  |
+| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | + | - |  |
+| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | + | - |  |
+| Honors throttling response | X | + | - | - | + | + | - |  |  | - | + | - |  |
 | Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - |  |
 | SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | - |  |  |
 | SchemaURL in ResourceMetrics and ScopeMetrics |  | + | + |  | + |  | - | + |  |  | - |  |  |
@@ -336,8 +336,8 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent) |  | + | + |  |  |  |  | + |  |  | + |  | + |
 | [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC | X | + | - |  |  |  |  | + |  |  |  |  |  |
 | [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X | + | - |  |  |  |  | + |  |  |  |  |  |
-| Metric Exporter configurable temporality preference |  | + | + |  | + |  |  | + |  |  |  |  | - |
-| Metric Exporter configurable default aggregation |  | + | + |  | + |  |  |  |  |  |  |  | - |
+| Metric Exporter configurable temporality preference |  | + | + |  | + |  |  | + |  |  | + |  | - |
+| Metric Exporter configurable default aggregation |  | + | + |  | + |  |  |  |  |  | + |  | - |
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)** | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | Zipkin V1 JSON | X | - | + |  | + | - | - | - | - | - | - | - | - |
 | Zipkin V1 Thrift | X | - | + |  | [-][py1174] | - | - | - | - | - | - | - | - |
@@ -346,7 +346,7 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | Service name mapping |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | SpanKind mapping |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | InstrumentationLibrary mapping |  | + | + | - | + | + | - | + | + | + | + | + | - |
-| InstrumentationScope mapping |  |  | + |  |  |  |  |  |  |  |  |  | - |
+| InstrumentationScope mapping |  |  | + |  |  |  |  |  |  |  | + |  | - |
 | Boolean attributes |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | Array attributes |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | Status mapping |  | + | + | + | + | + | + | + | + | + | + | + | - |
@@ -354,28 +354,28 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | Event attributes mapping to Annotations |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | Integer microseconds in timestamps |  | N/A | + |  | + | + | - | + | + | + | + | + | - |
 | **Prometheus** | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
-| [Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | - | - | - | - | - | + | - | - | - | - |
+| [Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | - | - | - | - | - | + | - | + | - | - |
 | [Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | + | + | - | - | - | + | + | + | + | - |
 | [UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) | X | - | + | + | + | - | - | - | - | - | + | - | - |
 | [Unit Suffixes](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) | X | + | + | - | + | - | - | - | + | + | + | - | - |
 | [Unit Full Words](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) | X | + | + | - | - | - | - | - | + | - | - | - | - |
 | [HELP Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | + | + | - | - | - | + | + | + | + | - |
 | [TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1) |  | + | + | + | + | - | - | - | + | + | + | + | - |
-| [otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) |  | + | + | - | - | - | - | - | + | - | - | - | - |
-| [otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) |  | + | - | - | - | - | - | - | - | - | - | - | - |
+| [otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) |  | + | + | - | - | - | - | - | + | - | + | - | - |
+| [otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) |  | + | - | - | - | - | - | - | - | - | + | - | - |
 | [otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1) | X | + | + | - | - | - | - | - | + | - | - | - | - |
 | [Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1) |  | + | + | + | + | - | - | - | + | + | + | - | - |
 | [Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | + | + | + | - |
-| [Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | - | - | - | - |
-| [Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums) | X | + | - | - | - | - | - | - | - | - | - | - | - |
+| [Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | - | + | - | - |
+| [Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums) | X | + | - | - | - | - | - | - | - | - | + | - | - |
 | [Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums) |  | + | + | + | + | - | - | - | + | + | + | - | - |
 | [Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums) | X | - | - | - | - | - | - | - | - | - | - | - | - |
 | [Cumulative Histograms become Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1) |  | + | + | + | + | - | - | - | + | + | + | + | - |
 | [Delta Histograms become Cumulative Prometheus Histograms](specification/compatibility/prometheus_and_openmetrics.md#histograms-1) | X | - | - | - | - | - | - | - | - | - | - | - | - |
 | [Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes) |  | + | + | + | + | - | - | - | + | + | + | + | - |
-| [Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes) |  | + | + | - | - | - | - | - | + | - | - | - | - |
-| [Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplar-conversion) | X | + | + | - | - | - | - | - | - | - | - | - | - |
-| [`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1) | X | + | + | + | + | - | - | - | + | - | - | - | - |
+| [Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes) |  | + | + | - | - | - | - | - | + | - | + | - | - |
+| [Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplar-conversion) | X | + | + | - | - | - | - | - | - | - | + | - | - |
+| [`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1) | X | + | + | + | + | - | - | - | + | - | + | - | - |
 
 ## OpenCensus Compatibility
 
@@ -392,12 +392,12 @@ Languages not covered by the OpenTracing project do not need to be listed here, 
 
 | Feature | Go | Java | JS | Python | Ruby | PHP | Rust | C++ | .NET | Swift |
 | ------- | -- | ---- | -- | ------ | ---- | --- | ---- | --- | ---- | ----- |
-| [Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim) |  |  |  |  |  | + |  |  |  |  |
-| [Tracer](specification/compatibility/opentracing.md#tracer-shim) |  |  |  |  |  | + |  |  |  |  |
-| [Span](specification/compatibility/opentracing.md#span-shim) |  |  |  |  |  | + |  |  |  |  |
-| [SpanContext](specification/compatibility/opentracing.md#spancontext-shim) |  |  |  |  |  | + |  |  |  |  |
-| [ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim) |  |  |  |  |  | + |  |  |  |  |
-| Error mapping for attributes/events |  |  |  |  |  | + |  |  |  |  |
+| [Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim) |  |  |  |  |  | + |  |  | + |  |
+| [Tracer](specification/compatibility/opentracing.md#tracer-shim) |  |  |  |  |  | + |  |  | + |  |
+| [Span](specification/compatibility/opentracing.md#span-shim) |  |  |  |  |  | + |  |  | + |  |
+| [SpanContext](specification/compatibility/opentracing.md#spancontext-shim) |  |  |  |  |  | + |  |  | + |  |
+| [ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim) |  |  |  |  |  | + |  |  | + |  |
+| Error mapping for attributes/events |  |  |  |  |  | + |  |  | + |  |
 | Migration to OpenTelemetry guide |  |  |  |  |  |  |  |  |  |  |
 
 [py1003]: https://github.com/open-telemetry/opentelemetry-python/issues/1003

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -16,11 +16,11 @@ sections:
           - name: Get a Tracer
             status: '+'
           - name: Get a Tracer with schema_url
-            status: '?'
+            status: '+'
           - name: Get a Tracer with scope attributes
-            status: '?'
+            status: '+'
           - name: Associate Tracer with InstrumentationScope
-            status: '?'
+            status: '+'
           - name: Safe for concurrent calls
             status: '+'
           - name: Shutdown (SDK only required)
@@ -152,7 +152,7 @@ sections:
           - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
             status: '?'
           - name: Fetch InstrumentationScope from ReadableSpan
-            status: '?'
+            status: '+'
           - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
             status: '?'
           - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
@@ -182,7 +182,7 @@ sections:
       - name: The fallback `Meter` `name` property keeps its original invalid value.
         status: '-'
       - name: Associate `Meter` with `InstrumentationScope`.
-        status: '?'
+        status: '+'
       - name: '`Counter` instrument is supported.'
         status: '+'
       - name: '`AsynchronousCounter` instrument is supported.'
@@ -192,7 +192,7 @@ sections:
       - name: '`AsynchronousGauge` instrument is supported.'
         status: '+'
       - name: '`Gauge` instrument is supported.'
-        status: '-'
+        status: '+'
       - name: '`UpDownCounter` instrument is supported.'
         status: '+'
       - name: '`AsynchronousUpDownCounter` instrument is supported.'
@@ -208,21 +208,21 @@ sections:
       - name:
           A valid instrument MUST be created and warning SHOULD be emitted when multiple instruments are registered under
           the same `Meter` using the same `name`.
-        status: '?'
+        status: '+'
       - name: Duplicate instrument registration name conflicts are resolved by using the first-seen for the stream name.
-        status: '?'
+        status: '+'
       - name: It is possible to register two instruments with same `name` under different `Meter`s.
         status: '+'
       - name: Instrument names conform to the specified syntax.
-        status: '?'
+        status: '+'
       - name: Instrument units conform to the specified syntax.
         status: '+'
       - name: Instrument descriptions conform to the specified syntax.
         status: '+'
       - name: Instrument supports the advisory ExplicitBucketBoundaries parameter.
-        status: '?'
+        status: '+'
       - name: Instrument supports the advisory Attributes parameter.
-        status: '?'
+        status: '-'
       - name: Synchronous instruments support Bind to pre-associate attributes.
         status: '-'
       - name: All methods of `MeterProvider` are safe to be called concurrently.
@@ -242,7 +242,7 @@ sections:
       - name:
           The supplied `name`, `version` and `schema_url` arguments passed to the `MeterProvider` are used to create an `InstrumentationScope`
           instance stored in the `Meter`.
-        status: '?'
+        status: '+'
       - name: Configuration is managed solely by the `MeterProvider`.
         status: '+'
       - name: The `MeterProvider` provides methods to update the configuration
@@ -258,11 +258,11 @@ sections:
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
-        status: '-'
+        status: '+'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
         status: '?'
       - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
-        status: '-'
+        status: '+'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
       - name: The `Drop` aggregation is available.
@@ -282,9 +282,9 @@ sections:
       - name: The metrics Reader implementation supports registering metric Exporters
         status: '+'
       - name: The metrics Reader implementation supports configuring the default aggregation on the basis of instrument kind.
-        status: '-'
+        status: '+'
       - name: The metrics Reader implementation supports configuring the default temporality on the basis of instrument kind.
-        status: '?'
+        status: '+'
       - name: The metrics Exporter has access to the aggregated metrics data (aggregated points, not raw measurements).
         status: '+'
       - name: The metrics Exporter `export` function can not be called concurrently from the same Exporter instance.
@@ -326,17 +326,17 @@ sections:
       - name: Exemplars contain the timestamp when the measurement was taken.
         status: '+'
       - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
-        status: '-'
+        status: '+'
       - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
-        status: '-'
+        status: '+'
       - name:
           The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
           `ExplicitBucketHistogram`.
-        status: '-'
+        status: '+'
       - name:
           The metrics SDK provides an `AlignedHistogramBucketExemplarReservoir` that is used by default for `ExplicitBucketHistogram`
           aggregation.
-        status: '-'
+        status: '+'
       - name: A metric Producer accepts an optional metric Filter
         status: '?'
       - name: The metric Reader implementation supports registering metric Filter and passing them  its registered metric Producers
@@ -356,29 +356,31 @@ sections:
   - name: Logs
     features:
       - name: LoggerProvider.Get Logger
-        status: '-'
+        status: '+'
       - name: LoggerProvider.Get Logger accepts attributes
-        status: '?'
+        status: '-'
       - name: LoggerProvider.Shutdown
-        status: '-'
+        status: '+'
       - name: LoggerProvider.ForceFlush
-        status: '-'
+        status: '+'
       - name: Logger.Emit(LogRecord)
         status: '-'
       - name: Logger.Emit(LogRecord) with Exception parameter
-        status: '?'
+        status: '-'
       - name: LogRecord.Set EventName
-        status: '?'
+        status: '+'
       - name: Logger.Enabled
-        status: '?'
+        status: '-'
+      - name: Ergonomic API
+        status: '+'
       - name: SimpleLogRecordProcessor
-        status: '?'
+        status: '+'
       - name: BatchLogRecordProcessor
-        status: '?'
+        status: '+'
       - name: Can plug custom LogRecordProcessor
-        status: '?'
+        status: '+'
       - name: LogRecordProcessor.Enabled
-        status: '?'
+        status: '-'
       - name: OTLP/gRPC exporter
         status: '+'
       - name: OTLP/HTTP exporter
@@ -386,7 +388,7 @@ sections:
       - name: OTLP File exporter
         status: '-'
       - name: Can plug custom LogRecordExporter
-        status: '?'
+        status: '+'
       - name: Trace Context Injection
         status: '+'
   - name: Resource
@@ -430,13 +432,13 @@ sections:
       - name: B3 Propagator
         status: '+'
       - name: Jaeger Propagator
-        status: '-'
+        status: '+'
       - name: OT Propagator
         status: '-'
       - name: OpenCensus Binary Propagator
         status: '?'
       - name: '[TextMapPropagator](specification/context/api-propagators.md#textmap-propagator)'
-        status: '?'
+        status: '+'
       - name: Fields
         status: '+'
       - name: Setter argument
@@ -450,7 +452,7 @@ sections:
   - name: Environment Variables
     features:
       - name: OTEL_SDK_DISABLED
-        status: '-'
+        status: '+'
       - name: OTEL_RESOURCE_ATTRIBUTES
         status: '+'
       - name: OTEL_SERVICE_NAME
@@ -486,13 +488,13 @@ sections:
       - name: OTEL_LINK_ATTRIBUTE_COUNT_LIMIT
         status: '+'
       - name: OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT
-        status: '?'
+        status: '+'
       - name: OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT
-        status: '?'
+        status: '+'
       - name: OTEL_TRACES_SAMPLER
-        status: '-'
+        status: '+'
       - name: OTEL_TRACES_SAMPLER_ARG
-        status: '-'
+        status: '+'
       - name: OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT
         status: '+'
       - name: OTEL_ATTRIBUTE_COUNT_LIMIT
@@ -506,7 +508,7 @@ sections:
       - name: OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
         status: '+'
       - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
-        status: '?'
+        status: '+'
       - name: OTEL_CONFIG_FILE
         status: '?'
   - name: Declarative configuration
@@ -556,15 +558,15 @@ sections:
           - name: OTLP/HTTP JSON Protobuf Exporter
             status: '-'
           - name: OTLP/HTTP gzip Content-Encoding support
-            status: '-'
+            status: '+'
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff
-            status: '-'
+            status: '+'
           - name: Honors non-retryable responses
-            status: '-'
+            status: '+'
           - name: Honors throttling response
-            status: '-'
+            status: '+'
           - name: Multi-destination spec compliance
             status: '-'
           - name: SchemaURL in ResourceSpans and ScopeSpans
@@ -584,9 +586,9 @@ sections:
               messages are handled and logged for OTLP/HTTP'
             status: '?'
           - name: Metric Exporter configurable temporality preference
-            status: '?'
+            status: '+'
           - name: Metric Exporter configurable default aggregation
-            status: '?'
+            status: '+'
       - heading: '**[Zipkin](specification/trace/sdk_exporters/zipkin.md)**'
         features:
           - name: Zipkin V1 JSON
@@ -604,7 +606,7 @@ sections:
           - name: InstrumentationLibrary mapping
             status: '+'
           - name: InstrumentationScope mapping
-            status: '?'
+            status: '+'
           - name: Boolean attributes
             status: '+'
           - name: Array attributes
@@ -620,7 +622,7 @@ sections:
       - heading: '**Prometheus**'
         features:
           - name: '[Metadata Deduplication](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
-            status: '-'
+            status: '+'
           - name: '[Name Sanitization](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
             status: '+'
           - name: '[UNIT Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
@@ -634,9 +636,9 @@ sections:
           - name: '[TYPE Metadata](specification/compatibility/prometheus_and_openmetrics.md#metric-metadata-1)'
             status: '+'
           - name: '[otel_scope_name and otel_scope_version labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
-            status: '-'
+            status: '+'
           - name: '[otel_scope_[attribute] labels on all Metrics](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
-            status: '-'
+            status: '+'
           - name: '[otel_scope labels can be disabled](specification/compatibility/prometheus_and_openmetrics.md#instrumentation-scope-1)'
             status: '-'
           - name: '[Gauges become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#gauges-1)'
@@ -644,9 +646,9 @@ sections:
           - name: '[Cumulative Monotonic Sums become Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
             status: '+'
           - name: '[Prometheus Counters have _total suffix by default](specification/compatibility/prometheus_and_openmetrics.md#sums)'
-            status: '-'
+            status: '+'
           - name: '[Prometheus Counters _total suffixing can be disabled](specification/compatibility/prometheus_and_openmetrics.md#sums)'
-            status: '-'
+            status: '+'
           - name: '[Cumulative Non-Monotonic Sums become Prometheus Gauges](specification/compatibility/prometheus_and_openmetrics.md#sums)'
             status: '+'
           - name: '[Delta Non-Monotonic Sums become Cumulative Prometheus Counters](specification/compatibility/prometheus_and_openmetrics.md#sums)'
@@ -658,11 +660,11 @@ sections:
           - name: '[Attributes Keys are Sanitized](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
             status: '+'
           - name: '[Colliding sanitized attribute keys are merged](specification/compatibility/prometheus_and_openmetrics.md#metric-attributes)'
-            status: '-'
+            status: '+'
           - name: '[Exemplars for Histograms and Monotonic sums](specification/compatibility/prometheus_and_openmetrics.md#exemplar-conversion)'
-            status: '-'
+            status: '+'
           - name: '[`target_info` metric from Resource](specification/compatibility/prometheus_and_openmetrics.md#resource-attributes-1)'
-            status: '-'
+            status: '+'
   - name: OpenCensus Compatibility
     features:
       - name: '[Trace Bridge](specification/compatibility/opencensus.md#trace-bridge)'
@@ -672,16 +674,16 @@ sections:
   - name: OpenTracing Compatibility
     features:
       - name: '[Create OpenTracing Shim](specification/compatibility/opentracing.md#create-an-opentracing-tracer-shim)'
-        status: '?'
+        status: '+'
       - name: '[Tracer](specification/compatibility/opentracing.md#tracer-shim)'
-        status: '?'
+        status: '+'
       - name: '[Span](specification/compatibility/opentracing.md#span-shim)'
-        status: '?'
+        status: '+'
       - name: '[SpanContext](specification/compatibility/opentracing.md#spancontext-shim)'
-        status: '?'
+        status: '+'
       - name: '[ScopeManager](specification/compatibility/opentracing.md#scopemanager-shim)'
-        status: '?'
+        status: '+'
       - name: Error mapping for attributes/events
-        status: '?'
+        status: '+'
       - name: Migration to OpenTelemetry guide
         status: '?'

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -258,11 +258,11 @@ sections:
       - name: The `View` instrument selection criteria supports the match-all wildcard.
         status: '+'
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
-        status: '+'
+        status: '-'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
         status: '?'
       - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
-        status: '+'
+        status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
         status: '+'
       - name: The `Drop` aggregation is available.
@@ -326,9 +326,9 @@ sections:
       - name: Exemplars contain the timestamp when the measurement was taken.
         status: '+'
       - name: The metrics SDK provides an `ExemplarReservoir` interface or extension point.
-        status: '+'
+        status: '-'
       - name: An `ExemplarReservoir` has an `offer` method with access to the measurement value, attributes, `Context` and timestamp.
-        status: '+'
+        status: '-'
       - name:
           The metrics SDK provides a `SimpleFixedSizeExemplarReservoir` that is used by default for all aggregations except
           `ExplicitBucketHistogram`.
@@ -356,7 +356,7 @@ sections:
   - name: Logs
     features:
       - name: LoggerProvider.Get Logger
-        status: '+'
+        status: '-'
       - name: LoggerProvider.Get Logger accepts attributes
         status: '-'
       - name: LoggerProvider.Shutdown
@@ -368,7 +368,7 @@ sections:
       - name: Logger.Emit(LogRecord) with Exception parameter
         status: '-'
       - name: LogRecord.Set EventName
-        status: '+'
+        status: '?'
       - name: Logger.Enabled
         status: '-'
       - name: Ergonomic API
@@ -562,11 +562,11 @@ sections:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff
-            status: '+'
+            status: '-'
           - name: Honors non-retryable responses
-            status: '+'
+            status: '-'
           - name: Honors throttling response
-            status: '+'
+            status: '-'
           - name: Multi-destination spec compliance
             status: '-'
           - name: SchemaURL in ResourceSpans and ScopeSpans


### PR DESCRIPTION
## Changes

Update the compliance matrix for .NET as of 1.16.0 of the .NET SDK.

I got Copilot to do most of the work of researching what was missing that had been implementing and finding the relevant PRs that implemented then. I cross checked the PRs _looked_ correct, but some of it might be incorrect, particularly things that seem to have been implemented for a while and predate my contributions to OTel. I then had Claude review the changes and cross-reference, which fixed some of the entries, but again there might still be some mistakes.

~~Some of the entries might only be available as experimental features, so maybe they shouldn't be updated?~~ Experimental entries removed, now marked as ~~strikethrough~~ below.

Entries updated with relevant PR links where appropriate below.

/cc @open-telemetry/dotnet-maintainers 

### Traces

- Get a Tracer with schema_url: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6736
- Get a Tracer with scope attributes: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6137
- Associate Tracer with InstrumentationScope: https://github.com/open-telemetry/opentelemetry-dotnet/pull/239
- Fetch InstrumentationScope from ReadableSpan: https://github.com/open-telemetry/opentelemetry-dotnet/pull/679

### Metrics

- Associate Meter with InstrumentationScope: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6714
- Gauge instrument is supported: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5867
- Valid instrument created / warning for duplicate name: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2916
- Duplicate instrument registration resolved by first-seen: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2916
- Instrument names conform to specified syntax: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3821
- Instrument supports advisory ExplicitBucketBoundaries: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5854
- Instrument supports advisory Attributes: Not implemented
- name/version/schema_url create InstrumentationScope: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6714
- ~~View allows configuring name, description, attributes, aggregation: https://github.com/open-telemetry/opentelemetry-dotnet/pull/2396~~
- ~~View allows configuring exemplar reservoir: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5558~~
- Metrics Reader supports default aggregation config: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6778
- Metrics Reader supports default temporality config: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4667
- ~~ExemplarReservoir interface/extension point: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5542~~
- ~~ExemplarReservoir has offer method: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5542~~
- SimpleFixedSizeExemplarReservoir: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4256
- AlignedHistogramBucketExemplarReservoir: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4119

### Logs

- ~~LoggerProvider.GetLogger: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4422~~
- LoggerProvider.GetLogger accepts attributes: Not implemented
- LoggerProvider.Shutdown: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648
- LoggerProvider.ForceFlush: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5648
- Logger.Emit(LogRecord) with Exception parameter: Not implemented
- ~~LogRecord.Set EventName: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6306~~
- Logger.Enabled: Not implemented
- Ergonomic API (ILogger bridge): https://github.com/open-telemetry/opentelemetry-dotnet/pull/3489
- SimpleLogRecordProcessor: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1622
- BatchLogRecordProcessor: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1622
- Can plug custom LogRecordProcessor: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4916
- LogRecordProcessor.Enabled: Not implemented
- Can plug custom LogRecordExporter: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1622

### Context Propagation

- Jaeger Propagator: https://github.com/open-telemetry/opentelemetry-dotnet/pull/3309
- TextMapPropagator: https://github.com/open-telemetry/opentelemetry-dotnet/pull/1427

### Environment Variables

- OTEL_SDK_DISABLED: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6568
- OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4887
- OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4887
- OTEL_TRACES_SAMPLER: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5448
- OTEL_TRACES_SAMPLER_ARG: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5448
- OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6778

### Exporters — OTLP

- OTLP/HTTP gzip Content-Encoding support: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7055
- ~~Honors retryable responses with backoff: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495~~
- ~~Honors non-retryable responses: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495~~
- ~~Honors throttling response: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495~~
- Metric Exporter configurable temporality preference: https://github.com/open-telemetry/opentelemetry-dotnet/pull/4667
- Metric Exporter configurable default aggregation: https://github.com/open-telemetry/opentelemetry-dotnet/pull/6778

### Exporters — Zipkin

- InstrumentationScope mapping: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5473

### Exporters — Prometheus

- Metadata Deduplication: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7237
- otel_scope_name and otel_scope_version labels: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7237
- otel_scope_[attribute] labels: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7237
- Prometheus Counters have _total suffix by default: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5305
- Prometheus Counters _total suffixing can be disabled: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5305
- Colliding sanitized attribute keys are merged: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7239
- Exemplars for Histograms and Monotonic sums: https://github.com/open-telemetry/opentelemetry-dotnet/pull/7222
- target_info metric from Resource: https://github.com/open-telemetry/opentelemetry-dotnet/pull/5407

### OpenTracing Compatibility

- Create OpenTracing Shim: https://github.com/open-telemetry/opentelemetry-dotnet/pull/197
- Tracer shim: https://github.com/open-telemetry/opentelemetry-dotnet/pull/197
- Span shim: https://github.com/open-telemetry/opentelemetry-dotnet/pull/197
- SpanContext shim: https://github.com/open-telemetry/opentelemetry-dotnet/pull/197
- ScopeManager shim: https://github.com/open-telemetry/opentelemetry-dotnet/pull/197
- Error mapping for attributes/events: https://github.com/open-telemetry/opentelemetry-dotnet/pull/197

