### PR TITLE
Stabilize maxExportBatchSize for Periodic exporting MetricReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ release.
 
 ### Metrics
 
+- Mark `maxExportBatchSize` on Periodic exporting MetricReader as stable.
+  ([#5184](https://github.com/open-telemetry/opentelemetry-specification/issues/5184))
 - Clarify `maxExportBatchSize` behavior, timeouts, and error handling for
   Periodic exporting MetricReader.
   ([#5265](https://github.com/open-telemetry/opentelemetry-specification/pull/5265))

--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -189,7 +189,7 @@ formats is required. Implementing more than one format is optional.
 | Metric SDK supports configuring cardinality limit at MeterReader level |  | - | + | + | - |  | - |  | - | - | - |  | - |
 | Metric SDK supports configuring cardinality limit per metric (using Views) |  | - | + | + | - |  | - |  | - | - | + |  | - |
 | Metric SDK supports per-timeseries cumulative start timestamps |  |  | + |  |  |  |  |  |  |  |  |  | - |
-| The metric SDK's periodic Reader implementation supports the `maxExportBatchSize` parameter |  | - | + | - | - | - | - | - | - | - | - | - | - |
+| The metric SDK's periodic Reader implementation supports the `maxExportBatchSize` parameter |  | + | + | + | - | - | - | - | - | - | - | - | - |
 
 ## Logs
 

--- a/spec-compliance-matrix/go.yaml
+++ b/spec-compliance-matrix/go.yaml
@@ -352,7 +352,7 @@ sections:
       - name: Metric SDK supports per-timeseries cumulative start timestamps
         status: '?'
       - name: The metric SDK's periodic Reader implementation supports the `maxExportBatchSize` parameter
-        status: '-'
+        status: '+'
   - name: Logs
     features:
       - name: LoggerProvider.Get Logger

--- a/spec-compliance-matrix/js.yaml
+++ b/spec-compliance-matrix/js.yaml
@@ -352,7 +352,7 @@ sections:
       - name: Metric SDK supports per-timeseries cumulative start timestamps
         status: '?'
       - name: The metric SDK's periodic Reader implementation supports the `maxExportBatchSize` parameter
-        status: '-'
+        status: '+'
   - name: Logs
     features:
       - name: LoggerProvider.Get Logger

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1553,7 +1553,8 @@ Configurable parameters:
   batches, `exportTimeoutMillis` applies to each individual `Export(batch)`
   invocation.
 * `maxExportBatchSize` - the maximum number of metric data points in a batch
-  that are provided to a single export.
+  that are provided to a single export. The default is that the batch size is not
+  limited.
 
 When `maxExportBatchSize` is configured, the reader MUST ensure no batch
 provided to `Export` exceeds the `maxExportBatchSize` by splitting the batch of

--- a/specification/metrics/sdk.md
+++ b/specification/metrics/sdk.md
@@ -1552,20 +1552,18 @@ Configurable parameters:
   configured and results in splitting the collected metric data into multiple
   batches, `exportTimeoutMillis` applies to each individual `Export(batch)`
   invocation.
-* **Status**: [Development](../document-status.md) - `maxExportBatchSize` - the
-  maximum number of metric data points in a batch that are provided to a single
-  export.
+* `maxExportBatchSize` - the maximum number of metric data points in a batch
+  that are provided to a single export.
 
-**Status**: [Development](../document-status.md) - When `maxExportBatchSize` is
-configured, the reader MUST ensure no batch provided to `Export` exceeds the
-`maxExportBatchSize` by splitting the batch of metric data points into smaller
-batches. The initial batch of metric data MUST be split into as many "full"
-batches of size `maxExportBatchSize` as possible -- even if this splits up data
-points that belong to the same metric into different batches. The reader MUST
-ensure all batches produced from a single `Collect()` are provided to `Export`
-serially and in-order before metric data points from a subsequent `Collect()`
-are provided. The reader MUST NOT combine metrics from different `Collect()`
-calls into the same batch provided to `Export`.
+When `maxExportBatchSize` is configured, the reader MUST ensure no batch
+provided to `Export` exceeds the `maxExportBatchSize` by splitting the batch of
+metric data points into smaller batches. The initial batch of metric data MUST
+be split into as many "full" batches of size `maxExportBatchSize` as possible --
+even if this splits up data points that belong to the same metric into different
+batches. The reader MUST ensure all batches produced from a single `Collect()`
+are provided to `Export` serially and in-order before metric data points from a
+subsequent `Collect()` are provided. The reader MUST NOT combine metrics from
+different `Collect()` calls into the same batch provided to `Export`.
 
 The reader MUST synchronize calls to `MetricExporter`'s `Export`
 to make sure that they are not invoked concurrently. If an export is still in


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-specification/issues/5184

## Changes

Marks the `maxExportBatchSize` parameter and its associated splitting / serial export requirements on `Periodic exporting MetricReader` as stable.

All three prototype implementations have been merged:
* Go: https://github.com/open-telemetry/opentelemetry-go/pull/8071
* Java: https://github.com/open-telemetry/opentelemetry-java/pull/8296
* JS: https://github.com/open-telemetry/opentelemetry-js/pull/6655

The declarative configuration change has been merged:
* https://github.com/open-telemetry/opentelemetry-configuration/pull/610

Also updates the spec compliance matrix for Go and JS (`+`).

---

* [x] Related issues: #5184
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [x] Links to the prototypes:
  * Go: https://github.com/open-telemetry/opentelemetry-go/pull/8071
  * Java: https://github.com/open-telemetry/opentelemetry-java/pull/8296
  * JS: https://github.com/open-telemetry/opentelemetry-js/pull/6655
* [x] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed