### PR TITLE
fix(spec/metrics): Histogram sum is optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Fix Histogram `sum` lacking optional marker.
+  ([5273](https://github.com/open-telemetry/opentelemetry-specification/pull/5273))
+
 ### Logs
 
 ### Baggage

--- a/specification/metrics/data-model.md
+++ b/specification/metrics/data-model.md
@@ -498,7 +498,7 @@ Histograms consist of the following:
     - The `start` timestamp best represents the first possible moment a
       measurement for this timeseries could have been recorded.
   - A count (`count`) of the total population of points in the histogram.
-  - A sum (`sum`) of all the values in the histogram.
+  - (optional) A sum (`sum`) of all the values in the histogram.
   - (optional) The min (`min`) of all values in the histogram.
   - (optional) The max (`max`) of all values in the histogram.
   - (optional) A series of buckets with:


### PR DESCRIPTION
The implemented data model has the sum as intentionally optional, see [histograms](https://github.com/open-telemetry/opentelemetry-proto/blob/4411380f9b4875100f3a07f746182c41fa1a8b5a/opentelemetry/proto/metrics/v1/metrics.proto#L462), [exponential histograms](https://github.com/open-telemetry/opentelemetry-proto/blob/4411380f9b4875100f3a07f746182c41fa1a8b5a/opentelemetry/proto/metrics/v1/metrics.proto#L547).

Bring the spec in line with reality.

Exporters already deal with it sometimes, it's not totally consistent.

The Prometheus remote write exporter [omits](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8d15f0637843c95ea7a25d6ae97ce0318b931403/pkg/translator/prometheusremotewrite/helper.go#L282) the `..._sum` series when `sum` is not present in the OTel histograms.

Other exporters and native histograms outputs set the output `sum` to 0 - effectively making up a value.
E.g. [exponential histogram](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8d15f0637843c95ea7a25d6ae97ce0318b931403/pkg/translator/prometheusremotewrite/histograms.go#L171) leaves the field at 0 if unset, doesn't reject the data point.

Noted in
https://github.com/open-telemetry/opentelemetry-specification/pull/5125#discussion_r3747917344

## Questions

- Do we fix the spec as proposed here or the coded model ?
- What is the strategy for exporters if `sum` is unset ?
  - Drop data point ? (current thinking in #5125, I support this)
  - Drop data point if export protocol requires it, otherwise omit ?
  - Export as 0 ?
  - Export as 0 if some config is set (enabled by default, to not be breaking) otherwise always drop ?

## Historical context

There was a lot of debate over the years about what to do with the `sum` when there are negative observations in a histogram (or summary), see https://github.com/prometheus/prometheus/issues/6669 , and OpenMetrics 1.0 said that if there are negative observations in a histogram, then the `sum` must not be present (https://github.com/prometheus/OpenMetrics/issues/193), which gave rise to optional sum. However no library actually implemented it and it's excluding legit use cases where there are negative observations. OpenMetrics 2.0 reverses curse to be more in line with implementations: https://github.com/prometheus/docs/pull/2627. 

In general it's unlikely that anyone actually generates histograms with `sum` absent, so it seems dropping such histograms is fine. If we want to be extra careful we could allow opt-in defaulting the `sum` to zero.

Fixes #

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [N/A] Related issues #
* [N/A] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [N/A] Links to the prototypes (when adding or changing features)
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
