### PR TITLE
Relax LogRecordExporter lifecycle concurrency requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ release.
 
 - Relax `LogRecordExporter` lifecycle concurrency requirements to allow SDKs to
   synchronize exporter calls.
-  ([#5275](https://github.com/open-telemetry/opentelemetry-specification/issues/5275))
+  ([#5275](https://github.com/open-telemetry/opentelemetry-specification/pull/5275))
 
 ### Baggage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ release.
 
 ### Logs
 
+- Relax `LogRecordExporter` lifecycle concurrency requirements to allow SDKs to
+  serialize exporter calls.
+  ([#5248](https://github.com/open-telemetry/opentelemetry-specification/issues/5248))
+
 ### Baggage
 
 ### Profiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ release.
 ### Logs
 
 - Relax `LogRecordExporter` lifecycle concurrency requirements to allow SDKs to
-  serialize exporter calls.
-  ([#5248](https://github.com/open-telemetry/opentelemetry-specification/issues/5248))
+  synchronize exporter calls.
+  ([#5275](https://github.com/open-telemetry/opentelemetry-specification/issues/5275))
 
 ### Baggage
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -610,7 +610,7 @@ protocol-dependent telemetry exporters. The protocol exporter is expected to be
 primarily a simple telemetry data encoder and transmitter.
 
 Each implementation MUST document the concurrency characteristics the SDK
-requires of the exporter
+requires of the exporter.
 
 ### LogRecordExporter operations
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -609,8 +609,8 @@ The goal of the interface is to minimize burden of implementation for
 protocol-dependent telemetry exporters. The protocol exporter is expected to be
 primarily a simple telemetry data encoder and transmitter.
 
-Each implementation MUST document the concurrency characteristics the SDK
-requires of the exporter.
+Each SDK implementation MUST document the concurrency characteristics it
+requires of the exporter, including any operations it invokes concurrently.
 
 ### LogRecordExporter operations
 
@@ -709,8 +709,14 @@ to be called concurrently.
 
 **Logger** - all methods MUST be safe to be called concurrently.
 
-**LogRecordExporter** - `ForceFlush` and `Shutdown` MUST be safe to be called
-concurrently.
+**LogRecordExporter** - This specification does not require `ForceFlush` and
+`Shutdown` to be safe to call concurrently. SDK implementations MAY serialize
+calls to `Export`, `ForceFlush`, and `Shutdown` for each exporter instance.
+
+This serialization can be provided by the `LoggerProvider` together with its
+registered `LogRecordProcessor`s. For example, they can coordinate shutdown so
+that after `LoggerProvider.Shutdown` successfully completes, no registered
+processor or associated exporter is invoked again.
 
 ## Self-observability
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -709,14 +709,10 @@ to be called concurrently.
 
 **Logger** - all methods MUST be safe to be called concurrently.
 
-**LogRecordExporter** - This specification does not require `ForceFlush` and
-`Shutdown` to be safe to call concurrently. SDK implementations MAY serialize
-calls to `Export`, `ForceFlush`, and `Shutdown` for each exporter instance.
-
-This serialization can be provided by the `LoggerProvider` together with its
-registered `LogRecordProcessor`s. For example, they can coordinate shutdown so
-that after `LoggerProvider.Shutdown` successfully completes, no registered
-processor or associated exporter is invoked again.
+Note that the synchronization can be provided by the `LoggerProvider` together
+with its registered `LogRecordProcessor`s. For example, they can coordinate
+shutdown so that after `LoggerProvider.Shutdown` successfully completes, no
+registered processor or associated exporter is invoked again.
 
 ## Self-observability
 

--- a/specification/logs/sdk.md
+++ b/specification/logs/sdk.md
@@ -609,8 +609,8 @@ The goal of the interface is to minimize burden of implementation for
 protocol-dependent telemetry exporters. The protocol exporter is expected to be
 primarily a simple telemetry data encoder and transmitter.
 
-Each SDK implementation MUST document the concurrency characteristics it
-requires of the exporter, including any operations it invokes concurrently.
+Each implementation MUST document the concurrency characteristics the SDK
+requires of the exporter
 
 ### LogRecordExporter operations
 


### PR DESCRIPTION
Fixes #5248

Please also see https://github.com/open-telemetry/opentelemetry-specification/pull/5279 for an alternative approach.

## Changes

- Relax the universal Logs SDK requirement that every `LogRecordExporter` make `ForceFlush` and `Shutdown` safe for concurrent invocation.
- Explicitly allow an SDK to serialize `Export`, `ForceFlush`, and `Shutdown` for each exporter instance, with provider/processor shutdown coordination as an example.

## Rationale

`LoggerProvider` still has to make logger creation, `ForceFlush`, and `Shutdown` safe for concurrent callers. That public concurrency guarantee does not require the SDK to propagate concurrent invocations through every layer of the pipeline to the exporter. The provider and its processors can absorb that concurrency, sequence calls to an exporter instance, and reach quiescence before a successful shutdown completes.

Keeping the choice at the SDK layer better matches the stated goal of minimizing the implementation burden for protocol exporters. When an SDK serializes these calls, a custom exporter can remain primarily an encoder and transmitter instead of adding synchronization solely to defend against an invocation pattern that the SDK does not use.

This change only concerns concurrent method invocation. It does not change the semantic obligations of `Export`, `ForceFlush`, or `Shutdown`. In particular, an asynchronous exporter remains responsible for coordinating lifecycle operations with work it has already accepted.

## Backwards compatibility

This is a backwards-compatible relaxation of a Stable requirement:

- Every currently conforming SDK and exporter remains conforming.
- SDKs can retain their current calling conventions and continue requiring concurrency-safe exporters.
- SDKs that already serialize exporter calls, or choose to do so, can document a simpler contract for custom exporters without changing API signatures or the required lifecycle results.
- Existing Stable exporters do not have to change. This specification relaxation does not revoke concurrency guarantees already published by a language implementation; changing such a guarantee remains subject to that project's normal compatibility policy.

## Prototype

- https://github.com/open-telemetry/opentelemetry-go/pull/8766.

## Implementation evidence

The SDK-side coordination model is already practical in Go and Rust:

- Go's [`LoggerProvider.Shutdown`](https://github.com/open-telemetry/opentelemetry-go/blob/8ed7ef906a3cb81ebccf8c155c471100e897b478/sdk/log/provider.go#L158-L215) stops admitting processor operations and waits for admitted operations before shutting processors down.
- Go's [`BatchProcessor`](https://github.com/open-telemetry/opentelemetry-go/blob/8ed7ef906a3cb81ebccf8c155c471100e897b478/sdk/log/batch.go#L79-L185) routes exporter lifecycle calls through its exporter-owning worker.
- Rust's [`SdkLoggerProvider`](https://github.com/open-telemetry/opentelemetry-rust/blob/efc4ef4acd17919751674cf1ef9505e4f050de59/opentelemetry-sdk/src/logs/logger_provider.rs#L85-L157) coordinates provider shutdown with its registered processors.
- Rust's [`BatchLogProcessor` worker](https://github.com/open-telemetry/opentelemetry-rust/blob/efc4ef4acd17919751674cf1ef9505e4f050de59/opentelemetry-sdk/src/logs/batch_log_processor.rs#L530-L590) sequences export, flush, and shutdown messages on one worker.

## Checklist

- [x] Related issue #5248
- [x] Related OTEP: none
- [x] Links to implementation evidence are included above
- [x] `CHANGELOG.md` updated
- [x] Spec compliance matrix reviewed; it has no entry for this requirement
- [x] Declarative config data model not applicable; no configuration changed
