### PR TITLE
fix(spec/compat): optional Sum in OTel histogram to NHCB handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 - Update the OpenTelemetry Exponential Histogram to Prometheus Native Histogram
   with standard (exponential) schema transformation.
   ([#4922](https://github.com/open-telemetry/opentelemetry-specification/issues/4922))
+- Fix missing handling of optional Sum in the OpenTelemetry Histogram to Prometheus
+  Histogram transformation.
+  ([#5271](https://github.com/open-telemetry/opentelemetry-specification/pull/5271))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -573,7 +573,8 @@ When converting to a Prometheus NHCB, only a single NHCB metric MUST be created:
     `PositiveDeltas` MUST be left empty.
 - If the `NoRecordedValue` flag is set to `false`:
   - `Count` is converted to Native Histogram `Count`.
-  - `Sum` is converted to the Native Histogram `Sum`.
+  - `Sum`, if set, is converted to the Native Histogram `Sum`; otherwise, the
+    metric point MUST be dropped.
   - The dense `BucketCounts` are converted into the
     [sparse bucket layout](https://prometheus.io/docs/specs/native_histograms/#buckets)
     in `PositiveSpans` and `PositiveDeltas` (even for buckets with negative


### PR DESCRIPTION
Blocked on general discussion in #5273 first.

Revealed in
https://github.com/open-telemetry/opentelemetry-specification/pull/5125#discussion_r3747917344

Fixes N/A

## Changes

Specify that when converting an OpenTelemetry Histogram to a Prometheus Native Histogram with Custom Buckets (NHCB); if the `Sum` is not present, then drop the data point and do not convert it. The `Sum` is not optional in
native histograms and we should not make up a value instead of it.


For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [N/A] Related issues #
* [N/A] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
