### PR TITLE
fix(spec/compat): OTel histogram optional sum to Prometheus histogram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ release.
 - Update the OpenTelemetry Exponential Histogram to Prometheus Native Histogram
   with standard (exponential) schema transformation.
   ([#4922](https://github.com/open-telemetry/opentelemetry-specification/issues/4922))
+- Fix the OpenTelemetry Histogram to Prometheus Histogram transformation to include
+  the case of unset `Sum` field.
+  ([#5274](https://github.com/open-telemetry/opentelemetry-specification/pull/5274))
 
 ### SDK Configuration
 

--- a/specification/compatibility/prometheus_and_openmetrics.md
+++ b/specification/compatibility/prometheus_and_openmetrics.md
@@ -521,8 +521,10 @@ When converting to a Prometheus Histogram, an OpenTelemetry Histogram MUST
 be converted following the rules below:
 
 - `Count` is converted to the Histogram `Count`.
-- `Sum` is converted to the Histogram `Sum`. The sum is positive and monotonic
-  when all observations in the histogram are positive or zero.
+- `Sum`, if set, is converted to the Histogram `Sum`. The sum is positive and monotonic
+  when all observations in the histogram are positive or zero. When the `Sum` is
+  not set and the output protocol requires the existence of `Sum`, then the data
+  point MUST be dropped, otherwise the `Sum` MUST be omitted.
 - The bucket boundaries in `ExplicitBounds` plus the implicit `+Inf` boundary
   and the `BucketCounts` are converted to Histogram `Buckets` in ascending order
   of the `ExplicitBounds` value. For each bucket the explicit bound is


### PR DESCRIPTION
Blocked on general discussion in #5273 first.

Fix the OpenTelemetry Histogram to Prometheus Histogram transformation to include the case of unset `Sum` field.

The result depends on the output protocol. If the sum is required in the output, drop the data point instead of making up a value to fill it.

Consequence of #5273 , found in https://github.com/open-telemetry/opentelemetry-specification/pull/5125#discussion_r3747917344

Fixes #

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
