### PR TITLE
Add max request / response size options to OTLP exporter.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ release.
 
 ### OpenTelemetry Protocol
 
+- Add max request / response size options to list of OTLP exporter configuration options.
+  ([#5235](https://github.com/open-telemetry/opentelemetry-specification/pull/5235))
+
 ### Compatibility
 
 ### SDK Configuration

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,6 +325,8 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | OTLP/HTTP binary Protobuf Exporter | * | + | + | + | + | + | + | + | + | + | + | - | + |
 | OTLP/HTTP JSON Protobuf Exporter |  | + | - | + | [-][py1003] |  | - | + |  | + | - | - | - |
 | OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | + | - | + |
+| Enforces request size limit |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| Enforces response size limit |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - |  |
 | Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - |  |
 | Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - |  |

--- a/spec-compliance-matrix/cpp.yaml
+++ b/spec-compliance-matrix/cpp.yaml
@@ -557,6 +557,10 @@ sections:
             status: '+'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '-'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -559,6 +559,10 @@ sections:
             status: '-'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/erlang.yaml
+++ b/spec-compliance-matrix/erlang.yaml
@@ -557,6 +557,10 @@ sections:
             status: '-'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '-'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -557,6 +557,10 @@ sections:
             status: '+'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '+'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/java.yaml
+++ b/spec-compliance-matrix/java.yaml
@@ -557,6 +557,10 @@ sections:
             status: '-'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '+'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -557,6 +557,10 @@ sections:
             status: '+'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '+'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -557,6 +557,10 @@ sections:
             status: '-'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '?'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/php.yaml
+++ b/spec-compliance-matrix/php.yaml
@@ -557,6 +557,10 @@ sections:
             status: '+'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/python.yaml
+++ b/spec-compliance-matrix/python.yaml
@@ -557,6 +557,10 @@ sections:
             status: '[-][py1003]'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '[-][py1108]'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/ruby.yaml
+++ b/spec-compliance-matrix/ruby.yaml
@@ -557,6 +557,10 @@ sections:
             status: '?'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '?'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/rust.yaml
+++ b/spec-compliance-matrix/rust.yaml
@@ -557,6 +557,10 @@ sections:
             status: '?'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '?'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '+'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/swift.yaml
+++ b/spec-compliance-matrix/swift.yaml
@@ -557,6 +557,10 @@ sections:
             status: '-'
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '-'
+          - name: Enforces request size limit
+            status:
+          - name: Enforces response size limit
+            status:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff

--- a/spec-compliance-matrix/template.yaml
+++ b/spec-compliance-matrix/template.yaml
@@ -358,6 +358,8 @@ sections:
           - name: OTLP/HTTP JSON Protobuf Exporter
           - name: OTLP/HTTP gzip Content-Encoding support
             optional: true
+          - name: Enforces request size limit
+          - name: Enforces response size limit
           - name: Concurrent sending
           - name: Honors retryable responses with backoff
             optional: true

--- a/specification/protocol/exporter.md
+++ b/specification/protocol/exporter.md
@@ -68,6 +68,14 @@ Each configuration option MUST be overridable by a signal specific option.
   - Env vars: `OTEL_EXPORTER_OTLP_TIMEOUT` `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` `OTEL_EXPORTER_OTLP_METRICS_TIMEOUT` `OTEL_EXPORTER_OTLP_LOGS_TIMEOUT`
   - Type: [Timeout][]
 
+- **Max Request Size**: Maximum size, in bytes, of a request message the exporter will send, as defined in the OTLP specification for [OTLP/gRPC][otlp-grpc-request] and [OTLP/HTTP][otlp-http-request].
+  - Default: 67108864 (64 MiB = 64*1024*1024)
+  - Type: [Integer][]
+
+- **Max Response Size**: Maximum size, in bytes, of a response message the exporter will accept, as defined in the OTLP specification for [OTLP/gRPC][otlp-grpc-response] and [OTLP/HTTP][otlp-http-response].
+  - Default: 4194304 (4 MiB = 4*1024*1024)
+  - Type: [Integer][]
+
 - **Protocol**: The transport protocol. Options MUST be one of: `grpc`, `http/protobuf`, `http/json`.
   See [Specify Protocol](./exporter.md#specify-protocol) for more details.
   - Default: `http/protobuf` [4]
@@ -220,6 +228,7 @@ MyDistribution/x.y.z OTel-OTLP-Exporter-Python/1.2.3
 [Timeout]: ../configuration/common.md#timeout
 [String]: ../configuration/common.md#string
 [Enum]: ../configuration/common.md#enum
+[Integer]: ../configuration/common.md#integer
 
 [resource-semconv]: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md#telemetry-sdk
 [otlphttp-req]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
@@ -227,6 +236,10 @@ MyDistribution/x.y.z OTel-OTLP-Exporter-Python/1.2.3
 [protocol-spec]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md
 [otlp-grpc]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc
 [otlp-http]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp
+[otlp-grpc-request]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc-request
+[otlp-grpc-response]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlpgrpc-response
+[otlp-http-request]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-request
+[otlp-http-response]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#otlphttp-response
 [retryable-grpc-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures
 [retryable-http-status-codes]: https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#failures-1
 [opentelemetry-distribution]: https://opentelemetry.io/docs/concepts/distributions/


### PR DESCRIPTION
Related to https://github.com/open-telemetry/opentelemetry-proto/pull/781, https://github.com/open-telemetry/opentelemetry-proto/pull/782.

As of opentelemetry-proto PRs linked above, OTLP clients now have normative requirements around enforcing request / response size limits. The OTLP spec states that implementations "SHOULD allow [these] limits[s] to be configured".

This PR extends the `opentelemetry-specification/specification/protocol/exporter.md` - the source of truth for SDK OTLP client implementation configuration options - to include these two new options.

This helps resolve [ambiguity in declarative configuration](https://github.com/open-telemetry/opentelemetry-configuration/pull/700#discussion_r3668265732) regarding whether `opentelemetry-specification/specification/protocol/exporter.md` or `opentelemetry-proto/docs/specification.md` is the source of truth for the which options the schema should include. 

cc @pellared, @marcalff 
