### PR TITLE
[chore][spec/profiles] list known values for sample_type

### DIFF
--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -102,7 +102,7 @@ CPU profiles measure CPU time consumed by the application. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| `cpu` | nanoseconds | CPU time samples |
+| `cpu` | `nanoseconds` | CPU time samples |
 
 ### Wall-clock profiles
 
@@ -110,7 +110,7 @@ Wall-clock (wall time) profiles measure elapsed time. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| `wall` | nanoseconds | Wall clock time in nanoseconds |
+| `wall` | `nanoseconds` | Wall clock time in nanoseconds |
 
 ### Off-CPU profiles
 
@@ -118,7 +118,7 @@ Off-CPU profiles measure time spent not running on the CPU (e.g., waiting for I/
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| `off_cpu` | nanoseconds | Off-CPU time |
+| `off_cpu` | `nanoseconds` | Off-CPU time |
 
 ### Memory profiles
 
@@ -126,10 +126,10 @@ Memory profiles measure memory allocation and usage. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| `inuse_space` | bytes | In-use memory at the time of profile collection |
-| `inuse_objects` | count | Number of in-use allocations |
-| `alloc_space` | bytes | Total allocated memory (including freed) |
-| `alloc_objects` | count | Total number of allocations (including freed) |
+| `inuse_space` | `bytes` | In-use memory at the time of profile collection |
+| `inuse_objects` | `count` | Number of in-use allocations |
+| `alloc_space` | `bytes` | Total allocated memory (including freed) |
+| `alloc_objects` | `count` | Total number of allocations (including freed) |
 
 ### Block contention profiles
 
@@ -137,7 +137,7 @@ Block (contention) profiles measure time spent blocked on synchronization primit
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| `block` | nanoseconds | Block wait time |
+| `block` | `nanoseconds` | Block wait time |
 
 ### Mutex profiles
 
@@ -145,7 +145,7 @@ Mutex profiles measure lock contention and time spent waiting on mutexes. Common
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| `mutex` | nanoseconds | Time spent in mutex contention |
+| `mutex` | `nanoseconds` | Time spent in mutex contention |
 
 ## Specifications
 

--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -94,7 +94,7 @@ tools, known values are utilized.
 | Profile field | Known values |
 | ------------- | ------------ |
 | Profile.original_payload_format | [pprof](https://github.com/google/pprof/tree/main/proto), [jfr](https://en.wikipedia.org/wiki/JDK_Flight_Recorder) or [linux_perf](https://perfwiki.github.io/) |
-| Profile.sample_type | [cpu](#cpu-profiles), [wall](#wall-clock-profiles), [off_cpu](#off-cpu-profiles), [memory](#memory-profiles), [block](#block-contention-profiles), [mutex](#mutex-profiles) |
+| Profile.sample_type | See [CPU](#cpu-profiles), [Wall-clock](#wall-clock-profiles), [Off-CPU](#off-cpu-profiles), [Memory](#memory-profiles), [Block contention](#block-contention-profiles), and [Mutex](#mutex-profiles) sections for known (type, unit) pairs. |
 
 ### CPU profiles
 

--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -102,7 +102,7 @@ CPU profiles measure CPU time consumed by the application. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| cpu | nanoseconds | CPU time samples |
+| `cpu` | nanoseconds | CPU time samples |
 
 ### Wall-clock profiles
 
@@ -110,7 +110,7 @@ Wall-clock (wall time) profiles measure elapsed time. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| wall | nanoseconds | Wall clock time in nanoseconds |
+| `wall` | nanoseconds | Wall clock time in nanoseconds |
 
 ### Off-CPU profiles
 
@@ -118,7 +118,7 @@ Off-CPU profiles measure time spent not running on the CPU (e.g., waiting for I/
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| off_cpu | nanoseconds | Off-CPU time |
+| `off_cpu` | nanoseconds | Off-CPU time |
 
 ### Memory profiles
 
@@ -126,10 +126,10 @@ Memory profiles measure memory allocation and usage. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| inuse_space | bytes | In-use memory at the time of profile collection |
-| inuse_objects | count | Number of in-use allocations |
-| alloc_space | bytes | Total allocated memory (including freed) |
-| alloc_objects | count | Total number of allocations (including freed) |
+| `inuse_space` | bytes | In-use memory at the time of profile collection |
+| `inuse_objects` | count | Number of in-use allocations |
+| `alloc_space` | bytes | Total allocated memory (including freed) |
+| `alloc_objects` | count | Total number of allocations (including freed) |
 
 ### Block contention profiles
 
@@ -137,7 +137,7 @@ Block (contention) profiles measure time spent blocked on synchronization primit
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| block | nanoseconds | Block wait time |
+| `block` | nanoseconds | Block wait time |
 
 ### Mutex profiles
 
@@ -145,7 +145,7 @@ Mutex profiles measure lock contention and time spent waiting on mutexes. Common
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
-| mutex | nanoseconds | Time spent in mutex contention |
+| `mutex` | nanoseconds | Time spent in mutex contention |
 
 ## Specifications
 

--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -17,6 +17,12 @@ path_base_for_github_subdir:
 - [Design goals](#design-goals)
 - [Data Format](#data-format)
 - [Known values](#known-values)
+  * [CPU profiles](#cpu-profiles)
+  * [Wall-clock profiles](#wall-clock-profiles)
+  * [Off-CPU profiles](#off-cpu-profiles)
+  * [Heap profiles](#heap-profiles)
+  * [Block contention profiles](#block-contention-profiles)
+  * [Mutex profiles](#mutex-profiles)
 - [Specifications](#specifications)
 - [References](#references)
 
@@ -87,7 +93,62 @@ tools, known values are utilized.
 
 | Profile field | Known values |
 | ------------- | ------------ |
-| original_payload_format | [pprof](https://github.com/google/pprof/tree/main/proto), [jfr](https://en.wikipedia.org/wiki/JDK_Flight_Recorder) or [linux_perf](https://perfwiki.github.io/) |
+| Profile.original_payload_format | [pprof](https://github.com/google/pprof/tree/main/proto), [jfr](https://en.wikipedia.org/wiki/JDK_Flight_Recorder) or [linux_perf](https://perfwiki.github.io/) |
+| Profile.sample_type | [cpu](#cpu-profiles), [wall](#wall-clock-profiles), [off_cpu](#off-cpu-profiles), [heap](#heap-profiles), [block](#block-contention-profiles), [mutex](#mutex-profiles) |
+
+### CPU profiles
+
+CPU profiles measure CPU time consumed by the application. Common values:
+
+| Type | Unit | Description |
+| ---- | ---- | ----------- |
+| cpu | nanoseconds | CPU time samples |
+
+### Wall-clock profiles
+
+Wall-clock (wall time) profiles measure elapsed time. Common values:
+
+| Type | Unit | Description |
+| ---- | ---- | ----------- |
+| wall | nanoseconds | Wall clock time in nanoseconds |
+
+### Off-CPU profiles
+
+Off-CPU profiles measure time spent not running on the CPU (e.g., waiting for I/O or locks). Common values:
+
+| Type | Unit | Description |
+| ---- | ---- | ----------- |
+| off_cpu | nanoseconds | Off-CPU time |
+
+### Heap profiles
+
+Heap profiles measure memory allocation and usage. Common values:
+
+| Type | Unit | Description |
+| ---- | ---- | ----------- |
+| inuse_space | bytes | In-use memory at the time of profile collection |
+| inuse_objects | count | Number of in-use allocations |
+| alloc_space | bytes | Total allocated memory (including freed) |
+| alloc_objects | count | Total number of allocations (including freed) |
+| allocated_space | bytes | Allocated memory |
+| allocated_objects | count | Number of allocated objects |
+| space | bytes | Generic memory measurement |
+
+### Block contention profiles
+
+Block (contention) profiles measure time spent blocked on synchronization primitives. Common values:
+
+| Type | Unit | Description |
+| ---- | ---- | ----------- |
+| block | nanoseconds | Block wait time |
+
+### Mutex profiles
+
+Mutex profiles measure lock contention and time spent waiting on mutexes. Common values:
+
+| Type | Unit | Description |
+| ---- | ---- | ----------- |
+| mutex | nanoseconds | Time spent in mutex contention |
 
 ## Specifications
 

--- a/specification/profiles/README.md
+++ b/specification/profiles/README.md
@@ -20,7 +20,7 @@ path_base_for_github_subdir:
   * [CPU profiles](#cpu-profiles)
   * [Wall-clock profiles](#wall-clock-profiles)
   * [Off-CPU profiles](#off-cpu-profiles)
-  * [Heap profiles](#heap-profiles)
+  * [Memory profiles](#memory-profiles)
   * [Block contention profiles](#block-contention-profiles)
   * [Mutex profiles](#mutex-profiles)
 - [Specifications](#specifications)
@@ -94,7 +94,7 @@ tools, known values are utilized.
 | Profile field | Known values |
 | ------------- | ------------ |
 | Profile.original_payload_format | [pprof](https://github.com/google/pprof/tree/main/proto), [jfr](https://en.wikipedia.org/wiki/JDK_Flight_Recorder) or [linux_perf](https://perfwiki.github.io/) |
-| Profile.sample_type | [cpu](#cpu-profiles), [wall](#wall-clock-profiles), [off_cpu](#off-cpu-profiles), [heap](#heap-profiles), [block](#block-contention-profiles), [mutex](#mutex-profiles) |
+| Profile.sample_type | [cpu](#cpu-profiles), [wall](#wall-clock-profiles), [off_cpu](#off-cpu-profiles), [memory](#memory-profiles), [block](#block-contention-profiles), [mutex](#mutex-profiles) |
 
 ### CPU profiles
 
@@ -120,9 +120,9 @@ Off-CPU profiles measure time spent not running on the CPU (e.g., waiting for I/
 | ---- | ---- | ----------- |
 | off_cpu | nanoseconds | Off-CPU time |
 
-### Heap profiles
+### Memory profiles
 
-Heap profiles measure memory allocation and usage. Common values:
+Memory profiles measure memory allocation and usage. Common values:
 
 | Type | Unit | Description |
 | ---- | ---- | ----------- |
@@ -130,9 +130,6 @@ Heap profiles measure memory allocation and usage. Common values:
 | inuse_objects | count | Number of in-use allocations |
 | alloc_space | bytes | Total allocated memory (including freed) |
 | alloc_objects | count | Total number of allocations (including freed) |
-| allocated_space | bytes | Allocated memory |
-| allocated_objects | count | Number of allocated objects |
-| space | bytes | Generic memory measurement |
 
 ### Block contention profiles
 


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-proto/issues/794

@open-telemetry/profiling-approvers 

## Changes

Provide a list of known values for `Profile.sample_type`.

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [x] Related issues https://github.com/open-telemetry/opentelemetry-proto/issues/794 
* [ ] ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps)~~
* [ ] ~~Links to the prototypes (when adding or changing features)~~
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * [x] For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] ~~[Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary~~
* [ ] ~~[Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed~~
