### PR TITLE
Clarify that a disabled Tracer/Meter/Logger may still generate SDK internal telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,21 @@ release.
 
 ### Traces
 
+- Clarify that a disabled `Tracer` MAY still emit the SDK's own internal
+  telemetry, even though it behaves as a No-op `Tracer`.
+  ([#5253](https://github.com/open-telemetry/opentelemetry-specification/pull/5253))
+
 ### Metrics
 
+- Clarify that a disabled `Meter` MAY still emit the SDK's own internal
+  telemetry, even though it behaves as a No-op `Meter`.
+  ([#5253](https://github.com/open-telemetry/opentelemetry-specification/pull/5253))
+
 ### Logs
+
+- Clarify that a disabled `Logger` MAY still emit the SDK's own internal
+  telemetry, even though it behaves as a No-op `Logger`.
+  ([#5253](https://github.com/open-telemetry/opentelemetry-specification/pull/5253))
 
 ### Baggage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,19 +11,19 @@ release.
 
 ### Traces
 
-- Clarify that a disabled `Tracer` MAY still emit the SDK's own internal
+- Clarify that a disabled `Tracer` MAY still generate the SDK's own internal
   telemetry, even though it behaves as a No-op `Tracer`.
   ([#5253](https://github.com/open-telemetry/opentelemetry-specification/pull/5253))
 
 ### Metrics
 
-- Clarify that a disabled `Meter` MAY still emit the SDK's own internal
+- Clarify that a disabled `Meter` MAY still generate the SDK's own internal
   telemetry, even though it behaves as a No-op `Meter`.
   ([#5253](https://github.com/open-telemetry/opentelemetry-specification/pull/5253))
 
 ### Logs
 
-- Clarify that a disabled `Logger` MAY still emit the SDK's own internal
+- Clarify that a disabled `Logger` MAY still generate the SDK's own internal
   telemetry, even though it behaves as a No-op `Logger`.
   ([#5253](https://github.com/open-telemetry/opentelemetry-specification/pull/5253))
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -195,8 +195,9 @@ It consists of the following parameters:
   i.e. `Logger`s are enabled by default).
 
   If a `Logger` is disabled, it MUST behave equivalently
-  to [No-op Logger](./noop.md#logger). Even so, the SDK MAY still emit its own
-  internal telemetry related to the disabled `Logger`.
+  to [No-op Logger](./noop.md#logger). Even so, the SDK MAY still generate its
+  own internal telemetry (for example, SDK self-observability metrics) about the
+  disabled `Logger`.
 
 * `minimum_severity`: A [SeverityNumber](./data-model.md#field-severitynumber)
   indicating the minimum severity level for log records to be processed.

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -195,7 +195,8 @@ It consists of the following parameters:
   i.e. `Logger`s are enabled by default).
 
   If a `Logger` is disabled, it MUST behave equivalently
-  to [No-op Logger](./noop.md#logger).
+  to [No-op Logger](./noop.md#logger). Even so, the SDK MAY still emit its own
+  internal telemetry related to the disabled `Logger`.
 
 * `minimum_severity`: A [SeverityNumber](./data-model.md#field-severitynumber)
   indicating the minimum severity level for log records to be processed.

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -964,8 +964,8 @@ It consists of the following parameters:
 
   If a `Meter` is disabled, it MUST behave equivalently
   to [No-op Meter](./noop.md#meter).
-  Even so, the SDK MAY still emit its own internal telemetry related to the
-  disabled `Meter`.
+  Even so, the SDK MAY still generate its own internal telemetry (for example,
+  SDK self-observability metrics) about the disabled `Meter`.
 
   The value of `enabled` MUST be used to resolve whether an instrument
   is [Enabled](./api.md#enabled). See [Instrument Enabled](#instrument-enabled)

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -964,6 +964,8 @@ It consists of the following parameters:
 
   If a `Meter` is disabled, it MUST behave equivalently
   to [No-op Meter](./noop.md#meter).
+  Even so, the SDK MAY still emit its own internal telemetry related to the
+  disabled `Meter`.
 
   The value of `enabled` MUST be used to resolve whether an instrument
   is [Enabled](./api.md#enabled). See [Instrument Enabled](#instrument-enabled)

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -209,8 +209,8 @@ It consists of the following parameters:
 
   If a `Tracer` is disabled, it MUST behave equivalently
   to a [No-op Tracer](./api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk).
-  Even so, the SDK MAY still emit its own internal telemetry related to the
-  disabled `Tracer`.
+  Even so, the SDK MAY still generate its own internal telemetry (for example,
+  SDK self-observability metrics) about the disabled `Tracer`.
 
   The value of `enabled` MUST be used to resolve whether a `Tracer`
   is [Enabled](./api.md#enabled). If `enabled` is `false`, `Enabled`

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -209,6 +209,8 @@ It consists of the following parameters:
 
   If a `Tracer` is disabled, it MUST behave equivalently
   to a [No-op Tracer](./api.md#behavior-of-the-api-in-the-absence-of-an-installed-sdk).
+  Even so, the SDK MAY still emit its own internal telemetry related to the
+  disabled `Tracer`.
 
   The value of `enabled` MUST be used to resolve whether a `Tracer`
   is [Enabled](./api.md#enabled). If `enabled` is `false`, `Enabled`


### PR DESCRIPTION
## What

Clarifies that a disabled `Tracer`, `Meter`, or `Logger` — which MUST behave as the corresponding No-op — MAY still generate the SDK's own internal (self-observability) telemetry about that disabled signal.

## Why

The SDK self-observability metrics (e.g. `otel.sdk.log.created`, and the span/processor metrics) are intended to be a complete funnel: the top-of-funnel intake count must remain a true superset of everything downstream, so that any drop is visible as a gap. That requires the SDK to be able to record its own internal telemetry even when the application-facing signal is disabled — for example, counting a log record submitted to a disabled `Logger`, or a span created by a disabled `Tracer`.

Today the spec says a disabled `Tracer`/`Meter`/`Logger` MUST behave equivalently to a No-op. Read literally, "No-op" could be taken to forbid the SDK from generating *any* telemetry, including its own internal metrics, which would make these signals blind to records dropped at a disabled signal. This came up in open-telemetry/opentelemetry-java#8697 (discussion: https://github.com/open-telemetry/opentelemetry-java/pull/8697#discussion_r3725394724).

## What this changes

Adds one sentence to each of the Tracer / Meter / Logger config sections stating that, even when disabled, the SDK MAY still generate its own internal telemetry related to that disabled signal. This is a non-normative clarification (`MAY`); it does not require any SDK to generate such telemetry, and it does not change the No-op behavior observed by the application.

This unblocks defining the self-observability metrics (starting with `otel.sdk.log.created`) to count at intake, independent of a signal's enabled/disabled state.

## Note on cost

A disabled signal is expected to behave as a No-op, which callers reasonably assume is at (or very near) zero cost. If an SDK's internal telemetry generation on the disabled path is not effectively free, that cost surfaces on the No-op path and erodes that assumption. Implementations that choose to generate internal telemetry for a disabled signal should therefore keep its cost as close to zero as possible (for example, a cheap counter increment, and no work at all when self-observability is turned off). The `MAY` wording deliberately leaves room for an implementation to generate nothing on this path.
