### PR TITLE
[chore] Update .NET compliance matrix entries

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -38,7 +38,7 @@ formats is required. Implementing more than one format is optional.
 | IsValid |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | IsRemote |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Conforms to the W3C TraceContext spec |  | + | + | + | + | + | + | + | + | + | + | + | + |
-| [Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness) |  | - | + |  |  |  |  |  |  |  |  |  | + |
+| [Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness) |  | - | + |  |  |  |  |  |  |  | - |  | + |
 | [Span](specification/trace/api.md#span) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | Create root span |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Create with default parent (active span) |  | N/A | + | + | + | + | + | + | + | + | + | + | + |
@@ -81,16 +81,16 @@ formats is required. Implementing more than one format is optional.
 | [Sampling](specification/trace/sdk.md#sampling) | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | Allow samplers to modify tracestate |  | + | + |  | + | + | + | + | + | + | + | + | + |
 | ShouldSample gets full parent Context |  | + | + | + | + | + | + | + | + | + | - | + | + |
-| Sampler: JaegerRemoteSampler |  | + | + | + |  |  |  | - | + |  |  |  | - |
+| Sampler: JaegerRemoteSampler |  | + | + | + |  |  |  | - | + |  | - |  | - |
 | [New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation) |  | + | + |  | + | + | + | + | + | + | - | + | + |
-| [IdGenerators](specification/trace/sdk.md#id-generators) |  | + | + | + | + | + | + | + | + | + |  | + | + |
-| [SpanLimits](specification/trace/sdk.md#span-limits) | X | + | + | + | + | + | + | + | + | - |  | + | + |
+| [IdGenerators](specification/trace/sdk.md#id-generators) |  | + | + | + | + | + | + | + | + | + | - | + | + |
+| [SpanLimits](specification/trace/sdk.md#span-limits) | X | + | + | + | + | + | + | + | + | - | - | + | + |
 | [Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1) |  | + | + | + | + | + | + | + | + | + | + |  | + |
-| [Attribute Limits](specification/common/README.md#attribute-limits) | X | + | + | + | + | + | + | + |  |  |  |  | + |
+| [Attribute Limits](specification/common/README.md#attribute-limits) | X | + | + | + | + | + | + | + |  |  | - |  | + |
 | Fetch InstrumentationScope from ReadableSpan |  | + | + | + | + |  |  | + |  |  | + |  | + |
-| [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X | - |  |  |  |  |  |  |  |  |  |  | - |
-| [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X | - | + |  |  |  |  |  |  |  |  |  | - |
-| [Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord) |  | - | + |  |  |  |  |  |  |  |  |  | + |
+| [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X | - |  |  |  |  |  |  |  |  | - |  | - |
+| [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X | - | + |  |  |  |  |  |  |  | - |  | - |
+| [Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord) |  | - | + |  |  |  |  |  |  |  | - |  | + |
 
 ## Baggage
 
@@ -107,7 +107,7 @@ formats is required. Implementing more than one format is optional.
 | It is possible to create any number of `MeterProvider`s. | X | + | + | + | + | + | + | + | + | + | + |  | - |
 | `MeterProvider` provides a way to get a `Meter`. |  | + | + | + | + | + | + | + | + | + | - |  | - |
 | `get_meter` accepts name, `version` and `schema_url`. |  | + | + | + | + |  | + | + | + | + | - |  | - |
-| `get_meter` accepts `attributes`. |  | + | - | - | + |  |  | + | + | + |  |  | - |
+| `get_meter` accepts `attributes`. |  | + | - | - | + |  |  | + | + | + | + |  | - |
 | When an invalid `name` is specified a working `Meter` implementation is returned as a fallback. |  | + | + | + | + | + | + |  | + | + | - |  | - |
 | The fallback `Meter` `name` property keeps its original invalid value. | X | + | - | + | + | + | + |  | + | - | - |  | - |
 | Associate `Meter` with `InstrumentationScope`. |  | + | + | + | + | + | + |  | + | + | + |  | - |
@@ -146,7 +146,7 @@ formats is required. Implementing more than one format is optional.
 | The `View` instrument selection criteria supports wildcards. | X | + | + | + | + | + | - |  | + | + | + |  | - |
 | The `View` instrument selection criteria supports the match-all wildcard. |  | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream. |  | + | + | + | + |  | + | + | + | + | - |  | - |
-| The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + | + | + |  |  | - |  |  |  |  |  | - |
+| The `View` allows configuring excluded attribute keys of resulting metric stream. |  | + | + | + |  |  | - |  |  |  | + |  | - |
 | The `View` allows configuring the exemplar reservoir of resulting metric stream. | X | + | - | - | - |  | - |  |  |  | - |  | - |
 | The SDK allows more than one `View` to be specified per instrument. | X | + | + | + | + | + | + |  | + | + | + |  | - |
 | The `Drop` aggregation is available. |  | + | + | + | + | + | + |  | + | + | + |  | - |
@@ -227,7 +227,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Retrieve attributes |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | [Default value](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#semantic-attributes-with-dedicated-environment-variable) for service.name |  | + | + |  | + | + | + | + |  | + | + |  | + |
 | [Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism |  | + | + | + | + | + | + | + | + | + | + | + | - |
-| [Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment) |  | + | + |  |  |  | - | + | + |  | - |  | - |
+| [Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment) |  | + | + |  |  |  | - | + | + |  | + |  | - |
 
 ## Context Propagation
 
@@ -288,7 +288,7 @@ Note: Support for environment variables is optional.
 | OTEL_METRICS_EXEMPLAR_FILTER | + | + |  |  | + |  | + |  | - | + |  | - |
 | OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | + | + | + | + | + |  | + |  | - | + |  | - |
 | OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION | + | + |  | + | + |  |  |  | - | + |  | - |
-| OTEL_CONFIG_FILE | + | + |  |  |  |  | + |  | + |  |  |  |
+| OTEL_CONFIG_FILE | + | + |  |  |  |  | + |  | + | - |  |  |
 
 ## Declarative configuration
 
@@ -298,19 +298,19 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 
 | Feature | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |
 | ------- | -- | ---- | -- | ------ | ---- | ------ | --- | ---- | --- | ---- | ----- | ------ |
-| `Parse` a configuration file | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Parse` operation accepts the configuration YAML file format | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Parse` operation performs environment variable substitution | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Parse` operation returns configuration model | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Parse` operation resolves plugin component configuration to `properties` |  | + |  |  |  |  | + |  | + |  |  | - |
-| `Create` SDK components | + | + |  |  |  |  | + |  | + |  |  | - |
-| The `Create` operation accepts configuration model | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Create` operation returns `TracerProvider` | + | + |  |  |  |  | + |  | + |  |  | - |
-| The `Create` operation returns `MeterProvider` | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Create` operation returns `LoggerProvider` | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Create` operation returns `Propagators` | + | + | + |  |  |  | + |  | + |  |  | - |
-| The `Create` operation calls `CreateComponent` of corresponding `PluginComponentProvider` when encountering plugin components |  | + |  |  |  |  | + |  | + |  |  | - |
-| Register a `PluginComponentProvider` |  | + |  |  |  |  | + |  | + |  |  | - |
+| `Parse` a configuration file | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Parse` operation accepts the configuration YAML file format | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Parse` operation performs environment variable substitution | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Parse` operation returns configuration model | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Parse` operation resolves plugin component configuration to `properties` |  | + |  |  |  |  | + |  | + | - |  | - |
+| `Create` SDK components | + | + |  |  |  |  | + |  | + | - |  | - |
+| The `Create` operation accepts configuration model | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Create` operation returns `TracerProvider` | + | + |  |  |  |  | + |  | + | - |  | - |
+| The `Create` operation returns `MeterProvider` | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Create` operation returns `LoggerProvider` | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Create` operation returns `Propagators` | + | + | + |  |  |  | + |  | + | - |  | - |
+| The `Create` operation calls `CreateComponent` of corresponding `PluginComponentProvider` when encountering plugin components |  | + |  |  |  |  | + |  | + | - |  | - |
+| Register a `PluginComponentProvider` |  | + |  |  |  |  | + |  | + | - |  | - |
 
 ## Exporters
 
@@ -330,8 +330,8 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - |  |
 | Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - |  |
 | Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - |  |
-| SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | - |  | + |
-| SchemaURL in ResourceMetrics and ScopeMetrics |  | + | + |  | + |  | - | + |  |  | - |  | + |
+| SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | + |  | + |
+| SchemaURL in ResourceMetrics and ScopeMetrics |  | + | + |  | + |  | - | + |  |  | + |  | + |
 | SchemaURL in ResourceLogs and ScopeLogs |  | + | + |  | + |  | - | + |  |  | - |  | + |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent) |  | + | + |  |  |  |  | + |  |  | + |  | + |
 | [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC | X | + | - |  |  |  |  | + |  |  |  |  | - |

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -54,7 +54,7 @@ sections:
           - name: Conforms to the W3C TraceContext spec
             status: '+'
           - name: '[Support W3C Trace Context Level 2 randomness](specification/trace/sdk.md#traceid-randomness)'
-            status: '?'
+            status: '-'
       - heading: '[Span](specification/trace/api.md#span)'
         features:
           - name: Create root span
@@ -140,25 +140,25 @@ sections:
           - name: ShouldSample gets full parent Context
             status: '-'
           - name: 'Sampler: JaegerRemoteSampler'
-            status: '?'
+            status: '-'
           - name: '[New Span ID created also for non-recording Spans](specification/trace/sdk.md#sdk-span-creation)'
             status: '-'
           - name: '[IdGenerators](specification/trace/sdk.md#id-generators)'
-            status: '?'
+            status: '-'
           - name: '[SpanLimits](specification/trace/sdk.md#span-limits)'
-            status: '?'
+            status: '-'
           - name: '[Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1)'
             status: '+'
           - name: '[Attribute Limits](specification/common/README.md#attribute-limits)'
-            status: '?'
+            status: '-'
           - name: Fetch InstrumentationScope from ReadableSpan
             status: '+'
           - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
-            status: '?'
+            status: '-'
           - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
-            status: '?'
+            status: '-'
           - name: '[Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord)'
-            status: '?'
+            status: '-'
   - name: Baggage
     features:
       - name: Basic support
@@ -176,7 +176,7 @@ sections:
       - name: '`get_meter` accepts name, `version` and `schema_url`.'
         status: '-'
       - name: '`get_meter` accepts `attributes`.'
-        status: '?'
+        status: '+'
       - name: When an invalid `name` is specified a working `Meter` implementation is returned as a fallback.
         status: '-'
       - name: The fallback `Meter` `name` property keeps its original invalid value.
@@ -260,7 +260,7 @@ sections:
       - name: The `View` allows configuring the name, description, attributes keys and aggregation of the resulting metric stream.
         status: '-'
       - name: The `View` allows configuring excluded attribute keys of resulting metric stream.
-        status: '?'
+        status: '+'
       - name: The `View` allows configuring the exemplar reservoir of resulting metric stream.
         status: '-'
       - name: The SDK allows more than one `View` to be specified per instrument.
@@ -408,7 +408,7 @@ sections:
       - name: '[Resource detector](specification/resource/sdk.md#detecting-resource-information-from-the-environment) interface/mechanism'
         status: '+'
       - name: '[Resource detectors populate Schema URL](specification/resource/sdk.md#detecting-resource-information-from-the-environment)'
-        status: '-'
+        status: '+'
   - name: Context Propagation
     features:
       - name: Create Context Key
@@ -510,35 +510,35 @@ sections:
       - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
         status: '+'
       - name: OTEL_CONFIG_FILE
-        status: '?'
+        status: '-'
   - name: Declarative configuration
     features:
       - name: '`Parse` a configuration file'
-        status: '?'
+        status: '-'
       - name: The `Parse` operation accepts the configuration YAML file format
-        status: '?'
+        status: '-'
       - name: The `Parse` operation performs environment variable substitution
-        status: '?'
+        status: '-'
       - name: The `Parse` operation returns configuration model
-        status: '?'
+        status: '-'
       - name: The `Parse` operation resolves plugin component configuration to `properties`
-        status: '?'
+        status: '-'
       - name: '`Create` SDK components'
-        status: '?'
+        status: '-'
       - name: The `Create` operation accepts configuration model
-        status: '?'
+        status: '-'
       - name: The `Create` operation returns `TracerProvider`
-        status: '?'
+        status: '-'
       - name: The `Create` operation returns `MeterProvider`
-        status: '?'
+        status: '-'
       - name: The `Create` operation returns `LoggerProvider`
-        status: '?'
+        status: '-'
       - name: The `Create` operation returns `Propagators`
-        status: '?'
+        status: '-'
       - name: The `Create` operation calls `CreateComponent` of corresponding `PluginComponentProvider` when encountering plugin components
-        status: '?'
+        status: '-'
       - name: Register a `PluginComponentProvider`
-        status: '?'
+        status: '-'
   - name: Exporters
     features:
       - name: '[Exporter interface](specification/trace/sdk.md#span-exporter)'
@@ -570,9 +570,9 @@ sections:
           - name: Multi-destination spec compliance
             status: '-'
           - name: SchemaURL in ResourceSpans and ScopeSpans
-            status: '-'
+            status: '+'
           - name: SchemaURL in ResourceMetrics and ScopeMetrics
-            status: '-'
+            status: '+'
           - name: SchemaURL in ResourceLogs and ScopeLogs
             status: '-'
           - name: Honors the [user agent spec](specification/protocol/exporter.md#user-agent)


### PR DESCRIPTION
## Changes

- Features implemented in [1.17.0](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/RELEASENOTES.md#1170) as `+`.
- Update unknown entries to `+` or `-` as appropriate.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] ~~Related issues~~
* [ ] ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps)~~
* [ ] ~~Links to the prototypes (when adding or changing features)~~
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] ~~[Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed~~
