### PR TITLE
Clarify case-insensitive env carrier lookup

### DIFF
--- a/specification/context/env-carriers.md
+++ b/specification/context/env-carriers.md
@@ -99,6 +99,13 @@ read a non-normalized environment variable named `x-b3-traceid`, even though
 that name normalizes to `X_B3_TRACEID`.
 
 > [!NOTE]
+> On platforms with case-insensitive environment variable lookup, such as
+> Windows, the platform lookup performed by `Get` may match an environment
+> variable whose name differs from the normalized key only by case. For example,
+> if a Windows process environment contains `traceparent`, reading the
+> normalized key `TRACEPARENT` may return the value of `traceparent`.
+
+> [!NOTE]
 > This normalization is consistent with the environment variable naming rules
 > defined in [POSIX.1-2024](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap08.html).
 


### PR DESCRIPTION
I think adding this note may be helpful for implementation and troubleshooting.

Personally, even though I was fully aware of the behavior on Windows, I still forgot about it at least twice while working on the implementations for OTel JS (https://github.com/open-telemetry/opentelemetry-js/pull/6853#discussion_r3478291814) and OTel Go (https://github.com/open-telemetry/opentelemetry-go-contrib/pull/9112).

In OTel Go, I even decided to include this in method documentation.

```go
// Get normalizes key and returns the corresponding value from the current
// process environment. It returns an empty string if the normalized
// environment variable is unset or set to an empty value.
//
// On platforms with case-insensitive environment lookup, such as Windows, the
// lookup may match an environment variable whose name differs from the
// normalized key only by case.
func (*Carrier) Get(key string) string {
	return os.Getenv(normalize(key))
}
```