### PR TITLE
Stale old issues (12+ months of inactivity) and close them if no activity after 14 days

### DIFF
--- a/.github/workflows/reopen-issue.yaml
+++ b/.github/workflows/reopen-issue.yaml
@@ -8,15 +8,15 @@ permissions:
 
 jobs:
   reopen:
-    # Only run on issues (not PRs), on closed issues, when the comment starts with "/reopen",
-    # and only if the commenter is the issue author or a member/collaborator/owner.
+    # Only run on issues (not PRs), on closed issues, when the comment is exactly "/reopen",
+    # and only if the commenter is the issue author or a member/collaborator/owner/contributor.
     if: >
       !github.event.issue.pull_request &&
       github.event.issue.state == 'closed' &&
       startsWith(github.event.comment.body, '/reopen') &&
       (
         github.event.comment.user.login == github.event.issue.user.login ||
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR", "CONTRIBUTOR"]'), github.event.comment.author_association)
       )
     permissions:
       issues: write # required to reopen the issue

--- a/.github/workflows/reopen-issue.yaml
+++ b/.github/workflows/reopen-issue.yaml
@@ -35,4 +35,3 @@ jobs:
             exit 0
           fi
           gh issue reopen "$ISSUE_NUMBER" --repo "$REPO"
-

--- a/.github/workflows/reopen-issue.yaml
+++ b/.github/workflows/reopen-issue.yaml
@@ -1,0 +1,38 @@
+name: "Reopen issue on command"
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  reopen:
+    # Only run on issues (not PRs), on closed issues, when the comment starts with "/reopen",
+    # and only if the commenter is the issue author or a member/collaborator/owner.
+    if: >
+      !github.event.issue.pull_request &&
+      github.event.issue.state == 'closed' &&
+      startsWith(github.event.comment.body, '/reopen') &&
+      (
+        github.event.comment.user.login == github.event.issue.user.login ||
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    permissions:
+      issues: write # required to reopen the issue
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reopen issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          # Require the comment to be exactly "/reopen" (ignoring surrounding whitespace)
+          if [ "$(echo "$COMMENT_BODY" | tr -d '[:space:]')" != "/reopen" ]; then
+            echo "Comment is not an exact /reopen command; skipping."
+            exit 0
+          fi
+          gh issue reopen "$ISSUE_NUMBER" --repo "$REPO"
+

--- a/.github/workflows/reopen-issue.yaml
+++ b/.github/workflows/reopen-issue.yaml
@@ -29,8 +29,8 @@ jobs:
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          # Require the comment to be exactly "/reopen" (ignoring surrounding whitespace)
-          if [ "$(echo "$COMMENT_BODY" | tr -d '[:space:]')" != "/reopen" ]; then
+          # Require the comment to be exactly "/reopen" (ignoring trailing whitespace)
+          if [[ ! "$COMMENT_BODY" =~ ^/reopen[[:space:]]*$ ]]; then
             echo "Comment is not an exact /reopen command; skipping."
             exit 0
           fi

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -1,4 +1,4 @@
-name: "Close stale pull requests"
+name: "Close stale pull requests and issues"
 on:
   schedule:
     - cron: "12 3 * * *" # arbitrary time not to DDOS GitHub
@@ -10,6 +10,7 @@ jobs:
   stale:
     permissions:
       pull-requests: write # required for marking and closing stale PRs
+      issues: write # required for marking and closing stale issues
       actions: write # required for the stale action to manage (reset) its state cache
     runs-on: ubuntu-latest
     steps:
@@ -19,9 +20,14 @@ jobs:
           stale-pr-message: 'This PR was marked stale. It will be closed in 14 days without additional activity.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'release:after-ga'
-          # opt out of defaults to avoid marking issues as stale
+          stale-issue-message: 'This issue was marked stale due to lack of activity. It will be closed in 14 days without additional activity.'
+          close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still relevant.'
+          # opt out of defaults to set explicit per-type values below
           days-before-stale: -1
           days-before-close: -1
           # overrides the above only for pull requests
           days-before-pr-stale: 14
           days-before-pr-close: 14
+          # overrides the above only for issues (~12 months of inactivity)
+          days-before-issue-stale: 365
+          days-before-issue-close: 14

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -21,7 +21,9 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'release:after-ga'
           stale-issue-message: 'This issue was marked stale due to lack of activity. It will be closed in 14 days without additional activity.'
-          close-issue-message: 'Closed as inactive. Feel free to reopen if this issue is still relevant.'
+          close-issue-message: > 
+            Closed due to inactivity. We appreciate your input, and if this issue is still relevant,
+            please feel free to reopen it. Thank you for your contribution!
           # opt out of defaults to set explicit per-type values below
           days-before-stale: -1
           days-before-close: -1

--- a/.github/workflows/stale-pr.yaml
+++ b/.github/workflows/stale-pr.yaml
@@ -24,12 +24,9 @@ jobs:
           close-issue-message: > 
             Closed due to inactivity. We appreciate your input, and if this issue is still relevant,
             please feel free to reopen it. Thank you for your contribution!
-          # opt out of defaults to set explicit per-type values below
-          days-before-stale: -1
-          days-before-close: -1
-          # overrides the above only for pull requests
+          # applies only to pull requests
           days-before-pr-stale: 14
           days-before-pr-close: 14
-          # overrides the above only for issues (~12 months of inactivity)
+          # applies only to issues (~12 months of inactivity)
           days-before-issue-stale: 365
           days-before-issue-close: 14

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -21,8 +21,7 @@ jobs:
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'release:after-ga'
           stale-issue-message: > 
-            This issue was marked stale due to lack of activity. It will be closed in 14 days without additional activity.
-            Please leave a comment if you would like to keep this issue open.
+            This issue was marked stale due to lack of activity. Please leave a comment if you would like to keep this issue open.
           close-issue-message: |
             Closed due to inactivity.
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,13 +20,12 @@ jobs:
           stale-pr-message: 'This PR was marked stale. It will be closed in 14 days without additional activity.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'release:after-ga'
-          stale-issue-message: > 
-            This issue was marked stale due to lack of activity. Please leave a comment if you would like to keep this issue open.
+          stale-issue-message: 'This issue was marked stale due to lack of activity. Please leave a comment if you would like to keep this issue open.'
           close-issue-message: |
             Closed due to inactivity.
 
             We appreciate your input, and if this issue is still relevant,
-            please reopen it, or comment "/reopen" and we'll reopen it for you.
+            please reopen it, or comment "/reopen" and we'll do it for you.
 
             Thank you for your contribution!
           # applies only to pull requests

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -27,6 +27,6 @@ jobs:
           # applies only to pull requests
           days-before-pr-stale: 14
           days-before-pr-close: 14
-          # applies only to issues (~12 months of inactivity)
+          # applies only to issues
           days-before-issue-stale: 365
           days-before-issue-close: 14

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -20,10 +20,16 @@ jobs:
           stale-pr-message: 'This PR was marked stale. It will be closed in 14 days without additional activity.'
           close-pr-message: 'Closed as inactive. Feel free to reopen if this PR is still being worked on.'
           exempt-pr-labels: 'release:after-ga'
-          stale-issue-message: 'This issue was marked stale due to lack of activity. It will be closed in 14 days without additional activity.'
-          close-issue-message: > 
-            Closed due to inactivity. We appreciate your input, and if this issue is still relevant,
-            please feel free to reopen it. Thank you for your contribution!
+          stale-issue-message: > 
+            This issue was marked stale due to lack of activity. It will be closed in 14 days without additional activity.
+            Please leave a comment if you would like to keep this issue open.
+          close-issue-message: |
+            Closed due to inactivity.
+
+            We appreciate your input, and if this issue is still relevant,
+            please reopen it, or comment "/reopen" and we'll reopen it for you.
+
+            Thank you for your contribution!
           # applies only to pull requests
           days-before-pr-stale: 14
           days-before-pr-close: 14


### PR DESCRIPTION
Related to #5207

As discussed on the Spec call, closing old issues with no activity can be the first step and we can implement additional improvements (AI-assisted triage, better communication as proposed in #5208) independently.

## Changes

- Stale issues after ~1 year of inactivity, Totally open to a different range
- Close after 14 days after issue is stalled
- automatically reopen issue if author, org member, or a collaborator posts "/reopen" comment on the issue. Open to relax to allow anyone to reopen

Once #5208 is finalized, we can add a link to new contrib.md section from the message in workflow