### PR TITLE
Specify criteria for automatic injection in SDKs and instrumentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ release.
 
 ### Supplementary Guidelines
 
+- Add to the library guidelines criteria for automatic injectability that are
+  the foundation of the technical contract for the OpenTelemetry Injector,
+  System Packages and the OpenTelemetry Operator.
+  ([#5308](https://github.com/open-telemetry/opentelemetry-specification/pull/5308))
+
 ### OTEPs
 
 ## v1.60.0 (2026-08-07)

--- a/specification/library-guidelines.md
+++ b/specification/library-guidelines.md
@@ -134,3 +134,46 @@ safeties should API implementations provide and how they should be documented:
 * [Metrics API](./metrics/api.md#concurrency-requirements)
 * [Metrics SDK](./metrics/sdk.md#concurrency-requirements)
 * [Tracing API](./trace/api.md#concurrency-requirements)
+
+### Automatic Injection
+
+**Status**: [Development](document-status.md)
+
+Injection is the automatic activation of the SDK and instrumentations in a
+process **without changing the application's source code or build**. Tools such
+as the [OpenTelemetry Injector], [OpenTelemetry System Packages], and the
+[OpenTelemetry Operator] rely on this capability, a form of
+[automatic instrumentation](glossary.md#automatic-instrumentation).
+
+For its SDK and instrumentations to be injectable, an implementation:
+
+* MUST provide a documented mechanism to activate the SDK and instrumentations
+  at process startup without modifying application code or build (e.g. an
+  environment variable, runtime flag, or attached agent). When it ships multiple
+  builds of a component for the same runtime (e.g. per CPU architecture or C
+  library flavor), it MUST documents a deterministic logic to select the
+  right build of the component at runtime. The mechanism MUST be a no-op when
+  OpenTelemetry is already active in the process.
+* SHOULD declare the runtimes and runtime versions it supports and detect at
+  startup whether the current runtime is supported. On an unsupported or
+  incompatible runtime it MUST fail safe: it MUST NOT crash or prevent the
+  application from starting, MAY disable itself and, if it disables, SHOULD emit
+  diagnostics explaining why.
+* SHOULD isolate the SDK, instrumentations, and their non-OpenTelemetry
+  dependencies from the application (e.g. via shading or a dedicated
+  classloader), so injection does not change the versions or resolution of the
+  application's own dependencies. When that is not possible, for example due to
+  limitations of the runtime, it SHOULD avoid whenever possible non-vendored
+  dependencies (e.g., by using shading in Java).
+* SHOULD support
+  [declarative configuration](configuration/README.md#declarative-configuration),
+  including [language-specific
+  instrumentation configurations](https://github.com/open-telemetry/opentelemetry-configuration/blob/v1.1.0/schema/instrumentation.yaml),
+  so injectors can configure it and other SDKs in other languages through a
+  single file.
+* SHOULD exercise its injection contract in CI, so that changes which break
+  injectability are caught before release.
+
+[OpenTelemetry Injector]: https://github.com/open-telemetry/opentelemetry-injector
+[OpenTelemetry Operator]: https://github.com/open-telemetry/opentelemetry-operator
+[OpenTelemetry System Packages]: https://github.com/open-telemetry/opentelemetry-packaging


### PR DESCRIPTION
Fixes #5267

## Changes

Adds to the library guidelines criteria for automatic injectability that are the foundation of the technical contract for the OpenTelemetry Injector, System Packages and the OpenTelemetry Operator.

* [X] Related issues #5267
* [ ] Related [OTEP(s)](https://github.com/open-telemetry/oteps) #
* [ ] Links to the prototypes (when adding or changing features)
* [X] [`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [ ] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] [Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed
