### PR TITLE
Mention intermediate OTEP 0232 maturity levels in signal lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ### Common
 
+- Mention the intermediate OTEP 0232 maturity levels in the signal lifecycle.
+  ([#5239](https://github.com/open-telemetry/opentelemetry-specification/pull/5239))
+
 ### OpenTelemetry Protocol
 
 ### Compatibility

--- a/specification/versioning-and-stability.md
+++ b/specification/versioning-and-stability.md
@@ -10,6 +10,7 @@
 - [Design goals](#design-goals)
 - [Signal lifecycle](#signal-lifecycle)
   * [Development](#development)
+  * [Other maturity levels](#other-maturity-levels)
   * [Stable](#stable)
     + [API Stability](#api-stability)
     + [SDK Stability](#sdk-stability)
@@ -91,6 +92,12 @@ Package **version numbers** MAY include a suffix, such as -alpha, -beta, -rc, or
 
 Note that "Development" status was previously called "Experimental" in this repository.
 Any uses of "Experimental" should be treated same as "Development".
+
+### Other maturity levels
+
+Between Development and Stable, a signal MAY transition through the
+intermediate maturity levels **Alpha**, **Beta**, and **Release Candidate**, as
+defined by [OTEP 0232](../oteps/0232-maturity-of-otel.md#explanation).
 
 ### Stable
 


### PR DESCRIPTION
- Part of #4076
- Names the OTEP 0232 intermediate maturity levels (Alpha, Beta, Release Candidate) in § Signal lifecycle, linking to their definitions rather than restating them, so docs pages have a spec link target for signals at those statuses (e.g. Rust's alpha/beta signals)
