### PR TITLE
Add ComposableAlwaysRecord sampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ release.
 
 ### Traces
 
+- Add `ComposableAlwaysRecord` sampler.
+  ([#5266](https://github.com/open-telemetry/opentelemetry-specification/issues/5266))
+
 ### Metrics
 
 ### Logs

--- a/specification/trace/sdk.md
+++ b/specification/trace/sdk.md
@@ -52,6 +52,7 @@ weight: 3
         * [ComposableParentThreshold](#composableparentthreshold)
         * [ComposableRuleBased](#composablerulebased)
         * [ComposableAnnotating](#composableannotating)
+        * [ComposableAlwaysRecord](#composablealwaysrecord)
   * [Sampling Requirements](#sampling-requirements)
     + [TraceID randomness](#traceid-randomness)
     + [Random trace flag](#random-trace-flag)
@@ -743,6 +744,37 @@ a `Composite(ComposableProbability(ratio))` configuration.
 
 * `attributes` - Attributes to add to sampled spans
 * `delegate` - The underlying sampler that makes the actual sampling decision
+
+###### ComposableAlwaysRecord
+
+`ComposableAlwaysRecord` is a sampler decorator that ensures every span is passed
+to the `SpanProcessor`, even those that would normally be dropped, at the
+composable layer. It mirrors the plain `AlwaysRecord` sampler but is usable
+inside a `CompositeSampler` where only `ComposableSampler` delegates are allowed.
+
+Based on the `SamplingIntent` from the wrapped delegate, `ComposableAlwaysRecord`
+MUST behave as follows:
+
+* If the delegate returns a `SamplingIntent` with no threshold (indicating `DROP`),
+  the wrapper MUST return a `SamplingIntent` that results in `RECORD_ONLY`.
+* Otherwise the wrapper MUST return the delegate's `SamplingIntent` unchanged.
+
+This ensures processors can observe all spans (for span-to-metrics pipelines)
+without requiring sampled export, while preserving the delegate's sampling
+threshold and `adjusted_count_reliable` semantics when a threshold is present.
+
+**Required parameters:**
+
+* `delegate` - The `ComposableSampler` being wrapped; it provides the original
+  sampling intent that `ComposableAlwaysRecord` modifies.
+* `delegate` MAY be any built-in or custom `ComposableSampler`.
+
+Note: When the delegate's intent indicates `DROP`, the resulting `RECORD_ONLY`
+intent MUST set `adjusted_count_reliable` to `false` and MUST NOT add attributes
+or modify the `TraceState` beyond ensuring the span is recorded. When the
+delegate indicates a sampling threshold, `ComposableAlwaysRecord` MUST NOT alter
+that threshold, `adjusted_count_reliable`, `attributes_provider`, or
+`trace_state_provider`.
 
 **Example configuration:**
 


### PR DESCRIPTION
Fixes #5266

## Problem

Composable samplers can only delegate to other composable samplers and cannot delegate to a plain `Sampler`. That is why `ComposableAlwaysOn` exists as the composable counterpart to plain `AlwaysOn`. The specification defines a plain `AlwaysRecord` decorator that ensures every span is recorded (converting `DROP` → `RECORD_ONLY`), but the corresponding composable `ComposableAlwaysRecord` type is missing. Without it, a `CompositeSampler` cannot achieve the `AlwaysRecord` guarantee because it only accepts `ComposableSampler` delegates.

Reproduction is structural: `specification/trace/sdk.md` lists `AlwaysRecord` under Built-in samplers and `ComposableAlwaysOn`/`ComposableAlwaysOff` under Built-in ComposableSamplers, but no `ComposableAlwaysRecord` exists. Issue #5266 reports the gap and notes it is needed for parity.

## Change

- Add `###### ComposableAlwaysRecord` under `Built-in ComposableSamplers` in `specification/trace/sdk.md`, mirroring the style of `ComposableAlwaysOn`/`ComposableAlwaysOff`/`ComposableAnnotating`.
- Update the SDK TOC to include `ComposableAlwaysRecord`.
- Define required behavior: wrap a delegate `ComposableSampler`; if delegate returns no threshold (`DROP`), return a `SamplingIntent` that results in `RECORD_ONLY`; otherwise return the delegate intent unchanged, preserving threshold, `adjusted_count_reliable`, `attributes_provider`, and `trace_state_provider`.
- Add constraints: `RECORD_ONLY` intent sets `adjusted_count_reliable=false` and adds no attributes; threshold-present path does not alter delegate state.
- Add Unreleased `CHANGELOG.md` entry under Traces.

Keep unrelated cleanup out of this PR.

## Why this approach

This follows the existing pattern where every useful plain sampler has a composable counterpart for use inside `CompositeSampler`. The delegate-wrapping shape matches `ComposableAnnotating`/`ComposableParentThreshold` (both wrap a delegate) and plain `AlwaysRecord` (both wrap a root). Alternative of not adding it would leave `CompositeSampler` unable to express always-record semantics needed for span-to-metrics pipelines.

## Testing

```text
command: git diff --check
result: clean

command: grep -n ComposableAlwaysRecord specification/trace/sdk.md
result: 55: * [ComposableAlwaysRecord](#composablealwaysrecord)
         748:###### ComposableAlwaysRecord

command: head -n 30 specification/trace/sdk.md (TOC renders)
result: TOC now includes ComposableAlwaysRecord alongside ComposableAnnotating
```

`make markdownlint` / `make cspell` require `npm ci` and Docker for link-check; local `git diff --check` passes and the markdown structure matches surrounding sections. Hosted CI will run the full `make check`.

## Documentation and release impact

- [x] User-facing documentation updated (`specification/trace/sdk.md`)
- [x] Changelog/release note needed (Unreleased Traces entry added)
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none beyond spec scope
- Follow-up issue, if any: none
- Security/licensing considerations: none, spec text only
