### PR TITLE
[chore] Update .NET spec compliance

### DIFF
--- a/spec-compliance-matrix.md
+++ b/spec-compliance-matrix.md
@@ -89,7 +89,7 @@ formats is required. Implementing more than one format is optional.
 | Fetch InstrumentationScope from ReadableSpan |  | + | + | + | + |  |  | + |  |  | + |  | + |
 | [TraceIdRatioBased sampler implements OpenTelemetry tracestate `th` field](specification/trace/sdk.md#traceidratiobased) | X | - |  |  |  |  |  |  |  |  | - |  | + |
 | [CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler) | X | - | + |  |  |  |  |  |  |  | - |  | + |
-| [Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord) |  | - | + |  |  |  |  |  |  |  | - |  | + |
+| [Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord) |  | - | + |  |  |  |  |  |  |  | + |  | + |
 
 ## Baggage
 

--- a/spec-compliance-matrix/dotnet.yaml
+++ b/spec-compliance-matrix/dotnet.yaml
@@ -156,7 +156,7 @@ sections:
           - name: '[CompositeSampler and built-in ComposableSamplers](specification/trace/sdk.md#compositesampler)'
             status: '-'
           - name: '[Sampler: AlwaysRecord](specification/trace/sdk.md#alwaysrecord)'
-            status: '-'
+            status: '+'
   - name: Baggage
     features:
       - name: Basic support


### PR DESCRIPTION
## Changes

Update AlwaysRecord sampler entry for .NET (see https://github.com/open-telemetry/opentelemetry-dotnet/pull/7695).

* [ ] ~~Related issues #~~
* [ ] ~~Related [OTEP(s)](https://github.com/open-telemetry/oteps) #~~
* [ ] ~~Links to the prototypes (when adding or changing features)~~
* [ ] ~~[`CHANGELOG.md`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/CHANGELOG.md) file updated for non-trivial changes~~
  * For trivial changes, include `[chore]` in the PR title to skip the changelog check
* [x] [Spec compliance matrix](https://github.com/open-telemetry/opentelemetry-specification/blob/main/spec-compliance-matrix/template.yaml) updated if necessary
* [ ] ~~[Declarative config data model](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/data-model.md#overview) is updated if SDK config surface is changed~~
