### PR TITLE
[chore] fix(otep-4947): Clarify endianness of thread context record fields

### DIFF
--- a/oteps/profiles/4947-thread-ctx.md
+++ b/oteps/profiles/4947-thread-ctx.md
@@ -109,7 +109,7 @@ We introduce a single thread-local - `otel_thread_ctx_v1`. This is a pointer to 
 
 This is the attached thread record itself. SDK-side implementations may choose to hold multiple instances of this for active spans, and attach/detach them by setting the TLS to point to the appropriate entry. We err on the side of simplicity and support string (utf-8 bytes) attributes only.
 
-The record layout is byte-packed exactly as shown, with no implicit compiler padding between fields. Multi-byte fields are in native machine (host) endianness.
+The record layout is byte-packed exactly as shown, with no implicit compiler padding between fields. Types longer than uint8 are in native machine (host) endianness. uint8 arrays do not imply an endianness.
 
 | Name            |            | Data type                          | Notes                                                                                                                                                    |
 | :-------------- | :--------- | :--------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -117,7 +117,7 @@ The record layout is byte-packed exactly as shown, with no implicit compiler pad
 | span-id         |            | uint8[8]                           | In W3C Trace Context format.                                                                                                                             |
 | valid           |            | uint8                              | This value is set to 1 when the record is valid. Consumers should ignore this record if any other value is set  when they read. All other values are reserved and treated as invalid. |
 | trace-flags     |            | uint8                              | W3C Trace Context trace-flags byte associated with trace-id/span-id above, including the sampled and random-trace-id bits. Zero if trace-id/span-id are unset. Also serves to align attrs-data-size at a two byte boundary.                          |
-| attrs-data-size |            | uint16                             | Size of `attrs-data`. This lets the reader know when it has consumed all `attrs-data` records within the TLS buffer. The total record is recommended to stay at or under 640 bytes. |
+| attrs-data-size |            | uint16                             | Size of `attrs-data` (native endianness). This lets the reader know when it has consumed all `attrs-data` records within the TLS buffer. The total record is recommended to stay at or under 640 bytes. |
 | attrs-data      |            | uint8[]                            | A byte buffer containing the attributes themselves. Its total length is given by `attrs-data-size`.                                                      |
 |                 | [x].key    | uint8 (*See below for alternative) | Index into the key table. Readers MUST ignore entries whose key index is outside `threadlocal.attribute_key_map`.                                        |
 |                 | [x].length | uint8 (*See below for alternative) | Length of val string                                                                                                                                     |


### PR DESCRIPTION
## Changes

During implementation work for OTEP-4947, we noticed that in some cases implementors were treating spanId and traceId in the TLS payload as integers that just happened to be serialised in a byte array, which would imply the need to address endian-ness. This PR clarifies the wording of the OTEP such that it is clear where endian-ness matters, and that in those cases it is the host's native byte order, and significantly, that this _does not _ apply to byte arrays which should be treated simply as byte arrays. 

For non-trivial changes, follow the [change proposal process](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CONTRIBUTING.md#proposing-a-change).

* [ ] Related issues #
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [ ] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
