### PR TITLE
Profiles: Link to current data format in the old OTEP [chore]

### DIFF
--- a/oteps/profiles/0239-profiles-data-model.md
+++ b/oteps/profiles/0239-profiles-data-model.md
@@ -1,6 +1,7 @@
 # Profiles Data Format
 
-> **Note:** This OTEP is obsolete and is kept here as part of the
+> [!WARNING]
+> This OTEP is obsolete and is kept here as part of the
 > historical record. The current specification of the profiles data
 > format is in [Profiles Data Format](../../specification/profiles/data-format.md).
 

--- a/oteps/profiles/0239-profiles-data-model.md
+++ b/oteps/profiles/0239-profiles-data-model.md
@@ -1,5 +1,9 @@
 # Profiles Data Format
 
+> **Note:** This OTEP is obsolete and is kept here as part of the
+> historical record. The current specification of the profiles data
+> format is in [Profiles Data Format](../../specification/profiles/data-format.md).
+
 Introduces Data Model for Profiles signal to OpenTelemetry.
 
 <!-- START doctoc -->


### PR DESCRIPTION
## Changes

Adds a note at the beginning of the old [profiles data model OTEP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/oteps/profiles/0239-profiles-data-model.md), mentioning to the reader that it's obsolete and kept as part of the historical record whilst also linking to the [current data format](https://opentelemetry.io/docs/specs/otel/profiles/data-format/).

As discussed in the Profiling SIG.

CC: @open-telemetry/profiling-maintainers 