### PR TITLE
Remove caching from env car propagation implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ release.
 - Clean up implementation guidelines for environment variable propagation
   carriers.
   ([#5166](https://github.com/open-telemetry/opentelemetry-specification/pull/5166))
+- Remove caching behavior suggestions for environment variable propagation
+  carrier implementations.
+  ([#5179](https://github.com/open-telemetry/opentelemetry-specification/pull/5179))
 
 ### Traces
 

--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -159,13 +159,6 @@ that implement these operations themselves. Whichever component performs `Get`,
 behavior described above. Language-specific helper components are only expected
 to operate on the carrier shapes supported by that language implementation.
 
-Implementations can consider a caching behavior that fits their API shape. For
-example, an implementation can:
-
-- Load environment variables whose names are already normalized into a cache
-  during initialization or on first use.
-- Cache the results of individual `Get` lookups by normalized key.
-
 Example implementations:
 
 - [OpenTelemetry .NET implementation][di]


### PR DESCRIPTION
## Changes

This PR removes the non-normative implementation guidance that suggested environment variable propagation carriers could cache environment variables or individual `Get` lookup results.

The environment carrier specification already frames environment variables as process-startup input: applications should extract context during initialization, then continue using the extracted `Context`. With that usage model, the specification does not need to recommend caching as an implementation pattern. Implementations can still use owned storage or explicit snapshots where their language API requires it, but that should be a language-specific design choice rather than general spec guidance.

Non-caching implementations so far:
- Go: https://github.com/open-telemetry/opentelemetry-go-contrib/blob/main/propagators/envcar/carrier.go
- Swift: https://github.com/open-telemetry/opentelemetry-swift-core/blob/main/Sources/OpenTelemetrySdk/Trace/Propagation/EnvironmentContextPropagator.swift
- JavaScript: https://github.com/open-telemetry/opentelemetry-js/pull/6853

## Motivation

This follows the same direction as the discussion that led to #5143 and #5144. The concern raised in the #5142 review was that environment carrier extraction should not require inspecting every environment variable. Full-carrier enumeration is inefficient, especially when OpenTelemetry is present but no environment propagation variables are configured.

#5144 addressed that by requiring `Get` to normalize the requested propagator key and read only that normalized environment variable name. `Keys` remains the operation that may enumerate keys, and it returns only names that are already normalized.

The caching examples added in #5166 can be read as encouraging implementations to reintroduce hidden first-use state, such as:

- loading the whole environment into a cache during initialization or on first use, or
- caching individual `Get` results by normalized key.

That guidance is unnecessary and can work against the intent of #5143/#5144:

- Standard extraction typically reads only a small set of keys such as `TRACEPARENT`, `TRACESTATE`, and `BAGGAGE`.
- Repeated extraction from the process environment is not the intended hot path; users should extract once at startup and reuse the resulting `Context`.
- Whole-environment snapshots can cost more than direct lookup for the common extraction path.
- Hidden caches can make later environment changes invisible in a way that is surprising unless the API explicitly describes itself as a snapshot.

This also aligns with [Performance](https://opentelemetry.io/community/mission/#we-value-performance), which is a core OpenTelemetry Engineering Value.

The Go PR reviews showed the same issue in an implementation: review feedback called out that `Get` should do a direct lookup of the normalized key and leave enumeration to `Keys`, instead of enumerating and storing the process environment on the first `Get`.
- https://github.com/open-telemetry/opentelemetry-go-contrib/pull/9112#discussion_r3432179522
- https://github.com/open-telemetry/opentelemetry-go-contrib/pull/9112#discussion_r3445703917

Also see: https://github.com/open-telemetry/opentelemetry-specification/pull/5142#issuecomment-4778744202

## Compatibility

This PR does not add or remove normative requirements. It only removes non-normative guidance that could steer language implementations toward default caching.

Language implementations remain free to use internal storage when required by their API shape, and users can still choose explicit snapshots or caller-provided maps where that is the clearer model. The specification should avoid presenting caching as the recommended default for environment carrier extraction.

## Related

- #5142
- #5143
- #5144
- #5166
- #5040
- #4771




