### PR TITLE
feat(spec/compat): stabilize OTel exponential histogram to Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 - Update the OpenTelemetry Exponential Histogram to Prometheus Native Histogram
   with standard (exponential) schema transformation.
   ([#4922](https://github.com/open-telemetry/opentelemetry-specification/issues/4922))
+- Stabilize the OpenTelemetry Exponential Histogram to Prometheus Native Histogram
+  with standard (exponential) schema transformation.
+  ([#5272](https://github.com/open-telemetry/opentelemetry-specification/pull/5272))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -605,7 +605,7 @@ When converting to a Prometheus NHCB, only a single NHCB metric MUST be created:
 
 ### Exponential Histograms
 
-**Status**: [Development](../document-status.md)
+**Status**: [Stable](../document-status.md)
 
 An [OpenTelemetry Exponential Histogram](../metrics/data-model.md#exponentialhistogram)
 with a cumulative aggregation temporality MUST be converted to a Prometheus


### PR DESCRIPTION
Blocked on general discussion in #5273 first.

Follows #5121

Fixes #4922

## Changes

Stabilize the OpenTelemetry Exponential Histogram to Prometheus Native Histogram with standard (exponential) schema transformation.

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues #
* [N/A] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [N/A] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
