### PR TITLE
Update kotlin spec compliance matrix

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -88,8 +88,8 @@ formats is required. Implementing more than one format is optional.
 | [Built-in `SpanProcessor`s implement `ForceFlush` spec](specification/trace/sdk.md#forceflush-1) |  | + | + | + | + | + | + | + | + | + | + |  | + |
 | [Attribute Limits](specification/common/README.md#attribute-limits) | X | + | + | + | + | + | + | + |  |  | - |  | + |
 | Fetch InstrumentationScope from ReadableSpan |  | + | + | + | + |  |  | + |  |  | + |  | + |
-| [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X | - |  |  |  |  |  |  |  |  | - |  | - |
-| [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X | - | + |  |  |  |  |  |  |  | - |  | - |
+| [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X | - |  |  |  |  |  |  |  |  | - |  | + |
+| [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X | - | + |  |  |  |  |  |  |  | - |  | + |
 | [Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord) |  | - | + |  |  |  |  |  |  |  | - |  | + |
 
 ## Baggage
@@ -206,7 +206,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Logger.Emit(LogRecord) with Exception parameter | X |  | + |  |  |  |  |  |  |  | - |  | + |
 | LogRecord.Set EventName |  | + | + |  |  | + |  |  | + | + |  |  | + |
 | Logger.Enabled | X | + | + |  |  |  |  | + | + | + | - |  | + |
-| Ergonomic API | X |  |  |  |  |  |  |  |  |  | + |  |  |
+| Ergonomic API | X |  |  |  |  |  |  |  |  |  | + |  | + |
 | SimpleLogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | BatchLogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
 | Can plug custom LogRecordProcessor |  | + | + | + | + | + |  | + | + | + | + |  | + |
@@ -242,7 +242,7 @@ Disclaimer: this list of features is still a work in progress, please refer to t
 | Composite Propagator |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Global Propagator |  | + | + | + | + | + | + | + | + | + | + | + | - |
 | TraceContext Propagator |  | + | + | + | + | + | + | + | + | + | + | + | + |
-| B3 Propagator |  | + | + | + | + | + | + | + | + | + | + | + | - |
+| B3 Propagator |  | + | + | + | + | + | + | + | + | + | + | + | + |
 | Jaeger Propagator | X | + | + | + | + | + | + | + | + | + | + | + | - |
 | OT Propagator | X | + | + | + | + |  |  |  |  |  | - |  | - |
 | OpenCensus Binary Propagator |  | + | - |  |  |  |  |  |  |  |  |  | - |
@@ -288,7 +288,7 @@ Note: Support for environment variables is optional.
 | OTEL_METRICS_EXEMPLAR_FILTER | + | + |  |  | + |  | + |  | - | + |  | - |
 | OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE | + | + | + | + | + |  | + |  | - | + |  | - |
 | OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION | + | + |  | + | + |  |  |  | - | + |  | - |
-| OTEL_CONFIG_FILE | + | + |  |  |  |  | + |  | + | - |  |  |
+| OTEL_CONFIG_FILE | + | + |  |  |  |  | + |  | + | - |  | - |
 
 ## Declarative configuration
 
@@ -327,11 +327,11 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | + | - | + |
 | Enforces request size limit |  |  |  |  |  |  |  |  |  |  |  |  |  |
 | Enforces response size limit |  |  |  |  |  |  |  |  |  |  |  |  |  |
-| Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - |  |
-| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - |  |
-| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - |  |
-| Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - |  |
-| Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - |  |
+| Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - | + |
+| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - | + |
+| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - | + |
+| Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - | + |
+| Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - | + |
 | SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | + |  | + |
 | SchemaURL in ResourceMetrics and ScopeMetrics |  | + | + |  | + |  | - | + |  |  | + |  | + |
 | SchemaURL in ResourceLogs and ScopeLogs |  | + | + |  | + |  | - | + |  |  | - |  | + |

--- a/spec-compliance-matrix/kotlin.yaml
+++ b/spec-compliance-matrix/kotlin.yaml
@@ -154,9 +154,9 @@ sections:
           - name: Fetch InstrumentationScope from ReadableSpan
             status: '+'
           - name: '[TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased)'
-            status: '-'
+            status: '+'
           - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
-            status: '-'
+            status: '+'
           - name: '[Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord)'
             status: '+'
   - name: Baggage
@@ -371,6 +371,8 @@ sections:
         status: '+'
       - name: Logger.Enabled
         status: '+'
+      - name: Ergonomic API
+        status: '+'
       - name: SimpleLogRecordProcessor
         status: '+'
       - name: BatchLogRecordProcessor
@@ -428,7 +430,7 @@ sections:
       - name: TraceContext Propagator
         status: '+'
       - name: B3 Propagator
-        status: '-'
+        status: '+'
       - name: Jaeger Propagator
         status: '-'
       - name: OT Propagator
@@ -507,7 +509,7 @@ sections:
         status: '-'
       - name: OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION
         status: '-'
-      - name: OTEL_EXPERIMENTAL_CONFIG_FILE
+      - name: OTEL_CONFIG_FILE
         status: '-'
   - name: Declarative configuration
     features:
@@ -562,15 +564,15 @@ sections:
           - name: Enforces response size limit
             status:
           - name: Concurrent sending
-            status: '?'
+            status: '+'
           - name: Honors retryable responses with backoff
-            status: '?'
+            status: '+'
           - name: Honors non-retryable responses
-            status: '?'
+            status: '+'
           - name: Honors throttling response
-            status: '?'
+            status: '+'
           - name: Multi-destination spec compliance
-            status: '?'
+            status: '+'
           - name: SchemaURL in ResourceSpans and ScopeSpans
             status: '+'
           - name: SchemaURL in ResourceMetrics and ScopeMetrics


### PR DESCRIPTION
## Changes

Updates the Kotlin SDK's spec compliance matrix entry for the [0.6.0 release](https://github.com/open-telemetry/opentelemetry-kotlin/releases/tag/v0.6.0).
