### PR TITLE
Add OTEL_EXPORTER_PROMETHEUS_DEFAULT_HISTOGRAM_AGGREGATION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ release.
 
 ### Metrics
 
+- Add `OTEL_EXPORTER_PROMETHEUS_DEFAULT_HISTOGRAM_AGGREGATION` environment variable for Prometheus exporter.
+  ([#4904](https://github.com/open-telemetry/opentelemetry-specification/issues/4904))
+
 ### Logs
 
 ### Baggage

--- a/specification/configuration/sdk-environment-variables.md
+++ b/specification/configuration/sdk-environment-variables.md
@@ -233,6 +233,7 @@ _is no specified default, or configuration via environment variables_.
 |-------------------------------|--------------------------------------|-------------|-------------|
 | OTEL_EXPORTER_PROMETHEUS_HOST | Host used by the Prometheus exporter | "localhost" | [String][]  |
 | OTEL_EXPORTER_PROMETHEUS_PORT | Port used by the Prometheus exporter | 9464        | [Integer][] |
+| OTEL_EXPORTER_PROMETHEUS_DEFAULT_HISTOGRAM_AGGREGATION | Configure the exporter's `default_aggregation` option (see above) for Histogram instrument kind. | `explicit_bucket_histogram` | [Enum][] |
 
 ## Exporter Selection
 

--- a/specification/metrics/sdk_exporters/prometheus.md
+++ b/specification/metrics/sdk_exporters/prometheus.md
@@ -127,6 +127,8 @@ the [MetricReader](../sdk.md#metricreader) default `aggregation` as a function
 of instrument kind. This option MAY be named `default_aggregation`, and MUST use
 the [default aggregation](../sdk.md#default-aggregation) by default.
 
+The Prometheus exporter MUST support configuration of the default aggregation for Histogram via the `OTEL_EXPORTER_PROMETHEUS_DEFAULT_HISTOGRAM_AGGREGATION` environment variable as described in the [environment variable specification](../../configuration/sdk-environment-variables.md#prometheus-exporter). The recognized (case-insensitive) values are `explicit_bucket_histogram` and `base2_exponential_bucket_histogram`.
+
 ### Resource Attributes as Metric Labels
 
 **Status**: [Development](../../document-status.md)


### PR DESCRIPTION
Fixes #4904

## Problem

Add a new environment variable and config for Prometheus exporter for default histogram aggregation. Similar with `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` the proposal is to add `OTEL_EXPORTER_PROMETHEUS_DEFAULT_HISTOGRAM_AGGREGATION`.

## Change

- Add `OTEL_EXPORTER_PROMETHEUS_DEFAULT_HISTOGRAM_AGGREGATION` to `specification/configuration/sdk-environment-variables.md` Prometheus Exporter table (`explicit_bucket_histogram` default, `Enum` type)
- Add env-var description to `specification/metrics/sdk_exporters/prometheus.md` Default Aggregation section (MUST support via env var, values `explicit_bucket_histogram` and `base2_exponential_bucket_histogram`, case-insensitive, ref to env var spec)
- Add Unreleased `CHANGELOG.md` entry under Metrics

Keep unrelated cleanup out of this PR.

## Why this approach

Mirrors `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION` for OTLP (same enum values, same default). The Prometheus exporter already has a `default_aggregation` config option; the env var is the standard SDK-env-var surface for it.

## Testing

```text
command: git diff --check
result: clean

command: grep -n "PROMETHEUS_DEFAULT_HISTOGRAM" specification/configuration/sdk-environment-variables.md specification/metrics/sdk_exporters/prometheus.md
result: 2 hits, table and docs section
```

## Documentation and release impact

- [x] User-facing documentation updated
- [x] Changelog/release note needed: metrics
- [ ] Migration or compatibility note needed
- [ ] No documentation impact

## Review notes

- Known limitations: none
- Follow-up issue, if any: none
- Security/licensing considerations: none
