### PR TITLE
docs(metrics): clarify that Sum data points contain numeric values

### DIFF
--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -412,6 +412,8 @@ in OTLP consist of the following:
     that are not less than the previous value.
 - A set of data points, each containing:
   - An independent set of Attribute name-value pairs.
+  - A numeric value representing either a delta or cumulative sum, depending on
+    the aggregation temporality.
   - A time window (of `(start, end]`) time for which the Sum was calculated.
     - The time interval is inclusive of the end time.
     - Times are specified in Value is UNIX Epoch time in nanoseconds since


### PR DESCRIPTION
## Summary

This is a documentation-only clarification to the Metrics Data Model description of `Sum`. It adds a single bullet point explicitly stating that each `Sum` data point carries a numeric value, mirroring how `Gauge` already describes its sampled value.

Fixes #4967.

---

## Problem

The `### Sums` section in the Metrics Data Model lists the fields that make up a Sum data point, but notably omits any mention of the **numeric value** that each data point carries  despite that being the primary purpose of a Sum (to report a delta or cumulative numeric measurement).

The current description only lists:
- An Aggregation Temporality
- A monotonic flag
- A set of data points, each containing:
  - Attribute name-value pairs
  - A time window
  - (optional) Exemplars
  - (optional) Data point flags

There is no mention of the actual **value** field in the data point.

By contrast, the `### Gauge` section explicitly lists:
- A sampled value (e.g. current CPU temperature)

This inconsistency can mislead readers into thinking Sum data points don't carry values, and leaves implementors uncertain about what field to populate.

---

## Change

Added one bullet to the `Sum` data point field list in `specification/metrics/data-model.md`:

```diff
 - A set of data points, each containing:
   - An independent set of Attribute name-value pairs.
+  - A numeric value representing either a delta or cumulative sum, depending on
+    the aggregation temporality.
   - A time window (of `(start, end]`) time for which the Sum was calculated.
   
 Impact

-  Documentation clarification only no behavior change
- No semantic change to how Sum works
- No API or SDK changes required
- Single file touched: specification/metrics/data-model.md
- Brings Sum data point description in line with how Gauge describes its data points