### PR TITLE
docs: restore configuration SDK alias

### DIFF
--- a/specification/configuration/sdk.md
+++ b/specification/configuration/sdk.md
@@ -1,5 +1,7 @@
 <!--- Hugo front matter used to generate the website version of this page:
 linkTitle: SDK
+aliases:
+  - /docs/reference/specification/sdk-configuration
 weight: 3
 --->
 


### PR DESCRIPTION
Resolves #4232

## Description

Restore the Hugo alias for the renamed Configuration SDK specification page.
This keeps the existing `/docs/reference/specification/sdk-configuration`
path resolving to the new page instead of returning a 404.

## Testing

- `git diff --check`

