### PR TITLE
Define configurable SDK component names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,8 @@ release.
 
 ### Common
 
-- Allow applications to configure names for SDK components that emit
-  self-observability telemetry.
-  ([#5298](https://github.com/open-telemetry/opentelemetry-specification/issues/5298))
+- Define optional application-provided names for SDK components.
+  ([#5300](https://github.com/open-telemetry/opentelemetry-specification/pull/5300))
 
 ### OpenTelemetry Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ release.
 
 ### Common
 
+- Allow applications to configure names for SDK components that emit
+  self-observability telemetry.
+  ([#5298](https://github.com/open-telemetry/opentelemetry-specification/issues/5298))
+
 ### OpenTelemetry Protocol
 
 ### Compatibility

--- a/specification/configuration/README.md
+++ b/specification/configuration/README.md
@@ -12,8 +12,8 @@ does not attempt to specify the details of what can be configured.
 
 ## SDK component names
 
-SDK components MAY allow users to configure an optional name that uniquely
-identifies the component within its containing SDK instance.
+SDK components MAY allow users to configure an optional name. When configured,
+the name MUST uniquely identify the component within its containing SDK instance.
 
 Component names may be used by configuration and management mechanisms to refer
 to individual component instances. Their use in self-observability telemetry is

--- a/specification/configuration/README.md
+++ b/specification/configuration/README.md
@@ -10,6 +10,16 @@ OpenTelemetry SDK components are highly configurable. This specification
 outlines the mechanisms by which OpenTelemetry components can be configured. It
 does not attempt to specify the details of what can be configured.
 
+## SDK component names
+
+SDK components MAY allow users to configure an optional name that uniquely
+identifies the component within its containing SDK instance.
+
+Component names may be used by configuration and management mechanisms to refer
+to individual component instances. Their use in self-observability telemetry is
+defined by the [SDK component name
+requirements](../self-observability.md#sdk-component-names).
+
 ## Configuration Interfaces
 
 ### Programmatic

--- a/specification/self-observability.md
+++ b/specification/self-observability.md
@@ -11,6 +11,20 @@ This is closely related to the
 [self-diagnostics](error-handling.md#self-diagnostics) guidance in the error
 handling document.
 
+## SDK component names
+
+SDK components that emit self-observability telemetry identified by
+[`otel.component.name`][otel-component-name] SHOULD allow users to configure an
+optional name.
+
+When a name is configured, the component MUST use it as `otel.component.name`
+for its self-observability telemetry. When no name is configured, the component
+MUST assign a name according to the semantic conventions.
+The resulting name MUST satisfy the uniqueness and cardinality requirements of
+`otel.component.name`.
+
+[otel-component-name]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-component-name
+
 ## SDK Self-Observability Metrics
 
 The names, attributes, and values used for SDK self-observability metrics are

--- a/specification/self-observability.md
+++ b/specification/self-observability.md
@@ -15,7 +15,7 @@ handling document.
 
 SDK components that emit self-observability telemetry identified by
 [`otel.component.name`][otel-component-name] SHOULD allow users to configure an
-optional name.
+optional [component name][component-names].
 
 When an application-provided name is configured, the component MUST use it as
 `otel.component.name` for its self-observability telemetry. Otherwise, the
@@ -23,6 +23,7 @@ component MUST automatically assign a name. In either case, the resulting name
 MUST satisfy the requirements of the `otel.component.name` semantic convention.
 
 [otel-component-name]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-component-name
+[component-names]: configuration/README.md#sdk-component-names
 
 ## SDK Self-Observability Metrics
 

--- a/specification/self-observability.md
+++ b/specification/self-observability.md
@@ -17,11 +17,10 @@ SDK components that emit self-observability telemetry identified by
 [`otel.component.name`][otel-component-name] SHOULD allow users to configure an
 optional name.
 
-When a name is configured, the component MUST use it as `otel.component.name`
-for its self-observability telemetry. When no name is configured, the component
-MUST assign a name according to the semantic conventions.
-The resulting name MUST satisfy the uniqueness and cardinality requirements of
-`otel.component.name`.
+When an application-provided name is configured, the component MUST use it as
+`otel.component.name` for its self-observability telemetry. Otherwise, the
+component MUST automatically assign a name. In either case, the resulting name
+MUST satisfy the requirements of the `otel.component.name` semantic convention.
 
 [otel-component-name]: https://opentelemetry.io/docs/specs/semconv/registry/attributes/otel/#otel-component-name
 


### PR DESCRIPTION
Fixes #5298

## Changes

Define optional names that uniquely identify SDK components within their containing SDK instance.

Component names may be used by configuration and management mechanisms. When a named component emits self-observability telemetry, it uses the application-provided value as `otel.component.name`. If no name is configured, it automatically assigns a name satisfying the `otel.component.name` semantic convention.

This preserves automatic naming for applications that do not configure a name while allowing future mechanisms to refer to individual component instances.

## Related changes

Together, these changes define configurable SDK component names, their fallback naming convention, and declarative configuration support.

- open-telemetry/semantic-conventions#4082
- open-telemetry/opentelemetry-configuration#737

- [x] Related issue #5298
- [x] Related OTEPs: not applicable
- [x] Links to prototypes: open-telemetry/opentelemetry-configuration#737
- [x] `CHANGELOG.md` updated
- [x] Spec compliance matrix: not applicable; no common API shape is required
- [x] Declarative configuration support is provided by open-telemetry/opentelemetry-configuration#737
