### PR TITLE
stale workflow: increase operations budget

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -34,6 +34,6 @@ jobs:
           # applies only to issues
           days-before-issue-stale: 365
           days-before-issue-close: 14
-          # process oldest-created first so close-eligible issues are 
-          # prioritized over newer issues
-          ascending: true
+          # TODO: remove or lower once we process through old issues backlog
+          # defaults to 30 new issues and PRs per run.
+          operations-per-run: 100

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -35,5 +35,5 @@ jobs:
           days-before-issue-stale: 365
           days-before-issue-close: 14
           # TODO: remove or lower once we process through old issues backlog
-          # defaults to 30 new issues and PRs per run.
+          # defaults to 30 operations per run, empirically ~12 issues or PRs.
           operations-per-run: 100

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -34,3 +34,6 @@ jobs:
           # applies only to issues
           days-before-issue-stale: 365
           days-before-issue-close: 14
+          # process oldest-created first so close-eligible issues are 
+          # prioritized over newer issues
+          ascending: true


### PR DESCRIPTION
Stale workflow does not close stale issues because it has a default limit of 30 operations per run to process. 

It's not a bad thing to slowly progresses through the repo instead of making a storm, but:

- operations != issues / prs. 30 operations resulted in 12 issues and prs processes yesterday
- workflow resumes from the last point it processed
- it does not revisit issues it processed until it reaches  the end
- at this speed and ~600 issues + prs it'll take us ~50 days to get to already stalled issues to start closing them

So let's give it a bigger operations budget and we can reduce it after it finishes the first pass of stalling and closing