### PR TITLE
[prometheus] Stabilize Prometheus -> OTLP: StateSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ release.
 
 ### Compatibility
 
+- Stabilize Prometheus StateSet metric transformation.
+  ([#5212](https://github.com/open-telemetry/opentelemetry-specification/pull/5212))
+
 ### SDK Configuration
 
 ### Supplementary Guidelines

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -164,7 +164,7 @@ A [Prometheus Info](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specif
 
 ### StateSet
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 A [Prometheus StateSet](https://github.com/prometheus/OpenMetrics/blob/v1.0.0/specification/OpenMetrics.md#stateset) metric MUST be converted to an OTLP Non-Monotonic Sum. A Prometheus StateSet metric can be thought of as a special-case of the Prometheus Gauge which has a 0 or 1 value, and has one metric point for every possible state. It is converted to an OTLP Non-Monotonic Sum, rather than an OTLP Gauge, because the value of 1 is intended to be viewed as a count, which should be summed together when aggregating away labels.
 


### PR DESCRIPTION
Part of https://github.com/open-telemetry/opentelemetry-specification/issues/4742

## Changes

Stabilize the conversion of Prometheus StateSet metrics to OTLP

* [x] Related issues https://github.com/open-telemetry/opentelemetry-specification/issues/4742
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes (when adding or changing features)
    * prometheus receiver implementation: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/47b5da2e5c81f8da0eb470a8ce94961425fa0208/receiver/prometheusreceiver/internal/util.go#L146-L147
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
