### PR TITLE
[chore] fix stale workflow

### DIFF
--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -10,6 +10,7 @@ jobs:
   stale:
     permissions:
       pull-requests: write # required for marking and closing stale PRs
+      actions: write # required for the stale action to manage (reset) its state cache
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0


### PR DESCRIPTION
Several PRs are consistently skipped since they were  "processed during the previous run", but there is no sign of them being processed in previous runs. 

These PRs have no activity in months and have `Stale` label, they should have been closed.

At the same time stale job logs show that it does not have permissions to delete state

```
Error delete _state: [403] Resource not accessible by integration - https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
the state will be removed
```

https://github.com/open-telemetry/opentelemetry-specification/actions/runs/29716847903/job/88271708240

```
#4809]            pull request skipped due being processed during the previous run
[#4783]            pull request skipped due being processed during the previous run
[#4755]            pull request skipped due being processed during the previous run
[#4702]            pull request skipped due being processed during the previous run
Batch  #1  processed.
No more issues found to process. Exiting...
Statistics:
Processed PRs: 31
Fetched items: 35
Fetched items events: 8
Fetched items comments: 8
Operations performed: 18
Github API rate used: 0
Github API rate remaining: 14999; reset at: Mon Jul 20 2026 05:25:29 GMT+0000 (Coordinated Universal Time)
state: persisting info about 0 issue(s)
Warning: Error delete _state: [403] Resource not accessible by integration - https://docs.github.com/rest/actions/cache#delete-github-actions-caches-for-a-repository-using-a-cache-key
the state will be removed
```


Adding `actions: write` permissions to let the job update state.

it works ~on my machine~ in semconv - https://github.com/open-telemetry/semantic-conventions/blob/421dda788ca3dd9f2537d95dc70e457c1fd52600/.github/workflows/stale-pr.yml#L13