### PR TITLE
chore: Fix markdown list formatting in metrics SDK spec

### DIFF
--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -869,9 +869,9 @@ intervals.
 For synchronous instruments, the start timestamp SHOULD be the time of the
 first measurement for the series.
 For asynchronous instrument, the start timestamp SHOULD be:
-  - The creation time of the instrument, if the first series measurement
+- The creation time of the instrument, if the first series measurement
     occurred in the first collection interval,
-  - Otherwise, the timestamp of the collection interval prior to the first
+- Otherwise, the timestamp of the collection interval prior to the first
     series measurement.
 
 ### Cardinality limits


### PR DESCRIPTION
Fix indentation of list items in async instrument timestamp section to use proper markdown list syntax.

Fixes #

## Changes

Please provide a brief description of the changes here.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
