### PR TITLE
[chore] Update OTLP compliance for .NET

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -328,16 +328,16 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | Enforces request size limit |  |  |  |  |  |  |  |  |  |  | + |  |  |
 | Enforces response size limit |  |  |  |  |  |  |  |  |  |  | + |  |  |
 | Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - | + |
-| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - | + |
-| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - | + |
-| Honors throttling response | X | + | - | - | + | + | - |  |  | - | - | - | + |
+| Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | + | - | + |
+| Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | + | - | + |
+| Honors throttling response | X | + | - | - | + | + | - |  |  | - | + | - | + |
 | Multi-destination spec compliance | X | + | - |  | [-][py1109] |  | - |  |  | - | - | - | + |
 | SchemaURL in ResourceSpans and ScopeSpans |  | + | + |  | + |  | + | + |  |  | + |  | + |
 | SchemaURL in ResourceMetrics and ScopeMetrics |  | + | + |  | + |  | - | + |  |  | + |  | + |
 | SchemaURL in ResourceLogs and ScopeLogs |  | + | + |  | + |  | - | + |  |  | - |  | + |
 | Honors the [user agent spec](specification/protocol/exporter.md#user-agent) |  | + | + |  |  |  |  | + |  |  | + |  | + |
-| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC | X | + | - |  |  |  |  | + |  |  |  |  | - |
-| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X | + | - |  |  |  |  | + |  |  |  |  | + |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success) messages are handled and logged for OTLP/gRPC | X | + | - |  |  |  |  | + |  |  | - |  | - |
+| [Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1) messages are handled and logged for OTLP/HTTP | X | + | - |  |  |  |  | + |  |  | - |  | + |
 | Metric Exporter configurable temporality preference |  | + | + |  | + |  |  | + |  |  | + |  | - |
 | Metric Exporter configurable default aggregation |  | + | + |  | + |  |  |  |  |  | + |  | - |
 | **[Zipkin](specification/trace/sdk_exporters/zipkin.md)** | Optional | Go | Java | JS | Python | Ruby | Erlang | PHP | Rust | C++ | .NET | Swift | Kotlin |

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -325,8 +325,8 @@ Disclaimer: Declarative configuration is currently in Development status - work 
 | OTLP/HTTP binary Protobuf Exporter | * | + | + | + | + | + | + | + | + | + | + | - | + |
 | OTLP/HTTP JSON Protobuf Exporter |  | + | - | + | [-][py1003] |  | - | + |  | + | - | - | - |
 | OTLP/HTTP gzip Content-Encoding support | X | + | + | + | + | + | - | + |  | - | + | - | + |
-| Enforces request size limit |  |  |  |  |  |  |  |  |  |  |  |  |  |
-| Enforces response size limit |  |  |  |  |  |  |  |  |  |  |  |  |  |
+| Enforces request size limit |  |  |  |  |  |  |  |  |  |  | + |  |  |
+| Enforces response size limit |  |  |  |  |  |  |  |  |  |  | + |  |  |
 | Concurrent sending |  | + | + | + | [-][py1108] |  | - | - | + | - | - | - | + |
 | Honors retryable responses with backoff | X | + | + | + | + | + | - | + |  | - | - | - | + |
 | Honors non-retryable responses | X | + | + | - | + | + | - | + |  | - | - | - | + |

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -566,11 +566,11 @@ sections:
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff
-            status: '-'
+            status: '+'
           - name: Honors non-retryable responses
-            status: '-'
+            status: '+'
           - name: Honors throttling response
-            status: '-'
+            status: '+'
           - name: Multi-destination spec compliance
             status: '-'
           - name: SchemaURL in ResourceSpans and ScopeSpans
@@ -584,11 +584,11 @@ sections:
           - name:
               '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success)
               messages are handled and logged for OTLP/gRPC'
-            status: '?'
+            status: '-'
           - name:
               '[Partial Success](https://github.com/open-telemetry/opentelemetry-proto/blob/main/docs/specification.md#partial-success-1)
               messages are handled and logged for OTLP/HTTP'
-            status: '?'
+            status: '-'
           - name: Metric Exporter configurable temporality preference
             status: '+'
           - name: Metric Exporter configurable default aggregation

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -560,9 +560,9 @@ sections:
           - name: OTLP/HTTP gzip Content-Encoding support
             status: '+'
           - name: Enforces request size limit
-            status:
+            status: '+'
           - name: Enforces response size limit
-            status:
+            status: '+'
           - name: Concurrent sending
             status: '-'
           - name: Honors retryable responses with backoff


### PR DESCRIPTION
## Changes

Update entries for .NET's OTLP exporter to:

- Add request and response size limits
- Add honouring (non-)retryable requests and throttling
- Mark partial success as not implemented

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] ~~Related issues #~~
* [ ] ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps) #~~
* [ ] ~~Links to the prototypes (when adding or changing features)~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes~~
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] ~~[Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed~~
