### PR TITLE
Remove requirement for attribute ordering from compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -59,7 +59,6 @@ formats is required. Implementing more than one format is optional.
 | [SpanProcessor.OnEnding](specification/trace/sdk.md#onending) | X | - | + | - | - | - | - | - | - | - | N/A | - | + |
 | [Span attributes](specification/trace/api.md#set-attributes) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | SetAttribute |  | + | + | + | + | + | + | + | + | + | + | + | + |
-| Set order preserved | X | + | - | + | + | + | + | + | + | + | + | + | - |
 | String type |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Boolean type |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Double floating-point type |  | + | + | + | + | + | + | - | + | + | + | + | + |

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '-'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '-'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -95,8 +95,6 @@ sections:
         features:
           - name: SetAttribute
             status: '+'
-          - name: Set order preserved
-            status: '+'
           - name: String type
             status: '+'
           - name: Boolean type

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -78,8 +78,6 @@ sections:
       - heading: '[Span attributes](specification/trace/api.md#set-attributes)'
         features:
           - name: SetAttribute
-          - name: Set order preserved
-            optional: true
           - name: String type
           - name: Boolean type
           - name: Double floating-point type


### PR DESCRIPTION
Fixes #4971.

## Changes

As discussed on #4971, the spec compliance matrix has a requirement that attributes retain insertion order. However, the specification doesn't have any such requirement, so I've removed this.

Note: this change does not require existing stable implementations to change if they currently retain insertion order for attributes. 
